### PR TITLE
Refactor `DTOInterface` - a better pattern for websockets.

### DIFF
--- a/litestar/_kwargs/extractors.py
+++ b/litestar/_kwargs/extractors.py
@@ -410,6 +410,6 @@ def create_dto_extractor(
     """
 
     async def dto_extractor(connection: Request[Any, Any, Any]) -> Any:
-        return dto_type.from_bytes(await connection.body(), connection).to_data_type()
+        return dto_type(connection).bytes_to_data_type(await connection.body())
 
     return dto_extractor  # type:ignore[return-value]

--- a/litestar/dto/interface.py
+++ b/litestar/dto/interface.py
@@ -4,8 +4,6 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from typing_extensions import Self
-
     from litestar.connection import Request
     from litestar.handlers import BaseRouteHandler
     from litestar.types import LitestarEncodableType
@@ -19,12 +17,16 @@ class DTOInterface(Protocol):
     __slots__ = ()
 
     @abstractmethod
-    def to_data_type(self) -> Any:
-        """Return the data held by the DTO."""
+    def __init__(self, connection: Request[Any, Any, Any]) -> None:
+        """Initialize the DTO.
+
+        Args:
+            connection: :class:`ASGIConnection <.connection.ASGIConnection>` instance.
+        """
 
     @abstractmethod
-    def to_encodable_type(self) -> bytes | LitestarEncodableType:
-        """Encode data held by the DTO type to a type supported by litestar serialization.
+    def data_to_encodable_type(self, data: Any) -> bytes | LitestarEncodableType:
+        """Encode data to a type supported by litestar serialization.
 
         Can return either bytes or a type that Litestar can return to bytes.
 
@@ -32,30 +34,15 @@ class DTOInterface(Protocol):
             Either ``bytes`` or a type that Litestar can convert to bytes.
         """
 
-    @classmethod
     @abstractmethod
-    def from_bytes(cls, raw: bytes, connection: Request[Any, Any, Any]) -> Self:
-        """Construct an instance from a :class:`Request <.connection.Request>`.
+    def bytes_to_data_type(self, raw: bytes) -> Any:
+        """Convert raw bytes to the data type that the DTO represents.
 
         Args:
             raw: Raw bytes of the payload.
-            connection: :class:`Request <.connection.Request>` instance.
 
         Returns:
-            DTOInterface instance.
-        """
-
-    @classmethod
-    @abstractmethod
-    def from_data(cls, data: Any, connection: Request[Any, Any, Any]) -> Self:
-        """Construct an instance from data.
-
-        Args:
-            data: User data, usually data returned from a handler.
-            connection: :class:`Request <.connection.Request>` instance.
-
-        Returns:
-            DTOInterface instance.
+            Data type that the DTO represents.
         """
 
     @classmethod

--- a/litestar/handlers/http_handlers/_utils.py
+++ b/litestar/handlers/http_handlers/_utils.py
@@ -4,7 +4,6 @@ from functools import lru_cache
 from inspect import isawaitable
 from typing import TYPE_CHECKING, Any, Sequence, cast
 
-from litestar.dto.interface import DTOInterface
 from litestar.enums import HttpMethod
 from litestar.exceptions import ValidationException
 from litestar.plugins import get_plugin_for_value
@@ -16,6 +15,7 @@ if TYPE_CHECKING:
     from litestar.background_tasks import BackgroundTask, BackgroundTasks
     from litestar.connection import Request
     from litestar.datastructures import Cookie, ResponseHeader
+    from litestar.dto.interface import DTOInterface
     from litestar.plugins import SerializationPluginProtocol
     from litestar.response import Response
     from litestar.response_containers import ResponseContainer
@@ -98,8 +98,8 @@ def create_data_handler(
         if isawaitable(data):
             data = await data
 
-        if return_dto and not isinstance(data, DTOInterface):
-            data = return_dto.from_data(data, request)
+        if return_dto:
+            data = return_dto(request).data_to_encodable_type(data)
         elif plugins:
             data = await normalize_response_data(data=data, plugins=plugins)
 

--- a/litestar/serialization.py
+++ b/litestar/serialization.py
@@ -27,7 +27,6 @@ from pydantic import (
 from pydantic.color import Color
 from pydantic.json import decimal_encoder
 
-from litestar.dto.interface import DTOInterface
 from litestar.exceptions import SerializationException
 from litestar.types import Empty
 
@@ -53,12 +52,6 @@ def _enc_constrained_bytes(bytes_: ConstrainedBytes) -> str:
 
 def _enc_constrained_date(date: ConstrainedDate) -> str:
     return date.isoformat()
-
-
-def _enc_dto(dto: DTOInterface) -> Any:
-    if isinstance(ret := dto.to_encodable_type(), bytes):
-        return msgspec.Raw(ret)
-    return ret
 
 
 def _enc_pattern(pattern: Pattern) -> Any:
@@ -96,8 +89,6 @@ DEFAULT_TYPE_ENCODERS: TypeEncodersMap = {
     float: float,
     set: set,
     frozenset: frozenset,
-    # internal types
-    DTOInterface: _enc_dto,
 }
 
 

--- a/tests/dto/__init__.py
+++ b/tests/dto/__init__.py
@@ -3,18 +3,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from typing_extensions import Self
-
 from litestar.dto.interface import DTOInterface
 from litestar.types.protocols import DataclassProtocol
 from litestar.types.serialization import LitestarEncodableType
 
 if TYPE_CHECKING:
-    from typing import Any, TypeAlias
+    from typing import Any
 
     from litestar.connection import Request
-
-AnyRequest: TypeAlias = "Request[Any, Any, Any]"
 
 
 @dataclass
@@ -24,32 +20,22 @@ class Model:
 
 
 class MockDTO(DTOInterface):
-    def to_data_type(self) -> Model:
+    def __init__(self, connection: Request[Any, Any, Any]) -> None:
+        pass
+
+    def bytes_to_data_type(self, raw: bytes) -> Model:
         return Model(a=1, b="2")
 
-    def to_encodable_type(self) -> bytes | LitestarEncodableType:
+    def data_to_encodable_type(self, data: DataclassProtocol) -> bytes | LitestarEncodableType:
         return Model(a=1, b="2")
-
-    @classmethod
-    def from_bytes(cls, raw: bytes, connection: AnyRequest) -> Self:
-        return cls()
-
-    @classmethod
-    def from_data(cls, data: DataclassProtocol, connection: AnyRequest) -> Self:
-        return cls()
 
 
 class MockReturnDTO(DTOInterface):
-    def to_data_type(self) -> Any:
+    def __init__(self, connection: Request[Any, Any, Any]) -> None:
+        pass
+
+    def bytes_to_data_type(self, raw: bytes) -> Any:
         raise RuntimeError("Return DTO should not have this method called")
 
-    def to_encodable_type(self) -> bytes | LitestarEncodableType:
+    def data_to_encodable_type(self, data: DataclassProtocol) -> bytes | LitestarEncodableType:
         return b'{"a": 1, "b": "2"}'
-
-    @classmethod
-    def from_bytes(cls, raw: bytes, connection: AnyRequest) -> Self:
-        raise RuntimeError("Return DTO should not have this method called")
-
-    @classmethod
-    def from_data(cls, data: DataclassProtocol, connection: AnyRequest) -> Self:
-        return cls()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -24,8 +24,6 @@ from pydantic import (
 )
 from pydantic.color import Color
 
-from litestar.connection import Request
-from litestar.dto.interface import DTOInterface
 from litestar.exceptions import SerializationException
 from litestar.serialization import (
     decode_json,
@@ -34,7 +32,6 @@ from litestar.serialization import (
     encode_json,
     encode_msgpack,
 )
-from litestar.types.serialization import LitestarEncodableType
 from tests import PersonFactory
 
 person = PersonFactory.build()
@@ -154,23 +151,3 @@ def test_decode_json_typed() -> None:
 def test_decode_msgpack_typed() -> None:
     model_json = model.json()
     assert decode_msgpack(encode_msgpack(model), Model).json() == model_json
-
-
-@pytest.mark.parametrize("ret_val", [b'{"a":1,"b":"2"}', {"a": 1, "b": "2"}])
-def test_encode_dto_instance(ret_val: "bytes | dict") -> None:
-    class DTO(DTOInterface):
-        def to_encodable_type(self) -> LitestarEncodableType:
-            return ret_val
-
-        def to_data_type(self) -> Any:
-            return None
-
-        @classmethod
-        def from_bytes(cls, raw: bytes, connection: Request[Any, Any, Any]) -> "DTO":
-            return cls()
-
-        @classmethod
-        def from_data(cls, data: Any, connection: Request[Any, Any, Any]) -> "DTO":
-            return cls()
-
-    assert encode_json(DTO()) == b'{"a":1,"b":"2"}'


### PR DESCRIPTION
Based on discussion in #1518.

This pattern emphasises and supports that the lifespan of a DTO instance should be bound to the lifespan of the connection.

Any connection-based logic can be performed once, and the DTO used to parse and serialize as often as necessary for the life of the connection.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
