### PR TITLE
Fix inconsistent parsing of unix timestamp between pydantic and cattrs.

### DIFF
--- a/litestar/_signature/models/attrs_signature_model.py
+++ b/litestar/_signature/models/attrs_signature_model.py
@@ -85,7 +85,7 @@ def _structure_date(value: Any, cls: type[date]) -> date:
         return value
 
     if isinstance(value, (float, int, Decimal)):
-        return cls.fromtimestamp(float(value))
+        return datetime.fromtimestamp(float(value), tz=timezone.utc).date()
 
     dt = _structure_datetime(value=value, cls=datetime)
     return cls(year=dt.year, month=dt.month, day=dt.day)

--- a/tests/signature/test_attrs_signature_modelling.py
+++ b/tests/signature/test_attrs_signature_modelling.py
@@ -7,7 +7,7 @@ from litestar._signature.models.attrs_signature_model import _converter
 from tests import Person, PersonFactory
 
 now = datetime.now(tz=timezone.utc)
-today = date.today()
+today = now.date()
 time_now = time(hour=now.hour, minute=now.minute, second=now.second, microsecond=now.microsecond)
 one_minute = timedelta(minutes=1)
 person = PersonFactory.build()


### PR DESCRIPTION
Timestamp parsed as date with pydantic returns UTC date, while cattrs implementation was returning local date.

Correct issue in tests where UTC dates were compared to local dates.

Closes #1491

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
