### PR TITLE
Pass context to HTMX Template response

### DIFF
--- a/litestar/contrib/htmx/response.py
+++ b/litestar/contrib/htmx/response.py
@@ -230,12 +230,7 @@ class HTMXTemplate(ResponseContainer[TemplateResponse]):
             )
         )
 
-        template = Template(
-            name=self.name,
-            background=self.background,
-            context=self.context,
-            encoding=self.encoding
-        )
+        template = Template(name=self.name, background=self.background, context=self.context, encoding=self.encoding)
 
         return template.to_response(
             headers=hx_headers, media_type=media_type, app=app, status_code=status_code, request=request

--- a/litestar/contrib/htmx/response.py
+++ b/litestar/contrib/htmx/response.py
@@ -233,7 +233,8 @@ class HTMXTemplate(ResponseContainer[TemplateResponse]):
         template = Template(
             name=self.name,
             background=self.background,
-            encoding=self.encoding,
+            context=self.context,
+            encoding=self.encoding
         )
 
         return template.to_response(

--- a/tests/contrib/htmx/test_htmx_response.py
+++ b/tests/contrib/htmx/test_htmx_response.py
@@ -233,8 +233,16 @@ async def test_hx_location_response_with_all_parameters() -> None:
 @pytest.mark.parametrize(
     "engine, template, expected",
     (
-        (JinjaTemplateEngine, "path: {{ request.scope['path'] }}", "path: /"),
-        (MakoTemplateEngine, "path: ${request.scope['path']}", "path: /"),
+        (
+            JinjaTemplateEngine,
+            "path: {{ request.scope['path'] }} custom_key: {{ custom_key }}",
+            "path: / custom_key: custom_value",
+        ),
+        (
+            MakoTemplateEngine,
+            "path: ${request.scope['path']} custom_key: ${custom_key}",
+            "path: / custom_key: custom_value",
+        ),
     ),
 )
 def test_HTMXTemplate_response_success(engine: Any, template: str, expected: str, template_dir: Path) -> None:
@@ -244,7 +252,7 @@ def test_HTMXTemplate_response_success(engine: Any, template: str, expected: str
     def handler() -> HTMXTemplate:
         return HTMXTemplate(
             name="abc.html",
-            context={"request": {"scope": {"path": "nope"}}},
+            context={"request": {"scope": {"path": "nope"}}, "custom_key": "custom_value"},
             push_url="/about",
             re_swap="beforebegin",
             re_target="#new-target-id",


### PR DESCRIPTION
The HTMXTemplate class currently does not pass the context to `Template`  in the `to_response` method, making it difficult to server render templates with dynamic data.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
