### PR TITLE
Enhancement: Support dependencies in WS listener hooks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,7 +103,7 @@ nitpick_ignore = [
     ("py:class", "litestar.utils.signature.ParsedParameter"),
     ("py:class", "litestar.utils.sync.AsyncCallable"),
     ("py:class", "BacklogStrategy"),
-    ("py:class", "ExceptionT")
+    ("py:class", "ExceptionT"),
 ]
 nitpick_ignore_regex = [
     (r"py:.*", r"litestar\.types.*"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,6 +103,7 @@ nitpick_ignore = [
     ("py:class", "litestar.utils.signature.ParsedParameter"),
     ("py:class", "litestar.utils.sync.AsyncCallable"),
     ("py:class", "BacklogStrategy"),
+    ("py:class", "ExceptionT")
 ]
 nitpick_ignore_regex = [
     (r"py:.*", r"litestar\.types.*"),

--- a/litestar/handlers/websocket_handlers/_utils.py
+++ b/litestar/handlers/websocket_handlers/_utils.py
@@ -120,7 +120,7 @@ def create_handler_function(
     listener_callback = AsyncCallable(listener_context.listener_callback)
 
     async def handler_fn(
-        *args: Any, socket: WebSocket, lifespan_stub__: Dict[str, Any], **kwargs: Any   # noqa: UP006
+        *args: Any, socket: WebSocket, lifespan_stub__: Dict[str, Any], **kwargs: Any  # noqa: UP006
     ) -> None:
         ctx = ConnectionContext.from_connection(socket)
         data_dto = listener_context.resolved_data_dto(ctx) if listener_context.resolved_data_dto else None

--- a/litestar/handlers/websocket_handlers/_utils.py
+++ b/litestar/handlers/websocket_handlers/_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, cast
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, cast
 
 from litestar.di import Provide
 from litestar.dto.interface import ConnectionContext
@@ -119,7 +119,9 @@ def create_handler_function(
 ) -> Callable[..., Coroutine[None, None, None]]:
     listener_callback = AsyncCallable(listener_context.listener_callback)
 
-    async def handler_fn(*args: Any, socket: WebSocket, lifespan_stub__: dict[str, Any], **kwargs: Any) -> None:
+    async def handler_fn(
+        *args: Any, socket: WebSocket, lifespan_stub__: Dict[str, Any], **kwargs: Any   # noqa: UP006
+    ) -> None:
         ctx = ConnectionContext.from_connection(socket)
         data_dto = listener_context.resolved_data_dto(ctx) if listener_context.resolved_data_dto else None
         return_dto = listener_context.resolved_return_dto(ctx) if listener_context.resolved_return_dto else None
@@ -160,7 +162,7 @@ def create_handler_signature(callback_signature: inspect.Signature) -> inspect.S
         new_params.append(inspect.Parameter(name="socket", kind=inspect.Parameter.KEYWORD_ONLY, annotation="WebSocket"))
 
     new_params.append(
-        inspect.Parameter(name="lifespan_stub__", kind=inspect.Parameter.KEYWORD_ONLY, annotation="dict[str, Any]")
+        inspect.Parameter(name="lifespan_stub__", kind=inspect.Parameter.KEYWORD_ONLY, annotation="Dict[str, Any]")
     )
 
     return callback_signature.replace(parameters=new_params)
@@ -173,7 +175,7 @@ def create_stub_dependency(src: AnyCallable) -> Provide:
     src = unwrap_partial(src)
 
     @wraps(src)
-    async def stub(**kwargs: Any) -> dict[str, Any]:
+    async def stub(**kwargs: Any) -> Dict[str, Any]:  # noqa: UP006
         return kwargs
 
     return Provide(stub)

--- a/litestar/handlers/websocket_handlers/listener.py
+++ b/litestar/handlers/websocket_handlers/listener.py
@@ -204,7 +204,7 @@ class websocket_listener(WebsocketRouteHandler):
         if not self.dependencies:
             self.dependencies = {}
         self.dependencies = dict(self.dependencies)
-        self.dependencies["lifespan_stub__"] = _utils.create_stub_dependency(
+        self.dependencies["connection_lifespan_dependencies"] = _utils.create_stub_dependency(
             self._connection_lifespan or self.default_connection_lifespan
         )
         if self.on_accept:

--- a/litestar/handlers/websocket_handlers/listener.py
+++ b/litestar/handlers/websocket_handlers/listener.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 from abc import ABC, abstractmethod
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from functools import partial
@@ -28,7 +27,6 @@ from litestar.types import (
     ExceptionHandler,
     Guard,
     Middleware,
-    SyncOrAsyncUnion,
     TypeEncodersMap,
 )
 from litestar.types.builtin_types import NoneType
@@ -64,6 +62,7 @@ class websocket_listener(WebsocketRouteHandler):
         "_send_mode": None,
         "_listener_context": None,
         "_connection_lifespan": None,
+        "_dependency_stubs": None,
     }
 
     def __init__(
@@ -71,7 +70,7 @@ class websocket_listener(WebsocketRouteHandler):
         path: str | None | list[str] | None = None,
         *,
         connection_accept_handler: Callable[[WebSocket], Coroutine[Any, Any, None]] = WebSocket.accept,
-        connection_lifespan: Callable[[WebSocket], AbstractAsyncContextManager[Any]] | None = None,
+        connection_lifespan: Callable[..., AbstractAsyncContextManager[Any]] | None = None,
         dependencies: Dependencies | None = None,
         dto: type[DTOInterface] | None | EmptyType = Empty,
         exception_handlers: dict[int | type[Exception], ExceptionHandler] | None = None,
@@ -80,8 +79,8 @@ class websocket_listener(WebsocketRouteHandler):
         receive_mode: WebSocketMode = "text",
         send_mode: WebSocketMode = "text",
         name: str | None = None,
-        on_accept: Callable[[WebSocket], SyncOrAsyncUnion[None]] | None = None,
-        on_disconnect: Callable[[WebSocket], SyncOrAsyncUnion[None]] | None = None,
+        on_accept: AnyCallable | None = None,
+        on_disconnect: AnyCallable | None = None,
         opt: dict[str, Any] | None = None,
         return_dto: type[DTOInterface] | None | EmptyType = Empty,
         signature_namespace: Mapping[str, Any] | None = None,
@@ -96,7 +95,8 @@ class websocket_listener(WebsocketRouteHandler):
             connection_accept_handler: A callable that accepts a :class:`WebSocket <.connection.WebSocket>` instance
                 and returns a coroutine that when awaited, will accept the connection. Defaults to ``WebSocket.accept``.
             connection_lifespan: An asynchronous context manager, handling the lifespan of the connection. By default,
-                it calls the ``connection_accept_handler``, ``on_connect`` and ``on_disconnect``.
+                it calls the ``connection_accept_handler``, ``on_connect`` and ``on_disconnect``. Can request any
+                dependencies, for example the :class:`WebSocket <.connection.WebSocket>` connection
             dependencies: A string keyed mapping of dependency :class:`Provider <.di.Provide>` instances.
             dto: :class:`DTOInterface <.dto.interface.DTOInterface>` to use for (de)serializing and
                 validation of request data.
@@ -106,10 +106,10 @@ class websocket_listener(WebsocketRouteHandler):
             receive_mode: Websocket mode to receive data in, either `text` or `binary`.
             send_mode: Websocket mode to receive data in, either `text` or `binary`.
             name: A string identifying the route handler.
-            on_accept: Callback invoked after a connection has been accepted, receiving the
-                :class:`WebSocket <.connection.WebSocket>` instance as its only argument
-            on_disconnect: Callback invoked after a connection has been closed, receiving the
-                :class:`WebSocket <.connection.WebSocket>` instance as its only argument
+            on_accept: Callback invoked after a connection has been accepted. Can request any dependencies, for example
+                the :class:`WebSocket <.connection.WebSocket>` connection
+            on_disconnect: Callback invoked after a connection has been closed. Can request any dependencies, for
+                example the :class:`WebSocket <.connection.WebSocket>` connection
             opt: A string keyed mapping of arbitrary values that can be accessed in :class:`Guards <.types.Guard>` or
                 wherever you have access to :class:`Request <.connection.Request>` or
                 :class:`ASGI Scope <.types.Scope>`.
@@ -146,9 +146,32 @@ class websocket_listener(WebsocketRouteHandler):
         self.dto = dto
         self.return_dto = return_dto
 
+        if not self.dependencies:
+            self.dependencies = {}
+        self.dependencies = dict(self.dependencies)
+        self.dependencies["lifespan_stub__"] = _utils.create_stub_dependency(
+            self._connection_lifespan or self.default_connection_lifespan
+        )
+        if self.on_accept:
+            self.dependencies["on_accept_dependencies"] = _utils.create_stub_dependency(self.on_accept.ref.value)
+        if self.on_disconnect:
+            self.dependencies["on_disconnect_dependencies"] = _utils.create_stub_dependency(
+                self.on_disconnect.ref.value
+            )
+
     @asynccontextmanager
-    async def default_connection_lifespan(self, socket: WebSocket) -> AsyncGenerator[None, None]:
+    async def default_connection_lifespan(
+        self,
+        socket: WebSocket,
+        on_accept_dependencies: dict[str, Any] | None = None,
+        on_disconnect_dependencies: dict[str, Any] | None = None,
+    ) -> AsyncGenerator[None, None]:
         """Handle the connection lifespan of a WebSocket.
+
+        Args:
+            socket: The WebSocket connection
+            on_accept_dependencies: Dependencies requested by the :attr:`on_accept` hook
+            on_disconnect_dependencies: Dependencies requested by the :attr:`on_disconnect` hook
 
         By, default this will
 
@@ -159,14 +182,14 @@ class websocket_listener(WebsocketRouteHandler):
         await self.connection_accept_handler(socket)
 
         if self.on_accept:
-            await self.on_accept(socket)
+            await self.on_accept(**on_accept_dependencies or {})
         try:
             yield
         except WebSocketDisconnect:
             pass
         finally:
             if self.on_disconnect:
-                await self.on_disconnect(socket)
+                await self.on_disconnect(**on_disconnect_dependencies or {})
 
     def _validate_handler_function(self) -> None:
         """Validate the route handler function once it's set by inspecting its return annotations."""
@@ -198,12 +221,6 @@ class websocket_listener(WebsocketRouteHandler):
     def _create_signature_model(self, app: Litestar) -> None:
         """Create signature model for handler function."""
         if not self.signature_model:
-            extra_signatures = []
-            if self.on_accept:
-                extra_signatures.append(inspect.signature(self.on_accept))
-            if self.on_disconnect:
-                extra_signatures.append(inspect.signature(self.on_disconnect))
-
             new_signature = _utils.create_handler_signature(
                 self._listener_context.listener_callback_signature.original_signature
             )
@@ -260,6 +277,10 @@ class WebsocketListener(ABC):
     """A sequence of :class:`Guard <.types.Guard>` callables."""
     middleware: list[Middleware] | None = None
     """A sequence of :class:`Middleware <.types.Middleware>`."""
+    on_accept: AnyCallable | None = None
+    """Called after a WebSocket connection has been accepted. Can receive any dependencies"""
+    on_disconnect: AnyCallable | None = None
+    """Called after a WebSocket connection has been disconnected. Can receive any dependencies"""
     receive_mode: WebSocketMode = "text"
     """Websocket mode to receive data in, either `text` or `binary`."""
     send_mode: WebSocketMode = "text"
@@ -301,9 +322,6 @@ class WebsocketListener(ABC):
             type_encoders=self.type_encoders,
         )(self.on_receive)
 
-    def on_accept(self, socket: WebSocket) -> SyncOrAsyncUnion[None]:  # noqa: B027
-        """Called after a WebSocket connection has been accepted"""
-
     @abstractmethod
     def on_receive(self, *args: Any, **kwargs: Any) -> Any:
         """Called after data has been received from the WebSocket.
@@ -316,6 +334,3 @@ class WebsocketListener(ABC):
         according to handler configuration.
         """
         raise NotImplementedError
-
-    def on_disconnect(self, socket: WebSocket) -> SyncOrAsyncUnion[None]:  # noqa: B027
-        """Called after a WebSocket connection has been disconnected"""

--- a/litestar/handlers/websocket_handlers/listener.py
+++ b/litestar/handlers/websocket_handlers/listener.py
@@ -221,7 +221,7 @@ class websocket_listener(WebsocketRouteHandler):
         on_accept_dependencies: Optional[Dict[str, Any]] = None,  # noqa: UP007, UP006
         on_disconnect_dependencies: Optional[Dict[str, Any]] = None,  # noqa: UP007, UP006
     ) -> AsyncGenerator[None, None]:
-        """Handle the connection lifespan of a WebSocket.
+        """Handle the connection lifespan of a :class:`WebSocket <.connection.WebSocket>`.
 
         Args:
             socket: The :class:`WebSocket <.connection.WebSocket>` connection

--- a/litestar/handlers/websocket_handlers/listener.py
+++ b/litestar/handlers/websocket_handlers/listener.py
@@ -224,7 +224,7 @@ class websocket_listener(WebsocketRouteHandler):
         """Handle the connection lifespan of a WebSocket.
 
         Args:
-            socket: The WebSocket connection
+            socket: The :class:`WebSocket <.connection.WebSocket>` connection
             on_accept_dependencies: Dependencies requested by the :attr:`on_accept` hook
             on_disconnect_dependencies: Dependencies requested by the :attr:`on_disconnect` hook
 
@@ -237,14 +237,14 @@ class websocket_listener(WebsocketRouteHandler):
         await self.connection_accept_handler(socket)
 
         if self.on_accept:
-            await self.on_accept(**on_accept_dependencies or {})
+            await self.on_accept(**(on_accept_dependencies or {}))
         try:
             yield
         except WebSocketDisconnect:
             pass
         finally:
             if self.on_disconnect:
-                await self.on_disconnect(**on_disconnect_dependencies or {})
+                await self.on_disconnect(**(on_disconnect_dependencies or {}))
 
     def _validate_handler_function(self) -> None:
         """Validate the route handler function once it's set by inspecting its return annotations."""
@@ -333,11 +333,11 @@ class WebsocketListener(ABC):
     middleware: list[Middleware] | None = None
     """A sequence of :class:`Middleware <.types.Middleware>`."""
     on_accept: AnyCallable | None = None
-    """Called after a WebSocket connection has been accepted. Can receive any dependencies"""
+    """Called after a :class:`WebSocket <.connection.WebSocket>` connection has been accepted. Can receive any dependencies"""
     on_disconnect: AnyCallable | None = None
-    """Called after a WebSocket connection has been disconnected. Can receive any dependencies"""
+    """Called after a :class:`WebSocket <.connection.WebSocket>` connection has been disconnected. Can receive any dependencies"""
     receive_mode: WebSocketMode = "text"
-    """Websocket mode to receive data in, either `text` or `binary`."""
+    """:class:`WebSocket <.connection.WebSocket>` mode to receive data in, either ``text`` or ``binary``."""
     send_mode: WebSocketMode = "text"
     """Websocket mode to send data in, either `text` or `binary`."""
     name: str | None = None

--- a/tests/handlers/websocket/test_listeners.py
+++ b/tests/handlers/websocket/test_listeners.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import AsyncGenerator, Dict, List, Optional, Type, Union, cast
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pytest_lazyfixture import lazy_fixture


### PR DESCRIPTION
Dependencies can be request an will be injected using the standard DI system.
This enables patterns like

```python
@asynccontextmanager
async def connection_lifespan(channel_name: str, socket: WebSocket, channels: ChannelsPlugin):
  await socket.accept()
  async with channels.start_subscription(channel_name) as subscriber:
    async with subscriber.run_in_backgroun(socket.send_data):
      yield


@websocket_listener("/{channel_name:str}", connection_lifespan=connection_lifespan)
def handler(data: str) -> None:
  ... # do something with data here
```

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

Add support for receiving dependencies in the `websocket_listener` hooks `on_accept`, `on_disconnect` and `connection_lifespan`.

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
