### PR TITLE
Docs: Fix wrong CLI argument name

### DIFF
--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -90,7 +90,7 @@ def main() -> None:
     build(
         output_dir=args.output,
         version=args.version,
-        ignore_missing_output=args.ignore_missing_output,
+        ignore_missing_output=args.ignore_missing_examples_output,
     )
 
 


### PR DESCRIPTION
Fix a misspelled argument name in `tools/build_docs.py`: `ignore_missing_output` > `ignore_missing_examples_output`

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
