### PR TITLE
Corrected several litestar.config imports in docs

### DIFF
--- a/docs/release-notes/migration_guide_2.rst
+++ b/docs/release-notes/migration_guide_2.rst
@@ -22,7 +22,7 @@ Changed module paths
 +----------------------------------------------------+------------------------------------------------------------------------+
 | ``starlite.AllowedHostsConfig``                    | ``litestar.config.allowed_hosts.AllowedHostsConfig``                   |
 +----------------------------------------------------+------------------------------------------------------------------------+
-| ``starlite.BaseLoggingConfig``                     | ``litestar.config.logging.BaseLoggingConfig``                          |
+| ``starlite.BaseLoggingConfig``                     | ``litestar.logging.BaseLoggingConfig``                                 |
 +----------------------------------------------------+------------------------------------------------------------------------+
 | ``starlite.CacheConfig``                           | ``litestar.config.cache.CacheConfig``                                  |
 +----------------------------------------------------+------------------------------------------------------------------------+
@@ -32,15 +32,15 @@ Changed module paths
 +----------------------------------------------------+------------------------------------------------------------------------+
 | ``starlite.CSRFConfig``                            | ``litestar.config.csrf.CSRFConfig``                                    |
 +----------------------------------------------------+------------------------------------------------------------------------+
-| ``starlite.LoggingConfig``                         | ``litestar.config.logging.LoggingConfig``                              |
+| ``starlite.LoggingConfig``                         | ``litestar.logging.LoggingConfig``                                     |
 +----------------------------------------------------+------------------------------------------------------------------------+
-| ``starlite.StructLoggingConfig``                   | ``litestar.config.logging.StructLoggingConfig``                        |
+| ``starlite.StructLoggingConfig``                   | ``litestar.logging.StructLoggingConfig``                               |
 +----------------------------------------------------+------------------------------------------------------------------------+
-| ``starlite.OpenAPIConfig``                         | ``litestar.config.openapi.OpenAPIConfig``                              |
+| ``starlite.OpenAPIConfig``                         | ``litestar.openapi.OpenAPIConfig``                                     |
 +----------------------------------------------------+------------------------------------------------------------------------+
-| ``starlite.StaticFilesConfig``                     | ``litestar.config.static_files.StaticFilesConfig``                     |
+| ``starlite.StaticFilesConfig``                     | ``litestar.static_files.config.StaticFilesConfig``                     |
 +----------------------------------------------------+------------------------------------------------------------------------+
-| ``starlite.TemplateConfig``                        | ``litestar.config.templates.TemplateConfig``                           |
+| ``starlite.TemplateConfig``                        | ``litestar.template.TemplateConfig``                                   |
 +----------------------------------------------------+------------------------------------------------------------------------+
 | **Provide**                                                                                                                 |
 +----------------------------------------------------+------------------------------------------------------------------------+

--- a/docs/usage/openapi.rst
+++ b/docs/usage/openapi.rst
@@ -27,7 +27,7 @@ OpenAPI schema generation is enabled by default. To configure it you can pass an
 .. code-block:: python
 
    from litestar import Litestar
-   from litestar.config.openapi import OpenAPIConfig
+   from litestar.openapi import OpenAPIConfig
 
    app = Litestar(
        route_handlers=[...], openapi_config=OpenAPIConfig(title="My API", version="1.0.0")
@@ -145,7 +145,7 @@ app instance itself. For example:
 .. code-block:: python
 
    from litestar import Litestar, get
-   from litestar.config.openapi import OpenAPIConfig
+   from litestar.openapi import OpenAPIConfig
    from litestar.openapi.spec import Components, SecurityScheme, Tag
 
 
@@ -224,7 +224,7 @@ For example, lets say we wanted to change the base path of the OpenAPI related e
 .. code-block:: python
 
    from litestar import Litestar
-   from litestar.config.openapi import OpenAPIConfig
+   from litestar.openapi import OpenAPIConfig
    from litestar.openapi import OpenAPIController
 
 
@@ -250,7 +250,7 @@ You can change the default download paths for JS and CSS bundles as well as goog
 .. code-block:: python
 
    from litestar import Litestar
-   from litestar.config.openapi import OpenAPIConfig
+   from litestar.openapi import OpenAPIConfig
    from litestar.openapi import OpenAPIController
 
 

--- a/docs/usage/the-litestar-app.rst
+++ b/docs/usage/the-litestar-app.rst
@@ -163,7 +163,7 @@ and the **html files** on the ``/html`` path:
 .. code-block:: python
 
    from litestar import Litestar
-   from litestar.config.static_files import StaticFilesConfig
+   from litestar.static_files.config import StaticFilesConfig
 
    app = Litestar(
        route_handlers=[...],
@@ -247,7 +247,7 @@ Litestar has builtin pydantic based logging configuration that allows users to e
 .. code-block:: python
 
    from litestar import Litestar, Request, get
-   from litestar.config.logging import LoggingConfig
+   from litestar.logging import LoggingConfig
 
 
    @get("/")
@@ -289,7 +289,7 @@ logging config for using it:
 .. code-block:: python
 
    from litestar import Litestar, Request, get
-   from litestar.config.logging import StructLoggingConfig
+   from litestar.logging import StructLoggingConfig
 
 
    @get("/")

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -653,7 +653,7 @@ class Litestar(Router):
             .. code-block: python
 
                 from litestar import Litestar
-                from litestar.config.static_files import StaticFilesConfig
+                from litestar.static_files.config import StaticFilesConfig
 
                 app = Litestar(
                     static_files_config=[StaticFilesConfig(directories=["css"], path="/static/css")]

--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -340,7 +340,7 @@ class LoggingMiddlewareConfig:
             .. code-block: python
 
                 from litestar import Litestar, Request, get
-                from litestar.config.logging import LoggingConfig
+                from litestar.logging import LoggingConfig
                 from litestar.middleware.logging import LoggingMiddlewareConfig
 
                 logging_config = LoggingConfig()


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [x] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [x] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

During development I noticed some inconsistencies in the docs with regards to importing
- `BaseLoggingConfig`
- `LoggingConfig`
- `StructLoggingConfig`
- `OpenAPIConfig`
- `StaticFilesConfig`
- `TemplateConfig`

These are not imported from `litestar.config.X` but rather `litestar.logging`. I'm not sure if `litestar.logging` is sufficient or if `litestar.logging.config` should be used.

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
