### PR TITLE
Enhancement: Managing a socket's lifespan using a context manager in websocket listeners

### DIFF
--- a/litestar/handlers/websocket_handlers/_utils.py
+++ b/litestar/handlers/websocket_handlers/_utils.py
@@ -4,11 +4,12 @@ import inspect
 from typing import TYPE_CHECKING, Any, Callable, Coroutine, cast
 
 from litestar.dto.interface import ConnectionContext
-from litestar.exceptions import WebSocketDisconnect
 from litestar.serialization import decode_json
 from litestar.utils import AsyncCallable
 
 if TYPE_CHECKING:
+    from contextlib import AbstractAsyncContextManager
+
     from msgspec.json import Encoder as JsonEncoder
 
     from litestar import WebSocket
@@ -111,34 +112,26 @@ def create_handle_send(
 
 def create_handler_function(
     listener_context: ListenerContext,
-    on_accept: AsyncCallable | None,
-    on_disconnect: AsyncCallable | None,
-    accept_connection_handler: Callable[[WebSocket], Coroutine[Any, Any, None]],
+    lifespan_manager: Callable[[WebSocket], AbstractAsyncContextManager],
 ) -> Callable[..., Coroutine[None, None, None]]:
-    async def handler_fn(socket: WebSocket, **kwargs: Any) -> None:
-        await accept_connection_handler(socket)
+    listener_callback = AsyncCallable(listener_context.listener_callback)
 
-        listener_callback = AsyncCallable(listener_context.listener_callback)
+    async def handler_fn(socket: WebSocket, **kwargs: Any) -> None:
         ctx = ConnectionContext.from_connection(socket)
         data_dto = listener_context.resolved_data_dto(ctx) if listener_context.resolved_data_dto else None
         return_dto = listener_context.resolved_return_dto(ctx) if listener_context.resolved_return_dto else None
-
-        if on_accept:
-            await on_accept(socket)
+        handle_receive = listener_context.handle_receive
+        handle_send = listener_context.handle_send if listener_context.can_send_data else None
 
         if listener_context.pass_socket:
             kwargs["socket"] = socket
 
-        while True:
-            try:
-                received_data = await listener_context.handle_receive(socket, data_dto)
+        async with lifespan_manager(socket):
+            while True:
+                received_data = await handle_receive(socket, data_dto)
                 data_to_send = await listener_callback(data=received_data, **kwargs)
-                if listener_context.can_send_data:
-                    await listener_context.handle_send(socket, data_to_send, return_dto)
-            except WebSocketDisconnect:
-                if on_disconnect:
-                    await on_disconnect(socket)
-                break
+                if handle_send:
+                    await handle_send(socket, data_to_send, return_dto)
 
     return handler_fn
 

--- a/litestar/handlers/websocket_handlers/listener.py
+++ b/litestar/handlers/websocket_handlers/listener.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
+import inspect
 from abc import ABC, abstractmethod
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Mapping, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncGenerator,
+    Callable,
+    Mapping,
+    cast,
+)
 
 from msgspec.json import Encoder as JsonEncoder
 
@@ -36,10 +45,8 @@ if TYPE_CHECKING:
     from litestar.dto.interface import DTOInterface
     from litestar.types.asgi_types import WebSocketMode
 
-__all__ = (
-    "WebsocketListener",
-    "websocket_listener",
-)
+
+__all__ = ("WebsocketListener", "websocket_listener")
 
 
 class websocket_listener(WebsocketRouteHandler):
@@ -48,21 +55,23 @@ class websocket_listener(WebsocketRouteHandler):
     returned
     """
 
-    __slots__ = (
-        "_on_accept",
-        "_on_disconnect",
-        "_pass_socket",
-        "_receive_mode",
-        "_send_mode",
-        "_listener_context",
-        "accept_connection_handler",
-    )
+    __slots__ = {
+        "connection_accept_handler": "Callback to accept a WebSocket connection. By default, calls WebSocket.accept",
+        "on_accept": "Callback invoked after a WebSocket connection has been accepted",
+        "on_disconnect": "Callback invoked after a WebSocket connection has been closed",
+        "_pass_socket": None,
+        "_receive_mode": None,
+        "_send_mode": None,
+        "_listener_context": None,
+        "_connection_lifespan": None,
+    }
 
     def __init__(
         self,
         path: str | None | list[str] | None = None,
         *,
         connection_accept_handler: Callable[[WebSocket], Coroutine[Any, Any, None]] = WebSocket.accept,
+        connection_lifespan: Callable[[WebSocket], AbstractAsyncContextManager[Any]] | None = None,
         dependencies: Dependencies | None = None,
         dto: type[DTOInterface] | None | EmptyType = Empty,
         exception_handlers: dict[int | type[Exception], ExceptionHandler] | None = None,
@@ -86,6 +95,8 @@ class websocket_listener(WebsocketRouteHandler):
                 to ``/``
             connection_accept_handler: A callable that accepts a :class:`WebSocket <.connection.WebSocket>` instance
                 and returns a coroutine that when awaited, will accept the connection. Defaults to ``WebSocket.accept``.
+            connection_lifespan: An asynchronous context manager, handling the lifespan of the connection. By default,
+                it calls the ``connection_accept_handler``, ``on_connect`` and ``on_disconnect``.
             dependencies: A string keyed mapping of dependency :class:`Provider <.di.Provide>` instances.
             dto: :class:`DTOInterface <.dto.interface.DTOInterface>` to use for (de)serializing and
                 validation of request data.
@@ -112,9 +123,11 @@ class websocket_listener(WebsocketRouteHandler):
         self._listener_context = _utils.ListenerContext()
         self._receive_mode: WebSocketMode = receive_mode
         self._send_mode: WebSocketMode = send_mode
-        self._on_accept = AsyncCallable(on_accept) if on_accept else None
-        self._on_disconnect = AsyncCallable(on_disconnect) if on_disconnect else None
-        self.accept_connection_handler = connection_accept_handler
+        self._connection_lifespan = connection_lifespan
+
+        self.connection_accept_handler = connection_accept_handler
+        self.on_accept = AsyncCallable(on_accept) if on_accept else None
+        self.on_disconnect = AsyncCallable(on_disconnect) if on_disconnect else None
         self.type_encoders = type_encoders
 
         super().__init__(
@@ -132,6 +145,26 @@ class websocket_listener(WebsocketRouteHandler):
         # need to be assigned after the super() call
         self.dto = dto
         self.return_dto = return_dto
+
+    @asynccontextmanager
+    async def default_connection_lifespan(self, socket: WebSocket) -> AsyncGenerator[None, None]:
+        """Handle the connection lifespan of a WebSocket.
+
+        By, default this will
+
+            - Call :attr:`connection_accept_handler` to accept a connection
+            - Call :attr:`on_accept` if defined after a connection has been accepted
+            - Call :attr:`on_disconnect` upon leaving the context
+        """
+        await self.connection_accept_handler(socket)
+
+        if self.on_accept:
+            await self.on_accept(socket)
+        try:
+            yield
+        finally:
+            if self.on_disconnect:
+                await self.on_disconnect(socket)
 
     def _validate_handler_function(self) -> None:
         """Validate the route handler function once it's set by inspecting its return annotations."""
@@ -152,9 +185,7 @@ class websocket_listener(WebsocketRouteHandler):
         self._listener_context.listener_callback = listener_callback
         self._listener_context.handler_function = handler_function = _utils.create_handler_function(
             listener_context=self._listener_context,
-            on_accept=self._on_accept,
-            on_disconnect=self._on_disconnect,
-            accept_connection_handler=self.accept_connection_handler,
+            lifespan_manager=self._connection_lifespan or self.default_connection_lifespan,
         )
         return super().__call__(handler_function)
 
@@ -165,6 +196,12 @@ class websocket_listener(WebsocketRouteHandler):
     def _create_signature_model(self, app: Litestar) -> None:
         """Create signature model for handler function."""
         if not self.signature_model:
+            extra_signatures = []
+            if self.on_accept:
+                extra_signatures.append(inspect.signature(self.on_accept))
+            if self.on_disconnect:
+                extra_signatures.append(inspect.signature(self.on_disconnect))
+
             new_signature = _utils.create_handler_signature(
                 self._listener_context.listener_callback_signature.original_signature
             )

--- a/tests/handlers/websocket/test_listeners.py
+++ b/tests/handlers/websocket/test_listeners.py
@@ -1,12 +1,10 @@
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import AsyncGenerator, Dict, List, Optional, Type, Union, cast
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
-from _pytest.fixtures import FixtureRequest
 from pytest_lazyfixture import lazy_fixture
-from pytest_mock import MockerFixture
 
 from litestar import Litestar, Request, WebSocket
 from litestar.datastructures import State

--- a/tests/handlers/websocket/test_listeners.py
+++ b/tests/handlers/websocket/test_listeners.py
@@ -4,6 +4,7 @@ from typing import AsyncGenerator, Dict, List, Optional, Type, Union, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from _pytest.fixtures import FixtureRequest
 from pytest_lazyfixture import lazy_fixture
 from pytest_mock import MockerFixture
 
@@ -279,10 +280,9 @@ def test_listener_accept_connection_callback() -> None:
         assert ws.extra_headers == [(b"cookie", b"custom-cookie")]
 
 
-@pytest.mark.parametrize("mock_class", [MagicMock, AsyncMock])
-def test_connection_callbacks(mock_class: Type[MagicMock]) -> None:
-    on_accept = mock_class()
-    on_disconnect = mock_class()
+def test_connection_callbacks() -> None:
+    on_accept = MagicMock()
+    on_disconnect = MagicMock()
 
     @websocket_listener("/", on_accept=on_accept, on_disconnect=on_disconnect)
     def handler(data: bytes) -> None:

--- a/tests/handlers/websocket/test_listeners.py
+++ b/tests/handlers/websocket/test_listeners.py
@@ -280,7 +280,7 @@ def test_listener_accept_connection_callback() -> None:
 
 
 @pytest.mark.parametrize("mock_class", [MagicMock, AsyncMock])
-def test_connection_callbacks(mock_class: type[MagicMock]) -> None:
+def test_connection_callbacks(mock_class: Type[MagicMock]) -> None:
     on_accept = mock_class()
     on_disconnect = mock_class()
 
@@ -296,7 +296,7 @@ def test_connection_callbacks(mock_class: type[MagicMock]) -> None:
     on_disconnect.assert_called_once()
 
 
-def test_connection_lifespan(mocker: MockerFixture) -> None:
+def test_connection_lifespan() -> None:
     on_accept = MagicMock()
     on_disconnect = MagicMock()
 


### PR DESCRIPTION
Change the way a socket's lifespan - accepting the connection and calling the appropriate event hooks - to use a context manager. 

In addition to simplifying the code a bit, this also gives the opportunity to optionally supply a custom context manager, enabling to easily integrate functionalities that require context which outlives the lifespan of a socket. An example of this would be the functionality to be introduced in #1587. 

With this PR we could do

```python

async def socket_lifespan(socket: WebSocket) -> None:
  await socket.connect()
  async with channels_plugin.start_subscription("some_channel" as subscriber:
    async with subscriber.run_in_background(socket.send_data):
      yield

@websocket_listener("/ws")
def socket_handler(data: str, channels: ChannelsPlugin) -> None:
  channels.broadcast(data, "some_channel")
```


### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
