### PR TITLE
Enables "Remove quotes from type annotation" rule.

### DIFF
--- a/litestar/_asgi/asgi_router.py
+++ b/litestar/_asgi/asgi_router.py
@@ -72,7 +72,7 @@ class ASGIRouter:
         self.route_handler_index: dict[str, RouteHandlerType] = {}
         self.route_mapping: dict[str, list[BaseRoute]] = defaultdict(list)
 
-    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI callable.
 
         The main entry point to the Router class.
@@ -123,7 +123,7 @@ class ASGIRouter:
             self.route_mapping[identifier].append(route)
             self.route_handler_index[identifier] = handler
 
-    async def _call_lifespan_handler(self, handler: "LifeSpanHandler") -> None:
+    async def _call_lifespan_handler(self, handler: LifeSpanHandler) -> None:
         """Determine whether the lifecycle handler expects an argument, and if so pass the `app.state` to it. If the
         handler is an async function, await the return.
 
@@ -158,7 +158,7 @@ class ASGIRouter:
         if self._mount_routes:
             self._mount_paths_regex = re.compile("|".join(sorted(set(self._mount_routes))))  # pyright: ignore
 
-    async def lifespan(self, receive: "LifeSpanReceive", send: "LifeSpanSend") -> None:
+    async def lifespan(self, receive: LifeSpanReceive, send: LifeSpanSend) -> None:
         """Handle the ASGI "lifespan" event on application startup and shutdown.
 
         Args:

--- a/litestar/_kwargs/dependencies.py
+++ b/litestar/_kwargs/dependencies.py
@@ -41,10 +41,10 @@ class Dependency:
 
 
 async def resolve_dependency(
-    dependency: "Dependency",
-    connection: "ASGIConnection",
+    dependency: Dependency,
+    connection: ASGIConnection,
     kwargs: dict[str, Any],
-    cleanup_group: "DependencyCleanupGroup",
+    cleanup_group: DependencyCleanupGroup,
 ) -> None:
     """Resolve a given instance of :class:`Dependency <litestar._kwargs.Dependency>`.
 

--- a/litestar/_kwargs/extractors.py
+++ b/litestar/_kwargs/extractors.py
@@ -305,7 +305,7 @@ def create_multipart_extractor(
         body_kwarg_multipart_form_part_limit = signature_field.kwarg_model.multipart_form_part_limit
 
     async def extract_multipart(
-        connection: "Request[Any, Any, Any]",
+        connection: Request[Any, Any, Any],
     ) -> Any:
         multipart_form_part_limit = (
             body_kwarg_multipart_form_part_limit
@@ -353,7 +353,7 @@ def create_url_encoded_data_extractor(
     """
 
     async def extract_url_encoded_extractor(
-        connection: "Request[Any, Any, Any]",
+        connection: Request[Any, Any, Any],
     ) -> Any:
         connection.scope["_form"] = form_values = (  # type: ignore[typeddict-unknown-key]
             connection.scope["_form"]  # type: ignore[typeddict-item]

--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -383,9 +383,7 @@ class KwargsModel:
 
         return output
 
-    async def resolve_dependencies(
-        self, connection: "ASGIConnection", kwargs: dict[str, Any]
-    ) -> "DependencyCleanupGroup":
+    async def resolve_dependencies(self, connection: ASGIConnection, kwargs: dict[str, Any]) -> DependencyCleanupGroup:
         """Resolve all dependencies into the kwargs, recursively.
 
         Args:

--- a/litestar/_openapi/parameters.py
+++ b/litestar/_openapi/parameters.py
@@ -30,8 +30,8 @@ if TYPE_CHECKING:
 
 
 def create_path_parameter_schema(
-    path_parameter: "PathParameterDefinition",
-    field: "SignatureField",
+    path_parameter: PathParameterDefinition,
+    field: SignatureField,
     generate_examples: bool,
     schemas: dict[str, Schema],
 ) -> Schema | Reference:
@@ -59,7 +59,7 @@ class ParameterCollection:
     instances are not the same, an exception is raised.
     """
 
-    def __init__(self, route_handler: "BaseRouteHandler") -> None:
+    def __init__(self, route_handler: BaseRouteHandler) -> None:
         """Initialize ``ParameterCollection``.
 
         Args:
@@ -96,11 +96,11 @@ class ParameterCollection:
 
 
 def create_parameter(
-    signature_field: "SignatureField",
+    signature_field: SignatureField,
     parameter_name: str,
-    path_parameters: tuple["PathParameterDefinition", ...],
+    path_parameters: tuple[PathParameterDefinition, ...],
     generate_examples: bool,
-    schemas: dict[str, "Schema"],
+    schemas: dict[str, Schema],
 ) -> Parameter:
     """Create an OpenAPI Parameter instance."""
     result: Schema | Reference | None = None
@@ -143,12 +143,12 @@ def create_parameter(
 
 def get_recursive_handler_parameters(
     field_name: str,
-    signature_field: "SignatureField",
-    dependencies: "Dependencies",
-    route_handler: "BaseRouteHandler",
-    path_parameters: tuple["PathParameterDefinition", ...],
+    signature_field: SignatureField,
+    dependencies: Dependencies,
+    route_handler: BaseRouteHandler,
+    path_parameters: tuple[PathParameterDefinition, ...],
     generate_examples: bool,
-    schemas: dict[str, "Schema"],
+    schemas: dict[str, Schema],
 ) -> list[Parameter]:
     """Create and return parameters for a handler.
 
@@ -174,11 +174,11 @@ def get_recursive_handler_parameters(
 
 def get_layered_parameter(
     field_name: str,
-    signature_field: "SignatureField",
-    layered_parameters: dict[str, "SignatureField"],
-    path_parameters: tuple["PathParameterDefinition", ...],
+    signature_field: SignatureField,
+    layered_parameters: dict[str, SignatureField],
+    path_parameters: tuple[PathParameterDefinition, ...],
     generate_examples: bool,
-    schemas: dict[str, "Schema"],
+    schemas: dict[str, Schema],
 ) -> Parameter:
     """Create a layered parameter for a given signature model field.
 
@@ -211,11 +211,11 @@ def get_layered_parameter(
 
 
 def create_parameter_for_handler(
-    route_handler: "BaseRouteHandler",
-    handler_fields: dict[str, "SignatureField"],
-    path_parameters: tuple["PathParameterDefinition", ...],
+    route_handler: BaseRouteHandler,
+    handler_fields: dict[str, SignatureField],
+    path_parameters: tuple[PathParameterDefinition, ...],
     generate_examples: bool,
-    schemas: dict[str, "Schema"],
+    schemas: dict[str, Schema],
 ) -> list[Parameter]:
     """Create a list of path/query/header Parameter models for the given PathHandler."""
     parameters = ParameterCollection(route_handler=route_handler)

--- a/litestar/_openapi/path_item.py
+++ b/litestar/_openapi/path_item.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from litestar.types.callable_types import OperationIDCreator
 
 
-def get_description_for_handler(route_handler: "HTTPRouteHandler", use_handler_docstrings: bool) -> str | None:
+def get_description_for_handler(route_handler: HTTPRouteHandler, use_handler_docstrings: bool) -> str | None:
     """Produce the operation description for a route handler, either by using the description value if provided,
 
     or the docstring - if config is enabled.
@@ -43,7 +43,7 @@ def get_description_for_handler(route_handler: "HTTPRouteHandler", use_handler_d
 
 
 def extract_layered_values(
-    route_handler: "HTTPRouteHandler",
+    route_handler: HTTPRouteHandler,
 ) -> tuple[list[str] | None, list[dict[str, list[str]]] | None]:
     """Extract the tags and security values from the route handler layers.
 
@@ -54,7 +54,7 @@ def extract_layered_values(
         A tuple of optional lists.
     """
     tags: list[str] = []
-    security: list["SecurityRequirement"] = []
+    security: list[SecurityRequirement] = []
     for layer in route_handler.ownership_layers:
         if layer.tags:
             tags.extend(layer.tags)
@@ -65,10 +65,10 @@ def extract_layered_values(
 
 def create_path_item(
     create_examples: bool,
-    operation_id_creator: "OperationIDCreator",
-    plugins: list["OpenAPISchemaPluginProtocol"],
-    route: "HTTPRoute",
-    schemas: dict[str, "Schema"],
+    operation_id_creator: OperationIDCreator,
+    plugins: list[OpenAPISchemaPluginProtocol],
+    route: HTTPRoute,
+    schemas: dict[str, Schema],
     use_handler_docstrings: bool,
 ) -> tuple[PathItem, list[str]]:
     """Create a PathItem for the given route parsing all http_methods into Operation Models.

--- a/litestar/_openapi/request_body.py
+++ b/litestar/_openapi/request_body.py
@@ -20,10 +20,10 @@ if TYPE_CHECKING:
 
 def create_request_body(
     route_handler: BaseRouteHandler,
-    field: "SignatureField",
+    field: SignatureField,
     generate_examples: bool,
-    plugins: list["OpenAPISchemaPluginProtocol"],
-    schemas: dict[str, "Schema"],
+    plugins: list[OpenAPISchemaPluginProtocol],
+    schemas: dict[str, Schema],
 ) -> RequestBody | None:
     """Create a RequestBody model for the given RouteHandler or return None."""
     media_type: RequestEncodingType | str = RequestEncodingType.JSON

--- a/litestar/_openapi/responses.py
+++ b/litestar/_openapi/responses.py
@@ -47,7 +47,7 @@ def pascal_case_to_text(string: str) -> str:
     return " ".join(re.split(CAPITAL_LETTERS_PATTERN, string)).strip()
 
 
-def create_cookie_schema(cookie: "Cookie") -> Schema:
+def create_cookie_schema(cookie: Cookie) -> Schema:
     """Given a Cookie instance, return its corresponding OpenAPI schema.
 
     Args:
@@ -63,10 +63,10 @@ def create_cookie_schema(cookie: "Cookie") -> Schema:
 
 
 def create_success_response(  # noqa: C901
-    route_handler: "HTTPRouteHandler",
+    route_handler: HTTPRouteHandler,
     generate_examples: bool,
-    plugins: list["OpenAPISchemaPluginProtocol"],
-    schemas: dict[str, "Schema"],
+    plugins: list[OpenAPISchemaPluginProtocol],
+    schemas: dict[str, Schema],
 ) -> OpenAPIResponse:
     """Create the schema for a success response."""
     return_annotation = route_handler.parsed_fn_signature.return_type.annotation
@@ -217,9 +217,9 @@ def create_error_responses(exceptions: list[type[HTTPException]]) -> Iterator[tu
 
 
 def create_additional_responses(
-    route_handler: "HTTPRouteHandler",
-    plugins: list["OpenAPISchemaPluginProtocol"],
-    schemas: dict[str, "Schema"],
+    route_handler: HTTPRouteHandler,
+    plugins: list[OpenAPISchemaPluginProtocol],
+    schemas: dict[str, Schema],
 ) -> Iterator[tuple[str, OpenAPIResponse]]:
     """Create the schema for additional responses, if any."""
     if not route_handler.responses:
@@ -239,11 +239,11 @@ def create_additional_responses(
 
 
 def create_responses(
-    route_handler: "HTTPRouteHandler",
+    route_handler: HTTPRouteHandler,
     raises_validation_error: bool,
     generate_examples: bool,
-    plugins: list["OpenAPISchemaPluginProtocol"],
-    schemas: dict[str, "Schema"],
+    plugins: list[OpenAPISchemaPluginProtocol],
+    schemas: dict[str, Schema],
 ) -> Responses | None:
     """Create a Response model embedded in a `Responses` dictionary for the given RouteHandler or return None."""
 

--- a/litestar/_openapi/schema_generation/constrained_fields.py
+++ b/litestar/_openapi/schema_generation/constrained_fields.py
@@ -49,7 +49,7 @@ __all__ = (
 
 
 def create_numerical_constrained_field_schema(
-    field_type: type["ConstrainedFloat"] | type["ConstrainedInt"] | type["ConstrainedDecimal"],
+    field_type: type[ConstrainedFloat] | type[ConstrainedInt] | type[ConstrainedDecimal],
 ) -> Schema:
     """Create Schema from Constrained Int/Float/Decimal field."""
     schema = Schema(type=OpenAPIType.INTEGER if issubclass(field_type, int) else OpenAPIType.NUMBER)
@@ -66,7 +66,7 @@ def create_numerical_constrained_field_schema(
     return schema
 
 
-def create_date_constrained_field_schema(field_type: type["ConstrainedDate"]) -> Schema:
+def create_date_constrained_field_schema(field_type: type[ConstrainedDate]) -> Schema:
     """Create Schema from Constrained Date Field."""
     schema = Schema(type=OpenAPIType.STRING, format=OpenAPIFormat.DATE)
     if field_type.le is not None:
@@ -80,7 +80,7 @@ def create_date_constrained_field_schema(field_type: type["ConstrainedDate"]) ->
     return schema
 
 
-def create_string_constrained_field_schema(field_type: type["ConstrainedStr"] | type["ConstrainedBytes"]) -> Schema:
+def create_string_constrained_field_schema(field_type: type[ConstrainedStr] | type[ConstrainedBytes]) -> Schema:
     """Create Schema from Constrained Str/Bytes field."""
     schema = Schema(type=OpenAPIType.STRING)
     if field_type.min_length:
@@ -95,9 +95,9 @@ def create_string_constrained_field_schema(field_type: type["ConstrainedStr"] | 
 
 
 def create_collection_constrained_field_schema(
-    field_type: type["ConstrainedList"] | type["ConstrainedSet"] | type["ConstrainedFrozenSet"],
-    children: tuple["SignatureField", ...] | None,
-    plugins: list["OpenAPISchemaPluginProtocol"],
+    field_type: type[ConstrainedList] | type[ConstrainedSet] | type[ConstrainedFrozenSet],
+    children: tuple[SignatureField, ...] | None,
+    plugins: list[OpenAPISchemaPluginProtocol],
     schemas: dict[str, Schema],
 ) -> Schema:
     """Create Schema from Constrained List/Set field.
@@ -144,19 +144,19 @@ def create_collection_constrained_field_schema(
 
 
 def create_constrained_field_schema(
-    field_type: type["ConstrainedBytes"]
-    | type["ConstrainedDate"]
-    | type["ConstrainedDecimal"]
-    | type["ConstrainedFloat"]
-    | type["ConstrainedFrozenSet"]
-    | type["ConstrainedInt"]
-    | type["ConstrainedList"]
-    | type["ConstrainedSet"]
-    | type["ConstrainedStr"],
-    children: tuple["SignatureField", ...] | None,
-    plugins: list["OpenAPISchemaPluginProtocol"],
+    field_type: type[ConstrainedBytes]
+    | type[ConstrainedDate]
+    | type[ConstrainedDecimal]
+    | type[ConstrainedFloat]
+    | type[ConstrainedFrozenSet]
+    | type[ConstrainedInt]
+    | type[ConstrainedList]
+    | type[ConstrainedSet]
+    | type[ConstrainedStr],
+    children: tuple[SignatureField, ...] | None,
+    plugins: list[OpenAPISchemaPluginProtocol],
     schemas: dict[str, Schema],
-) -> "Schema":
+) -> Schema:
     """Create Schema for Pydantic Constrained fields (created using constr(), conint() and so forth, or by subclassing
     Constrained*)
 

--- a/litestar/_openapi/schema_generation/examples.py
+++ b/litestar/_openapi/schema_generation/examples.py
@@ -37,7 +37,7 @@ def _normalize_example_value(value: Any) -> Any:
     return value
 
 
-def _create_field_meta(field: "SignatureField") -> FieldMeta:
+def _create_field_meta(field: SignatureField) -> FieldMeta:
     return FieldMeta(
         name=field.name,
         annotation=field.field_type,
@@ -47,7 +47,7 @@ def _create_field_meta(field: "SignatureField") -> FieldMeta:
     )
 
 
-def create_examples_for_field(field: "SignatureField") -> list["Example"]:
+def create_examples_for_field(field: SignatureField) -> list[Example]:
     """Create an OpenAPI Example instance.
 
     Args:

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -452,7 +452,7 @@ def create_schema_for_builtin_generics(
     generate_examples: bool,
     plugins: list[OpenAPISchemaPluginProtocol],
     schemas: dict[str, Schema],
-) -> "Schema":
+) -> Schema:
     """Handle builtin generic types.
 
     Args:

--- a/litestar/_openapi/typescript_converter/schema_parsing.py
+++ b/litestar/_openapi/typescript_converter/schema_parsing.py
@@ -59,7 +59,7 @@ def normalize_typescript_namespace(value: str, allow_quoted: bool) -> str:
     return invalid_namespace_re.sub("", value)
 
 
-def is_schema_value(value: Any) -> "TypeGuard[Schema]":
+def is_schema_value(value: Any) -> TypeGuard[Schema]:
     """Typeguard for a schema value.
 
     Args:

--- a/litestar/_openapi/utils.py
+++ b/litestar/_openapi/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from litestar.types.internal_types import PathParameterDefinition
 
@@ -16,9 +16,9 @@ SEPARATORS_CLEANUP_PATTERN = re.compile(r"[!#$%&'*+\-.^_`|~:]+")
 
 
 def default_operation_id_creator(
-    route_handler: "HTTPRouteHandler",
-    http_method: "Method",
-    path_components: list[Union[str, "PathParameterDefinition"]],
+    route_handler: HTTPRouteHandler,
+    http_method: Method,
+    path_components: list[str | PathParameterDefinition],
 ) -> str:
     """Create a unique 'operationId' for an OpenAPI PathItem entry.
 

--- a/litestar/_signature/models/attrs_signature_model.py
+++ b/litestar/_signature/models/attrs_signature_model.py
@@ -218,7 +218,7 @@ def _extract_exceptions(e: Any) -> list[ErrorMessage]:
     Returns:
         A list of normalized exception messages.
     """
-    messages: "list[ErrorMessage]" = []
+    messages: list[ErrorMessage] = []
     if hasattr(e, "exceptions"):
         for exc in cast("list[Exception]", e.exceptions):
             if hasattr(exc, "exceptions"):  # pragma: no cover

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -722,7 +722,7 @@ class Litestar(Router):
         """
         if self.before_send:
 
-            async def wrapped_send(message: "Message") -> None:
+            async def wrapped_send(message: Message) -> None:
                 for hook in self.before_send:
                     await hook(message, self.state, scope)
                 await send(message)

--- a/litestar/connection/base.py
+++ b/litestar/connection/base.py
@@ -29,7 +29,7 @@ HandlerT = TypeVar("HandlerT")
 StateT = TypeVar("StateT", bound=State)
 
 
-async def empty_receive() -> "NoReturn":  # pragma: no cover
+async def empty_receive() -> NoReturn:  # pragma: no cover
     """Raise a ``RuntimeError``.
 
     Serves as a placeholder ``send`` function.
@@ -40,7 +40,7 @@ async def empty_receive() -> "NoReturn":  # pragma: no cover
     raise RuntimeError()
 
 
-async def empty_send(_: "Message") -> "NoReturn":  # pragma: no cover
+async def empty_send(_: Message) -> NoReturn:  # pragma: no cover
     """Raise a ``RuntimeError``.
 
     Serves as a placeholder ``send`` function.

--- a/litestar/connection/websocket.py
+++ b/litestar/connection/websocket.py
@@ -69,7 +69,7 @@ class WebSocket(Generic[UserT, AuthT, StateT], ASGIConnection["WebsocketRouteHan
             An ASGI receive function.
         """
 
-        async def wrapped_receive() -> "ReceiveMessage":
+        async def wrapped_receive() -> ReceiveMessage:
             if self.connection_state == "disconnect":
                 raise WebSocketException(detail=DISCONNECT_MESSAGE)
             message = await receive()
@@ -93,7 +93,7 @@ class WebSocket(Generic[UserT, AuthT, StateT], ASGIConnection["WebsocketRouteHan
             An ASGI send function.
         """
 
-        async def wrapped_send(message: "Message") -> None:
+        async def wrapped_send(message: Message) -> None:
             if self.connection_state == "disconnect":
                 raise WebSocketDisconnect(detail=DISCONNECT_MESSAGE)  # pragma: no cover
             await send(message)
@@ -268,7 +268,7 @@ class WebSocket(Generic[UserT, AuthT, StateT], ASGIConnection["WebsocketRouteHan
         data: Any,
         mode: Literal["text", "binary"] = "text",
         encoding: str = "utf-8",
-        serializer: "Serializer" = default_serializer,
+        serializer: Serializer = default_serializer,
     ) -> None:
         """Send data as JSON.
 

--- a/litestar/contrib/opentelemetry/middleware.py
+++ b/litestar/contrib/opentelemetry/middleware.py
@@ -46,7 +46,7 @@ class OpenTelemetryInstrumentationMiddleware(AbstractMiddleware):
             tracer_provider=config.tracer_provider,
         )
 
-    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI callable.
 
         Args:

--- a/litestar/contrib/repository/abc.py
+++ b/litestar/contrib/repository/abc.py
@@ -171,7 +171,7 @@ class AbstractAsyncRepository(Generic[T], metaclass=ABCMeta):
         """
 
     @abstractmethod
-    async def update_many(self, data: "list[T]") -> list[T]:
+    async def update_many(self, data: list[T]) -> list[T]:
         """Update multiple instances with the attribute values present on instances in ``data``.
 
         Args:
@@ -217,7 +217,7 @@ class AbstractAsyncRepository(Generic[T], metaclass=ABCMeta):
         """
 
     @abstractmethod
-    async def list(self, *filters: FilterTypes, **kwargs: Any) -> "list[T]":
+    async def list(self, *filters: FilterTypes, **kwargs: Any) -> list[T]:
         """Get a list of instances, optionally filtered.
 
         Args:

--- a/litestar/contrib/repository/testing/generic_mock_repository.py
+++ b/litestar/contrib/repository/testing/generic_mock_repository.py
@@ -333,7 +333,7 @@ class GenericAsyncMockRepository(AbstractAsyncRepository[ModelT], Generic[ModelT
         """
         return await self.list(*filters, **kwargs), await self.count(*filters, **kwargs)
 
-    async def list(self, *filters: "FilterTypes", **kwargs: Any) -> list[ModelT]:
+    async def list(self, *filters: FilterTypes, **kwargs: Any) -> list[ModelT]:
         """Get a list of instances, optionally filtered.
 
         Args:

--- a/litestar/contrib/sqlalchemy/types.py
+++ b/litestar/contrib/sqlalchemy/types.py
@@ -25,12 +25,12 @@ class GUID(TypeDecorator):
     impl = CHAR
     cache_ok = True
 
-    def load_dialect_impl(self, dialect: "Dialect") -> Any:
+    def load_dialect_impl(self, dialect: Dialect) -> Any:
         if dialect.name == "postgresql":
             return dialect.type_descriptor(PG_UUID())
         return dialect.type_descriptor(CHAR(32))
 
-    def process_bind_param(self, value: str | uuid.UUID | None, dialect: "Dialect") -> str | None:
+    def process_bind_param(self, value: str | uuid.UUID | None, dialect: Dialect) -> str | None:
         if value is None:
             return value
         if dialect.name == "postgresql":
@@ -42,7 +42,7 @@ class GUID(TypeDecorator):
         # hexstring
         return "%.32x" % value.int
 
-    def process_result_value(self, value: str | uuid.UUID | None, dialect: "Dialect") -> uuid.UUID | None:
+    def process_result_value(self, value: str | uuid.UUID | None, dialect: Dialect) -> uuid.UUID | None:
         if value is None:
             return value
         if not isinstance(value, uuid.UUID):
@@ -56,7 +56,7 @@ class JSON(_JSON):
     Uses JSONB type for postgres, otherwise uses the generic JSON data type.
     """
 
-    def load_dialect_impl(self, dialect: "Dialect") -> Any:
+    def load_dialect_impl(self, dialect: Dialect) -> Any:
         if dialect.name == "postgresql":
             return dialect.type_descriptor(PG_JSONB())  # type: ignore[no-untyped-call]
         return dialect.type_descriptor(_JSON())

--- a/litestar/data_extractors.py
+++ b/litestar/data_extractors.py
@@ -254,7 +254,7 @@ class ConnectionDataExtractor:
         """
         return request.content_type
 
-    async def extract_body(self, request: "Request[Any, Any, Any]") -> Any:
+    async def extract_body(self, request: Request[Any, Any, Any]) -> Any:
         """Extract the body from an ``ASGIConnection``
 
         Args:

--- a/litestar/file_system.py
+++ b/litestar/file_system.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 class BaseLocalFileSystem(FileSystemProtocol):
     """Base class for a local file system."""
 
-    async def info(self, path: "PathType", **kwargs: Any) -> "FileInfo":
+    async def info(self, path: PathType, **kwargs: Any) -> FileInfo:
         """Retrieve information about a given file path.
 
         Args:
@@ -38,7 +38,7 @@ class BaseLocalFileSystem(FileSystemProtocol):
         result = await Path(path).stat()
         return await FileSystemAdapter.parse_stat_result(path=path, result=result)
 
-    async def open(self, file: "PathType", mode: str, buffering: int = -1) -> AsyncFile[AnyStr]:
+    async def open(self, file: PathType, mode: str, buffering: int = -1) -> AsyncFile[AnyStr]:
         """Return a file-like object from the filesystem.
 
         Notes:
@@ -63,7 +63,7 @@ class FileSystemAdapter:
         """
         self.file_system = file_system
 
-    async def info(self, path: "PathType") -> "FileInfo":
+    async def info(self, path: PathType) -> FileInfo:
         """Proxies the call to the underlying FS Spec's ``info`` method, ensuring it's done in an async fashion and with
         strong typing.
 
@@ -89,8 +89,8 @@ class FileSystemAdapter:
 
     async def open(
         self,
-        file: "PathType",
-        mode: "OpenBinaryMode" = "rb",
+        file: PathType,
+        mode: OpenBinaryMode = "rb",
         buffering: int = -1,
     ) -> AsyncFile[bytes]:
         """Return a file-like object from the filesystem.
@@ -120,7 +120,7 @@ class FileSystemAdapter:
             raise InternalServerException from e
 
     @staticmethod
-    async def parse_stat_result(path: "PathType", result: "stat_result") -> "FileInfo":
+    async def parse_stat_result(path: PathType, result: stat_result) -> FileInfo:
         """Convert a ``stat_result`` instance into a ``FileInfo``.
 
         Args:

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -370,7 +370,7 @@ class BaseRouteHandler(Generic[T]):
         if return_dto := self.resolve_return_dto():
             return_dto.on_registration(HandlerContext("return", str(self), self.parsed_fn_signature.return_type))
 
-    async def authorize_connection(self, connection: "ASGIConnection") -> None:
+    async def authorize_connection(self, connection: ASGIConnection) -> None:
         """Ensure the connection is authorized by running all the route guards in scope."""
         for guard in self.resolve_guards():
             await guard(connection, copy(self))  # type: ignore

--- a/litestar/handlers/http_handlers/_utils.py
+++ b/litestar/handlers/http_handlers/_utils.py
@@ -70,7 +70,7 @@ def create_data_handler(
     cookie_headers = [cookie.to_encoded_header() for cookie in cookies if not cookie.documentation_only]
     raw_headers = [*normalized_headers, *cookie_headers]
 
-    async def create_response(data: Any) -> "ASGIApp":
+    async def create_response(data: Any) -> ASGIApp:
         response = response_class(
             background=background,
             content=data,
@@ -90,7 +90,7 @@ def create_data_handler(
         return_dto: type[DTOInterface] | None,
         request: Request[Any, Any, Any],
         **kwargs: Any,
-    ) -> "ASGIApp":
+    ) -> ASGIApp:
         if isawaitable(data):
             data = await data
 
@@ -130,7 +130,7 @@ def create_generic_asgi_response_handler(
         A handler function.
     """
 
-    async def handler(data: "ASGIApp", **kwargs: Any) -> "ASGIApp":
+    async def handler(data: ASGIApp, **kwargs: Any) -> ASGIApp:
         if hasattr(data, "set_cookie"):
             for cookie in cookies:
                 data.set_cookie(**cookie.dict)
@@ -178,7 +178,7 @@ def create_response_container_handler(
     """
     normalized_headers = normalize_headers(headers)
 
-    async def handler(data: ResponseContainer, app: Litestar, request: Request, **kwargs: Any) -> "ASGIApp":
+    async def handler(data: ResponseContainer, app: Litestar, request: Request, **kwargs: Any) -> ASGIApp:
         response = data.to_response(
             app=app,
             headers={**normalized_headers, **data.headers},
@@ -206,7 +206,7 @@ def create_response_handler(
         A handler function.
     """
 
-    async def handler(data: Response, **kwargs: Any) -> "ASGIApp":
+    async def handler(data: Response, **kwargs: Any) -> ASGIApp:
         data.cookies = filter_cookies(frozenset(data.cookies), cookies)
         return await after_request(data) if after_request else data  # type: ignore
 

--- a/litestar/middleware/allowed_hosts.py
+++ b/litestar/middleware/allowed_hosts.py
@@ -48,7 +48,7 @@ class AllowedHostsMiddleware(AbstractMiddleware):
             if redirect_domains:
                 self.redirect_domains = re.compile("|".join(sorted(redirect_domains)))  # pyright: ignore
 
-    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI callable.
 
         Args:

--- a/litestar/middleware/authentication.py
+++ b/litestar/middleware/authentication.py
@@ -55,7 +55,7 @@ class AbstractAuthenticationMiddleware(ABC):
         self.exclude_opt_key = exclude_from_auth_key
         self.exclude = build_exclude_path_pattern(exclude=exclude)
 
-    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI callable.
 
         Args:

--- a/litestar/middleware/base.py
+++ b/litestar/middleware/base.py
@@ -25,7 +25,7 @@ class MiddlewareProtocol(Protocol):  # pragma: no cover
 
     app: ASGIApp
 
-    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Execute the ASGI middleware.
 
         Called by the previous middleware in the stack if a response is not awaited prior.
@@ -117,7 +117,7 @@ class AbstractMiddleware:
 
         original__call__ = cls.__call__
 
-        async def wrapped_call(self: AbstractMiddleware, scope: "Scope", receive: "Receive", send: "Send") -> None:
+        async def wrapped_call(self: AbstractMiddleware, scope: Scope, receive: Receive, send: Send) -> None:
             if should_bypass_middleware(
                 scope=scope,
                 scopes=self.scopes,
@@ -132,7 +132,7 @@ class AbstractMiddleware:
         setattr(cls, "__call__", wrapped_call)
 
     @abstractmethod
-    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Execute the ASGI middleware.
 
         Called by the previous middleware in the stack if a response is not awaited prior.

--- a/litestar/middleware/compression.py
+++ b/litestar/middleware/compression.py
@@ -116,7 +116,7 @@ class CompressionMiddleware(AbstractMiddleware):
         )
         self.config = config
 
-    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI callable.
 
         Args:
@@ -176,7 +176,7 @@ class CompressionMiddleware(AbstractMiddleware):
         initial_message = Ref[Optional["HTTPResponseStartEvent"]](None)
         started = Ref[bool](False)
 
-        async def send_wrapper(message: "Message") -> None:
+        async def send_wrapper(message: Message) -> None:
             """Handle and compresses the HTTP Message with brotli.
 
             Args:

--- a/litestar/middleware/cors.py
+++ b/litestar/middleware/cors.py
@@ -29,7 +29,7 @@ class CORSMiddleware(AbstractMiddleware):
         super().__init__(app=app, scopes={ScopeType.HTTP})
         self.config = config
 
-    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI callable.
 
         Args:
@@ -60,7 +60,7 @@ class CORSMiddleware(AbstractMiddleware):
             An ASGI send function.
         """
 
-        async def wrapped_send(message: "Message") -> None:
+        async def wrapped_send(message: Message) -> None:
             if message["type"] == "http.response.start":
                 message.setdefault("headers", [])
                 headers = MutableScopeHeaders.from_message(message=message)

--- a/litestar/middleware/csrf.py
+++ b/litestar/middleware/csrf.py
@@ -82,7 +82,7 @@ class CSRFMiddleware(MiddlewareProtocol):
         self.config = config
         self.exclude = build_exclude_path_pattern(exclude=config.exclude)
 
-    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI callable.
 
         Args:
@@ -135,7 +135,7 @@ class CSRFMiddleware(MiddlewareProtocol):
             An ASGI send function.
         """
 
-        async def send_wrapper(message: "Message") -> None:
+        async def send_wrapper(message: Message) -> None:
             """Send function that wraps the original send to inject a cookie.
 
             Args:

--- a/litestar/middleware/exceptions/middleware.py
+++ b/litestar/middleware/exceptions/middleware.py
@@ -134,7 +134,7 @@ class ExceptionHandlerMiddleware:
         self.exception_handlers = exception_handlers
         self.debug = debug
 
-    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI-callable.
 
         Args:
@@ -164,7 +164,7 @@ class ExceptionHandlerMiddleware:
                 await self.handle_websocket_exception(send=send, exc=e)
 
     async def handle_request_exception(
-        self, litestar_app: "Litestar", scope: "Scope", receive: "Receive", send: "Send", exc: Exception
+        self, litestar_app: Litestar, scope: Scope, receive: Receive, send: Send, exc: Exception
     ) -> None:
         """Handle exception raised inside 'http' scope routes.
 
@@ -189,7 +189,7 @@ class ExceptionHandlerMiddleware:
         await response(scope=scope, receive=receive, send=send)
 
     @staticmethod
-    async def handle_websocket_exception(send: "Send", exc: Exception) -> None:
+    async def handle_websocket_exception(send: Send, exc: Exception) -> None:
         """Handle exception raised inside 'websocket' scope routes.
 
         Args:

--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -93,7 +93,7 @@ class LoggingMiddleware(AbstractMiddleware):
             obfuscate_headers=self.config.response_headers_to_obfuscate,
         )
 
-    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI callable.
 
         Args:
@@ -116,7 +116,7 @@ class LoggingMiddleware(AbstractMiddleware):
 
         await self.app(scope, receive, send)
 
-    async def log_request(self, scope: "Scope", receive: "Receive") -> None:
+    async def log_request(self, scope: Scope, receive: Receive) -> None:
         """Extract request data and log the message.
 
         Args:
@@ -165,7 +165,7 @@ class LoggingMiddleware(AbstractMiddleware):
             return value.decode("utf-8")
         return value
 
-    async def extract_request_data(self, request: "Request") -> dict[str, Any]:
+    async def extract_request_data(self, request: Request) -> dict[str, Any]:
         """Create a dictionary of values for the message.
 
         Args:
@@ -224,7 +224,7 @@ class LoggingMiddleware(AbstractMiddleware):
             An ASGI send function.
         """
 
-        async def send_wrapper(message: "Message") -> None:
+        async def send_wrapper(message: Message) -> None:
             if message["type"] == HTTP_RESPONSE_START:
                 set_litestar_scope_state(scope, HTTP_RESPONSE_START, message)
             elif message["type"] == HTTP_RESPONSE_BODY:

--- a/litestar/middleware/rate_limit.py
+++ b/litestar/middleware/rate_limit.py
@@ -58,7 +58,7 @@ class RateLimitMiddleware(AbstractMiddleware):
         self.max_requests: int = config.rate_limit[1]
         self.unit: DurationUnit = config.rate_limit[0]
 
-    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI callable.
 
         Args:
@@ -98,7 +98,7 @@ class RateLimitMiddleware(AbstractMiddleware):
             Send wrapper callable.
         """
 
-        async def send_wrapper(message: "Message") -> None:
+        async def send_wrapper(message: Message) -> None:
             """Wrap the ASGI ``Send`` callable.
 
             Args:
@@ -174,7 +174,7 @@ class RateLimitMiddleware(AbstractMiddleware):
         cache_object.history = [int(time()), *cache_object.history]
         await store.set(key, encode_json(cache_object), expires_in=DURATION_VALUES[self.unit])
 
-    async def should_check_request(self, request: "Request[Any, Any, Any]") -> bool:
+    async def should_check_request(self, request: Request[Any, Any, Any]) -> bool:
         """Return a boolean indicating if a request should be checked for rate limiting.
 
         Args:

--- a/litestar/middleware/session/base.py
+++ b/litestar/middleware/session/base.py
@@ -146,9 +146,7 @@ class BaseSessionBackend(ABC, Generic[ConfigT]):
         return cast("dict[str, Any]", decode_json(data))
 
     @abstractmethod
-    async def store_in_message(
-        self, scope_session: "ScopeSession", message: "Message", connection: ASGIConnection
-    ) -> None:
+    async def store_in_message(self, scope_session: ScopeSession, message: Message, connection: ASGIConnection) -> None:
         """Store the necessary information in the outgoing ``Message``
 
         Args:
@@ -207,7 +205,7 @@ class SessionMiddleware(AbstractMiddleware, Generic[BaseSessionBackendT]):
             None
         """
 
-        async def wrapped_send(message: "Message") -> None:
+        async def wrapped_send(message: Message) -> None:
             """Wrap the ``send`` function.
 
             Declared in local scope to make use of closure values.
@@ -229,7 +227,7 @@ class SessionMiddleware(AbstractMiddleware, Generic[BaseSessionBackendT]):
 
         return wrapped_send
 
-    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI-callable.
 
         Args:

--- a/litestar/middleware/session/client_side.py
+++ b/litestar/middleware/session/client_side.py
@@ -126,9 +126,7 @@ class ClientSideSessionBackend(BaseSessionBackend["CookieBackendConfig"]):
             for i, datum in enumerate(data)
         ]
 
-    async def store_in_message(
-        self, scope_session: "ScopeSession", message: "Message", connection: "ASGIConnection"
-    ) -> None:
+    async def store_in_message(self, scope_session: ScopeSession, message: Message, connection: ASGIConnection) -> None:
         """Store data from ``scope_session`` in ``Message`` in the form of cookies. If the contents of ``scope_session``
         are too large to fit a single cookie, it will be split across several cookies, following the naming scheme of
         ``<cookie key>-<n>``. If the session is empty or shrinks, cookies will be cleared by setting their value to
@@ -179,7 +177,7 @@ class ClientSideSessionBackend(BaseSessionBackend["CookieBackendConfig"]):
                 Cookie(value="null", key=cookie_key, expires=0, **cookie_params).to_header(header=""),
             )
 
-    async def load_from_connection(self, connection: "ASGIConnection") -> dict[str, Any]:
+    async def load_from_connection(self, connection: ASGIConnection) -> dict[str, Any]:
         """Load session data from a connection's session-cookies and return it as a dictionary.
 
         Args:

--- a/litestar/middleware/session/server_side.py
+++ b/litestar/middleware/session/server_side.py
@@ -86,9 +86,7 @@ class ServerSideSessionBackend(BaseSessionBackend["ServerSideSessionConfig"]):
         """
         return secrets.token_hex(self.config.session_id_bytes)
 
-    async def store_in_message(
-        self, scope_session: "ScopeSession", message: "Message", connection: "ASGIConnection"
-    ) -> None:
+    async def store_in_message(self, scope_session: ScopeSession, message: Message, connection: ASGIConnection) -> None:
         """Store the necessary information in the outgoing ``Message`` by setting a cookie containing the session-ID.
 
         If the session is empty, a null-cookie will be set. Otherwise, the serialised
@@ -123,7 +121,7 @@ class ServerSideSessionBackend(BaseSessionBackend["ServerSideSessionConfig"]):
             await self.set(session_id=session_id, data=serialised_data, store=store)
             headers["Set-Cookie"] = Cookie(value=session_id, key=self.config.key, **cookie_params).to_header(header="")
 
-    async def load_from_connection(self, connection: "ASGIConnection") -> dict[str, Any]:
+    async def load_from_connection(self, connection: ASGIConnection) -> dict[str, Any]:
         """Load session data from a connection and return it as a dictionary to be used in the current application
         scope.
 

--- a/litestar/openapi/controller.py
+++ b/litestar/openapi/controller.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 class OpenAPISchemaResponse(Response):
     """Response class for OpenAPI Schemas."""
 
-    def render(self, content: "OpenAPI") -> bytes:
+    def render(self, content: OpenAPI) -> bytes:
         """Handle rendering of schema into the correct format - either YAML or JSON.
 
         Args:
@@ -93,7 +93,7 @@ class OpenAPIController(Controller):
     return_dto = None
 
     @staticmethod
-    def get_schema_from_request(request: Request) -> "OpenAPI":
+    def get_schema_from_request(request: Request) -> OpenAPI:
         """Return the OpenAPI pydantic model from the request instance.
 
         Args:
@@ -104,7 +104,7 @@ class OpenAPIController(Controller):
         """
         return request.app.openapi_schema
 
-    def should_serve_endpoint(self, request: "Request") -> bool:
+    def should_serve_endpoint(self, request: Request) -> bool:
         """Verify that the requested path is within the enabled endpoints in the openapi_config.
 
         Args:

--- a/litestar/partial.py
+++ b/litestar/partial.py
@@ -155,7 +155,7 @@ class Partial(Generic[T]):
         )
 
     @classmethod
-    def _create_partial_typeddict(cls, item: "TypedDictClass") -> None:
+    def _create_partial_typeddict(cls, item: TypedDictClass) -> None:
         """Receives a typeddict class and creates a new type with all attributes ``Optional``.
 
         Args:

--- a/litestar/plugins.py
+++ b/litestar/plugins.py
@@ -107,7 +107,7 @@ class OpenAPISchemaPluginProtocol(Protocol[ModelT]):
         """
         raise NotImplementedError()
 
-    def to_openapi_schema(self, model_class: type[ModelT]) -> "Schema":
+    def to_openapi_schema(self, model_class: type[ModelT]) -> Schema:
         """Given a model class, transform it into an OpenAPI schema class.
 
         Args:

--- a/litestar/response/base.py
+++ b/litestar/response/base.py
@@ -292,7 +292,7 @@ class Response(Generic[T]):
         if self.background is not None:
             await self.background()
 
-    async def start_response(self, send: "Send") -> None:
+    async def start_response(self, send: Send) -> None:
         """Emit the start event of the response. This event includes the headers and status codes.
 
         Args:
@@ -316,7 +316,7 @@ class Response(Generic[T]):
 
         await send(event)
 
-    async def send_body(self, send: "Send", receive: "Receive") -> None:
+    async def send_body(self, send: Send, receive: Receive) -> None:
         """Emit the response body.
 
         Args:
@@ -332,7 +332,7 @@ class Response(Generic[T]):
         event: HTTPResponseBodyEvent = {"type": "http.response.body", "body": self.body, "more_body": False}
         await send(event)
 
-    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI callable of the ``Response``.
 
         Args:

--- a/litestar/response/file.py
+++ b/litestar/response/file.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
 
 async def async_file_iterator(
-    file_path: "PathType", chunk_size: int, adapter: "FileSystemAdapter"
+    file_path: PathType, chunk_size: int, adapter: FileSystemAdapter
 ) -> AsyncGenerator[bytes, None]:
     """Return an async that asynchronously reads a file and yields its chunks.
 
@@ -178,7 +178,7 @@ class FileResponse(StreamingResponse):
             return self.file_info["size"]
         return 0
 
-    async def send_body(self, send: "Send", receive: "Receive") -> None:
+    async def send_body(self, send: Send, receive: Receive) -> None:
         """Emit a stream of events correlating with the response body.
 
         Args:
@@ -200,7 +200,7 @@ class FileResponse(StreamingResponse):
             }
             await send(body_event)
 
-    async def start_response(self, send: "Send") -> None:
+    async def start_response(self, send: Send) -> None:
         """Emit the start event of the response. This event includes the headers and status codes.
 
         Args:

--- a/litestar/response/streaming.py
+++ b/litestar/response/streaming.py
@@ -73,7 +73,7 @@ class StreamingResponse(Response[StreamType[Union[str, bytes]]]):
             content if isinstance(content, (AsyncIterable, AsyncIterator)) else AsyncIteratorWrapper(content)
         )
 
-    async def _listen_for_disconnect(self, cancel_scope: "CancelScope", receive: "Receive") -> None:
+    async def _listen_for_disconnect(self, cancel_scope: CancelScope, receive: Receive) -> None:
         """Listen for a cancellation message, and if received - call cancel on the cancel scope.
 
         Args:
@@ -92,7 +92,7 @@ class StreamingResponse(Response[StreamType[Union[str, bytes]]]):
             else:
                 await self._listen_for_disconnect(cancel_scope=cancel_scope, receive=receive)
 
-    async def _stream(self, send: "Send") -> None:
+    async def _stream(self, send: Send) -> None:
         """Send the chunks from the iterator as a stream of ASGI 'http.response.body' events.
 
         Args:
@@ -111,7 +111,7 @@ class StreamingResponse(Response[StreamType[Union[str, bytes]]]):
         terminus_event: HTTPResponseBodyEvent = {"type": "http.response.body", "body": b"", "more_body": False}
         await send(terminus_event)
 
-    async def send_body(self, send: "Send", receive: "Receive") -> None:
+    async def send_body(self, send: Send, receive: Receive) -> None:
         """Emit a stream of events correlating with the response body.
 
         Args:

--- a/litestar/routes/asgi.py
+++ b/litestar/routes/asgi.py
@@ -36,7 +36,7 @@ class ASGIRoute(BaseRoute):
             handler_names=[unwrap_partial(route_handler.handler_name)],
         )
 
-    async def handle(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+    async def handle(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI app that authorizes the connection and then awaits the handler function.
 
         Args:

--- a/litestar/routes/base.py
+++ b/litestar/routes/base.py
@@ -96,7 +96,7 @@ class BaseRoute(ABC):
         self.methods = set(methods or [])
 
     @abstractmethod
-    async def handle(self, scope: "Scope", receive: "Receive", send: "Send") -> None:  # pragma: no cover
+    async def handle(self, scope: Scope, receive: Receive, send: Send) -> None:  # pragma: no cover
         """ASGI App of the route.
 
         Args:

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -56,7 +56,7 @@ class HTTPRoute(BaseRoute):
             handler_names=[route_handler.handler_name for route_handler in self.route_handlers],
         )
 
-    async def handle(self, scope: "HTTPScope", receive: "Receive", send: "Send") -> None:  # type: ignore[override]
+    async def handle(self, scope: HTTPScope, receive: Receive, send: Send) -> None:  # type: ignore[override]
         """ASGI app that creates a Request from the passed in args, determines which handler function to call and then
         handles the call.
 
@@ -101,11 +101,11 @@ class HTTPRoute(BaseRoute):
 
     async def _get_response_for_request(
         self,
-        scope: "Scope",
+        scope: Scope,
         request: Request[Any, Any, Any],
-        route_handler: "HTTPRouteHandler",
-        parameter_model: "KwargsModel",
-    ) -> "ASGIApp":
+        route_handler: HTTPRouteHandler,
+        parameter_model: KwargsModel,
+    ) -> ASGIApp:
         """Return a response for the request.
 
         If caching is enabled and a response exist in the cache, the cached response will be returned.
@@ -140,8 +140,8 @@ class HTTPRoute(BaseRoute):
         return response
 
     async def _call_handler_function(
-        self, scope: "Scope", request: Request, parameter_model: "KwargsModel", route_handler: "HTTPRouteHandler"
-    ) -> "ASGIApp":
+        self, scope: Scope, request: Request, parameter_model: KwargsModel, route_handler: HTTPRouteHandler
+    ) -> ASGIApp:
         """Call the before request handlers, retrieve any data required for the route handler, and call the route
         handler's ``to_response`` method.
 
@@ -168,8 +168,8 @@ class HTTPRoute(BaseRoute):
 
     @staticmethod
     async def _get_response_data(
-        route_handler: "HTTPRouteHandler", parameter_model: "KwargsModel", request: Request
-    ) -> tuple[Any, "DependencyCleanupGroup" | None]:
+        route_handler: HTTPRouteHandler, parameter_model: KwargsModel, request: Request
+    ) -> tuple[Any, DependencyCleanupGroup | None]:
         """Determine what kwargs are required for the given route handler's ``fn`` and calls it."""
         parsed_kwargs: dict[str, Any] = {}
         cleanup_group: DependencyCleanupGroup | None = None

--- a/litestar/routes/websocket.py
+++ b/litestar/routes/websocket.py
@@ -43,7 +43,7 @@ class WebSocketRoute(BaseRoute):
             handler_names=[route_handler.handler_name],
         )
 
-    async def handle(self, scope: "WebSocketScope", receive: "Receive", send: "Send") -> None:  # type: ignore[override]
+    async def handle(self, scope: WebSocketScope, receive: Receive, send: Send) -> None:  # type: ignore[override]
         """ASGI app that creates a WebSocket from the passed in args, and then awaits the handler function.
 
         Args:

--- a/litestar/security/session_auth/middleware.py
+++ b/litestar/security/session_auth/middleware.py
@@ -37,7 +37,7 @@ class MiddlewareWrapper:
         self.config = config
         self.has_wrapped_middleware = False
 
-    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Handle creating a middleware stack and calling it.
 
         Args:
@@ -93,7 +93,7 @@ class SessionAuthMiddleware(AbstractAuthenticationMiddleware):
         super().__init__(app=app, exclude=exclude, exclude_from_auth_key=exclude_opt_key, scopes=scopes)
         self.retrieve_user_handler = retrieve_user_handler
 
-    async def authenticate_request(self, connection: "ASGIConnection[Any, Any, Any, Any]") -> AuthenticationResult:
+    async def authenticate_request(self, connection: ASGIConnection[Any, Any, Any, Any]) -> AuthenticationResult:
         """Authenticate an incoming connection.
 
         Args:

--- a/litestar/testing/client/async_client.py
+++ b/litestar/testing/client/async_client.py
@@ -83,7 +83,7 @@ class AsyncTestClient(AsyncClient, BaseTestClient, Generic[T]):  # type: ignore[
             ),
         )
 
-    async def __aenter__(self) -> "AsyncTestClient[T]":
+    async def __aenter__(self) -> AsyncTestClient[T]:
         async with AsyncExitStack() as stack:
             self.blocking_portal = portal = stack.enter_context(self.portal())
             self.lifespan_handler = LifeSpanHandler(client=self)
@@ -158,7 +158,7 @@ class AsyncTestClient(AsyncClient, BaseTestClient, Generic[T]):  # type: ignore[
 
     async def get(  # type: ignore [override]
         self,
-        url: "URLTypes",
+        url: URLTypes,
         *,
         params: QueryParamTypes | None = None,
         headers: HeaderTypes | None = None,

--- a/litestar/testing/life_span_handler.py
+++ b/litestar/testing/life_span_handler.py
@@ -31,7 +31,7 @@ class LifeSpanHandler(Generic[T]):
             self.task = portal.start_task_soon(self.lifespan)
             portal.call(self.wait_startup)
 
-    async def receive(self) -> "LifeSpanSendMessage":
+    async def receive(self) -> LifeSpanSendMessage:
         message = await self.stream_send.receive()
         if message is None:
             self.task.result()

--- a/litestar/testing/transport.py
+++ b/litestar/testing/transport.py
@@ -57,7 +57,7 @@ class TestClientTransport(Generic[T]):
 
     @staticmethod
     def create_receive(request: Request, context: SendReceiveContext) -> Receive:
-        async def receive() -> "ReceiveMessage":
+        async def receive() -> ReceiveMessage:
             if context["request_complete"]:
                 if not context["response_complete"].is_set():
                     await context["response_complete"].wait()
@@ -82,7 +82,7 @@ class TestClientTransport(Generic[T]):
 
     @staticmethod
     def create_send(request: Request, context: SendReceiveContext) -> Send:
-        async def send(message: "Message") -> None:
+        async def send(message: Message) -> None:
             if message["type"] == "http.response.start":
                 assert not context[  # noqa: S101
                     "response_started"
@@ -193,5 +193,5 @@ class TestClientTransport(Generic[T]):
             setattr(response, "context", context["context"])
             return response
 
-    async def handle_async_request(self, request: "Request") -> "Response":
+    async def handle_async_request(self, request: Request) -> Response:
         return self.handle_request(request=request)

--- a/litestar/testing/websocket_test_session.py
+++ b/litestar/testing/websocket_test_session.py
@@ -70,12 +70,12 @@ class WebSocketTestSession:
     async def do_asgi_call(self) -> None:
         """The sub-thread in which the websocket session runs."""
 
-        async def receive() -> "WebSocketReceiveMessage":
+        async def receive() -> WebSocketReceiveMessage:
             while self.receive_queue.empty():
                 await sleep(0)
             return self.receive_queue.get()
 
-        async def send(message: "WebSocketSendMessage") -> None:
+        async def send(message: WebSocketSendMessage) -> None:
             if message["type"] == "websocket.accept":
                 headers = message.get("headers", [])
                 if headers:

--- a/litestar/utils/predicates.py
+++ b/litestar/utils/predicates.py
@@ -243,7 +243,7 @@ def is_typed_dict(annotation: Any) -> TypeGuard[TypedDictClass]:
     return is_typeddict(annotation)
 
 
-def is_pydantic_model_class(annotation: Any) -> "TypeGuard[type[pydantic.BaseModel]]":  # pyright: ignore
+def is_pydantic_model_class(annotation: Any) -> TypeGuard[type[pydantic.BaseModel]]:  # pyright: ignore
     """Given a type annotation determine if the annotation is a subclass of pydantic's BaseModel.
 
     Args:
@@ -257,7 +257,7 @@ def is_pydantic_model_class(annotation: Any) -> "TypeGuard[type[pydantic.BaseMod
     return False  # pragma: no cover
 
 
-def is_pydantic_model_instance(annotation: Any) -> "TypeGuard[pydantic.BaseModel]":  # pyright: ignore
+def is_pydantic_model_instance(annotation: Any) -> TypeGuard[pydantic.BaseModel]:  # pyright: ignore
     """Given a type annotation determine if the annotation is an instance of pydantic's BaseModel.
 
     Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,7 +283,6 @@ ignore = [
     "D205",  # pydocstyle - 1 blank line required between summary line and description
     "D415",  # pydocstyle - first line should end with a period, question mark, or exclamation point
     "E501",  # pycodestyle line too long, handled by black
-    "UP037", # pyupgrade - removes quotes from type annotation
 ]
 line-length = 120
 src = ["litestar", "tests", "docs/examples"]

--- a/tests/app/test_before_send.py
+++ b/tests/app/test_before_send.py
@@ -25,7 +25,7 @@ def test_before_send() -> None:
             headers = MutableScopeHeaders(message)
             headers.add("My Header", state.message)
 
-    def on_startup(state: "State") -> None:
+    def on_startup(state: State) -> None:
         state.message = "value injected during send"
 
     with create_test_client(handler, on_startup=[on_startup], before_send=[before_send_hook_handler]) as client:

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -113,12 +113,12 @@ def runner() -> CliRunner:
 
 
 @pytest.fixture
-def mock_uvicorn_run(mocker: MockerFixture) -> "MagicMock":
+def mock_uvicorn_run(mocker: MockerFixture) -> MagicMock:
     return mocker.patch("uvicorn.run")
 
 
 @pytest.fixture
-def mock_confirm_ask(mocker: MockerFixture) -> Generator["MagicMock", None, None]:
+def mock_confirm_ask(mocker: MockerFixture) -> Generator[MagicMock, None, None]:
     yield mocker.patch("rich.prompt.Confirm.ask", return_value=True)
 
 

--- a/tests/cli/test_session_commands.py
+++ b/tests/cli/test_session_commands.py
@@ -23,7 +23,7 @@ def test_get_session_backend() -> None:
     assert get_session_backend(app) is session_middleware.kwargs["backend"]
 
 
-def test_delete_session_no_backend(runner: "CliRunner", monkeypatch: "MonkeyPatch") -> None:
+def test_delete_session_no_backend(runner: CliRunner, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("LITESTAR_APP", "docs.examples.hello_world:app")
     result = runner.invoke(cli_command, "sessions delete foo")
 
@@ -31,7 +31,7 @@ def test_delete_session_no_backend(runner: "CliRunner", monkeypatch: "MonkeyPatc
     assert "Session middleware not installed" in result.output
 
 
-def test_delete_session_cookie_backend(runner: "CliRunner", monkeypatch: "MonkeyPatch") -> None:
+def test_delete_session_cookie_backend(runner: CliRunner, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("LITESTAR_APP", "docs.examples.middleware.session.cookie_backend:app")
 
     result = runner.invoke(cli_command, "sessions delete foo")
@@ -41,7 +41,7 @@ def test_delete_session_cookie_backend(runner: "CliRunner", monkeypatch: "Monkey
 
 
 def test_delete_session(
-    runner: "CliRunner", monkeypatch: "MonkeyPatch", mocker: "MockerFixture", mock_confirm_ask: "MagicMock"
+    runner: CliRunner, monkeypatch: MonkeyPatch, mocker: MockerFixture, mock_confirm_ask: MagicMock
 ) -> None:
     monkeypatch.setenv("LITESTAR_APP", "docs.examples.middleware.session.file_store:app")
     mock_delete = mocker.patch("litestar.stores.file.FileStore.delete")
@@ -53,7 +53,7 @@ def test_delete_session(
     mock_delete.assert_called_once_with("foo")
 
 
-def test_clear_sessions_no_backend(runner: "CliRunner", monkeypatch: "MonkeyPatch") -> None:
+def test_clear_sessions_no_backend(runner: CliRunner, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("LITESTAR_APP", "docs.examples.hello_world:app")
     result = runner.invoke(cli_command, "sessions clear")
 
@@ -61,7 +61,7 @@ def test_clear_sessions_no_backend(runner: "CliRunner", monkeypatch: "MonkeyPatc
     assert "Session middleware not installed" in result.output
 
 
-def test_clear_sessions_cookie_backend(runner: "CliRunner", monkeypatch: "MonkeyPatch") -> None:
+def test_clear_sessions_cookie_backend(runner: CliRunner, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("LITESTAR_APP", "docs.examples.middleware.session.cookie_backend:app")
 
     result = runner.invoke(cli_command, "sessions clear")
@@ -71,7 +71,7 @@ def test_clear_sessions_cookie_backend(runner: "CliRunner", monkeypatch: "Monkey
 
 
 def test_clear_sessions(
-    runner: "CliRunner", monkeypatch: "MonkeyPatch", mocker: "MockerFixture", mock_confirm_ask: "MagicMock"
+    runner: CliRunner, monkeypatch: MonkeyPatch, mocker: MockerFixture, mock_confirm_ask: MagicMock
 ) -> None:
     monkeypatch.setenv("LITESTAR_APP", "docs.examples.middleware.session.file_store:app")
     mock_delete = mocker.patch("litestar.stores.file.FileStore.delete_all")

--- a/tests/contrib/sqlalchemy/test_dto.py
+++ b/tests/contrib/sqlalchemy/test_dto.py
@@ -371,7 +371,7 @@ dto_type = SQLAlchemyDTO[A]
 
 
 async def test_dto_self_referencing_relationships(
-    create_module: "Callable[[str], ModuleType]", connection_context: ConnectionContext
+    create_module: Callable[[str], ModuleType], connection_context: ConnectionContext
 ) -> None:
     module = create_module(
         """


### PR DESCRIPTION
This PR enables the UP037 pyupgrade rule, which removes strings from annotations where ever `__future__.annotations` is imported.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
