### PR TITLE
Fix retrieve type hints from class with no `__init__` method.

### DIFF
--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -45,6 +45,8 @@ def get_fn_type_hints(fn: Any, namespace: dict[str, Any] | None = None) -> dict[
     """
     fn_to_inspect: Any = fn
 
+    module_name = fn_to_inspect.__module__
+
     if isclass(fn_to_inspect):
         fn_to_inspect = fn_to_inspect.__init__
 
@@ -61,7 +63,7 @@ def get_fn_type_hints(fn: Any, namespace: dict[str, Any] | None = None) -> dict[
     namespace = {
         **_GLOBAL_NAMES,
         **vars(typing),
-        **vars(sys.modules[fn_to_inspect.__module__]),
+        **vars(sys.modules[module_name]),
         **(namespace or {}),
     }
     return get_type_hints(fn_to_inspect, globalns=namespace, include_extras=True)

--- a/tests/utils/test_signature.py
+++ b/tests/utils/test_signature.py
@@ -42,6 +42,18 @@ def test_get_fn_type_hints(fn: Any) -> None:
     assert get_fn_type_hints(fn) == {"a": int, "b": str, "c": float, "return": NoneType}
 
 
+def test_get_fn_type_hints_class_no_init() -> None:
+    """Test that get_fn_type_hints works with classes that don't have an __init__ method.
+
+    Ref: https://github.com/litestar-org/litestar/issues/1504
+    """
+
+    class C:
+        ...
+
+    assert get_fn_type_hints(C) == {}
+
+
 class _TD(TypedDict):
     req_int: Required[int]
     req_list_int: Required[List[int]]


### PR DESCRIPTION
This PR fixes an issue where accessing the `__module__` attribute of `object.__init__()` would fail with `'wrapper_descriptor' object has no attribute '__module__'`.

This occurs where the callable that is inspected is a class object without a user-defined `__init__()` method.

Closes #1504

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
