### PR TITLE
Add SQLAlchemy repository model protocol

### DIFF
--- a/litestar/contrib/repository/abc.py
+++ b/litestar/contrib/repository/abc.py
@@ -258,7 +258,7 @@ class AbstractRepository(Generic[T], metaclass=ABCMeta):
         return item_or_none
 
     @classmethod
-    def get_id_attribute_value(cls, item: T) -> Any:
+    def get_id_attribute_value(cls, item: T | type[T]) -> Any:
         """Get value of attribute named as :attr:`id_attribute <AbstractRepository.id_attribute>` on ``item``.
 
         Args:

--- a/litestar/contrib/sqlalchemy/base.py
+++ b/litestar/contrib/sqlalchemy/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from typing import Any, TypeVar
+from typing import Any, Protocol, TypeVar
 from uuid import UUID, uuid4
 
 from pydantic import AnyHttpUrl, AnyUrl, EmailStr
@@ -49,6 +49,21 @@ def touch_updated_timestamp(session: Session, *_: Any) -> None:
     for instance in session.dirty:
         if hasattr(instance, "updated"):
             instance.updated = datetime.now()  # noqa: DTZ005
+
+
+class ModelProtocol(Protocol):
+    """The base SQLAlchemy model protocol."""
+
+    __table__: Any
+    __name__: Any
+
+    def to_dict(self, exclude: set[str] | None = None) -> dict[str, Any]:
+        """Convert model to dictionary.
+
+        Returns:
+            dict[str, Any]: A dict representation of the model
+        """
+        ...
 
 
 @declarative_mixin

--- a/litestar/contrib/sqlalchemy/base.py
+++ b/litestar/contrib/sqlalchemy/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from typing import Any, Protocol, TypeVar
+from typing import Any, ClassVar, Protocol, TypeVar, runtime_checkable
 from uuid import UUID, uuid4
 
 from pydantic import AnyHttpUrl, AnyUrl, EmailStr
@@ -51,11 +51,12 @@ def touch_updated_timestamp(session: Session, *_: Any) -> None:
             instance.updated = datetime.now()  # noqa: DTZ005
 
 
+@runtime_checkable
 class ModelProtocol(Protocol):
     """The base SQLAlchemy model protocol."""
 
-    __table__: Any
-    __name__: Any
+    __table__: ClassVar[Any]
+    __name__: str
 
     def to_dict(self, exclude: set[str] | None = None) -> dict[str, Any]:
         """Convert model to dictionary.

--- a/litestar/contrib/sqlalchemy/base.py
+++ b/litestar/contrib/sqlalchemy/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol, TypeVar, runtime_checkable
 from uuid import UUID, uuid4
 
 from pydantic import AnyHttpUrl, AnyUrl, EmailStr
@@ -18,6 +18,9 @@ from sqlalchemy.orm import (
     mapped_column,
     registry,
 )
+
+if TYPE_CHECKING:
+    from sqlalchemy.sql import FromClause
 
 __all__ = ("AuditBase", "AuditColumns", "Base", "CommonTableAttributes", "UUIDPrimaryKey", "touch_updated_timestamp")
 
@@ -55,8 +58,8 @@ def touch_updated_timestamp(session: Session, *_: Any) -> None:
 class ModelProtocol(Protocol):
     """The base SQLAlchemy model protocol."""
 
-    __table__: Any
-    __name__: str
+    __table__: FromClause
+    __name__: ClassVar[str]
 
     def to_dict(self, exclude: set[str] | None = None) -> dict[str, Any]:
         """Convert model to dictionary.
@@ -94,8 +97,8 @@ class CommonTableAttributes:
     """Common attributes for SQLALchemy tables."""
 
     __abstract__ = True
-    __name__: str
-    __table__: Any
+    __name__: ClassVar[str]
+    __table__: FromClause
 
     # noinspection PyMethodParameters
     @declared_attr.directive

--- a/litestar/contrib/sqlalchemy/base.py
+++ b/litestar/contrib/sqlalchemy/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from typing import Any, ClassVar, Protocol, TypeVar, runtime_checkable
+from typing import Any, Protocol, TypeVar, runtime_checkable
 from uuid import UUID, uuid4
 
 from pydantic import AnyHttpUrl, AnyUrl, EmailStr
@@ -55,7 +55,7 @@ def touch_updated_timestamp(session: Session, *_: Any) -> None:
 class ModelProtocol(Protocol):
     """The base SQLAlchemy model protocol."""
 
-    __table__: ClassVar[Any]
+    __table__: Any
     __name__: str
 
     def to_dict(self, exclude: set[str] | None = None) -> dict[str, Any]:

--- a/litestar/contrib/sqlalchemy/repository.py
+++ b/litestar/contrib/sqlalchemy/repository.py
@@ -264,7 +264,7 @@ class SQLAlchemyRepository(AbstractRepository[ModelT], Generic[ModelT]):
         statement = kwargs.pop("base_select", self.statement)
         statement = statement.with_only_columns(
             sql_func.count(
-                getattr(self.model_type, self.id_attribute),
+                self.get_id_attribute_value(self.model_type)
             ),
             maintain_column_froms=True,
         ).order_by(None)

--- a/litestar/contrib/sqlalchemy/repository.py
+++ b/litestar/contrib/sqlalchemy/repository.py
@@ -263,9 +263,7 @@ class SQLAlchemyRepository(AbstractRepository[ModelT], Generic[ModelT]):
         """
         statement = kwargs.pop("base_select", self.statement)
         statement = statement.with_only_columns(
-            sql_func.count(
-                self.get_id_attribute_value(self.model_type)
-            ),
+            sql_func.count(self.get_id_attribute_value(self.model_type)),
             maintain_column_froms=True,
         ).order_by(None)
         statement = self._apply_filters(*filters, apply_pagination=False, statement=statement)

--- a/litestar/contrib/sqlalchemy/repository.py
+++ b/litestar/contrib/sqlalchemy/repository.py
@@ -351,7 +351,7 @@ class SQLAlchemyRepository(AbstractRepository[ModelT], Generic[ModelT]):
         statement = kwargs.pop("base_select", self.statement)
         statement = statement.add_columns(
             over(
-                sql_func.count(getattr(self.model_type, self.id_attribute)),
+                sql_func.count(self.get_id_attribute_value(self.model_type)),
             )
         )
         statement = self._apply_filters(*filters, statement=statement)


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
This PR aims to relax the SQLAlchemy contrib repository typing. This allows subclassing the repository while providing a Protocol based on declarative mixins as a type parameter, where the end-user model definition is not known.
As a side effect, the repository will accept any SQLAlchemy declarative model with a `to_dict` method as a type parameter without that model specifically subclassing `contrib.sqlalchemy.base.Base`.

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
