### PR TITLE
Backport #1577 to v1.51

### DIFF
--- a/tests/plugins/piccolo_orm/endpoints.py
+++ b/tests/plugins/piccolo_orm/endpoints.py
@@ -5,7 +5,7 @@ from piccolo.testing import ModelBuilder
 from starlite import get, post
 from tests.plugins.piccolo_orm.tables import Concert, RecordingStudio, Venue
 
-studio = cast("RecordingStudio", ModelBuilder.build_sync(RecordingStudio, persist=False))
+studio = ModelBuilder.build_sync(RecordingStudio, persist=False)
 venues = cast("List[Venue]", [ModelBuilder.build_sync(Venue, persist=False) for _ in range(3)])
 
 

--- a/tests/static_files/test_file_serving_resolution.py
+++ b/tests/static_files/test_file_serving_resolution.py
@@ -17,8 +17,6 @@ if TYPE_CHECKING:
 
     from starlite.types import FileSystemProtocol
 
-mimetypes.encodings_map[".br"] = "br"
-
 
 def test_default_static_files_config(tmpdir: "Path") -> None:
     path = tmpdir / "test.txt"

--- a/tests/static_files/test_file_serving_resolution.py
+++ b/tests/static_files/test_file_serving_resolution.py
@@ -1,6 +1,8 @@
+import gzip
 import mimetypes
 from typing import TYPE_CHECKING
 
+import brotli
 import pytest
 from fsspec.implementations.local import LocalFileSystem
 
@@ -160,6 +162,25 @@ def test_static_files_response_mimetype(tmpdir: "Path", extension: str) -> None:
         assert expected_mime_type
         assert response.status_code == HTTP_200_OK
         assert response.headers["content-type"].startswith(expected_mime_type)
+
+
+@pytest.mark.parametrize("extension", ["gz", "br"])
+def test_static_files_response_encoding(tmp_path: "Path", extension: str) -> None:
+    fn = f"test.js.{extension}"
+    path = tmp_path / fn
+    if extension == "br":
+        compressed_data = brotli.compress(b"content")
+    elif extension == "gz":
+        compressed_data = gzip.compress(b"content")
+    path.write_bytes(compressed_data)  # pyright: ignore
+    static_files_config = StaticFilesConfig(path="/static", directories=[tmp_path])
+    expected_encoding_type = mimetypes.guess_type(fn)[1]
+
+    with create_test_client([], static_files_config=[static_files_config]) as client:
+        response = client.get(f"/static/{fn}")
+        assert expected_encoding_type
+        assert response.status_code == HTTP_200_OK
+        assert response.headers["content-encoding"].startswith(expected_encoding_type)
 
 
 @pytest.mark.parametrize("send_as_attachment,disposition", [(True, "attachment"), (False, "inline")])

--- a/tests/static_files/test_file_serving_resolution.py
+++ b/tests/static_files/test_file_serving_resolution.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
 
     from starlite.types import FileSystemProtocol
 
+mimetypes.encodings_map[".br"] = "br"
+
 
 def test_default_static_files_config(tmpdir: "Path") -> None:
     path = tmpdir / "test.txt"


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

Backport of #1577 for v1.51
> Fix content-encoding headers for gzip/brotli compressed files not being set

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

Closes #1576 
