### PR TITLE
Simplifies DTO config options.

### DIFF
--- a/litestar/dto/factory/backends/abc.py
+++ b/litestar/dto/factory/backends/abc.py
@@ -28,7 +28,7 @@ BackendT = TypeVar("BackendT")
 class BackendContext:
     """Context required by DTO backends to perform their work."""
 
-    __slots__ = ("parsed_type", "field_definitions", "model_type")
+    __slots__ = ("parsed_type", "field_definitions", "model_type", "reverse_name_map")
 
     def __init__(self, parsed_type: ParsedType, field_definitions: FieldDefinitionsType, model_type: type[Any]) -> None:
         """Create a backend context.
@@ -41,6 +41,9 @@ class BackendContext:
         self.parsed_type: Final[ParsedType] = parsed_type
         self.field_definitions: Final[FieldDefinitionsType] = field_definitions
         self.model_type: Final[type[Any]] = model_type
+        self.reverse_name_map = {
+            f.serialization_name: f.name for f in field_definitions.values() if f.serialization_name
+        }
 
 
 class AbstractDTOBackend(ABC, Generic[BackendT]):

--- a/litestar/dto/factory/backends/msgspec/backend.py
+++ b/litestar/dto/factory/backends/msgspec/backend.py
@@ -37,15 +37,20 @@ class MsgspecDTOBackend(AbstractDTOBackend[Struct]):
 
     def populate_data_from_builtins(self, data: Any) -> Any:
         parsed_data = cast("Struct | Collection[Struct]", from_builtins(data, self.annotation))
-        return _build_data_from_struct(self.context.model_type, parsed_data, self.context.field_definitions)
+        return _build_data_from_struct(
+            self.context.model_type, parsed_data, self.context.field_definitions, self.context.reverse_name_map
+        )
 
     def populate_data_from_raw(self, raw: bytes, connection_context: ConnectionContext) -> T | Collection[T]:
         parsed_data = self.parse_raw(raw, connection_context)
-        return _build_data_from_struct(self.context.model_type, parsed_data, self.context.field_definitions)
+        return _build_data_from_struct(
+            self.context.model_type, parsed_data, self.context.field_definitions, self.context.reverse_name_map
+        )
 
     def encode_data(self, data: Any, connection_context: ConnectionContext) -> LitestarEncodableType:
         if isinstance(data, CollectionsCollection):
             return self.context.parsed_type.origin(  # type:ignore[no-any-return]
-                _build_struct_from_model(datum, self.data_container_type) for datum in data  # pyright:ignore
+                _build_struct_from_model(datum, self.data_container_type, self.context.reverse_name_map)
+                for datum in data  # pyright:ignore
             )
-        return _build_struct_from_model(data, self.data_container_type)
+        return _build_struct_from_model(data, self.data_container_type, self.context.reverse_name_map)

--- a/litestar/dto/factory/backends/msgspec/utils.py
+++ b/litestar/dto/factory/backends/msgspec/utils.py
@@ -45,24 +45,34 @@ def _create_struct_field_def(
 
 def _create_struct_for_field_definitions(model_name: str, field_definitions: FieldDefinitionsType) -> type[Struct]:
     struct_fields: list[tuple[str, type] | tuple[str, type, MsgspecField]] = []
-    for k, v in field_definitions.items():
+    for _k, v in field_definitions.items():
+        field_name = v.serialization_name or v.name
         if isinstance(v, NestedFieldDefinition):
-            nested_struct = _create_struct_for_field_definitions(f"{model_name}.{k}", v.nested_field_definitions)
+            nested_struct = _create_struct_for_field_definitions(
+                f"{model_name}.{field_name}", v.nested_field_definitions
+            )
             struct_fields.append(
-                _create_struct_field_def(k, v.make_field_type(nested_struct), _create_msgspec_field(v.field_definition))
+                _create_struct_field_def(
+                    field_name, v.make_field_type(nested_struct), _create_msgspec_field(v.field_definition)
+                )
             )
         else:
-            struct_fields.append(_create_struct_field_def(k, v.parsed_type.annotation, _create_msgspec_field(v)))
+            struct_fields.append(
+                _create_struct_field_def(field_name, v.parsed_type.annotation, _create_msgspec_field(v))
+            )
     return defstruct(model_name, struct_fields, frozen=True, kw_only=True)
 
 
-def _build_model_from_struct(model_type: type[T], data: Struct, field_definitions: FieldDefinitionsType) -> T:
+def _build_model_from_struct(
+    model_type: type[T], data: Struct, field_definitions: FieldDefinitionsType, reverse_name_map: dict[str, str]
+) -> T:
     """Create instance of ``model_type``.
 
     Args:
         model_type: the model type received by the DTO on type narrowing.
         data: primitive data that has been parsed and validated via the backend.
         field_definitions: model field definitions.
+        reverse_name_map: reverse name map for field definitions.
 
     Returns:
         Data parsed into ``model_type``.
@@ -70,26 +80,32 @@ def _build_model_from_struct(model_type: type[T], data: Struct, field_definition
     unstructured_data = {}
     for k in data.__slots__:  # type:ignore[attr-defined]
         v = getattr(data, k)
-
-        field = field_definitions[k]
+        field_name = reverse_name_map.get(k, k)
+        field = field_definitions[field_name]
 
         if isinstance(field, NestedFieldDefinition) and isinstance(v, CollectionsCollection):
             parsed_type = field.field_definition.parsed_type
             if parsed_type.origin is None:  # pragma: no cover
                 raise RuntimeError("Unexpected origin value for collection type.")
-            unstructured_data[k] = parsed_type.origin(
-                _build_model_from_struct(field.nested_type, item, field.nested_field_definitions) for item in v
+            unstructured_data[field_name] = parsed_type.origin(
+                _build_model_from_struct(field.nested_type, item, field.nested_field_definitions, reverse_name_map)
+                for item in v
             )
         elif isinstance(field, NestedFieldDefinition) and isinstance(v, Struct):
-            unstructured_data[k] = _build_model_from_struct(field.nested_type, v, field.nested_field_definitions)
+            unstructured_data[field_name] = _build_model_from_struct(
+                field.nested_type, v, field.nested_field_definitions, reverse_name_map
+            )
         else:
-            unstructured_data[k] = v
+            unstructured_data[field_name] = v
 
     return model_type(**unstructured_data)
 
 
 def _build_data_from_struct(
-    model_type: type[T], data: Struct | Collection[Struct], field_definitions: FieldDefinitionsType
+    model_type: type[T],
+    data: Struct | Collection[Struct],
+    field_definitions: FieldDefinitionsType,
+    reverse_name_map: dict[str, str],
 ) -> T | Collection[T]:
     """Create instance or iterable of instances of ``model_type``.
 
@@ -97,18 +113,20 @@ def _build_data_from_struct(
         model_type: the model type received by the DTO on type narrowing.
         data: primitive data that has been parsed and validated via the backend.
         field_definitions: model field definitions.
+        reverse_name_map: reverse name map for field definitions.
 
     Returns:
         Data parsed into ``model_type``.
     """
     if isinstance(data, CollectionsCollection):
         return type(data)(  # type:ignore[return-value]
-            _build_data_from_struct(model_type, item, field_definitions) for item in data  # type:ignore[call-arg]
+            _build_data_from_struct(model_type, item, field_definitions, reverse_name_map)  # type:ignore[call-arg]
+            for item in data
         )
-    return _build_model_from_struct(model_type, data, field_definitions)
+    return _build_model_from_struct(model_type, data, field_definitions, reverse_name_map)
 
 
-def _build_struct_from_model(model: Any, struct_type: type[StructT]) -> StructT:
+def _build_struct_from_model(model: Any, struct_type: type[StructT], reverse_name_map: dict[str, str]) -> StructT:
     """Convert ``model`` to instance of ``struct_type``
 
     It is expected that attributes of ``struct_type`` are a subset of the attributes of ``model``.
@@ -116,15 +134,17 @@ def _build_struct_from_model(model: Any, struct_type: type[StructT]) -> StructT:
     Args:
         model: a model instance
         struct_type: a subclass of ``msgspec.Struct``
+        reverse_name_map: reverse name map for field definitions.
 
     Returns:
         Instance of ``struct_type``.
     """
     data = {}
     for key, parsed_type in get_model_type_hints(struct_type).items():
-        model_val = getattr(model, key)
+        model_name = reverse_name_map.get(key, key)
+        model_val = getattr(model, model_name)
         if parsed_type.is_subclass_of(Struct):
-            data[key] = _build_struct_from_model(model_val, parsed_type.annotation)
+            data[key] = _build_struct_from_model(model_val, parsed_type.annotation, {})
         elif parsed_type.is_union:
             data[key] = _handle_union_type(parsed_type, model_val)
         elif parsed_type.is_collection:
@@ -152,7 +172,7 @@ def _handle_union_type(parsed_type: ParsedType, model_val: Any) -> Any:
             # for the nested model type instance. For the most likely case of an optional union of a single
             # nested type, this should be sufficient.
             try:
-                return _build_struct_from_model(model_val, inner_type.annotation)
+                return _build_struct_from_model(model_val, inner_type.annotation, {})
             except (AttributeError, TypeError):
                 continue
     return model_val
@@ -169,5 +189,5 @@ def _handle_collection_type(parsed_type: ParsedType, model_val: Any) -> Any:
         Model value.
     """
     if parsed_type.inner_types and (inner_type := parsed_type.inner_types[0]).is_subclass_of(Struct):
-        return parsed_type.origin(_build_struct_from_model(m, inner_type.annotation) for m in model_val)
+        return parsed_type.origin(_build_struct_from_model(m, inner_type.annotation, {}) for m in model_val)
     return model_val

--- a/litestar/dto/factory/config.py
+++ b/litestar/dto/factory/config.py
@@ -5,9 +5,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import AbstractSet, Sequence
-
-    from .types import FieldDefinition, FieldMappingType
+    from typing import AbstractSet
 
 
 __all__ = ("DTOConfig",)
@@ -19,11 +17,7 @@ class DTOConfig:
 
     exclude: AbstractSet[str] = field(default_factory=set)
     """Explicitly exclude fields from the generated DTO, incompatible with ``include``."""
-    include: AbstractSet[str] = field(default_factory=set)
-    """Explicitly include fields on the generated DTO, incompatible with ``exclude``."""
-    field_mapping: FieldMappingType = field(default_factory=dict)
-    """Mapping of field names, to new name, or tuple of new name, new type."""
-    field_definitions: Sequence[FieldDefinition] = field(default_factory=tuple)
-    """Additional fields for data transfer."""
+    rename_fields: dict[str, str] = field(default_factory=dict)
+    """Mapping of field names, to new name."""
     max_nested_depth: int = 1
     """The maximum depth of nested items allowed for data transfer."""

--- a/litestar/dto/factory/types.py
+++ b/litestar/dto/factory/types.py
@@ -17,12 +17,7 @@ if TYPE_CHECKING:
 
     from .field import DTOField
 
-__all__ = (
-    "FieldDefinition",
-    "FieldDefinitionsType",
-    "FieldMappingType",
-    "NestedFieldDefinition",
-)
+__all__ = ("FieldDefinition", "FieldDefinitionsType", "NestedFieldDefinition")
 
 
 @dataclass(frozen=True)
@@ -33,6 +28,7 @@ class FieldDefinition(ParsedParameter):
     """Default factory of the field."""
     dto_field: DTOField | None = field(default=None)
     """DTO field configuration."""
+    serialization_name: str | None = field(default=None)
 
     def copy_with(self, **kwargs: Any) -> FieldDefinition:
         """Copy the field definition with the given keyword arguments.
@@ -54,6 +50,16 @@ class NestedFieldDefinition:
     nested_type: Any
     nested_field_definitions: FieldDefinitionsType = field(default_factory=dict)
 
+    @property
+    def name(self) -> str:
+        """Name of the field."""
+        return self.field_definition.name
+
+    @property
+    def serialization_name(self) -> str | None:
+        """Serialization name of the field."""
+        return self.field_definition.serialization_name
+
     def make_field_type(self, inner_type: type) -> Any:
         if self.field_definition.parsed_type.is_collection:
             return self.field_definition.parsed_type.safe_generic_origin[inner_type]
@@ -64,6 +70,3 @@ class NestedFieldDefinition:
 
 FieldDefinitionsType: TypeAlias = "Mapping[str, FieldDefinition | NestedFieldDefinition]"
 """Generic representation of names and types."""
-
-FieldMappingType: TypeAlias = "Mapping[str, str | FieldDefinition]"
-"""Type of the field mappings configuration property."""

--- a/tests/contrib/sqlalchemy/test_dto.py
+++ b/tests/contrib/sqlalchemy/test_dto.py
@@ -144,7 +144,7 @@ async def test_write_dto_field_default(base: type[DeclarativeBase], connection_c
     class Model(base):
         field: Mapped[int] = mapped_column(default=3)
 
-    dto_type = SQLAlchemyDTO[Annotated[Model, DTOConfig(include={"field"})]]
+    dto_type = SQLAlchemyDTO[Annotated[Model, DTOConfig(exclude={"id", "created", "updated"})]]
     model = await get_model_from_dto(dto_type, Model, connection_context, b'{"a":"b"}')
     assert_model_values(model, {"field": 3})
 
@@ -157,7 +157,7 @@ async def test_write_dto_for_model_field_factory_default(
     class Model(base):
         field: Mapped[UUID] = mapped_column(default=lambda: val)
 
-    dto_type = SQLAlchemyDTO[Annotated[Model, DTOConfig(include={"field"})]]
+    dto_type = SQLAlchemyDTO[Annotated[Model, DTOConfig(exclude={"id", "created", "updated"})]]
     model = await get_model_from_dto(dto_type, Model, connection_context, b'{"a":"b"}')
     assert_model_values(model, {"field": val})
 

--- a/tests/dto/factory/backends/test_utils.py
+++ b/tests/dto/factory/backends/test_utils.py
@@ -41,5 +41,5 @@ class FooBarStruct(Struct):
 
 def test_build_struct_from_model_with_non_optional_nested_union() -> None:
     model = FooBarDC(baz=BarDC(bar="bar"))
-    struct = _build_struct_from_model(model, FooBarStruct)
+    struct = _build_struct_from_model(model, FooBarStruct, {})
     assert isinstance(struct.baz, BarStruct)


### PR DESCRIPTION
- removes `include` parameter: as yet not totally clear to me how this should interact with `exclude`, especially once dotted excludes are introduced.
- `field_mapping` becomes `rename_fields`. `field_mapping` was also able to remap field types, but I'd rather separate the two behaviors.
- `field_definitions` removed - this needs more thought, as extra fields cannot just be marshalled into a model that doesn't have them defined. I believe this functionality will be replaced with a `ComputedField` that will allow multiple field definitions to be added to the ser/de model, and a callable that transforms them into a value for a model field. See #1563.

Also this PR fixed a bug where renamed fields weren't handled by the msgspec backend.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
