### PR TITLE
Documentation: Add websockets + event emitter example

### DIFF
--- a/docs/examples/websockets/chat.py
+++ b/docs/examples/websockets/chat.py
@@ -1,0 +1,50 @@
+from asyncio import gather
+from pathlib import Path
+from uuid import uuid4
+
+from starlite import Starlite, WebSocket, websocket
+from starlite.datastructures.state import State
+from starlite.events import listener
+from starlite.exceptions import WebSocketDisconnect
+from starlite.static_files import StaticFilesConfig
+
+
+class MyState(State):
+    websockets: dict[str, WebSocket]
+
+
+@listener("ws_receive")
+async def on_ws_receive(sender_id: str, message: str) -> None:
+    state: MyState = app.state
+    message_container = {"from": sender_id, "message": message}
+    await gather(*[socket.send_json(message_container) for socket in state.websockets.values()])
+
+
+@websocket("/chat")
+async def chat(socket: WebSocket, state: MyState) -> None:
+    await socket.accept()
+    client_id = uuid4().hex
+    await socket.send_json({"from": "Server", "message": f"Connected as {client_id}"})
+    state.websockets[client_id] = socket
+    while True:
+        try:
+            message = await socket.receive_text()
+        except WebSocketDisconnect:
+            del state.websockets[client_id]
+            break
+        else:
+            app.emit("ws_receive", client_id, message)
+
+
+app = Starlite(
+    route_handlers=[chat],
+    listeners=[on_ws_receive],
+    state=State({"websockets": {}}),
+    static_files_config=[
+        StaticFilesConfig(
+            directories=[Path("static")],
+            path="/",
+            html_mode=True,
+        )
+    ],
+)

--- a/docs/examples/websockets/index.html
+++ b/docs/examples/websockets/index.html
@@ -1,0 +1,33 @@
+<html>
+  <body>
+    <div id="messages"></div>
+    <div>
+      <input id="input" placeholder="Send a message" />
+      <button id="submit-message">Send</button>
+    </div>
+    <script>
+      const messagesEl = document.getElementById("messages");
+      const inputEl = document.getElementById("input");
+      const submitButton = document.getElementById("submit-message");
+
+      const writeMessage = ({ from, message }) => {
+        const messageEl = document.createElement("div");
+        messageEl.textContent = `${from}: ${message}`;
+        messagesEl.appendChild(messageEl);
+      };
+
+      const onSubmit = () => {
+        const message = inputEl.value;
+        socket.send(message);
+        inputEl.value = "";
+      };
+
+      const socket = new WebSocket(`ws://${window.location.host}/chat/`);
+      socket.addEventListener("message", (event) => {
+        writeMessage(JSON.parse(event.data));
+      });
+
+      submitButton.addEventListener("click", () => onSubmit());
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Add an example that showcases real-world usage of events via a simple websocket based chat application. 

The issue with the current events example is that it's not useful when a backend is used that allows for inter-process communication (such as redis), the listener would be called for each application process, which for the given example is undesirable, since it's sending an email that should only be sent once. A message queue would be more appropriate for this case.

<hr>
I'm not sure where to add this example though, since it covers both websockets and events in a way that's currently not present in the docs.

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
