### PR TITLE
Docs: Don't fail preview builds when example output is missing

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -36,7 +36,7 @@ jobs:
         run: git fetch origin gh-pages --depth=1
       - name: Build docs (preview)
         if: ${{ github.event_name != 'release' && github.ref == 'refs/heads/main'}}
-        run: poetry run python tools/build_docs.py docs-build  --version=dev
+        run: poetry run python tools/build_docs.py docs-build  --version=dev --ignore-missing-examples-output
       - name: Build docs (release)
         if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
         run: poetry run python tools/build_docs.py docs-build

--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -27,6 +27,7 @@ REDIRECT_TEMPLATE = """
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--version", required=False)
+parser.add_argument("--ignore-missing-examples-output", action="store_true", default=False)
 parser.add_argument("output")
 
 
@@ -49,11 +50,14 @@ def load_version_spec() -> VersionSpec:
     return {"versions": [], "latest": ""}
 
 
-def build(output_dir: str, version: str | None) -> None:
+def build(output_dir: str, version: str | None, ignore_missing_output: bool) -> None:
     if version is None:
         version = importlib.metadata.version("litestar").rsplit(".")[0]
     else:
         os.environ["_LITESTAR_DOCS_BUILD_VERSION"] = version
+
+    if ignore_missing_output:
+        os.environ["_LITESTAR_DOCS_IGNORE_MISSING_EXAMPLE_OUTPUT"] = "1"
 
     subprocess.run(["make", "docs"], check=True)  # noqa: S603 S607
 
@@ -83,7 +87,11 @@ def build(output_dir: str, version: str | None) -> None:
 
 def main() -> None:
     args = parser.parse_args()
-    build(output_dir=args.output, version=args.version)
+    build(
+        output_dir=args.output,
+        version=args.version,
+        ignore_missing_output=args.ignore_missing_output,
+    )
 
 
 if __name__ == "__main__":

--- a/tools/sphinx_ext/run_examples.py
+++ b/tools/sphinx_ext/run_examples.py
@@ -34,6 +34,8 @@ AVAILABLE_PORTS = list(range(9000, 9999))
 
 logger = logging.getLogger("sphinx")
 
+ignore_missing_output = os.getenv("_LITESTAR_DOCS_IGNORE_MISSING_EXAMPLE_OUTPUT", "") == "1"
+
 
 def _load_app_from_path(path: Path) -> Litestar:
     module = importlib.import_module(str(path.with_suffix("")).replace("/", "."))
@@ -115,7 +117,9 @@ def exec_examples(app_file: Path, run_configs: list[list[str]]) -> str:
             )
             stdout = proc.stdout.splitlines()
             if not stdout:
-                logger.error(f"Example: {app_file}:{args} yielded no results")
+                logger.debug(proc.stderr)
+                if not ignore_missing_output:
+                    logger.error(f"Example: {app_file}:{args} yielded no results")
                 continue
 
             result = "\n".join(line for line in ("> " + (" ".join(clean_args)), *stdout))


### PR DESCRIPTION
We are currently experiencing a quite frequently failing CI because the examples run from the documentation sometimes don't produce output. This can be safely ignored during preview and CI builds.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
