### PR TITLE
Update `Litestar.logger` levels when setting `Litestar.debug`

### DIFF
--- a/litestar/app.py
+++ b/litestar/app.py
@@ -449,7 +449,9 @@ class Litestar(Router):
 
         self.asgi_handler = self._create_asgi_handler()
 
-        self.stores = config.stores if isinstance(config.stores, StoreRegistry) else StoreRegistry(config.stores)
+        self.stores: StoreRegistry = (
+            config.stores if isinstance(config.stores, StoreRegistry) else StoreRegistry(config.stores)
+        )
 
     @property
     def debug(self) -> bool:
@@ -459,6 +461,8 @@ class Litestar(Router):
     def debug(self, value: bool) -> None:
         if self.logger:
             self.logger.setLevel(logging.DEBUG if value else logging.INFO)
+        if isinstance(self.logging_config, LoggingConfig):
+            self.logging_config.loggers["litestar"]["level"] = "DEBUG" if value else "INFO"
         self._debug = value
 
     async def __call__(

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import date, datetime, time, timedelta
 from functools import partial
 from itertools import chain
@@ -132,6 +133,7 @@ class Litestar(Router):
     """
 
     __slots__ = (
+        "_debug",
         "_openapi_schema",
         "after_exception",
         "after_shutdown",
@@ -145,7 +147,6 @@ class Litestar(Router):
         "compression_config",
         "cors_config",
         "csrf_config",
-        "debug",
         "event_emitter",
         "get_logger",
         "logger",
@@ -373,6 +374,7 @@ class Litestar(Router):
             config = handler(config)
 
         self._openapi_schema: OpenAPI | None = None
+        self._debug: bool = True
         self.get_logger: GetLogger = get_logger_placeholder
         self.logger: Logger | None = None
         self.routes: list[HTTPRoute | ASGIRoute | WebSocketRoute] = []
@@ -389,7 +391,6 @@ class Litestar(Router):
         self.compression_config = config.compression_config
         self.cors_config = config.cors_config
         self.csrf_config = config.csrf_config
-        self.debug = config.debug
         self.event_emitter = config.event_emitter_backend(listeners=config.listeners)
         self.logging_config = config.logging_config
         self.multipart_form_part_limit = config.multipart_form_part_limit
@@ -405,6 +406,7 @@ class Litestar(Router):
         self.static_files_config = config.static_files_config
         self.template_engine = config.template_config.engine_instance if config.template_config else None
         self.websocket_class = config.websocket_class or WebSocket
+        self.debug = config.debug
 
         super().__init__(
             after_request=config.after_request,
@@ -435,9 +437,6 @@ class Litestar(Router):
         for route_handler in config.route_handlers:
             self.register(route_handler)
 
-        if self.debug and isinstance(self.logging_config, LoggingConfig):
-            self.logging_config.loggers["litestar"]["level"] = "DEBUG"
-
         if self.logging_config:
             self.get_logger = self.logging_config.configure()
             self.logger = self.get_logger("litestar")
@@ -451,6 +450,16 @@ class Litestar(Router):
         self.asgi_handler = self._create_asgi_handler()
 
         self.stores = config.stores if isinstance(config.stores, StoreRegistry) else StoreRegistry(config.stores)
+
+    @property
+    def debug(self) -> bool:
+        return self._debug
+
+    @debug.setter
+    def debug(self, value: bool) -> None:
+        if self.logger:
+            self.logger.setLevel(logging.DEBUG if value else logging.INFO)
+        self._debug = value
 
     async def __call__(
         self,

--- a/litestar/types/protocols.py
+++ b/litestar/types/protocols.py
@@ -79,6 +79,16 @@ class Logger(Protocol):  # pragma: no cover
              **kwargs: Any kwargs.
         """
 
+    def setLevel(self, level: int) -> None:  # noqa: N802
+        """Set the log level
+
+        Args:
+            level: Log level to set as an integer
+
+        Returns:
+            None
+        """
+
 
 @runtime_checkable
 class DataclassProtocol(Protocol):

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from litestar import Litestar
@@ -11,3 +13,16 @@ def test_access_openapi_schema_raises_if_not_configured() -> None:
     app = Litestar(openapi_config=None)
     with pytest.raises(ImproperlyConfiguredException):
         app.openapi_schema
+
+
+def test_set_debug_updates_logging_level() -> None:
+    app = Litestar()
+
+    assert app.logger is not None
+    assert app.logger.level == logging.INFO  # type: ignore[attr-defined]
+
+    app.debug = True
+    assert app.logger.level == logging.DEBUG  # type: ignore[attr-defined]
+
+    app.debug = False
+    assert app.logger.level == logging.INFO  # type: ignore[attr-defined]


### PR DESCRIPTION
This fixes the behaviour reported in #1476.

- Make `Litestar.debug` into a property which updates the logging level and config of `litestar` logger accordingly when being set
- Add `Logger.setLevel` to the `Logger` protocol

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
