### PR TITLE
Fix #1615: Using `websocket_listener` in controller causes `TypeError: .handler_fn() got multiple values for argument 'socket'`

### DIFF
--- a/litestar/handlers/websocket_handlers/_utils.py
+++ b/litestar/handlers/websocket_handlers/_utils.py
@@ -116,7 +116,7 @@ def create_handler_function(
 ) -> Callable[..., Coroutine[None, None, None]]:
     listener_callback = AsyncCallable(listener_context.listener_callback)
 
-    async def handler_fn(socket: WebSocket, **kwargs: Any) -> None:
+    async def handler_fn(*args: Any, socket: WebSocket, **kwargs: Any) -> None:
         ctx = ConnectionContext.from_connection(socket)
         data_dto = listener_context.resolved_data_dto(ctx) if listener_context.resolved_data_dto else None
         return_dto = listener_context.resolved_return_dto(ctx) if listener_context.resolved_return_dto else None
@@ -129,7 +129,7 @@ def create_handler_function(
         async with lifespan_manager(socket):
             while True:
                 received_data = await handle_receive(socket, data_dto)
-                data_to_send = await listener_callback(data=received_data, **kwargs)
+                data_to_send = await listener_callback(*args, data=received_data, **kwargs)
                 if handle_send:
                     await handle_send(socket, data_to_send, return_dto)
 

--- a/litestar/handlers/websocket_handlers/listener.py
+++ b/litestar/handlers/websocket_handlers/listener.py
@@ -18,7 +18,7 @@ from msgspec.json import Encoder as JsonEncoder
 from litestar._signature import create_signature_model
 from litestar.connection import WebSocket
 from litestar.dto.interface import HandlerContext
-from litestar.exceptions import ImproperlyConfiguredException
+from litestar.exceptions import ImproperlyConfiguredException, WebSocketDisconnect
 from litestar.serialization import default_serializer
 from litestar.types import (
     AnyCallable,
@@ -162,6 +162,8 @@ class websocket_listener(WebsocketRouteHandler):
             await self.on_accept(socket)
         try:
             yield
+        except WebSocketDisconnect:
+            pass
         finally:
             if self.on_disconnect:
                 await self.on_disconnect(socket)


### PR DESCRIPTION
Fix #1615.

The bug was caused by the positional `self` argument used in the handler methods, and the listener not passing on position arguments. 

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
