### PR TITLE
Set compressed static file headers

### DIFF
--- a/litestar/response/file.py
+++ b/litestar/response/file.py
@@ -125,8 +125,14 @@ class FileResponse(StreamingResponse):
                 providing an :class:`os.stat_result`.
         """
         if not media_type:
-            mimetype, _ = guess_type(filename) if filename else (None, None)
+            mimetype, _encoding = guess_type(filename) if filename else (None, None)
             media_type = mimetype or "application/octet-stream"
+            if _encoding is not None:
+                encoding_header = {"content-encoding": _encoding}
+                if headers is None:
+                    headers = encoding_header
+                else:
+                    headers.update(encoding_header)
 
         self.chunk_size = chunk_size
         self.content_disposition_type = content_disposition_type


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

Fix `content-encoding` headers for gzip/brotli compressed files not being set

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
Closes #1576
