### PR TITLE
Enhancement: Declaring dependencies without Provide

### DIFF
--- a/litestar/_openapi/parameters.py
+++ b/litestar/_openapi/parameters.py
@@ -23,9 +23,9 @@ __all__ = (
 
 
 if TYPE_CHECKING:
+    from litestar.di import Provide
     from litestar.handlers.base import BaseRouteHandler
     from litestar.openapi.spec import Reference
-    from litestar.types import Dependencies
     from litestar.types.internal_types import PathParameterDefinition
 
 
@@ -144,7 +144,7 @@ def create_parameter(
 def get_recursive_handler_parameters(
     field_name: str,
     signature_field: SignatureField,
-    dependencies: Dependencies,
+    dependency_providers: dict[str, Provide],
     route_handler: BaseRouteHandler,
     path_parameters: tuple[PathParameterDefinition, ...],
     generate_examples: bool,
@@ -156,7 +156,7 @@ def get_recursive_handler_parameters(
     `create_parameter_for_handler()` is called to generate parameters for the dependency.
     """
 
-    if field_name not in dependencies:
+    if field_name not in dependency_providers:
         return [
             create_parameter(
                 generate_examples=generate_examples,
@@ -166,7 +166,7 @@ def get_recursive_handler_parameters(
                 signature_field=signature_field,
             )
         ]
-    dependency_fields = dependencies[field_name].signature_model.fields
+    dependency_fields = dependency_providers[field_name].signature_model.fields
     return create_parameter_for_handler(
         route_handler, dependency_fields, path_parameters, generate_examples, schemas=schemas
     )
@@ -239,7 +239,7 @@ def create_parameter_for_handler(
             continue
 
         for parameter in get_recursive_handler_parameters(
-            dependencies=dependencies,
+            dependency_providers=dependencies,
             field_name=field_name,
             generate_examples=generate_examples,
             path_parameters=path_parameters,

--- a/litestar/config/app.py
+++ b/litestar/config/app.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
         AfterExceptionHookHandler,
         AfterRequestHookHandler,
         AfterResponseHookHandler,
+        AnyCallable,
         BeforeMessageSendHookHandler,
         BeforeRequestHookHandler,
         ControllerRouterHandler,
@@ -45,6 +46,7 @@ if TYPE_CHECKING:
         TypeEncodersMap,
     )
     from litestar.types.empty import EmptyType
+
 
 __all__ = ("AppConfig",)
 
@@ -121,7 +123,7 @@ class AppConfig:
     """If set this enables the builtin CSRF middleware."""
     debug: bool = field(default=False)
     """If ``True``, app errors rendered as HTML with a stack trace."""
-    dependencies: dict[str, Provide] = field(default_factory=dict)
+    dependencies: dict[str, Provide | AnyCallable] = field(default_factory=dict)
     """A string keyed dictionary of dependency :class:`Provider <.di.Provide>` instances."""
     dto: type[DTOInterface] | None | EmptyType = field(default=Empty)
     """:class:`DTOInterface <.dto.interface.DTOInterface>` to use for (de)serializing and validation of request data."""

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -252,7 +252,7 @@ class BaseRouteHandler(Generic[T]):
             for layer in self.ownership_layers:
                 for key, value in (layer.dependencies or {}).items():
                     if not isinstance(value, Provide):
-                        value = Provide(value, sync_to_thread=True)  # noqa: PLW2901
+                        value = Provide(value)  # noqa: PLW2901
                     self._validate_dependency_is_unique(
                         dependencies=self._resolved_dependencies, key=key, provider=value
                     )

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Generic, Mapping, Sequence, TypeVar, cast
 
 from litestar._signature import create_signature_model
 from litestar._signature.field import SignatureField
+from litestar.di import Provide
 from litestar.dto.interface import HandlerContext
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types import Dependencies, Empty, ExceptionHandlersMap, Guard, Middleware, TypeEncodersMap
@@ -20,7 +21,6 @@ if TYPE_CHECKING:
     from litestar._signature.models import SignatureModel
     from litestar.connection import ASGIConnection
     from litestar.controller import Controller
-    from litestar.di import Provide
     from litestar.dto.interface import DTOInterface
     from litestar.params import ParameterKwarg
     from litestar.plugins import SerializationPluginProtocol
@@ -251,6 +251,8 @@ class BaseRouteHandler(Generic[T]):
 
             for layer in self.ownership_layers:
                 for key, value in (layer.dependencies or {}).items():
+                    if not isinstance(value, Provide):
+                        value = Provide(value, sync_to_thread=True)  # noqa: PLW2901
                     self._validate_dependency_is_unique(
                         dependencies=self._resolved_dependencies, key=key, provider=value
                     )

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -32,6 +32,7 @@ from litestar.types import (
     ASGIApp,
     BeforeRequestHookHandler,
     CacheKeyBuilder,
+    Dependencies,
     Empty,
     EmptyType,
     ExceptionHandlersMap,
@@ -55,7 +56,6 @@ if TYPE_CHECKING:
     from litestar.connection import Request
     from litestar.datastructures import CacheControlHeader, ETag
     from litestar.datastructures.headers import Header
-    from litestar.di import Provide
     from litestar.dto.interface import DTOInterface
     from litestar.openapi.datastructures import ResponseSpec
     from litestar.openapi.spec import SecurityRequirement
@@ -124,7 +124,7 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
         cache: bool | int | type[CACHE_FOREVER] = False,
         cache_control: CacheControlHeader | None = None,
         cache_key_builder: CacheKeyBuilder | None = None,
-        dependencies: Mapping[str, Provide] | None = None,
+        dependencies: Dependencies | None = None,
         dto: type[DTOInterface] | None | EmptyType = Empty,
         etag: ETag | None = None,
         exception_handlers: ExceptionHandlersMap | None = None,

--- a/litestar/handlers/http_handlers/decorators.py
+++ b/litestar/handlers/http_handlers/decorators.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from litestar.background_tasks import BackgroundTask, BackgroundTasks
     from litestar.config.response_cache import CACHE_FOREVER
     from litestar.datastructures import CacheControlHeader, ETag
-    from litestar.di import Provide
     from litestar.dto.interface import DTOInterface
     from litestar.openapi.datastructures import ResponseSpec
     from litestar.openapi.spec import SecurityRequirement
@@ -27,6 +26,7 @@ if TYPE_CHECKING:
         AfterResponseHookHandler,
         BeforeRequestHookHandler,
         CacheKeyBuilder,
+        Dependencies,
         EmptyType,
         ExceptionHandlersMap,
         Guard,
@@ -60,7 +60,7 @@ class delete(HTTPRouteHandler):
         cache: bool | int | type[CACHE_FOREVER] = False,
         cache_control: CacheControlHeader | None = None,
         cache_key_builder: CacheKeyBuilder | None = None,
-        dependencies: dict[str, Provide] | None = None,
+        dependencies: Dependencies | None = None,
         dto: type[DTOInterface] | None | EmptyType = Empty,
         etag: ETag | None = None,
         exception_handlers: ExceptionHandlersMap | None = None,
@@ -221,7 +221,7 @@ class get(HTTPRouteHandler):
         cache: bool | int | type[CACHE_FOREVER] = False,
         cache_control: CacheControlHeader | None = None,
         cache_key_builder: CacheKeyBuilder | None = None,
-        dependencies: dict[str, Provide] | None = None,
+        dependencies: Dependencies | None = None,
         dto: type[DTOInterface] | None | EmptyType = Empty,
         etag: ETag | None = None,
         exception_handlers: ExceptionHandlersMap | None = None,
@@ -383,7 +383,7 @@ class head(HTTPRouteHandler):
         cache: bool | int | type[CACHE_FOREVER] = False,
         cache_control: CacheControlHeader | None = None,
         cache_key_builder: CacheKeyBuilder | None = None,
-        dependencies: dict[str, Provide] | None = None,
+        dependencies: Dependencies | None = None,
         dto: type[DTOInterface] | None | EmptyType = Empty,
         etag: ETag | None = None,
         exception_handlers: ExceptionHandlersMap | None = None,
@@ -562,7 +562,7 @@ class patch(HTTPRouteHandler):
         cache: bool | int | type[CACHE_FOREVER] = False,
         cache_control: CacheControlHeader | None = None,
         cache_key_builder: CacheKeyBuilder | None = None,
-        dependencies: dict[str, Provide] | None = None,
+        dependencies: Dependencies | None = None,
         dto: type[DTOInterface] | None | EmptyType = Empty,
         etag: ETag | None = None,
         exception_handlers: ExceptionHandlersMap | None = None,
@@ -723,7 +723,7 @@ class post(HTTPRouteHandler):
         cache: bool | int | type[CACHE_FOREVER] = False,
         cache_control: CacheControlHeader | None = None,
         cache_key_builder: CacheKeyBuilder | None = None,
-        dependencies: dict[str, Provide] | None = None,
+        dependencies: Dependencies | None = None,
         dto: type[DTOInterface] | None | EmptyType = Empty,
         etag: ETag | None = None,
         exception_handlers: ExceptionHandlersMap | None = None,
@@ -884,7 +884,7 @@ class put(HTTPRouteHandler):
         cache: bool | int | type[CACHE_FOREVER] = False,
         cache_control: CacheControlHeader | None = None,
         cache_key_builder: CacheKeyBuilder | None = None,
-        dependencies: dict[str, Provide] | None = None,
+        dependencies: Dependencies | None = None,
         dto: type[DTOInterface] | None | EmptyType = Empty,
         etag: ETag | None = None,
         exception_handlers: ExceptionHandlersMap | None = None,

--- a/litestar/router.py
+++ b/litestar/router.py
@@ -20,7 +20,6 @@ __all__ = ("Router",)
 
 if TYPE_CHECKING:
     from litestar.datastructures import CacheControlHeader, ETag
-    from litestar.di import Provide
     from litestar.dto.interface import DTOInterface
     from litestar.openapi.spec import SecurityRequirement
     from litestar.routes import BaseRoute
@@ -39,7 +38,7 @@ if TYPE_CHECKING:
         RouteHandlerType,
         TypeEncodersMap,
     )
-    from litestar.types.composite_types import ResponseHeaders
+    from litestar.types.composite_types import Dependencies, ResponseHeaders
     from litestar.types.empty import EmptyType
 
 
@@ -84,7 +83,7 @@ class Router:
         after_response: AfterResponseHookHandler | None = None,
         before_request: BeforeRequestHookHandler | None = None,
         cache_control: CacheControlHeader | None = None,
-        dependencies: Mapping[str, Provide] | None = None,
+        dependencies: Dependencies | None = None,
         dto: type[DTOInterface] | None | EmptyType = Empty,
         etag: ETag | None = None,
         exception_handlers: ExceptionHandlersMap | None = None,

--- a/litestar/types/composite_types.py
+++ b/litestar/types/composite_types.py
@@ -23,7 +23,7 @@ from typing import (
 from litestar.enums import ScopeType
 
 from .asgi_types import ASGIApp
-from .callable_types import ExceptionHandler
+from .callable_types import AnyCallable, ExceptionHandler
 
 if TYPE_CHECKING:
     from litestar.datastructures.cookie import Cookie
@@ -44,7 +44,7 @@ else:
 T = TypeVar("T")
 
 
-Dependencies = Mapping[str, Provide]
+Dependencies = Mapping[str, Union[Provide, AnyCallable]]
 ExceptionHandlersMap = Mapping[Union[int, Type[Exception]], ExceptionHandler]
 MaybePartial = Union[T, partial]
 Middleware = Union[

--- a/tests/handlers/base/test_resolution.py
+++ b/tests/handlers/base/test_resolution.py
@@ -18,17 +18,6 @@ def test_resolve_dependencies_without_provide() -> None:
     assert handler.resolve_dependencies() == {"foo": Provide(foo), "bar": Provide(bar)}
 
 
-def test_resolve_dependencies_without_provide_sync_to_thread_by_default() -> None:
-    def foo() -> None:
-        pass
-
-    @get(dependencies={"foo": foo})
-    async def handler() -> None:
-        pass
-
-    assert handler.resolve_dependencies()["foo"].sync_to_thread is True
-
-
 def function_factory() -> Callable[[], Awaitable[None]]:
     async def func() -> None:
         return None

--- a/tests/handlers/base/test_resolution.py
+++ b/tests/handlers/base/test_resolution.py
@@ -35,14 +35,16 @@ def test_resolve_from_layers() -> None:
         path = "/controller"
         dependencies = {"controller": controller_dependency}
 
-        @get("/handler", dependencies={"handler": handler_dependency})
+        @get("/handler", dependencies={"handler": handler_dependency}, name="foo")
         async def handler(self) -> None:
             pass
 
     router = Router("/router", route_handlers=[MyController], dependencies={"router": router_dependency})
     app = Litestar([router], dependencies={"app": app_dependency})
 
-    handler = app.routes[0].route_handlers[0]  # type: ignore[union-attr]
+    handler_map = app.get_handler_index_by_name("foo")
+    assert handler_map
+    handler = handler_map["handler"]
 
     assert handler.resolve_dependencies() == {
         "app": Provide(app_dependency),

--- a/tests/handlers/base/test_resolution.py
+++ b/tests/handlers/base/test_resolution.py
@@ -1,0 +1,63 @@
+from typing import Awaitable, Callable
+
+from litestar import Controller, Litestar, Router, get
+from litestar.di import Provide
+
+
+def test_resolve_dependencies_without_provide() -> None:
+    async def foo() -> None:
+        pass
+
+    async def bar() -> None:
+        pass
+
+    @get(dependencies={"foo": foo, "bar": Provide(bar)})
+    async def handler() -> None:
+        pass
+
+    assert handler.resolve_dependencies() == {"foo": Provide(foo), "bar": Provide(bar)}
+
+
+def test_resolve_dependencies_without_provide_sync_to_thread_by_default() -> None:
+    def foo() -> None:
+        pass
+
+    @get(dependencies={"foo": foo})
+    async def handler() -> None:
+        pass
+
+    assert handler.resolve_dependencies()["foo"].sync_to_thread is True
+
+
+def function_factory() -> Callable[[], Awaitable[None]]:
+    async def func() -> None:
+        return None
+
+    return func
+
+
+def test_resolve_from_layers() -> None:
+    app_dependency = function_factory()
+    router_dependency = function_factory()
+    controller_dependency = function_factory()
+    handler_dependency = function_factory()
+
+    class MyController(Controller):
+        path = "/controller"
+        dependencies = {"controller": controller_dependency}
+
+        @get("/handler", dependencies={"handler": handler_dependency})
+        async def handler(self) -> None:
+            pass
+
+    router = Router("/router", route_handlers=[MyController], dependencies={"router": router_dependency})
+    app = Litestar([router], dependencies={"app": app_dependency})
+
+    handler = app.routes[0].route_handlers[0]  # type: ignore[union-attr]
+
+    assert handler.resolve_dependencies() == {
+        "app": Provide(app_dependency),
+        "router": Provide(router_dependency),
+        "controller": Provide(controller_dependency),
+        "handler": Provide(handler_dependency),
+    }


### PR DESCRIPTION
As discussed in #1305, add support for declaring dependencies without using `Provide`. The usage of `Provide` internally remains unchanged, and dependencies declared without `Provide` will simply be wrapped in it upon resolution.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
