### PR TITLE
Speed up some tests

### DIFF
--- a/tests/dependency_injection/test_http_handler_dependency_injection.py
+++ b/tests/dependency_injection/test_http_handler_dependency_injection.py
@@ -15,7 +15,7 @@ def router_first_dependency() -> bool:
 
 
 async def router_second_dependency() -> bool:
-    await sleep(0.1)
+    await sleep(0)
     return False
 
 
@@ -26,7 +26,7 @@ def controller_first_dependency(headers: Dict[str, Any]) -> dict:
 
 async def controller_second_dependency(request: "Request") -> dict:
     assert request
-    await sleep(0.1)
+    await sleep(0)
     return {}
 
 

--- a/tests/dependency_injection/test_websocket_handler_dependency_injection.py
+++ b/tests/dependency_injection/test_websocket_handler_dependency_injection.py
@@ -15,7 +15,7 @@ def router_first_dependency() -> bool:
 
 
 async def router_second_dependency() -> bool:
-    await sleep(0.1)
+    await sleep(0)
     return False
 
 
@@ -26,7 +26,7 @@ def controller_first_dependency(headers: Dict[str, Any]) -> dict:
 
 async def controller_second_dependency(socket: WebSocket) -> dict:
     assert socket
-    await sleep(0.1)
+    await sleep(0)
     return {}
 
 

--- a/tests/life_cycle_hooks/test_after_response.py
+++ b/tests/life_cycle_hooks/test_after_response.py
@@ -1,4 +1,3 @@
-from asyncio import sleep
 from typing import TYPE_CHECKING, Dict
 
 import pytest
@@ -22,7 +21,6 @@ def create_sync_test_handler(msg: str) -> "AfterResponseHookHandler":
 
 def create_async_test_handler(msg: str) -> "AfterResponseHookHandler":
     async def handler(_: Request) -> None:
-        await sleep(0.001)
         state["msg"] = msg
 
     return handler

--- a/tests/middleware/session/test_server_side_backend.py
+++ b/tests/middleware/session/test_server_side_backend.py
@@ -1,7 +1,6 @@
 from secrets import token_hex
 from typing import TYPE_CHECKING
 
-import anyio
 import pytest
 
 from litestar import Litestar, Request, get
@@ -12,6 +11,8 @@ from litestar.stores.memory import MemoryStore
 from litestar.testing import TestClient
 
 if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+
     from litestar.middleware.session.server_side import ServerSideSessionBackend
 
 
@@ -66,7 +67,10 @@ async def test_get_set(
 
 
 async def test_get_renew_on_access(
-    server_side_session_backend: "ServerSideSessionBackend", session_data: bytes, memory_store: MemoryStore
+    server_side_session_backend: "ServerSideSessionBackend",
+    session_data: bytes,
+    memory_store: MemoryStore,
+    frozen_datetime: "FrozenDateTimeFactory",
 ) -> None:
     server_side_session_backend.config.max_age = 1
     server_side_session_backend.config.renew_on_access = True
@@ -76,7 +80,7 @@ async def test_get_renew_on_access(
 
     await server_side_session_backend.get("foo", memory_store)
 
-    await anyio.sleep(1.01)
+    frozen_datetime.tick(1.01)
 
     assert await server_side_session_backend.get("foo", memory_store) is not None
 
@@ -114,11 +118,16 @@ async def test_delete_idempotence(
 
 
 async def test_max_age_expires(
-    server_side_session_backend: "ServerSideSessionBackend", session_data: bytes, memory_store: MemoryStore
+    server_side_session_backend: "ServerSideSessionBackend",
+    session_data: bytes,
+    memory_store: MemoryStore,
+    frozen_datetime: "FrozenDateTimeFactory",
 ) -> None:
     server_side_session_backend.config.max_age = 1
     await server_side_session_backend.set("foo", session_data, memory_store)
-    await anyio.sleep(1)
+
+    frozen_datetime.tick(1)
+
     assert not await server_side_session_backend.get("foo", memory_store)
 
 

--- a/tests/middleware/test_cors_middleware.py
+++ b/tests/middleware/test_cors_middleware.py
@@ -1,8 +1,6 @@
 from typing import Any, Dict, List, Mapping, Optional, cast
 
 import pytest
-from hypothesis import given, settings
-from hypothesis.strategies import booleans, lists, none, one_of, sampled_from
 
 from litestar import get
 from litestar.config.cors import CORSConfig
@@ -38,13 +36,10 @@ def test_setting_cors_middleware() -> None:
         assert cors_middleware.config.allow_origin_regex == cors_config.allow_origin_regex
 
 
-@given(
-    origin=one_of(none(), sampled_from(["http://www.example.com", "https://moishe.zuchmir.com"])),
-    allow_origins=lists(sampled_from(["*", "http://www.example.com", "https://moishe.zuchmir.com"])),
-    allow_credentials=booleans(),
-    expose_headers=lists(sampled_from(["X-First-Header", "SomeOtherHeader", "X-Second-Header"])),
-)
-@settings(deadline=None)
+@pytest.mark.parametrize("origin", [None, "http://www.example.com", "https://moishe.zuchmir.com"])
+@pytest.mark.parametrize("allow_origins", ["*", "http://www.example.com", "https://moishe.zuchmir.com"])
+@pytest.mark.parametrize("allow_credentials", [True, False])
+@pytest.mark.parametrize("expose_headers", ["X-First-Header", "SomeOtherHeader", "X-Second-Header"])
 def test_cors_simple_response(
     origin: Optional[str], allow_origins: List[str], allow_credentials: bool, expose_headers: List[str]
 ) -> None:


### PR DESCRIPTION
Speed up some tests by removing delays and improving patterns.

Two notoriously slow tests remain which are

https://github.com/litestar-org/litestar/blob/bab2ad40005b4e45c20ea8880a65126357828ee4/tests/contrib/jwt/test_auth.py#L40

and https://github.com/litestar-org/litestar/blob/bab2ad40005b4e45c20ea8880a65126357828ee4/tests/contrib/jwt/test_auth.py#L139

They both use hypothesis to generate a bunch of inputs. These should probably be integration tests that can be toggled selectively, and replaced with simpler unit tests for regular runs, but this is left as an exercise to the reader.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
