### PR TITLE
fix: Add `--no-schema` option to `litestar routes` command.

### DIFF
--- a/docs/usage/cli.rst
+++ b/docs/usage/cli.rst
@@ -143,6 +143,16 @@ The ``routes`` command displays a tree view of the routing table
    litestar routes
 
 
+Options
+~~~~~~~
+
++-----------------+-----------------------+
+| Flag            | Description           |
++=================+=======================+
+| ``--no-schema`` | Exclude schema routes |
++-----------------+-----------------------+
+
+
 .. image:: /images/cli/litestar_routes.png
    :alt: litestar info
 

--- a/litestar/cli/commands/core.py
+++ b/litestar/cli/commands/core.py
@@ -98,7 +98,7 @@ def run_command(
 
 
 @command(name="routes")
-@option("--no-schema", help="Exclude shema routes", is_flag=True, default=False)
+@option("--no-schema", help="Exclude schema routes", is_flag=True, default=False)
 def routes_command(app: Litestar, no_schema: bool) -> None:  # pragma: no cover
     """Display information about the application's routes."""
 

--- a/litestar/cli/commands/core.py
+++ b/litestar/cli/commands/core.py
@@ -9,6 +9,7 @@ import click
 from click import command, option
 from rich.tree import Tree
 
+from litestar.app import DEFAULT_OPENAPI_CONFIG
 from litestar.cli._utils import LitestarEnv, console, show_app_info
 from litestar.routes import HTTPRoute, WebSocketRoute
 from litestar.utils.helpers import unwrap_partial
@@ -104,8 +105,11 @@ def routes_command(app: Litestar, no_schema: bool) -> None:  # pragma: no cover
 
     tree = Tree("", hide_root=True)
 
+    openapi_config = app.openapi_config or DEFAULT_OPENAPI_CONFIG
+    schema_path = openapi_config.openapi_controller.path  # /schema or user-defined path
+
     for route in sorted(app.routes, key=lambda r: r.path):
-        if no_schema and route.path.startswith("/schema"):
+        if no_schema and route.path.startswith(schema_path):
             continue
 
         if isinstance(route, HTTPRoute):

--- a/litestar/cli/commands/core.py
+++ b/litestar/cli/commands/core.py
@@ -98,12 +98,16 @@ def run_command(
 
 
 @command(name="routes")
-def routes_command(app: Litestar) -> None:  # pragma: no cover
+@option("--no-schema", help="Exclude shema routes", is_flag=True, default=False)
+def routes_command(app: Litestar, no_schema: bool) -> None:  # pragma: no cover
     """Display information about the application's routes."""
 
     tree = Tree("", hide_root=True)
 
     for route in sorted(app.routes, key=lambda r: r.path):
+        if no_schema and route.path.startswith("/schema"):
+            continue
+
         if isinstance(route, HTTPRoute):
             branch = tree.add(f"[green]{route.path}[/green] (HTTP)")
             for handler in route.route_handlers:

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -4,6 +4,19 @@ app = Litestar([])
 """
 
 
+APP_FILE_CONTENT_OPENAPI_CONFIG = """
+from litestar import Litestar
+from litestar.openapi import OpenAPIConfig, OpenAPIController
+
+class CustomOpenAPIController(OpenAPIController):
+    path = "/api-docs"
+
+app = Litestar(
+    openapi_config=OpenAPIConfig(title="", version="", openapi_controller=CustomOpenAPIController),
+)
+"""
+
+
 CREATE_APP_FILE_CONTENT = """
 from litestar import Litestar
 

--- a/tests/cli/test_core_commands.py
+++ b/tests/cli/test_core_commands.py
@@ -11,6 +11,7 @@ from litestar import __version__ as litestar_version
 from litestar.cli._utils import LoadedApp
 from litestar.cli.main import litestar_group as cli_command
 from tests.cli import (
+    APP_FILE_CONTENT,
     CREATE_APP_FILE_CONTENT,
     GENERIC_APP_FACTORY_FILE_CONTENT,
     GENERIC_APP_FACTORY_FILE_CONTENT_STRING_ANNOTATION,
@@ -186,3 +187,24 @@ def test_version_command(short: bool, runner: CliRunner) -> None:
     result = runner.invoke(cli_command, "version --short" if short else "version")
 
     assert result.output.strip() == litestar_version.formatted(short=short)
+
+
+@pytest.mark.parametrize(
+    "enable_no_schema_option, has_schema_line",
+    [
+        (True, False),
+        (False, True),
+    ],
+)
+def test_routes_command_no_schema(
+    runner: CliRunner,
+    enable_no_schema_option: bool,
+    has_schema_line: bool,
+    create_app_file: CreateAppFileFixture,
+) -> None:
+    create_app_file("app.py", content=APP_FILE_CONTENT)
+    command = "routes --no-schema" if enable_no_schema_option else "routes"
+    result = runner.invoke(cli_command, command)
+
+    assert result.exit_code == 0
+    assert ("/schema" in result.output) == has_schema_line


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [x] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

This PR adds --no-schema option to litestar routes CLI command to exclude schema routes from the list.



### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

#1614