### PR TITLE
Fix Github issue link in routing documentation

### DIFF
--- a/docs/usage/routing.rst
+++ b/docs/usage/routing.rst
@@ -18,7 +18,7 @@ parameters.
 .. seealso::
 
    If you are interested in the technical aspects of the implementation, refer to
-   `this GitHub issue <https://github.com/starlpytestite-api/litestar/issues/177>`_ - it includes
+   `this GitHub issue <https://github.com/litestar-org/litestar/issues/177>`_ - it includes
    an indepth discussion of the pertinent code.
 
 


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

Change invalid URL path (404) to correct one for issue link in routing usage docs.
This project is G.R.E.A.T! Keep going guys!

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
