### PR TITLE
Fix #1547: Remove bool coercion in URL parsing

### DIFF
--- a/litestar/_parsers.py
+++ b/litestar/_parsers.py
@@ -34,8 +34,7 @@ def parse_query_string(query_string: bytes) -> tuple[tuple[str, Any], ...]:
     Returns:
         A tuple of key value pairs.
     """
-    _bools = {"true": True, "false": False, "True": True, "False": False}
-    return tuple((k, v if v not in _bools else _bools[v]) for k, v in fast_parse_query_string(query_string, "&"))
+    return tuple(fast_parse_query_string(query_string, "&"))
 
 
 @lru_cache(1024)

--- a/tests/datastructures/test_url.py
+++ b/tests/datastructures/test_url.py
@@ -34,7 +34,7 @@ def test_url() -> None:
     assert url.password == "hunter2"
     assert url.port == 81
     assert url.hostname == "example.org"
-    assert url.query_params.dict() == {"query": ["param"], "bool": [True]}
+    assert url.query_params.dict() == {"query": ["param"], "bool": ["true"]}
 
 
 @pytest.mark.parametrize(

--- a/tests/signature/test_parsing.py
+++ b/tests/signature/test_parsing.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING, Any, Iterable, List, Literal, Optional, Sequence, cast
+from unittest.mock import MagicMock
 
 import pytest
 from pydantic import BaseModel
@@ -311,3 +312,18 @@ def test_signature_field_is_non_string_sequence(preferred_validation_backend: Li
 
     assert model.fields["a"].is_non_string_sequence
     assert model.fields["b"].is_non_string_sequence
+
+
+@pytest.mark.parametrize("signature_backend", ["pydantic", "attrs"])
+@pytest.mark.parametrize("query,expected", [("1", True), ("true", True), ("0", False), ("false", False)])
+def test_query_param_bool(query: str, expected: bool, signature_backend: Literal["pydantic", "attrs"]) -> None:
+    mock = MagicMock()
+
+    @get("/")
+    def handler(param: bool) -> None:
+        mock(param)
+
+    with create_test_client(route_handlers=[handler], preferred_validation_backend=signature_backend) as client:
+        response = client.get(f"/?param={query}")
+        assert response.status_code == HTTP_200_OK, response.json()
+        mock.assert_called_once_with(expected)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -87,8 +87,8 @@ def test_parse_query_string() -> None:
         "value": ["10"],
         "veggies": ["tomato", "potato", "aubergine"],
         "calories": ["122.53"],
-        "healthy": [True],
-        "polluting": [False],
+        "healthy": ["True"],
+        "polluting": ["False"],
     }
 
 


### PR DESCRIPTION
Fix #1547 by removing the unconditional coercion of bool-like strings (e.g. `"True"`) to booleans. 

The approach taken here is to let the signature model handle this, which Pydantic seems to do by default, whereas I couldn't get attrs to do the same thing. @Goldziher any insights on how to make them behave in the same way here?


### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
