### PR TITLE
Fix the typing for `url_for` kwargs unpack

### DIFF
--- a/litestar/connection/base.py
+++ b/litestar/connection/base.py
@@ -287,7 +287,7 @@ class ASGIConnection(Generic[HandlerT, UserT, AuthT, StateT]):
         """
         self.scope["session"] = Empty
 
-    def url_for(self, name: str, **path_parameters: dict[str, Any]) -> str:
+    def url_for(self, name: str, **path_parameters: Any) -> str:
         """Return the url for a given route handler name.
 
         Args:


### PR DESCRIPTION
The `url_for` function types its kwargs unpack using the container type of `dict[str, Any]`. This should just use `Any`.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [N/A] New code has 100% test coverage
- [N/A] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [N/A] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

Lint fails this function call when using keyword args:
![dict_str_any](https://user-images.githubusercontent.com/162092/235835620-d9660a8d-e1c9-465b-8f6f-22c58ca68c1a.png)


### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
