### PR TITLE
Fix #1419: Support `RequestFactory` with empty `data`

### DIFF
--- a/starlite/testing/request_factory.py
+++ b/starlite/testing/request_factory.py
@@ -269,6 +269,8 @@ class RequestFactory:
             for chunk in stream:
                 body += chunk
             scope["_body"] = body  # type: ignore[typeddict-unknown-key]
+        else:
+            scope["_body"] = b""  # type: ignore[typeddict-unknown-key]
         self._create_cookie_header(headers, cookies)
         scope["headers"] = self._build_headers(headers)
         return Request(scope=scope)

--- a/tests/testing/test_testing.py
+++ b/tests/testing/test_testing.py
@@ -22,6 +22,11 @@ _DEFAULT_REQUEST_FACTORY_URL = "http://test.org:3000/"
 pet = PetFactory.build()
 
 
+async def test_request_factory_empty_body() -> None:
+    request = RequestFactory().post(data={})
+    await request.body()
+
+
 def test_request_factory_no_cookie_header() -> None:
     headers: Dict[str, str] = {}
     RequestFactory._create_cookie_header(headers)


### PR DESCRIPTION
Adds support for creating requests from a `RequestFactory` with an empty body.
Fixes #1419

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)
