### PR TITLE
Enhancement: Add MessagePack support and generator methods to `WebSocket`

### DIFF
--- a/litestar/serialization.py
+++ b/litestar/serialization.py
@@ -220,16 +220,16 @@ def encode_msgpack(obj: Any, enc_hook: Callable[[Any], Any] | None = default_ser
 
 
 @overload
-def decode_msgpack(raw: bytes | str) -> Any:
+def decode_msgpack(raw: bytes) -> Any:
     ...
 
 
 @overload
-def decode_msgpack(raw: bytes | str, type_: type[T]) -> T:
+def decode_msgpack(raw: bytes, type_: type[T]) -> T:
     ...
 
 
-def decode_msgpack(raw: bytes | str, type_: Any = Empty) -> Any:
+def decode_msgpack(raw: bytes, type_: Any = Empty) -> Any:
     """Decode a MessagePack string/bytes into an object.
 
     Args:
@@ -242,9 +242,6 @@ def decode_msgpack(raw: bytes | str, type_: Any = Empty) -> Any:
     Raises:
         SerializationException: If error decoding ``raw``.
     """
-    if isinstance(raw, str):
-        raw = raw.encode("utf-8")
-
     try:
         if type_ is Empty:
             return _msgspec_msgpack_decoder.decode(raw)

--- a/litestar/serialization.py
+++ b/litestar/serialization.py
@@ -220,16 +220,16 @@ def encode_msgpack(obj: Any, enc_hook: Callable[[Any], Any] | None = default_ser
 
 
 @overload
-def decode_msgpack(raw: bytes) -> Any:
+def decode_msgpack(raw: bytes | str) -> Any:
     ...
 
 
 @overload
-def decode_msgpack(raw: bytes, type_: type[T]) -> T:
+def decode_msgpack(raw: bytes | str, type_: type[T]) -> T:
     ...
 
 
-def decode_msgpack(raw: bytes, type_: Any = Empty) -> Any:
+def decode_msgpack(raw: bytes | str, type_: Any = Empty) -> Any:
     """Decode a MessagePack string/bytes into an object.
 
     Args:
@@ -242,6 +242,9 @@ def decode_msgpack(raw: bytes, type_: Any = Empty) -> Any:
     Raises:
         SerializationException: If error decoding ``raw``.
     """
+    if isinstance(raw, str):
+        raw = raw.encode("utf-8")
+
     try:
         if type_ is Empty:
             return _msgspec_msgpack_decoder.decode(raw)

--- a/litestar/testing/websocket_test_session.py
+++ b/litestar/testing/websocket_test_session.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 from anyio import sleep
 
 from litestar.exceptions import WebSocketDisconnect
-from litestar.serialization import decode_json, encode_json
+from litestar.serialization import decode_json, decode_msgpack, encode_json, encode_msgpack
 from litestar.status_codes import WS_1000_NORMAL_CLOSURE
 
 if TYPE_CHECKING:
@@ -146,9 +146,20 @@ class WebSocketTestSession:
             mode: Either ``text`` or ``binary``
 
         Returns:
-            None.
+            None
         """
         self.send(encode_json(data), mode=mode)
+
+    def send_msgpack(self, data: Any) -> None:
+        """Sends the given data as MessagePack.
+
+        Args:
+            data: The data to send.
+
+        Returns:
+            None
+        """
+        self.send(encode_msgpack(data), mode="binary")
 
     def close(self, code: int = WS_1000_NORMAL_CLOSURE) -> None:
         """Sends an 'websocket.disconnect' event.
@@ -232,3 +243,7 @@ class WebSocketTestSession:
             return decode_json(cast("str", message.get("text", "")))
 
         return decode_json(cast("bytes", message.get("bytes", b"")))
+
+    def receive_msgpack(self, block: bool = True, timeout: float | None = None) -> Any:
+        message = self.receive(block=block, timeout=timeout)
+        return decode_msgpack(cast("bytes", message.get("bytes", b"")))


### PR DESCRIPTION
Add the following methods to `WebSocket`:

- `send_msgpack`: Send data as MessagePack
- `receive_msgpack`: Receive data and decode as MessagPack 
- `iter_data`: an async generator over data supporting `text` and `binary`
- `iter_json`: Like `iter_data` but decodes data as JSON
- `iter_msgpack`: Like `iter_data` but decodes data as MessagePack and only supports `binary` mode

Add the following methods to `WebSocketTestSession`:

- `send_msgpack`: Send data as MessagePack
- `receive_msgpack`: Receive data and decode as MessagPack 


### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"

[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
