### PR TITLE
RFC: Caching middleware

### DIFF
--- a/starlite/_asgi/routing_trie/mapping.py
+++ b/starlite/_asgi/routing_trie/mapping.py
@@ -187,6 +187,7 @@ def build_route_middleware_stack(
     from starlite.middleware.allowed_hosts import AllowedHostsMiddleware
     from starlite.middleware.compression import CompressionMiddleware
     from starlite.middleware.csrf import CSRFMiddleware
+    from starlite.middleware.response_cache import ResponseCacheMiddleware
 
     # we wrap the route.handle method in the ExceptionHandlerMiddleware
     asgi_handler = wrap_in_exception_handler(
@@ -198,6 +199,10 @@ def build_route_middleware_stack(
 
     if app.compression_config:
         asgi_handler = CompressionMiddleware(app=asgi_handler, config=app.compression_config)
+
+    if app.response_cache_config:
+        asgi_handler = ResponseCacheMiddleware(app=asgi_handler, config=app.response_cache_config)
+
     if app.allowed_hosts:
         asgi_handler = AllowedHostsMiddleware(app=asgi_handler, config=app.allowed_hosts)
 

--- a/starlite/config/response_cache.py
+++ b/starlite/config/response_cache.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
-from urllib.parse import urlencode
+from typing import TYPE_CHECKING
 
 __all__ = ("ResponseCacheConfig", "default_cache_key_builder")
 
 
 if TYPE_CHECKING:
     from starlite import Starlite
-    from starlite.connection import Request
     from starlite.stores.base import Store
-    from starlite.types import CacheKeyBuilder
+    from starlite.types import CacheKeyBuilder, Scope
 
 
-def default_cache_key_builder(request: Request[Any, Any, Any]) -> str:
+def default_cache_key_builder(scope: Scope) -> str:
     """Given a request object, returns a cache key by combining the path with the sorted query params.
 
     Args:
@@ -22,10 +20,9 @@ def default_cache_key_builder(request: Request[Any, Any, Any]) -> str:
 
     Returns:
         A combination of url path and query parameters
+    #
     """
-    query_params: list[tuple[str, Any]] = list(request.query_params.dict().items())
-    query_params.sort(key=lambda x: x[0])
-    return request.url.path + urlencode(query_params, doseq=True)
+    return scope["path"] + scope["query_string"].decode("latin-1")
 
 
 @dataclass

--- a/starlite/middleware/response_cache.py
+++ b/starlite/middleware/response_cache.py
@@ -1,0 +1,35 @@
+from msgspec.msgpack import encode as encode_msgpack
+
+from starlite.config.response_cache import ResponseCacheConfig
+from starlite.enums import ScopeType
+from starlite.types import ASGIApp, Message, Receive, Scope, Send
+from starlite.utils import get_starlite_scope_state
+
+from .base import AbstractMiddleware
+
+__all__ = ["ResponseCacheMiddleware"]
+
+
+class ResponseCacheMiddleware(AbstractMiddleware):
+    def __init__(self, app: ASGIApp, config: ResponseCacheConfig) -> None:
+        self.config = config
+        super().__init__(app=app, scopes={ScopeType.HTTP})
+        self._messages = []
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        route_handler = scope["route_handler"]
+        if not getattr(route_handler, "cache", False):
+            await self.app(scope, receive, send)
+            return
+
+        store = self.config.get_store_from_app(scope["app"])
+
+        async def wrapped_send(message: Message) -> None:
+            if not get_starlite_scope_state(scope, "is_cached"):
+                self._messages.append(message)
+                if message["type"] == "http.response.body" and not message["more_body"]:
+                    key = (route_handler.cache_key_builder or self.config.key_builder)(scope)
+                    await store.set(key, encode_msgpack(self._messages))
+            await send(message)
+
+        await self.app(scope, receive, wrapped_send)

--- a/tests/test_response_caching.py
+++ b/tests/test_response_caching.py
@@ -6,10 +6,11 @@ from uuid import uuid4
 
 import pytest
 
-from starlite import Request, Starlite, get
+from starlite import Starlite, get
 from starlite.config.response_cache import ResponseCacheConfig
 from starlite.stores.base import Store
 from starlite.testing import TestClient, create_test_client
+from starlite.types import Scope
 
 if TYPE_CHECKING:
     from freezegun.api import FrozenDateTimeFactory
@@ -90,8 +91,8 @@ def test_default_expiration(mock: MagicMock, frozen_datetime: "FrozenDateTimeFac
 
 @pytest.mark.parametrize("sync_to_thread", (True, False))
 async def test_custom_cache_key(sync_to_thread: bool, anyio_backend: str, mock: MagicMock) -> None:
-    def custom_cache_key_builder(request: Request) -> str:
-        return request.url.path + ":::cached"
+    def custom_cache_key_builder(scope: Scope) -> str:
+        return scope["path"] + ":::cached"
 
     @get("/cached", sync_to_thread=sync_to_thread, cache=True, cache_key_builder=custom_cache_key_builder)
     async def handler() -> str:


### PR DESCRIPTION
This is a **very** rough draft of how the response caching could be transferred to a middleware. It's goal is to serve as a proof of concept, not as an actual implementation.

This solves the problem of compression being applied *after* a response is cached by caching a response with a middleware. It takes a very radical approach here: Instead of caching a response object, the raw `http` ASGI event data is stored, and sent again upon a cache hit. This has the side benefit of further reducing the size of the stored response and improving performance by foregoing pickling.

This approach though has some serious drawbacks: Caching the raw events means they'll be sent as-is, post-transformations won't apply (e.g. setting additional headers) things background tasks won't run again. This may actually be desirable though, depending on how aggressive the caching is *meant* to be. For example setting headers on an already cached response might be seen as an antipattern and should lead to an invalidation of the cached response. 

The behaviour of the cache as implemented in this PR is more akin to how a proxy cache would work, whereas the previous implementation was a lot more high level, but also less aggressive and strict. We should decide which we way want to go with the caching before we move forward with this.

An alternative approach do harmonise caching and compression would necessitate handling them both at the route level, which would mean implementing stream compression would be a lot more complicated, and other special cases would have to be taken into account; Implementing compression as a middleware is the easiest, and most robust approach here and IMO should be preferred.
