### PR TITLE
Simply update time with SQLAlchemy

### DIFF
--- a/litestar/contrib/sqlalchemy/base.py
+++ b/litestar/contrib/sqlalchemy/base.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm import (
 if TYPE_CHECKING:
     from sqlalchemy.sql import FromClause
 
-__all__ = ("AuditBase", "AuditColumns", "Base", "CommonTableAttributes", "UUIDPrimaryKey", "touch_updated_timestamp")
+__all__ = ("AuditBase", "AuditColumns", "Base", "CommonTableAttributes", "UUIDPrimaryKey")
 
 
 BaseT = TypeVar("BaseT", bound="Base")
@@ -35,23 +35,6 @@ convention = {
     "pk": "pk_%(table_name)s",
 }
 """Templates for automated constraint name generation."""
-
-
-@listens_for(Session, "before_flush")
-def touch_updated_timestamp(session: Session, *_: Any) -> None:
-    """Set timestamp on update.
-
-    Called from SQLAlchemy's
-    :meth:`before_flush <sqlalchemy.orm.SessionEvents.before_flush>` event to bump the ``updated``
-    timestamp on modified instances.
-
-    Args:
-        session: The sync :class:`Session <sqlalchemy.orm.Session>` instance that underlies the async
-            session.
-    """
-    for instance in session.dirty:
-        if hasattr(instance, "updated"):
-            instance.updated = datetime.now()  # noqa: DTZ005
 
 
 @runtime_checkable
@@ -88,7 +71,7 @@ class AuditColumns:
 
     created: Mapped[datetime] = mapped_column(default=datetime.now)
     """Date/time of instance creation."""
-    updated: Mapped[datetime] = mapped_column(default=datetime.now)
+    updated: Mapped[datetime] = mapped_column(default=datetime.now, onupdate=datetime.now)
     """Date/time of instance last update."""
 
 

--- a/litestar/contrib/sqlalchemy/base.py
+++ b/litestar/contrib/sqlalchemy/base.py
@@ -8,11 +8,9 @@ from uuid import UUID, uuid4
 
 from pydantic import AnyHttpUrl, AnyUrl, EmailStr
 from sqlalchemy import JSON, MetaData, String, Uuid
-from sqlalchemy.event import listens_for
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
-    Session,
     declarative_mixin,
     declared_attr,
     mapped_column,


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

We can simply update time with SQLAlchemy by passing `onupdate`  parameter to `mapped_column`.

### Close Issue(s)