### PR TITLE
Adds `connection_accept_handler` to `websocket_listener`.

### DIFF
--- a/docs/examples/websockets/setting_custom_connection_headers.py
+++ b/docs/examples/websockets/setting_custom_connection_headers.py
@@ -1,0 +1,13 @@
+from litestar import Litestar, WebSocket, websocket_listener
+
+
+async def accept_connection(socket: WebSocket) -> None:
+    await socket.accept(headers={"Cookie": "custom-cookie"})
+
+
+@websocket_listener("/", connection_accept_handler=accept_connection)
+def handler(data: str) -> str:
+    return data
+
+
+app = Litestar([handler])

--- a/docs/usage/websockets.rst
+++ b/docs/usage/websockets.rst
@@ -217,6 +217,17 @@ function via the ``socket`` argument:
     to be asynchronous.
 
 
+Customising connection acceptance
+---------------------------------
+
+By default, Litestar will accept all incoming connections by awaiting ``WebSocket.accept()`` without arguments.
+This behavior can be customized by passing a custom ``connection_accept_handler`` function. Litestar will await this
+function to accept the connection.
+
+.. literalinclude:: /examples/websockets/setting_custom_connection_headers.py
+    :language: python
+
+
 Class based WebSocket handling
 ------------------------------
 

--- a/litestar/handlers/websocket_handlers/_utils.py
+++ b/litestar/handlers/websocket_handlers/_utils.py
@@ -113,9 +113,10 @@ def create_handler_function(
     listener_context: ListenerContext,
     on_accept: AsyncCallable | None,
     on_disconnect: AsyncCallable | None,
+    accept_connection_handler: Callable[[WebSocket], Coroutine[Any, Any, None]],
 ) -> Callable[..., Coroutine[None, None, None]]:
     async def handler_fn(socket: WebSocket, **kwargs: Any) -> None:
-        await socket.accept()
+        await accept_connection_handler(socket)
 
         listener_callback = AsyncCallable(listener_context.listener_callback)
         ctx = ConnectionContext.from_connection(socket)

--- a/litestar/handlers/websocket_handlers/listener.py
+++ b/litestar/handlers/websocket_handlers/listener.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Callable, Mapping, cast
 from msgspec.json import Encoder as JsonEncoder
 
 from litestar._signature import create_signature_model
+from litestar.connection import WebSocket
 from litestar.dto.interface import HandlerContext
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.serialization import default_serializer
@@ -29,7 +30,9 @@ from . import _utils
 from .route_handler import WebsocketRouteHandler
 
 if TYPE_CHECKING:
-    from litestar import Litestar, WebSocket
+    from typing import Coroutine
+
+    from litestar import Litestar
     from litestar.dto.interface import DTOInterface
     from litestar.types.asgi_types import WebSocketMode
 
@@ -52,12 +55,14 @@ class websocket_listener(WebsocketRouteHandler):
         "_receive_mode",
         "_send_mode",
         "_listener_context",
+        "accept_connection_handler",
     )
 
     def __init__(
         self,
         path: str | None | list[str] | None = None,
         *,
+        accept_connection_handler: Callable[[WebSocket], Coroutine[Any, Any, None]] = WebSocket.accept,
         dependencies: Dependencies | None = None,
         dto: type[DTOInterface] | None | EmptyType = Empty,
         exception_handlers: dict[int | type[Exception], ExceptionHandler] | None = None,
@@ -79,6 +84,8 @@ class websocket_listener(WebsocketRouteHandler):
         Args:
             path: A path fragment for the route handler function or a sequence of path fragments. If not given defaults
                 to ``/``
+            accept_connection_handler: A callable that accepts a :class:`WebSocket <.connection.WebSocket>` instance
+                and returns a coroutine that when awaited, will accept the connection. Defaults to ``WebSocket.accept``.
             dependencies: A string keyed mapping of dependency :class:`Provider <.di.Provide>` instances.
             dto: :class:`DTOInterface <.dto.interface.DTOInterface>` to use for (de)serializing and
                 validation of request data.
@@ -107,6 +114,7 @@ class websocket_listener(WebsocketRouteHandler):
         self._send_mode: WebSocketMode = send_mode
         self._on_accept = AsyncCallable(on_accept) if on_accept else None
         self._on_disconnect = AsyncCallable(on_disconnect) if on_disconnect else None
+        self.accept_connection_handler = accept_connection_handler
         self.type_encoders = type_encoders
 
         super().__init__(
@@ -146,6 +154,7 @@ class websocket_listener(WebsocketRouteHandler):
             listener_context=self._listener_context,
             on_accept=self._on_accept,
             on_disconnect=self._on_disconnect,
+            accept_connection_handler=self.accept_connection_handler,
         )
         return super().__call__(handler_function)
 

--- a/litestar/handlers/websocket_handlers/listener.py
+++ b/litestar/handlers/websocket_handlers/listener.py
@@ -62,7 +62,7 @@ class websocket_listener(WebsocketRouteHandler):
         self,
         path: str | None | list[str] | None = None,
         *,
-        accept_connection_handler: Callable[[WebSocket], Coroutine[Any, Any, None]] = WebSocket.accept,
+        connection_accept_handler: Callable[[WebSocket], Coroutine[Any, Any, None]] = WebSocket.accept,
         dependencies: Dependencies | None = None,
         dto: type[DTOInterface] | None | EmptyType = Empty,
         exception_handlers: dict[int | type[Exception], ExceptionHandler] | None = None,
@@ -84,7 +84,7 @@ class websocket_listener(WebsocketRouteHandler):
         Args:
             path: A path fragment for the route handler function or a sequence of path fragments. If not given defaults
                 to ``/``
-            accept_connection_handler: A callable that accepts a :class:`WebSocket <.connection.WebSocket>` instance
+            connection_accept_handler: A callable that accepts a :class:`WebSocket <.connection.WebSocket>` instance
                 and returns a coroutine that when awaited, will accept the connection. Defaults to ``WebSocket.accept``.
             dependencies: A string keyed mapping of dependency :class:`Provider <.di.Provide>` instances.
             dto: :class:`DTOInterface <.dto.interface.DTOInterface>` to use for (de)serializing and
@@ -114,7 +114,7 @@ class websocket_listener(WebsocketRouteHandler):
         self._send_mode: WebSocketMode = send_mode
         self._on_accept = AsyncCallable(on_accept) if on_accept else None
         self._on_disconnect = AsyncCallable(on_disconnect) if on_disconnect else None
-        self.accept_connection_handler = accept_connection_handler
+        self.accept_connection_handler = connection_accept_handler
         self.type_encoders = type_encoders
 
         super().__init__(

--- a/tests/handlers/websocket/test_listeners.py
+++ b/tests/handlers/websocket/test_listeners.py
@@ -262,3 +262,16 @@ def test_listener_callback_request_and_body_arg_raises() -> None:
             ...
 
         handler_body.on_registration(Litestar())
+
+
+def test_listener_accept_connection_callback() -> None:
+    async def accept_connection(socket: WebSocket) -> None:
+        await socket.accept(headers={"Cookie": "custom-cookie"})
+
+    @websocket_listener("/", accept_connection_handler=accept_connection)
+    def handler(data: bytes) -> None:
+        return None
+
+    client = create_test_client([handler])
+    with client.websocket_connect("/") as ws:
+        assert ws.extra_headers == [(b"cookie", b"custom-cookie")]

--- a/tests/handlers/websocket/test_listeners.py
+++ b/tests/handlers/websocket/test_listeners.py
@@ -268,7 +268,7 @@ def test_listener_accept_connection_callback() -> None:
     async def accept_connection(socket: WebSocket) -> None:
         await socket.accept(headers={"Cookie": "custom-cookie"})
 
-    @websocket_listener("/", accept_connection_handler=accept_connection)
+    @websocket_listener("/", connection_accept_handler=accept_connection)
     def handler(data: bytes) -> None:
         return None
 


### PR DESCRIPTION
This provides an avenue for parameters to be passed to `WebSocket.accept()`.

Closes #1571

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [x] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [x] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
