### PR TITLE
Revert Pydantic to a non-optional dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -250,14 +250,14 @@ pytz = {version = ">=2015.7", markers = "python_version < \"3.9\""}
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.12.1"
+version = "4.12.2"
 description = "Screen-scraping library"
 category = "dev"
 optional = false
 python-versions = ">=3.6.0"
 files = [
-    {file = "beautifulsoup4-4.12.1-py3-none-any.whl", hash = "sha256:e44795bb4f156d94abb5fbc56efff871c1045bfef72e9efe77558db9f9616ac3"},
-    {file = "beautifulsoup4-4.12.1.tar.gz", hash = "sha256:c7bdbfb20a0dbe09518b96a809d93351b2e2bcb8046c0809466fa6632a10c257"},
+    {file = "beautifulsoup4-4.12.2-py3-none-any.whl", hash = "sha256:bd2520ca0d9d7d12694a53d44ac482d181b4ec1888909b035a3dbf40d0f57d4a"},
+    {file = "beautifulsoup4-4.12.2.tar.gz", hash = "sha256:492bbc69dca35d12daac71c4db1bfff0c876c00ef4a2ffacce226d4638eb72da"},
 ]
 
 [package.dependencies]
@@ -1692,41 +1692,41 @@ mongomock = ">=3.23.0,<5.0.0"
 
 [[package]]
 name = "msgspec"
-version = "0.14.0"
+version = "0.14.1"
 description = "A fast serialization and validation library, with builtin support for JSON, MessagePack, YAML, and TOML."
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "msgspec-0.14.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f001981317161efd31703dfe2dbccb65feba2222baedf1e1d0d3fbc4e4481d4a"},
-    {file = "msgspec-0.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e06dc68ccd9a456f21abf0dbcbe3d1ed00aa53f39fd01eb1f226e2e98d6e49f"},
-    {file = "msgspec-0.14.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e497794d5df290911fa6b38682788e3ebee48ec9ed33b0ef5f1f9c2ac7011f45"},
-    {file = "msgspec-0.14.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a53047a5bbeb9f04e78990a2d17a2735c15744be13246e2c3a625db0941887d"},
-    {file = "msgspec-0.14.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:a7a89677eae142c155c51d87c1df73fc5333db7cff1e08af8976aeaab2c81114"},
-    {file = "msgspec-0.14.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:18a5724546fd883a575b46e26fd81d37b47b66278e89e9610a5c87aea4fdebfc"},
-    {file = "msgspec-0.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:f8cca6587fe94b6998151d15c05bf97bbbd4ab47ebf57b18ed49d20bb2a1713d"},
-    {file = "msgspec-0.14.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c8699dbcc1eef9496bbc0d098667a0fc19041ba1c3a74af532244a5048db19ab"},
-    {file = "msgspec-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2e46843d258c3043c4807649710c20a34c37b9b91c6cd78684575f78283ec873"},
-    {file = "msgspec-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e29c330a183d2a015ee0edf8d4799540aec0ab9ffb14426c637cf1f121ed652"},
-    {file = "msgspec-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89f5c94f72bed3d3b6e9252b903391fb584759d1cecb607b4788392ad264fad2"},
-    {file = "msgspec-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:86da8fdc94f0a38c188cb9f896174e0ba9bb474eb6b4c2937ef96075dcc76e52"},
-    {file = "msgspec-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:21ee98a51930ccf57a6b16b55a1049d8cc358315196aae6c621f3d93cc25714d"},
-    {file = "msgspec-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e5f46b3d03a0b08bbfcd0bad9595dc732b505556cd2a7f9f01ba5b3355ae7c"},
-    {file = "msgspec-0.14.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7de7ae6d69a2d08bacab29727e594220788c5a9ae6b0bd1fddd966fa70b8cc1c"},
-    {file = "msgspec-0.14.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f674712b5f75bfbb45328b3953dff8df1ff50acc16468d7a7916424266af9cf5"},
-    {file = "msgspec-0.14.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4b59025a865120703a3e51da79f7ff50aee674003317d3046352f806fd5e7d28"},
-    {file = "msgspec-0.14.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6866a184a408d40d1098ff922b9592beca53ae9b90495f34ebb78a2d23a47dac"},
-    {file = "msgspec-0.14.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f972fc150f5a397e4df9aa369a21b3cc733d588855aa27d603977463cd50c983"},
-    {file = "msgspec-0.14.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b3d0433dbf09a1ed8b197d0809d513c5f11de62cca50b1b9ac2b6d72e602ab4e"},
-    {file = "msgspec-0.14.0-cp38-cp38-win_amd64.whl", hash = "sha256:e8da19d4a46f3fde25e2c32e798785716df873d29a4ca763d8becf3715c20efc"},
-    {file = "msgspec-0.14.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8b4798f9ff27aea6cc4edf072ec735c95e42a9ba499fef0120f09c52dfc469cd"},
-    {file = "msgspec-0.14.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1431df375e36f678d0d9b802c1792c904e70c315002c08ecf85ff1007cabcdb7"},
-    {file = "msgspec-0.14.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15d910a223737735196297dd4d26b54679e2ac2b95beaef3837ff918a13be7db"},
-    {file = "msgspec-0.14.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d8b4969739f60fc3751e1c73c4cf31f061654a00b452675cbb22ea99f06c2df"},
-    {file = "msgspec-0.14.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:a8fee0ffa0753f632cd94fa304a2e9ca9c92f9695fdb2ea160ac048dc278d008"},
-    {file = "msgspec-0.14.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a15d07d9daeb7daad32b19c194913452ba14748a37d230bcee45e118767b7b8e"},
-    {file = "msgspec-0.14.0-cp39-cp39-win_amd64.whl", hash = "sha256:f0f178d36eb91ba99003bd5e0bae4c1cb834f0d86b4ae9b5a8e88d4ef544ba86"},
-    {file = "msgspec-0.14.0.tar.gz", hash = "sha256:eef6506652f6d5968371ab3ed70895dcea39207246feb83e386640289d7d129f"},
+    {file = "msgspec-0.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0298c9d1584b9038623229c78f0c6e5286a164f7e74de96df0ac82a69f4ca33a"},
+    {file = "msgspec-0.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5d490f02e1e3924538587ae49489b15b37c9e244bf84c268796693c3c3690df5"},
+    {file = "msgspec-0.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc66cc096c2a491492d11a8a678d209e63dc8f7c2244b54d89fcd4a18121d43b"},
+    {file = "msgspec-0.14.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06e3038932e7deebbff59310d737b8753f34783af0cc47d2bdcb85333dd96e67"},
+    {file = "msgspec-0.14.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e7a169690662482dcbd6a3f79fe0a07e4e54672e41bff1f46144c20fd13243e3"},
+    {file = "msgspec-0.14.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f04efc87250f35b27d8704df14a4b304b1efc901b3eebb6476f88bc09f1241fe"},
+    {file = "msgspec-0.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:180c20b722a5efcc615580fb89cfb9016a21852fc154bdb3d2014f97deb4142b"},
+    {file = "msgspec-0.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d6d7470823390cd0dcc16e9df51a161728d0884826a0d0e0acde5839a68d66c4"},
+    {file = "msgspec-0.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1439a41e963e316abcbfdd5481ef95d828272df8d8e503aa779152d7c9058dd1"},
+    {file = "msgspec-0.14.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f0058f1e01ba4b6798135b5d107b2d4cb442278c569d3e848947be30a7f7f429"},
+    {file = "msgspec-0.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5c2041a49a4a97328237af0c6c596b98e3aa26f8561ab2c30a0524cb6340a5e"},
+    {file = "msgspec-0.14.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:654595f4c9659814adbe44883ccf436990c45b9a9c8b2a9d2762dd096392cf67"},
+    {file = "msgspec-0.14.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:487ce8509e494e3f6a65d3e2a7b1c4a0ab5ede999334b0e1938fa28da057fcfc"},
+    {file = "msgspec-0.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:291b2917114ac873c1aa2f495c2a01d17dc534540843387c96be7a87c5c8f75d"},
+    {file = "msgspec-0.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a4c5ec7d747eab9de830bce763fe493522b0504ae0b204d0fd6a0c41b76753d1"},
+    {file = "msgspec-0.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:54469a55b4260c12daf357cc52460c0dab5a0ea073ff3db62ead3f3496ccdcd6"},
+    {file = "msgspec-0.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a303fe7000d89c58a45d7bfd089280668e421a77a5d365765c101ce7f32f0f4b"},
+    {file = "msgspec-0.14.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:09460fc3a4aec4f34ceff180f5a227ce28eb9521720059de0c21057a4a775323"},
+    {file = "msgspec-0.14.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:3b9f6137185653d412a52a79543c746e37ff1391b5f6fc8ef755e22175f3a65e"},
+    {file = "msgspec-0.14.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:38e324d07c644da3f92a54e3ee13aeb459ccf3a05bcbf496e65b537cafb182c3"},
+    {file = "msgspec-0.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:d5417df2fadc85b31da81588e1eb81dcc064ac61c7215aa2b8576a82f69b5b5e"},
+    {file = "msgspec-0.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9f219547416ea4ada1f210c4a0da7c76845f0fac76457f0674ad4aa96a3f1cb8"},
+    {file = "msgspec-0.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8356dca33a9ebc0b6b53a45f77b130a22cdbb9cec14280f96e20d7121e93f460"},
+    {file = "msgspec-0.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7d8d7c0406379d0676d82f39aa4c618b8677503a677e2177a8a59fa5b7d2fad3"},
+    {file = "msgspec-0.14.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37b6b366f81c86591cbc3507274ccea5f8c243502a890b2dd3253d5be829c2bf"},
+    {file = "msgspec-0.14.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:852ae70eb9240a3542e49240b088bfbbb99c01e8fbab4efd93d6661898c86226"},
+    {file = "msgspec-0.14.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1934d5f768eb336a27249b9c6a457f15c4efb4dbd4ae56b4646682b75dd02328"},
+    {file = "msgspec-0.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:f27b7f846818abf25b138dcfe2c56e9d138742f4b164154abeb843add16c9064"},
+    {file = "msgspec-0.14.1.tar.gz", hash = "sha256:f72c895f7034bc9666cfb50259f81d3a08fb4ae43118ced899f418bb00f57812"},
 ]
 
 [package.extras]
@@ -3334,4 +3334,4 @@ tortoise-orm = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "c5fc84638ceb35721c58996b6164f27efbc550d941e1f46a79f9535f3d534df9"
+content-hash = "479d51eff67e94c98442af4837d4fd4aab93abadf8981a5068cc5d9e38ee8c32"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ multidict = ">=6.0.2"
 opentelemetry-instrumentation-asgi = { version = "*", optional = true }
 picologging = { version = "*", optional = true }
 polyfactory = "*"
-pydantic = { version = "*", optional = true }
+pydantic = "<2"
 python-dateutil = { version = "*", optional = true }
 python-jose = { version = "*", optional = true }
 pytimeparse = { version = "*", optional = true }


### PR DESCRIPTION
Pydantic has been made an optional dependency in #1431, but Litestar still depends on Pydantic in various places (some datastructures and as a default signature modelling backend). This PR reverts Pydantic to a non-optional dependency.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
