### PR TITLE
Move httpx log suppression into a fixture

### DIFF
--- a/docs/examples/conftest.py
+++ b/docs/examples/conftest.py
@@ -1,0 +1,1 @@
+from tests.conftest import reset_httpx_logging  # noqa: F401

--- a/docs/examples/tests/application_hooks/test_application_after_exception_hook.py
+++ b/docs/examples/tests/application_hooks/test_application_after_exception_hook.py
@@ -1,6 +1,8 @@
 import logging
 from typing import TYPE_CHECKING
 
+import pytest
+
 from examples.application_hooks import after_exception_hook
 from litestar.testing import TestClient
 
@@ -8,6 +10,7 @@ if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
 
 
+@pytest.mark.usefixtures("reset_httpx_logging")
 def test_application_shutdown_hooks(caplog: "LogCaptureFixture") -> None:
     with caplog.at_level(logging.INFO), TestClient(app=after_exception_hook.app) as client:
         assert len(caplog.messages) == 0

--- a/docs/examples/tests/application_state/test_using_application_state.py
+++ b/docs/examples/tests/application_state/test_using_application_state.py
@@ -1,11 +1,14 @@
 from logging import INFO
 from typing import Any
 
+import pytest
+
 from examples.application_state.using_application_state import app
 from litestar.status_codes import HTTP_200_OK
 from litestar.testing import TestClient
 
 
+@pytest.mark.usefixtures("reset_httpx_logging")
 def test_using_application_state(caplog: Any) -> None:
     with caplog.at_level(INFO, "examples.application_state.using_application_state"), TestClient(app=app) as client:
         response = client.get("/")

--- a/docs/examples/tests/middleware/test_logging_middleware.py
+++ b/docs/examples/tests/middleware/test_logging_middleware.py
@@ -25,6 +25,7 @@ def get_logger() -> "GetLogger":
     ).configure()
 
 
+@pytest.mark.usefixtures("reset_httpx_logging")
 def test_logging_middleware_regular_logger(get_logger: "GetLogger", caplog: "LogCaptureFixture") -> None:
     with TestClient(app=app) as client, caplog.at_level(logging.INFO):
         client.app.get_logger = get_logger

--- a/docs/examples/tests/responses/test_background_tasks.py
+++ b/docs/examples/tests/responses/test_background_tasks.py
@@ -1,6 +1,8 @@
 import logging
 from typing import TYPE_CHECKING
 
+import pytest
+
 from examples.responses.background_tasks_1 import app as app_1
 from examples.responses.background_tasks_2 import app as app_2
 from examples.responses.background_tasks_3 import app as app_3
@@ -9,6 +11,9 @@ from litestar.testing import TestClient
 
 if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
+
+
+pytestmark = pytest.mark.usefixtures("reset_httpx_logging")
 
 
 def test_background_tasks_1(caplog: "LogCaptureFixture") -> None:

--- a/litestar/testing/client/async_client.py
+++ b/litestar/testing/client/async_client.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from contextlib import AsyncExitStack
 from typing import TYPE_CHECKING, Any, Generic, Mapping, TypeVar
 
@@ -30,9 +29,6 @@ if TYPE_CHECKING:
 
 
 T = TypeVar("T", bound=ASGIApp)
-
-# ensure that httpx logging is not interfering with our test client
-logging.getLogger("httpx").setLevel(logging.WARNING)
 
 
 class AsyncTestClient(AsyncClient, BaseTestClient, Generic[T]):  # type: ignore[misc]

--- a/litestar/testing/client/sync_client.py
+++ b/litestar/testing/client/sync_client.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from contextlib import ExitStack
 from typing import TYPE_CHECKING, Any, Generic, Mapping, TypeVar
 from urllib.parse import urljoin
@@ -33,9 +32,6 @@ if TYPE_CHECKING:
 
 
 T = TypeVar("T", bound=ASGIApp)
-
-# ensure that httpx logging is not interfering with our test client
-logging.getLogger("httpx").setLevel(logging.WARNING)
 
 
 class TestClient(Client, BaseTestClient, Generic[T]):  # type: ignore[misc]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,7 +289,7 @@ def frozen_datetime() -> Generator["FrozenDateTimeFactory", None, None]:
 
 
 @pytest.fixture()
-def reset_httpx_logging() -> None:
+def reset_httpx_logging() -> Generator[None, None, None]:
     # ensure that httpx logging is not interfering with our test client
     httpx_logger = logging.getLogger("httpx")
     initial_level = httpx_logger.level

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import importlib.util
+import logging
 import sys
 from os import environ, urandom
 from pathlib import Path
@@ -285,3 +286,13 @@ def mock_db() -> MemoryStore:
 def frozen_datetime() -> Generator["FrozenDateTimeFactory", None, None]:
     with freeze_time() as frozen:
         yield cast("FrozenDateTimeFactory", frozen)
+
+
+@pytest.fixture()
+def reset_httpx_logging() -> None:
+    # ensure that httpx logging is not interfering with our test client
+    httpx_logger = logging.getLogger("httpx")
+    initial_level = httpx_logger.level
+    httpx_logger.setLevel(logging.WARNING)
+    yield
+    httpx_logger.setLevel(initial_level)

--- a/tests/middleware/test_logging_middleware.py
+++ b/tests/middleware/test_logging_middleware.py
@@ -21,6 +21,9 @@ if TYPE_CHECKING:
     from litestar.types.callable_types import GetLogger
 
 
+pytestmark = pytest.mark.usefixtures("reset_httpx_logging")
+
+
 @get("/")
 def handler() -> Response:
     return Response(


### PR DESCRIPTION
A change was introduced in #1487 that would globally alter HTTPX' logging configuration, potentially breaking user code.

This PR changes this to use fixtures instead which restore the default configuration on cleanup.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
