### PR TITLE
DTO Factory nested field exclusion.

### DIFF
--- a/docs/examples/data_transfer_objects/factory/excluding_fields.py
+++ b/docs/examples/data_transfer_objects/factory/excluding_fields.py
@@ -1,6 +1,8 @@
 from datetime import datetime
+from uuid import UUID
 
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing_extensions import Annotated
 
 from litestar import Litestar, post
@@ -10,20 +12,30 @@ from litestar.dto.factory import DTOConfig, dto_field
 from .my_lib import Base
 
 
+class Address(Base):
+    street: Mapped[str]
+    city: Mapped[str]
+    state: Mapped[str]
+    zip: Mapped[str]
+
+
 class User(Base):
     name: Mapped[str]
     password: Mapped[str] = mapped_column(info=dto_field("private"))
     created_at: Mapped[datetime] = mapped_column(info=dto_field("read-only"))
+    address_id: Mapped[UUID] = mapped_column(ForeignKey("address.id"), info=dto_field("private"))
+    address: Mapped[Address] = relationship(info=dto_field("read-only"))
 
 
 UserDTO = SQLAlchemyDTO[User]
-config = DTOConfig(exclude={"id"})
+config = DTOConfig(exclude={"id", "address.id", "address.street"})
 ReadUserDTO = SQLAlchemyDTO[Annotated[User, config]]
 
 
 @post("/users", dto=UserDTO, return_dto=ReadUserDTO)
 def create_user(data: User) -> User:
     data.created_at = datetime.min
+    data.address = Address(street="123 Main St", city="Anytown", state="NY", zip="12345")
     return data
 
 

--- a/docs/usage/dto/1-dto-factory.rst
+++ b/docs/usage/dto/1-dto-factory.rst
@@ -55,14 +55,19 @@ fields are never serialized into return data.
 Excluding fields
 ----------------
 
-Fields can be explicitly excluded using :class:`DTOConfig <litestar.dto.factory.DTOConfig>`. The following example
-creates an explicit DTO for outbound data which excludes the ``id`` field from the serialized response.
+Fields can be explicitly excluded using :class:`DTOConfig <litestar.dto.factory.DTOConfig>`.
+
+The following example demonstrates excluding attributes from the serialized response, including excluding fields from
+nested models.
 
 .. literalinclude:: /examples/data_transfer_objects/factory/excluding_fields.py
     :caption: Excluding fields
     :language: python
-    :emphasize-lines: 4,7,20,21,23
+    :emphasize-lines: 6,10,31,32,35
     :linenos:
+
+Examining the output of the above POST request, we can see that the user's ID, the ID of the user's address field and
+the user's street address are excluded from the serialized response.
 
 Renaming fields
 ---------------

--- a/litestar/dto/factory/abc.py
+++ b/litestar/dto/factory/abc.py
@@ -17,10 +17,11 @@ from .types import FieldDefinition, FieldDefinitionsType, NestedFieldDefinition
 from .utils import RenameStrategies, parse_configs_from_annotation
 
 if TYPE_CHECKING:
-    from typing import Any, ClassVar, Collection, Generator
+    from typing import AbstractSet, Any, ClassVar, Collection, Generator
 
     from typing_extensions import Self
 
+    from litestar.dto.factory.types import RenameStrategy
     from litestar.dto.interface import HandlerContext
     from litestar.dto.types import ForType
     from litestar.openapi.spec import Reference, Schema
@@ -164,7 +165,15 @@ class AbstractDTOFactory(DTOInterface, Generic[DataT], metaclass=ABCMeta):
 
             backend_context = BackendContext(
                 handler_context.parsed_type,
-                _parse_model(cls, handler_type.annotation, cls.config, handler_context.dto_for),
+                _parse_model(
+                    dto_factory_type=cls,
+                    model_type=handler_type.annotation,
+                    dto_for=handler_context.dto_for,
+                    exclude=cls.config.exclude,
+                    rename_fields=cls.config.rename_fields,
+                    rename_strategy=cls.config.rename_strategy,
+                    max_nested_depth=cls.config.max_nested_depth,
+                ),
                 handler_type.annotation,
             )
             backend = cls._type_backend_map.setdefault(key, backend_type(backend_context))
@@ -190,8 +199,11 @@ class AbstractDTOFactory(DTOInterface, Generic[DataT], metaclass=ABCMeta):
 def _parse_model(
     dto_factory_type: type[AbstractDTOFactory],
     model_type: Any,
-    config: DTOConfig,
     dto_for: ForType,
+    exclude: AbstractSet[str],
+    rename_fields: dict[str, str],
+    rename_strategy: RenameStrategy | None,
+    max_nested_depth: int,
     nested_depth: int = 0,
 ) -> FieldDefinitionsType:
     """Reduce :attr:`model_type` to :class:`FieldDefinitionsType`.
@@ -220,31 +232,47 @@ def _parse_model(
     """
     defined_fields: dict[str, FieldDefinition | NestedFieldDefinition] = {}
     for field_definition in dto_factory_type.generate_field_definitions(model_type):
-        if _should_exclude_field(field_definition, config, dto_for):
+        if _should_exclude_field(field_definition, exclude, dto_for):
             continue
 
-        if rename := config.rename_fields.get(field_definition.name):
+        if rename := rename_fields.get(field_definition.name):
             field_definition = field_definition.copy_with(serialization_name=rename)  # noqa: PLW2901
-        elif config.rename_strategy:
-            alias = RenameStrategies(config.rename_strategy)(field_definition.name)
+        elif rename_strategy:
+            alias = RenameStrategies(rename_strategy)(field_definition.name)
             field_definition = field_definition.copy_with(serialization_name=alias)  # noqa: PLW2901
 
         if dto_factory_type.detect_nested_field(field_definition):
-            nested_field_definition = _handle_nested(dto_factory_type, field_definition, nested_depth, config, dto_for)
-            if nested_field_definition is not None:
-                defined_fields[field_definition.name] = nested_field_definition
-            continue
+            if nested_depth == max_nested_depth:
+                continue
 
-        defined_fields[field_definition.name] = field_definition
+            nested_exclude = {split[1] for s in exclude if (split := s.split(".", 1))[0] == field_definition.name}
+            nested_type = _get_model_type(field_definition.annotation)
+            nested = NestedFieldDefinition(
+                field_definition=field_definition,
+                nested_type=nested_type,
+                nested_field_definitions=_parse_model(
+                    dto_factory_type,
+                    nested_type,
+                    dto_for,
+                    nested_exclude,
+                    rename_fields,
+                    rename_strategy,
+                    max_nested_depth,
+                    nested_depth + 1,
+                ),
+            )
+            defined_fields[field_definition.name] = nested
+        else:
+            defined_fields[field_definition.name] = field_definition
     return defined_fields
 
 
-def _should_exclude_field(field_definition: FieldDefinition, config: DTOConfig, dto_for: ForType) -> bool:
+def _should_exclude_field(field_definition: FieldDefinition, exclude: AbstractSet[str], dto_for: ForType) -> bool:
     """Returns ``True`` where a field should be excluded from data transfer.
 
     Args:
         field_definition: defined DTO field
-        config: DTO configuration
+        exclude: names of fields to exclude
         dto_for: indicates whether the DTO is for the request body or response.
 
     Returns:
@@ -252,31 +280,10 @@ def _should_exclude_field(field_definition: FieldDefinition, config: DTOConfig, 
     """
     field_name = field_definition.name
     dto_field = field_definition.dto_field
-    excluded = field_name in config.exclude
+    excluded = field_name in exclude
     private = dto_field and dto_field.mark is Mark.PRIVATE
     read_only_for_write = dto_for == "data" and dto_field and dto_field.mark is Mark.READ_ONLY
     return bool(excluded or private or read_only_for_write)
-
-
-def _handle_nested(
-    dto_factory_type: type[AbstractDTOFactory],
-    field_definition: FieldDefinition,
-    nested_depth: int,
-    config: DTOConfig,
-    dto_for: ForType,
-) -> NestedFieldDefinition | None:
-    if nested_depth == config.max_nested_depth:
-        return None
-
-    nested = NestedFieldDefinition(
-        field_definition=field_definition,
-        nested_type=_get_model_type(field_definition.annotation),
-    )
-
-    nested.nested_field_definitions = _parse_model(
-        dto_factory_type, nested.nested_type, config, dto_for, nested_depth + 1
-    )
-    return nested
 
 
 def _get_model_type(annotation: type) -> Any:

--- a/litestar/dto/factory/config.py
+++ b/litestar/dto/factory/config.py
@@ -18,7 +18,11 @@ class DTOConfig:
     """Control the generated DTO."""
 
     exclude: AbstractSet[str] = field(default_factory=set)
-    """Explicitly exclude fields from the generated DTO."""
+    """Explicitly exclude fields from the generated DTO.
+
+    The field names are dot-separated paths to nested fields, e.g. ``"address.street"`` will exclude the ``"street"``
+    field from a nested ``"address"`` model.
+    """
     rename_fields: dict[str, str] = field(default_factory=dict)
     """Mapping of field names, to new name."""
     rename_strategy: RenameStrategy | None = None

--- a/litestar/dto/factory/types.py
+++ b/litestar/dto/factory/types.py
@@ -17,7 +17,12 @@ if TYPE_CHECKING:
 
     from .field import DTOField
 
-__all__ = ("FieldDefinition", "FieldDefinitionsType", "NestedFieldDefinition")
+__all__ = (
+    "FieldDefinition",
+    "FieldDefinitionsType",
+    "NestedFieldDefinition",
+    "RenameStrategy",
+)
 
 
 @dataclass(frozen=True)

--- a/tests/dto/factory/test_abc.py
+++ b/tests/dto/factory/test_abc.py
@@ -9,9 +9,11 @@ import pytest
 from typing_extensions import Annotated
 
 from litestar.dto.factory._backends import PydanticDTOBackend
+from litestar.dto.factory.abc import _parse_model
 from litestar.dto.factory.config import DTOConfig
 from litestar.dto.factory.exc import InvalidAnnotation
 from litestar.dto.factory.stdlib.dataclass import DataclassDTO
+from litestar.dto.factory.types import NestedFieldDefinition
 from litestar.dto.interface import ConnectionContext, HandlerContext
 from litestar.enums import RequestEncodingType
 from litestar.utils.signature import ParsedType
@@ -19,7 +21,8 @@ from litestar.utils.signature import ParsedType
 from . import Model
 
 if TYPE_CHECKING:
-    from typing import Any
+    from types import ModuleType
+    from typing import Any, Callable
 
     from pytest import MonkeyPatch
 
@@ -182,3 +185,48 @@ def test_create_openapi_schema(monkeypatch: MonkeyPatch) -> None:
     with patch("litestar.dto.factory._backends.abc.AbstractDTOBackend.create_openapi_schema") as mock:
         dto_type.create_openapi_schema("data", "handler", True, {})
         mock.assert_called_once_with(True, {})
+
+
+def test_parse_model_nested_exclude(create_module: Callable[[str], ModuleType]) -> None:
+    module = create_module(
+        """
+from dataclasses import dataclass
+from typing import List
+
+from litestar.dto.factory.stdlib.dataclass import DataclassDTO
+
+@dataclass
+class NestedNestedModel:
+    e: int
+    f: int
+
+@dataclass
+class NestedModel:
+    c: int
+    d: List[NestedNestedModel]
+
+@dataclass
+class Model:
+    a: int
+    b: NestedModel
+
+dto_type = DataclassDTO[Model]
+    """
+    )
+    parsed = _parse_model(
+        dto_factory_type=module.dto_type,
+        model_type=module.Model,
+        dto_for="data",
+        exclude={"a", "b.c", "b.d.e"},
+        rename_fields={},
+        rename_strategy=None,
+        max_nested_depth=2,
+    )
+    assert "a" not in parsed
+    assert "b" in parsed
+    assert isinstance(parsed["b"], NestedFieldDefinition)
+    assert "c" not in parsed["b"].nested_field_definitions
+    assert "d" in parsed["b"].nested_field_definitions
+    assert isinstance(parsed["b"].nested_field_definitions["d"], NestedFieldDefinition)
+    assert "e" not in parsed["b"].nested_field_definitions["d"].nested_field_definitions
+    assert "f" in parsed["b"].nested_field_definitions["d"].nested_field_definitions


### PR DESCRIPTION
This PR adds support for excluding nested model fields using dot-notation, e.g., `"a.b"` excludes field `b` from nested model field `a`.

Closes #1197

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [x] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [x] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
