### PR TITLE
Moves model parsing into `AbstractDTOBackend`.

### DIFF
--- a/litestar/dto/factory/_backends/abc.py
+++ b/litestar/dto/factory/_backends/abc.py
@@ -9,16 +9,21 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 from litestar._openapi.schema_generation import create_schema
 from litestar._signature.field import SignatureField
 
-from .utils import build_annotation_for_backend
+from .types import NestedFieldDefinition, TransferFieldDefinition
+from .utils import RenameStrategies, build_annotation_for_backend, get_model_type, should_exclude_field
 
 if TYPE_CHECKING:
-    from typing import Any, Final
+    from typing import AbstractSet, Any, Callable, Final, Generator
 
-    from litestar.dto.factory.types import FieldDefinitionsType
+    from litestar.dto.factory import DTOConfig
+    from litestar.dto.factory.types import FieldDefinition
     from litestar.dto.interface import ConnectionContext
+    from litestar.dto.types import ForType
     from litestar.openapi.spec import Reference, Schema
     from litestar.types.serialization import LitestarEncodableType
     from litestar.utils.signature import ParsedType
+
+    from .types import FieldDefinitionsType
 
 __all__ = ("AbstractDTOBackend", "BackendContext")
 
@@ -28,29 +33,52 @@ BackendT = TypeVar("BackendT")
 class BackendContext:
     """Context required by DTO backends to perform their work."""
 
-    __slots__ = ("parsed_type", "field_definitions", "model_type", "reverse_name_map")
+    __slots__ = (
+        "config",
+        "dto_for",
+        "field_definition_generator",
+        "model_type",
+        "nested_field_detector",
+        "parsed_type",
+    )
 
-    def __init__(self, parsed_type: ParsedType, field_definitions: FieldDefinitionsType, model_type: type[Any]) -> None:
+    def __init__(
+        self,
+        dto_config: DTOConfig,
+        dto_for: ForType,
+        parsed_type: ParsedType,
+        field_definition_generator: Callable[[Any], Generator[FieldDefinition, None, None]],
+        nested_field_detector: Callable[[FieldDefinition], bool],
+        model_type: type[Any],
+    ) -> None:
         """Create a backend context.
 
         Args:
+            dto_config: DTO config.
+            dto_for: "data" or "return"
             parsed_type: Parsed type.
-            field_definitions: Field definitions.
+            field_definition_generator: Generator that produces
+                :class:`FieldDefinition <.dto.factory.types.FieldDefinition>` instances given ``model_type``.
+            nested_field_detector: Function that detects if a field is nested.
             model_type: Model type.
         """
+        self.config: Final[DTOConfig] = dto_config
+        self.dto_for: Final[ForType] = dto_for
         self.parsed_type: Final[ParsedType] = parsed_type
-        self.field_definitions: Final[FieldDefinitionsType] = field_definitions
+        self.field_definition_generator: Final[
+            Callable[[Any], Generator[FieldDefinition, None, None]]
+        ] = field_definition_generator
+        self.nested_field_detector: Final[Callable[[FieldDefinition], bool]] = nested_field_detector
         self.model_type: Final[type[Any]] = model_type
-        self.reverse_name_map = {
-            f.serialization_name: f.name for f in field_definitions.values() if f.serialization_name
-        }
 
 
 class AbstractDTOBackend(ABC, Generic[BackendT]):
     __slots__ = (
-        "data_container_type",
         "annotation",
         "context",
+        "data_container_type",
+        "parsed_field_definitions",
+        "reverse_name_map",
     )
 
     def __init__(self, context: BackendContext) -> None:
@@ -60,8 +88,78 @@ class AbstractDTOBackend(ABC, Generic[BackendT]):
             context: context of the type represented by this backend.
         """
         self.context = context
+        self.parsed_field_definitions = self.parse_model(context.model_type, context.config.exclude)
+        self.reverse_name_map = {
+            f.serialization_name: f.name for f in self.parsed_field_definitions.values() if f.serialization_name
+        }
         self.data_container_type = self.create_data_container_type(context)
         self.annotation = build_annotation_for_backend(context.parsed_type.annotation, self.data_container_type)
+
+    def parse_model(
+        self,
+        model_type: Any,
+        exclude: AbstractSet[str],
+        nested_depth: int = 0,
+    ) -> FieldDefinitionsType:
+        """Reduce :attr:`model_type` to :class:`FieldDefinitionsType`.
+
+        .. important::
+            Implementations must respect the :attr:`config` object. For example:
+                - fields marked private must never be included in the field definitions.
+                - if a ``purpose`` is declared, then read-only fields must be taken into account.
+                - field renaming must be implemented.
+                - additional fields must be included, subject to ``purpose``.
+                - nested depth and nested recursion depth must be adhered to.
+
+        Returns:
+            Fields for data transfer.
+
+            Key is the name of the new field, and value is a tuple of type and default value pairs.
+
+            Add a new field called "new_field", that is a string, and required:
+            {"new_field": (str, ...)}
+
+            Add a new field called "new_field", that is a string, and not-required:
+            {"new_field": (str, "default")}
+
+            Add a new field called "new_field", that may be `None`:
+            {"new_field": (str | None, None)}
+        """
+        defined_fields: dict[str, TransferFieldDefinition | NestedFieldDefinition] = {}
+        for field_definition in self.context.field_definition_generator(model_type):
+            if should_exclude_field(field_definition, exclude, self.context.dto_for):
+                continue
+
+            if rename := self.context.config.rename_fields.get(field_definition.name):
+                serialization_name = rename
+            elif self.context.config.rename_strategy:
+                serialization_name = RenameStrategies(self.context.config.rename_strategy)(field_definition.name)
+            else:
+                serialization_name = field_definition.name
+
+            transfer_field_definition = TransferFieldDefinition(
+                name=field_definition.name,
+                default=field_definition.default,
+                parsed_type=field_definition.parsed_type,
+                default_factory=field_definition.default_factory,
+                serialization_name=serialization_name,
+            )
+
+            if self.context.nested_field_detector(transfer_field_definition):
+                if nested_depth == self.context.config.max_nested_depth:
+                    continue
+
+                nested_exclude = {split[1] for s in exclude if (split := s.split(".", 1))[0] == field_definition.name}
+                nested_type = get_model_type(transfer_field_definition.annotation)
+                nested = NestedFieldDefinition(
+                    field_definition=transfer_field_definition,
+                    nested_type=nested_type,
+                    nested_field_definitions=self.parse_model(nested_type, nested_exclude, nested_depth + 1),
+                )
+                defined_fields[transfer_field_definition.name] = nested
+            else:
+                defined_fields[transfer_field_definition.name] = transfer_field_definition
+        return defined_fields
 
     @abstractmethod
     def create_data_container_type(self, context: BackendContext) -> type[BackendT]:

--- a/litestar/dto/factory/_backends/msgspec/backend.py
+++ b/litestar/dto/factory/_backends/msgspec/backend.py
@@ -28,7 +28,7 @@ class MsgspecDTOBackend(AbstractDTOBackend[Struct]):
     __slots__ = ()
 
     def create_data_container_type(self, context: BackendContext) -> type[Struct]:
-        return _create_struct_for_field_definitions(str(uuid4()), context.field_definitions)
+        return _create_struct_for_field_definitions(str(uuid4()), self.parsed_field_definitions)
 
     def parse_raw(self, raw: bytes, connection_context: ConnectionContext) -> Struct | Collection[Struct]:
         return decode_media_type(  # type:ignore[no-any-return]
@@ -38,19 +38,19 @@ class MsgspecDTOBackend(AbstractDTOBackend[Struct]):
     def populate_data_from_builtins(self, data: Any) -> Any:
         parsed_data = cast("Struct | Collection[Struct]", from_builtins(data, self.annotation))
         return _build_data_from_struct(
-            self.context.model_type, parsed_data, self.context.field_definitions, self.context.reverse_name_map
+            self.context.model_type, parsed_data, self.parsed_field_definitions, self.reverse_name_map
         )
 
     def populate_data_from_raw(self, raw: bytes, connection_context: ConnectionContext) -> T | Collection[T]:
         parsed_data = self.parse_raw(raw, connection_context)
         return _build_data_from_struct(
-            self.context.model_type, parsed_data, self.context.field_definitions, self.context.reverse_name_map
+            self.context.model_type, parsed_data, self.parsed_field_definitions, self.reverse_name_map
         )
 
     def encode_data(self, data: Any, connection_context: ConnectionContext) -> LitestarEncodableType:
         if isinstance(data, CollectionsCollection):
             return self.context.parsed_type.origin(  # type:ignore[no-any-return]
-                _build_struct_from_model(datum, self.data_container_type, self.context.reverse_name_map)
+                _build_struct_from_model(datum, self.data_container_type, self.reverse_name_map)
                 for datum in data  # pyright:ignore
             )
-        return _build_struct_from_model(data, self.data_container_type, self.context.reverse_name_map)
+        return _build_struct_from_model(data, self.data_container_type, self.reverse_name_map)

--- a/litestar/dto/factory/_backends/msgspec/utils.py
+++ b/litestar/dto/factory/_backends/msgspec/utils.py
@@ -5,14 +5,14 @@ from typing import TYPE_CHECKING, NewType, TypeVar
 
 from msgspec import Struct, defstruct, field
 
-from litestar.dto.factory.types import NestedFieldDefinition
+from litestar.dto.factory._backends.types import FieldDefinitionsType, NestedFieldDefinition
 from litestar.dto.factory.utils import get_model_type_hints
 from litestar.types import Empty
 
 if TYPE_CHECKING:
     from typing import Any, Collection
 
-    from litestar.dto.factory.types import FieldDefinition, FieldDefinitionsType
+    from litestar.dto.factory.types import FieldDefinition
     from litestar.utils.signature import ParsedType
 
 

--- a/litestar/dto/factory/_backends/pydantic/backend.py
+++ b/litestar/dto/factory/_backends/pydantic/backend.py
@@ -27,7 +27,7 @@ class PydanticDTOBackend(AbstractDTOBackend[BaseModel]):
     __slots__ = ()
 
     def create_data_container_type(self, context: BackendContext) -> type[BaseModel]:
-        return _create_model_for_field_definitions(str(uuid4()), context.field_definitions)
+        return _create_model_for_field_definitions(str(uuid4()), self.parsed_field_definitions)
 
     def parse_raw(self, raw: bytes, connection_context: ConnectionContext) -> BaseModel | Collection[BaseModel]:
         return decode_media_type(  # type:ignore[no-any-return]
@@ -36,11 +36,11 @@ class PydanticDTOBackend(AbstractDTOBackend[BaseModel]):
 
     def populate_data_from_builtins(self, data: Any) -> T | Collection[T]:
         parsed_data = cast("BaseModel | Collection[BaseModel]", parse_obj_as(self.annotation, data))
-        return _build_data_from_pydantic_model(self.context.model_type, parsed_data, self.context.field_definitions)
+        return _build_data_from_pydantic_model(self.context.model_type, parsed_data, self.parsed_field_definitions)
 
     def populate_data_from_raw(self, raw: bytes, connection_context: ConnectionContext) -> T | Collection[T]:
         parsed_data = self.parse_raw(raw, connection_context)
-        return _build_data_from_pydantic_model(self.context.model_type, parsed_data, self.context.field_definitions)
+        return _build_data_from_pydantic_model(self.context.model_type, parsed_data, self.parsed_field_definitions)
 
     def encode_data(self, data: Any, connection_context: ConnectionContext) -> LitestarEncodableType:
         if isinstance(data, CollectionsCollection):

--- a/litestar/dto/factory/_backends/pydantic/utils.py
+++ b/litestar/dto/factory/_backends/pydantic/utils.py
@@ -6,13 +6,13 @@ from typing import TYPE_CHECKING, TypeVar
 from pydantic import BaseModel, create_model
 from pydantic.fields import FieldInfo
 
-from litestar.dto.factory.types import NestedFieldDefinition
+from litestar.dto.factory._backends.types import FieldDefinitionsType, NestedFieldDefinition
 from litestar.types import Empty
 
 if TYPE_CHECKING:
     from typing import Any, Collection
 
-    from litestar.dto.factory.types import FieldDefinition, FieldDefinitionsType
+    from litestar.dto.factory.types import FieldDefinition
 
 __all__ = ("_create_model_for_field_definitions", "_build_data_from_pydantic_model")
 

--- a/litestar/dto/factory/_backends/types.py
+++ b/litestar/dto/factory/_backends/types.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from litestar.dto.factory.types import FieldDefinition
+
+if TYPE_CHECKING:
+    from typing import Any, Mapping
+
+    from typing_extensions import TypeAlias
+
+
+@dataclass(frozen=True)
+class TransferFieldDefinition(FieldDefinition):
+    serialization_name: str | None = field(default=None)
+    """Name of the field as it should feature on the transfer model."""
+
+
+@dataclass
+class NestedFieldDefinition:
+    """For representing nested model."""
+
+    field_definition: TransferFieldDefinition
+    nested_type: Any
+    nested_field_definitions: FieldDefinitionsType = field(default_factory=dict)
+
+    @property
+    def name(self) -> str:
+        """Name of the field."""
+        return self.field_definition.name
+
+    @property
+    def serialization_name(self) -> str | None:
+        """Serialization name of the field."""
+        return self.field_definition.serialization_name
+
+    def make_field_type(self, inner_type: type) -> Any:
+        if self.field_definition.parsed_type.is_collection:
+            return self.field_definition.parsed_type.safe_generic_origin[inner_type]
+        if self.field_definition.parsed_type.is_optional:
+            return self.field_definition.parsed_type.safe_generic_origin[inner_type, None]
+        return inner_type
+
+
+FieldDefinitionsType: TypeAlias = "Mapping[str, TransferFieldDefinition | NestedFieldDefinition]"
+"""Generic representation of names and types."""

--- a/litestar/dto/factory/_backends/utils.py
+++ b/litestar/dto/factory/_backends/utils.py
@@ -1,13 +1,25 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, TypeVar, cast
 
 from typing_extensions import get_origin
 
-if TYPE_CHECKING:
-    from typing import Any, Iterable
+from litestar.dto.factory import Mark
+from litestar.types.builtin_types import NoneType
+from litestar.utils.signature import ParsedType
 
-__all__ = ("build_annotation_for_backend",)
+if TYPE_CHECKING:
+    from typing import AbstractSet, Any, Iterable
+
+    from litestar.dto.factory.types import FieldDefinition, RenameStrategy
+    from litestar.dto.types import ForType
+
+__all__ = (
+    "RenameStrategies",
+    "build_annotation_for_backend",
+    "get_model_type",
+    "should_exclude_field",
+)
 
 T = TypeVar("T")
 
@@ -29,3 +41,85 @@ def build_annotation_for_backend(annotation: Any, model: type[T]) -> type[T] | t
         return origin[model]  # type:ignore[no-any-return]
     except TypeError:  # pragma: no cover
         return annotation.copy_with((model,))  # type:ignore[no-any-return]
+
+
+def should_exclude_field(field_definition: FieldDefinition, exclude: AbstractSet[str], dto_for: ForType) -> bool:
+    """Returns ``True`` where a field should be excluded from data transfer.
+
+    Args:
+        field_definition: defined DTO field
+        exclude: names of fields to exclude
+        dto_for: indicates whether the DTO is for the request body or response.
+
+    Returns:
+        ``True`` if the field should not be included in any data transfer.
+    """
+    field_name = field_definition.name
+    dto_field = field_definition.dto_field
+    excluded = field_name in exclude
+    private = dto_field and dto_field.mark is Mark.PRIVATE
+    read_only_for_write = dto_for == "data" and dto_field and dto_field.mark is Mark.READ_ONLY
+    return bool(excluded or private or read_only_for_write)
+
+
+def get_model_type(annotation: type) -> Any:
+    """Get model type represented by the DTO.
+
+    If ``annotation`` is a collection, then the inner type is returned.
+
+    Args:
+        annotation: any type.
+
+    Returns:
+        The model type that is represented by the DTO.
+    """
+    parsed_type = ParsedType(annotation)
+    if parsed_type.is_collection:
+        return parsed_type.inner_types[0].annotation
+    if parsed_type.is_optional:
+        return next(t for t in parsed_type.inner_types if t.annotation is not NoneType).annotation
+    return parsed_type.annotation
+
+
+class RenameStrategies:
+    """Useful renaming strategies than be used with :class:`DTOConfig`"""
+
+    def __init__(self, renaming_strategy: RenameStrategy) -> None:
+        self.renaming_strategy = renaming_strategy
+
+    def __call__(self, field_name: str) -> str:
+        if not isinstance(self.renaming_strategy, str):
+            return self.renaming_strategy(field_name)
+
+        return cast(str, getattr(self, self.renaming_strategy)(field_name))
+
+    @staticmethod
+    def upper(field_name: str) -> str:
+        return field_name.upper()
+
+    @staticmethod
+    def lower(field_name: str) -> str:
+        return field_name.lower()
+
+    @staticmethod
+    def camel(field_name: str) -> str:
+        return RenameStrategies._camelize(field_name)
+
+    @staticmethod
+    def pascal(field_name: str) -> str:
+        return RenameStrategies._camelize(field_name, capitalize_first_letter=True)
+
+    @staticmethod
+    def _camelize(string: str, capitalize_first_letter: bool = False) -> str:
+        """Convert a string to camel case.
+
+        Args:
+            string (str): The string to convert
+            capitalize_first_letter (bool): Default is False, a True value will convert to PascalCase
+        Returns:
+            str: The string converted to camel case or Pascal case
+        """
+        return "".join(
+            word if index == 0 and not capitalize_first_letter else word.capitalize()
+            for index, word in enumerate(string.split("_"))
+        )

--- a/litestar/dto/factory/abc.py
+++ b/litestar/dto/factory/abc.py
@@ -5,29 +5,26 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 
 from litestar.dto.interface import ConnectionContext, DTOInterface
 from litestar.enums import RequestEncodingType
-from litestar.types.builtin_types import NoneType
 from litestar.utils.signature import ParsedType
 
 from ._backends import MsgspecDTOBackend, PydanticDTOBackend
 from ._backends.abc import BackendContext
 from .config import DTOConfig
 from .exc import InvalidAnnotation
-from .field import Mark
-from .types import FieldDefinition, FieldDefinitionsType, NestedFieldDefinition
-from .utils import RenameStrategies, parse_configs_from_annotation
+from .utils import parse_configs_from_annotation
 
 if TYPE_CHECKING:
-    from typing import AbstractSet, Any, ClassVar, Collection, Generator
+    from typing import Any, ClassVar, Collection, Generator
 
     from typing_extensions import Self
 
-    from litestar.dto.factory.types import RenameStrategy
     from litestar.dto.interface import HandlerContext
     from litestar.dto.types import ForType
     from litestar.openapi.spec import Reference, Schema
     from litestar.types.serialization import LitestarEncodableType
 
     from ._backends import AbstractDTOBackend
+    from .types import FieldDefinition
 
 __all__ = ["AbstractDTOFactory"]
 
@@ -44,7 +41,6 @@ class AbstractDTOFactory(DTOInterface, Generic[DataT], metaclass=ABCMeta):
     model_type: ClassVar[type[Any]]
     """If ``annotation`` is an iterable, this is the inner type, otherwise will be the same as ``annotation``."""
 
-    _reverse_field_mappings: ClassVar[dict[str, FieldDefinition]]
     _type_backend_map: ClassVar[dict[tuple[ForType, ParsedType, RequestEncodingType | str | None], AbstractDTOBackend]]
     _handler_backend_map: ClassVar[dict[tuple[ForType, str], AbstractDTOBackend]]
 
@@ -85,12 +81,7 @@ class AbstractDTOFactory(DTOInterface, Generic[DataT], metaclass=ABCMeta):
             # otherwise, create a new config
             config = DTOConfig()
 
-        cls_dict: dict[str, Any] = {
-            "config": config,
-            "_reverse_field_mappings": {},
-            "_type_backend_map": {},
-            "_handler_backend_map": {},
-        }
+        cls_dict: dict[str, Any] = {"config": config, "_type_backend_map": {}, "_handler_backend_map": {}}
         if not parsed_type.is_type_var:
             cls_dict.update(model_type=parsed_type.annotation)
 
@@ -98,16 +89,16 @@ class AbstractDTOFactory(DTOInterface, Generic[DataT], metaclass=ABCMeta):
 
     def builtins_to_data_type(self, builtins: Any) -> Any:
         """Coerce the unstructured data into the data type."""
-        backend = self._handler_backend_map[("data", self.connection_context.handler_id)]
+        backend = self._get_backend("data", self.connection_context.handler_id)
         return backend.populate_data_from_builtins(builtins)
 
     def bytes_to_data_type(self, raw: bytes) -> Any:
         """Return the data held by the DTO."""
-        backend = self._handler_backend_map[("data", self.connection_context.handler_id)]
+        backend = self._get_backend("data", self.connection_context.handler_id)
         return backend.populate_data_from_raw(raw, self.connection_context)
 
     def data_to_encodable_type(self, data: DataT | Collection[DataT]) -> LitestarEncodableType:
-        backend = self._handler_backend_map[("return", self.connection_context.handler_id)]
+        backend = self._get_backend("return", self.connection_context.handler_id)
         return backend.encode_data(data, self.connection_context)
 
     @classmethod
@@ -164,16 +155,11 @@ class AbstractDTOFactory(DTOInterface, Generic[DataT], metaclass=ABCMeta):
                 backend_type = MsgspecDTOBackend
 
             backend_context = BackendContext(
+                cls.config,
+                handler_context.dto_for,
                 handler_context.parsed_type,
-                _parse_model(
-                    dto_factory_type=cls,
-                    model_type=handler_type.annotation,
-                    dto_for=handler_context.dto_for,
-                    exclude=cls.config.exclude,
-                    rename_fields=cls.config.rename_fields,
-                    rename_strategy=cls.config.rename_strategy,
-                    max_nested_depth=cls.config.max_nested_depth,
-                ),
+                cls.generate_field_definitions,
+                cls.detect_nested_field,
                 handler_type.annotation,
             )
             backend = cls._type_backend_map.setdefault(key, backend_type(backend_context))
@@ -192,114 +178,10 @@ class AbstractDTOFactory(DTOInterface, Generic[DataT], metaclass=ABCMeta):
         Returns:
             OpenAPI request body.
         """
-        backend = cls._handler_backend_map[(dto_for, handler_id)]
+        backend = cls._get_backend(dto_for, handler_id)
         return backend.create_openapi_schema(generate_examples, schemas)
 
-
-def _parse_model(
-    dto_factory_type: type[AbstractDTOFactory],
-    model_type: Any,
-    dto_for: ForType,
-    exclude: AbstractSet[str],
-    rename_fields: dict[str, str],
-    rename_strategy: RenameStrategy | None,
-    max_nested_depth: int,
-    nested_depth: int = 0,
-) -> FieldDefinitionsType:
-    """Reduce :attr:`model_type` to :class:`FieldDefinitionsType`.
-
-    .. important::
-        Implementations must respect the :attr:`config` object. For example:
-            - fields marked private must never be included in the field definitions.
-            - if a ``purpose`` is declared, then read-only fields must be taken into account.
-            - field mappings must be implemented.
-            - additional fields must be included, subject to ``purpose``.
-            - nested depth and nested recursion depth must be adhered to.
-
-    Returns:
-        Fields for data transfer.
-
-        Key is the name of the new field, and value is a tuple of type and default value pairs.
-
-        Add a new field called "new_field", that is a string, and required:
-        {"new_field": (str, ...)}
-
-        Add a new field called "new_field", that is a string, and not-required:
-        {"new_field": (str, "default")}
-
-        Add a new field called "new_field", that may be `None`:
-        {"new_field": (str | None, None)}
-    """
-    defined_fields: dict[str, FieldDefinition | NestedFieldDefinition] = {}
-    for field_definition in dto_factory_type.generate_field_definitions(model_type):
-        if _should_exclude_field(field_definition, exclude, dto_for):
-            continue
-
-        if rename := rename_fields.get(field_definition.name):
-            field_definition = field_definition.copy_with(serialization_name=rename)  # noqa: PLW2901
-        elif rename_strategy:
-            alias = RenameStrategies(rename_strategy)(field_definition.name)
-            field_definition = field_definition.copy_with(serialization_name=alias)  # noqa: PLW2901
-
-        if dto_factory_type.detect_nested_field(field_definition):
-            if nested_depth == max_nested_depth:
-                continue
-
-            nested_exclude = {split[1] for s in exclude if (split := s.split(".", 1))[0] == field_definition.name}
-            nested_type = _get_model_type(field_definition.annotation)
-            nested = NestedFieldDefinition(
-                field_definition=field_definition,
-                nested_type=nested_type,
-                nested_field_definitions=_parse_model(
-                    dto_factory_type,
-                    nested_type,
-                    dto_for,
-                    nested_exclude,
-                    rename_fields,
-                    rename_strategy,
-                    max_nested_depth,
-                    nested_depth + 1,
-                ),
-            )
-            defined_fields[field_definition.name] = nested
-        else:
-            defined_fields[field_definition.name] = field_definition
-    return defined_fields
-
-
-def _should_exclude_field(field_definition: FieldDefinition, exclude: AbstractSet[str], dto_for: ForType) -> bool:
-    """Returns ``True`` where a field should be excluded from data transfer.
-
-    Args:
-        field_definition: defined DTO field
-        exclude: names of fields to exclude
-        dto_for: indicates whether the DTO is for the request body or response.
-
-    Returns:
-        ``True`` if the field should not be included in any data transfer.
-    """
-    field_name = field_definition.name
-    dto_field = field_definition.dto_field
-    excluded = field_name in exclude
-    private = dto_field and dto_field.mark is Mark.PRIVATE
-    read_only_for_write = dto_for == "data" and dto_field and dto_field.mark is Mark.READ_ONLY
-    return bool(excluded or private or read_only_for_write)
-
-
-def _get_model_type(annotation: type) -> Any:
-    """Get model type represented by the DTO.
-
-    If ``annotation`` is a collection, then the inner type is returned.
-
-    Args:
-        annotation: any type.
-
-    Returns:
-        The model type that is represented by the DTO.
-    """
-    parsed_type = ParsedType(annotation)
-    if parsed_type.is_collection:
-        return parsed_type.inner_types[0].annotation
-    if parsed_type.is_optional:
-        return next(t for t in parsed_type.inner_types if t.annotation is not NoneType).annotation
-    return parsed_type.annotation
+    @classmethod
+    def _get_backend(cls, dto_for: ForType, handler_id: str) -> AbstractDTOBackend:
+        """Return the backend for the handler/dto_for combo."""
+        return cls._handler_backend_map[(dto_for, handler_id)]

--- a/litestar/dto/factory/types.py
+++ b/litestar/dto/factory/types.py
@@ -4,11 +4,9 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable, Literal
 
 from litestar.types.empty import Empty
-from litestar.utils.dataclass import simple_asdict
 from litestar.utils.signature import ParsedParameter
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
     from typing import Any
 
     from typing_extensions import TypeAlias
@@ -17,12 +15,7 @@ if TYPE_CHECKING:
 
     from .field import DTOField
 
-__all__ = (
-    "FieldDefinition",
-    "FieldDefinitionsType",
-    "NestedFieldDefinition",
-    "RenameStrategy",
-)
+__all__ = ("FieldDefinition", "RenameStrategy")
 
 
 @dataclass(frozen=True)
@@ -33,48 +26,7 @@ class FieldDefinition(ParsedParameter):
     """Default factory of the field."""
     dto_field: DTOField | None = field(default=None)
     """DTO field configuration."""
-    serialization_name: str | None = field(default=None)
 
-    def copy_with(self, **kwargs: Any) -> FieldDefinition:
-        """Copy the field definition with the given keyword arguments.
-
-        Args:
-            **kwargs: Keyword arguments to update the field definition with.
-
-        Returns:
-            Updated field definition.
-        """
-        return FieldDefinition(**{**simple_asdict(self, convert_nested=False), **kwargs})
-
-
-@dataclass
-class NestedFieldDefinition:
-    """For representing nested model."""
-
-    field_definition: FieldDefinition
-    nested_type: Any
-    nested_field_definitions: FieldDefinitionsType = field(default_factory=dict)
-
-    @property
-    def name(self) -> str:
-        """Name of the field."""
-        return self.field_definition.name
-
-    @property
-    def serialization_name(self) -> str | None:
-        """Serialization name of the field."""
-        return self.field_definition.serialization_name
-
-    def make_field_type(self, inner_type: type) -> Any:
-        if self.field_definition.parsed_type.is_collection:
-            return self.field_definition.parsed_type.safe_generic_origin[inner_type]
-        if self.field_definition.parsed_type.is_optional:
-            return self.field_definition.parsed_type.safe_generic_origin[inner_type, None]
-        return inner_type
-
-
-FieldDefinitionsType: TypeAlias = "Mapping[str, FieldDefinition | NestedFieldDefinition]"
-"""Generic representation of names and types."""
 
 RenameStrategy: TypeAlias = 'Literal["lower", "upper", "camel", "pascal"] | Callable[[str], str]'
 """A pre-defined strategy or a custom callback for converting DTO field names."""

--- a/litestar/dto/factory/utils.py
+++ b/litestar/dto/factory/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing
 from inspect import getmodule
-from typing import TYPE_CHECKING, TypeVar, cast
+from typing import TYPE_CHECKING, TypeVar
 
 from msgspec import Struct
 from typing_extensions import get_type_hints
@@ -14,12 +14,9 @@ from .config import DTOConfig
 if TYPE_CHECKING:
     from typing import Any
 
-    from .types import RenameStrategy
-
 __all__ = (
     "get_model_type_hints",
     "parse_configs_from_annotation",
-    "RenameStrategies",
 )
 
 T = TypeVar("T")
@@ -54,47 +51,3 @@ def parse_configs_from_annotation(parsed_type: ParsedType) -> tuple[DTOConfig, .
         The type and config object extracted from the annotation.
     """
     return tuple(item for item in parsed_type.metadata if isinstance(item, DTOConfig))
-
-
-class RenameStrategies:
-    """Useful renaming strategies than be used with :class:`DTOConfig`"""
-
-    def __init__(self, renaming_strategy: RenameStrategy) -> None:
-        self.renaming_strategy = renaming_strategy
-
-    def __call__(self, field_name: str) -> str:
-        if not isinstance(self.renaming_strategy, str):
-            return self.renaming_strategy(field_name)
-
-        return cast(str, getattr(self, self.renaming_strategy)(field_name))
-
-    @staticmethod
-    def upper(field_name: str) -> str:
-        return field_name.upper()
-
-    @staticmethod
-    def lower(field_name: str) -> str:
-        return field_name.lower()
-
-    @staticmethod
-    def camel(field_name: str) -> str:
-        return RenameStrategies._camelize(field_name)
-
-    @staticmethod
-    def pascal(field_name: str) -> str:
-        return RenameStrategies._camelize(field_name, capitalize_first_letter=True)
-
-    @staticmethod
-    def _camelize(string: str, capitalize_first_letter: bool = False) -> str:
-        """Convert a string to camel case.
-
-        Args:
-            string (str): The string to convert
-            capitalize_first_letter (bool): Default is False, a True value will convert to PascalCase
-        Returns:
-            str: The string converted to camel case or Pascal case
-        """
-        return "".join(
-            word if index == 0 and not capitalize_first_letter else word.capitalize()
-            for index, word in enumerate(string.split("_"))
-        )


### PR DESCRIPTION
This PR moves the bulk of the logic for parsing a model type from `AbstractDTOFactory` to `AbstractDTOBackend`. This is purely a refactor - no functionality change - just moves functions (that were private anyway) to within the `_backend` module.

The immediate motivation for this is to move the implementation of `renaming_strategy` from the frontend to the backend. Our configuration for this closely mirrors that of msgspec, and so by making the field parsing part of the backend, this will allow us to defer field renaming to msgspec, or use our own implementation of the renaming strategy for other backend types.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
