### PR TITLE
Enhancement: Warn about sync dependencies without an explicit `sync_to_thread` value

### DIFF
--- a/docs/examples/application_state/using_application_state.py
+++ b/docs/examples/application_state/using_application_state.py
@@ -27,7 +27,7 @@ def middleware_factory(*, app: "ASGIApp") -> "ASGIApp":
     return my_middleware
 
 
-def my_dependency(state: State) -> Any:
+async def my_dependency(state: State) -> Any:
     """Dependencies can receive state via injection."""
     logger.info("state value in dependency: %s", state.value)
 

--- a/docs/examples/dependency_injection/dependency_skip_validation.py
+++ b/docs/examples/dependency_injection/dependency_skip_validation.py
@@ -7,7 +7,7 @@ from litestar.di import Provide
 from litestar.params import Dependency
 
 
-def provide_str() -> str:
+async def provide_str() -> str:
     """Returns a string."""
     return "whoops"
 

--- a/docs/examples/dependency_injection/dependency_validation_error.py
+++ b/docs/examples/dependency_injection/dependency_validation_error.py
@@ -4,7 +4,7 @@ from litestar import Litestar, get
 from litestar.di import Provide
 
 
-def provide_str() -> str:
+async def provide_str() -> str:
     """Returns a string."""
     return "whoops"
 

--- a/docs/usage/dependency-injection.rst
+++ b/docs/usage/dependency-injection.rst
@@ -10,19 +10,19 @@ the application:
    from litestar.di import Provide
 
 
-   def bool_fn() -> bool:
+   async def bool_fn() -> bool:
        ...
 
 
-   def dict_fn() -> dict:
+   async def dict_fn() -> dict:
        ...
 
 
-   def list_fn() -> list:
+   async def list_fn() -> list:
        ...
 
 
-   def int_fn() -> int:
+   async def int_fn() -> int:
        ...
 
 
@@ -61,6 +61,21 @@ The above example illustrates how dependencies are declared on the different lay
 Dependencies can be either callables - sync or async functions, methods or class instances that implement the
 :meth:`object.__call__` method, or classes. These are in turn wrapped inside an instance of the
 :class:`Provide <.di.Provide>` class.
+
+.. admonition:: Sync vs. Async dependencies
+    :class: important
+
+    Litestar supports both synchronous and asynchronous dependencies. To ensure
+    To ensure synchronous dependencies don't block the main thread and therefore the
+    entire application (for example when they perform blocking I/O), the parameter
+    ``sync_to_thread`` will cause them to be run in a thread pool. If a synchronous
+    function is non-blocking, it should be considered to make it an async function
+    instead.
+
+.. tip::
+    Litestar will warn about the usage of synchronous dependency functions which don't
+    have ``sync_to_thread`` set.
+
 
 Pre-requisites and Scope
 ------------------------

--- a/docs/usage/dependency-injection.rst
+++ b/docs/usage/dependency-injection.rst
@@ -65,15 +65,14 @@ Dependencies can be either callables - sync or async functions, methods or class
 .. admonition:: Sync vs. Async dependencies
     :class: important
 
-    Litestar supports both synchronous and asynchronous dependencies. To ensure
-    To ensure synchronous dependencies don't block the main thread and therefore the
-    entire application (for example when they perform blocking I/O), the parameter
-    ``sync_to_thread`` will cause them to be run in a thread pool. If a synchronous
-    function is non-blocking, it should be considered to make it an async function
-    instead.
+    Litestar supports both **synchronous** and **asynchronous** dependencies.
+    To ensure **synchronous** dependencies don't block the main thread
+    - *and therefore the entire application, for example when they perform blocking I/O* -
+    the parameter ``sync_to_thread`` will ensure they are run in a thread pool.
+    If a **synchronous** function is non-blocking, you should consider making it an async function instead.
 
 .. tip::
-    Litestar will warn about the usage of synchronous dependency functions which don't
+    Litestar will warn about the usage of synchronous dependency functions which do not
     have ``sync_to_thread`` set.
 
 

--- a/litestar/channels/plugin.py
+++ b/litestar/channels/plugin.py
@@ -109,7 +109,7 @@ class ChannelsPlugin(InitPluginProtocol):
 
     def on_app_init(self, app_config: AppConfig) -> AppConfig:
         """Plugin hook. Set up a ``channels`` dependency, add route handlers and register application hooks"""
-        app_config.dependencies["channels"] = Provide(lambda: self, use_cache=True)
+        app_config.dependencies["channels"] = Provide(lambda: self, use_cache=True, sync_to_thread=False)
         app_config.on_startup.append(self._on_startup)
         app_config.on_shutdown.append(self._on_shutdown)
 

--- a/litestar/contrib/sqlalchemy/plugins/init/plugin.py
+++ b/litestar/contrib/sqlalchemy/plugins/init/plugin.py
@@ -35,8 +35,8 @@ class SQLAlchemyInitPlugin(InitPluginProtocol, _slots_base.SlotsBase):
         """
         app_config.dependencies.update(
             {
-                self._config.engine_dependency_key: Provide(self._config.provide_engine),
-                self._config.session_dependency_key: Provide(self._config.provide_session),
+                self._config.engine_dependency_key: Provide(self._config.provide_engine, sync_to_thread=False),
+                self._config.session_dependency_key: Provide(self._config.provide_session, sync_to_thread=False),
             }
         )
         app_config.before_send.append(self._config.before_send_handler)

--- a/litestar/di.py
+++ b/litestar/di.py
@@ -53,8 +53,8 @@ class Provide:
         if self.has_sync_callable and sync_to_thread is None:
             warnings.warn(
                 "Using a synchronous callable with Provide might block the main thread "
-                "if the callable performs blocking operations and sync_to_thread is not"
-                " set to True. If the callable is non-blocking, either make it "
+                "if the callable performs blocking operations and sync_to_thread is not "
+                "set to True. If the callable is non-blocking, either make it "
                 "asynchronous or set sync_to_thread=False explicitly to silence this "
                 "warning.",
                 category=LitestarWarning,

--- a/litestar/di.py
+++ b/litestar/di.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from litestar.exceptions import ImproperlyConfiguredException, LitestarWarning
 from litestar.types import Empty
-from litestar.utils import Ref, get_name, is_async_callable
+from litestar.utils import Ref, is_async_callable
 
 __all__ = ("Provide",)
 
@@ -54,10 +54,11 @@ class Provide:
             warnings.warn(
                 "Using a synchronous callable with Provide might block the main thread "
                 "if the callable performs blocking operations and sync_to_thread is not"
-                f" set to True. If {get_name(dependency)!r} is non-blocking you can "
-                f"either make it an asynchronous callable or set sync_to_thread=False "
-                f"explicitly to silence this warning.",
+                " set to True. If the callable is non-blocking, either make it "
+                "asynchronous or set sync_to_thread=False explicitly to silence this "
+                "warning.",
                 category=LitestarWarning,
+                stacklevel=1,
             )
         self.sync_to_thread = bool(sync_to_thread)
         self.use_cache = use_cache

--- a/litestar/exceptions/__init__.py
+++ b/litestar/exceptions/__init__.py
@@ -1,8 +1,4 @@
-from .base_exceptions import (
-    LitestarException,
-    MissingDependencyException,
-    SerializationException,
-)
+from .base_exceptions import LitestarException, LitestarWarning, MissingDependencyException, SerializationException
 from .http_exceptions import (
     ClientException,
     HTTPException,
@@ -25,6 +21,8 @@ __all__ = (
     "HTTPException",
     "ImproperlyConfiguredException",
     "InternalServerException",
+    "LitestarException",
+    "LitestarWarning",
     "MethodNotAllowedException",
     "MissingDependencyException",
     "NoRouteMatchFoundException",
@@ -33,7 +31,6 @@ __all__ = (
     "PermissionDeniedException",
     "SerializationException",
     "ServiceUnavailableException",
-    "LitestarException",
     "TemplateNotFoundException",
     "TooManyRequestsException",
     "ValidationException",

--- a/litestar/exceptions/base_exceptions.py
+++ b/litestar/exceptions/base_exceptions.py
@@ -45,3 +45,7 @@ class MissingDependencyException(LitestarException, ImportError):
 
 class SerializationException(LitestarException):
     """Encoding or decoding of an object failed."""
+
+
+class LitestarWarning(UserWarning):
+    """Base class for Litestar warnings"""

--- a/tests/dependency_injection/test_dependency_validation.py
+++ b/tests/dependency_injection/test_dependency_validation.py
@@ -5,12 +5,12 @@ from litestar.di import Provide
 from litestar.exceptions import ImproperlyConfiguredException
 
 
-def first_method(query_param: int) -> int:
+async def first_method(query_param: int) -> int:
     assert isinstance(query_param, int)
     return query_param
 
 
-def second_method(path_param: str) -> str:
+async def second_method(path_param: str) -> str:
     assert isinstance(path_param, str)
     return path_param
 

--- a/tests/dependency_injection/test_http_handler_dependency_injection.py
+++ b/tests/dependency_injection/test_http_handler_dependency_injection.py
@@ -45,12 +45,15 @@ test_path = "/test"
 
 class FirstController(Controller):
     path = test_path
-    dependencies = {"first": Provide(controller_first_dependency), "second": Provide(controller_second_dependency)}
+    dependencies = {
+        "first": Provide(controller_first_dependency, sync_to_thread=False),
+        "second": Provide(controller_second_dependency),
+    }
 
     @get(
         path="/{path_param:str}",
         dependencies={
-            "first": Provide(local_method_first_dependency),
+            "first": Provide(local_method_first_dependency, sync_to_thread=False),
         },
     )
     def test_method(self, first: int, second: dict, third: bool) -> None:
@@ -63,7 +66,7 @@ def test_controller_dependency_injection() -> None:
     with create_test_client(
         FirstController,
         dependencies={
-            "second": Provide(router_first_dependency),
+            "second": Provide(router_first_dependency, sync_to_thread=False),
             "third": Provide(router_second_dependency),
         },
     ) as client:
@@ -75,8 +78,8 @@ def test_function_dependency_injection() -> None:
     @get(
         path=test_path + "/{path_param:str}",
         dependencies={
-            "first": Provide(local_method_first_dependency),
-            "third": Provide(local_method_second_dependency),
+            "first": Provide(local_method_first_dependency, sync_to_thread=False),
+            "third": Provide(local_method_second_dependency, sync_to_thread=False),
         },
     )
     def test_function(first: int, second: bool, third: str) -> None:
@@ -87,7 +90,7 @@ def test_function_dependency_injection() -> None:
     with create_test_client(
         test_function,
         dependencies={
-            "first": Provide(router_first_dependency),
+            "first": Provide(router_first_dependency, sync_to_thread=False),
             "second": Provide(router_second_dependency),
         },
     ) as client:

--- a/tests/dependency_injection/test_injection_of_classes.py
+++ b/tests/dependency_injection/test_injection_of_classes.py
@@ -18,12 +18,12 @@ def test_injection_of_classes() -> None:
 
     class MyController(Controller):
         path = "/test"
-        dependencies = {"path_param_dependency": Provide(TopLevelDependency)}
+        dependencies = {"path_param_dependency": Provide(TopLevelDependency, sync_to_thread=False)}
 
         @get(
             path="/{path_param:int}",
             dependencies={
-                "container": Provide(HandlerDependency),
+                "container": Provide(HandlerDependency, sync_to_thread=False),
             },
         )
         def test_function(self, container: HandlerDependency) -> str:

--- a/tests/dependency_injection/test_injection_of_generic_models.py
+++ b/tests/dependency_injection/test_injection_of_generic_models.py
@@ -37,7 +37,7 @@ def root(store: DictStore) -> Optional[Item]:
     return store.get("0")
 
 
-def get_item_store() -> DictStore:
+async def get_item_store() -> DictStore:
     return DictStore(model=Item)  # type: ignore
 
 

--- a/tests/dependency_injection/test_inter_dependencies.py
+++ b/tests/dependency_injection/test_inter_dependencies.py
@@ -7,13 +7,13 @@ from litestar.testing import create_test_client
 
 
 def test_inter_dependencies() -> None:
-    def top_dependency(query_param: int) -> int:
+    async def top_dependency(query_param: int) -> int:
         return query_param
 
-    def mid_level_dependency() -> int:
+    async def mid_level_dependency() -> int:
         return 5
 
-    def local_dependency(path_param: int, mid_level: int, top_level: int) -> int:
+    async def local_dependency(path_param: int, mid_level: int, top_level: int) -> int:
         return path_param + mid_level + top_level
 
     class MyController(Controller):
@@ -36,10 +36,10 @@ def test_inter_dependencies() -> None:
 
 
 def test_inter_dependencies_on_same_app_level() -> None:
-    def first_dependency() -> int:
+    async def first_dependency() -> int:
         return randint(1, 10)
 
-    def second_dependency(injected_integer: int) -> bool:
+    async def second_dependency(injected_integer: int) -> bool:
         return injected_integer % 2 == 0
 
     @get("/true-or-false")

--- a/tests/dependency_injection/test_request_local_caching.py
+++ b/tests/dependency_injection/test_request_local_caching.py
@@ -7,13 +7,13 @@ from litestar.testing import create_test_client
 def test_caching_per_request() -> None:
     value = 1
 
-    def first_dependency() -> int:
+    async def first_dependency() -> int:
         nonlocal value
         tmp = value
         value += 1
         return tmp  # noqa: R504
 
-    def second_dependency(first: int) -> int:
+    async def second_dependency(first: int) -> int:
         return first + 5
 
     @get()

--- a/tests/dependency_injection/test_websocket_handler_dependency_injection.py
+++ b/tests/dependency_injection/test_websocket_handler_dependency_injection.py
@@ -45,12 +45,15 @@ test_path = "/test"
 
 class FirstController(Controller):
     path = test_path
-    dependencies = {"first": Provide(controller_first_dependency), "second": Provide(controller_second_dependency)}
+    dependencies = {
+        "first": Provide(controller_first_dependency, sync_to_thread=True),
+        "second": Provide(controller_second_dependency),
+    }
 
     @websocket(
         path="/{path_param:str}",
         dependencies={
-            "first": Provide(local_method_first_dependency),
+            "first": Provide(local_method_first_dependency, sync_to_thread=False),
         },
     )
     async def test_method(self, socket: WebSocket, first: int, second: dict, third: bool) -> None:
@@ -68,7 +71,7 @@ def test_controller_dependency_injection() -> None:
     client = create_test_client(
         FirstController,
         dependencies={
-            "second": Provide(router_first_dependency),
+            "second": Provide(router_first_dependency, sync_to_thread=False),
             "third": Provide(router_second_dependency),
         },
     )
@@ -80,8 +83,8 @@ def test_function_dependency_injection() -> None:
     @websocket(
         path=test_path + "/{path_param:str}",
         dependencies={
-            "first": Provide(local_method_first_dependency),
-            "third": Provide(local_method_second_dependency),
+            "first": Provide(local_method_first_dependency, sync_to_thread=False),
+            "third": Provide(local_method_second_dependency, sync_to_thread=False),
         },
     )
     async def test_function(socket: WebSocket, first: int, second: bool, third: str) -> None:
@@ -97,7 +100,7 @@ def test_function_dependency_injection() -> None:
     client = create_test_client(
         test_function,
         dependencies={
-            "first": Provide(router_first_dependency),
+            "first": Provide(router_first_dependency, sync_to_thread=False),
             "second": Provide(router_second_dependency),
         },
     )

--- a/tests/handlers/websocket/test_listeners.py
+++ b/tests/handlers/websocket/test_listeners.py
@@ -220,7 +220,7 @@ def test_listener_pass_socket(mock: MagicMock) -> None:
 
 
 def test_listener_pass_additional_dependencies(mock: MagicMock) -> None:
-    def foo_dependency(state: State) -> int:
+    async def foo_dependency(state: State) -> int:
         if not hasattr(state, "foo"):
             state.foo = 0
         state.foo += 1

--- a/tests/kwargs/test_dependency_batches.py
+++ b/tests/kwargs/test_dependency_batches.py
@@ -6,7 +6,7 @@ from litestar._kwargs.dependencies import Dependency, create_dependency_batches
 from litestar.di import Provide
 
 
-def dummy() -> None:
+async def dummy() -> None:
     pass
 
 

--- a/tests/kwargs/test_generator_dependencies.py
+++ b/tests/kwargs/test_generator_dependencies.py
@@ -68,7 +68,7 @@ def test_generator_dependency(
 ) -> None:
     dependency = request.getfixturevalue(dependency_fixture)
 
-    @get("/", dependencies={"dep": Provide(dependency)}, cache=cache)
+    @get("/", dependencies={"dep": Provide(dependency, sync_to_thread=False)}, cache=cache)
     def handler(dep: str) -> Dict[str, str]:
         return {"value": dep}
 
@@ -91,7 +91,7 @@ async def test_generator_dependency_websocket(
 ) -> None:
     dependency = request.getfixturevalue(dependency_fixture)
 
-    @websocket("/ws", dependencies={"dep": Provide(dependency)})
+    @websocket("/ws", dependencies={"dep": Provide(dependency, sync_to_thread=False)})
     async def ws_handler(socket: WebSocket, dep: str) -> None:
         await socket.accept()
         await socket.send_json({"value": dep})
@@ -114,7 +114,7 @@ def test_generator_dependency_handle_exception(
 ) -> None:
     dependency = request.getfixturevalue(dependency_fixture)
 
-    @get("/", dependencies={"dep": Provide(dependency)})
+    @get("/", dependencies={"dep": Provide(dependency, sync_to_thread=False)})
     def handler(dep: str) -> Dict[str, str]:
         raise ValueError("foo")
 
@@ -138,7 +138,7 @@ def test_generator_dependency_exception_during_cleanup(
     dependency = request.getfixturevalue(dependency_fixture)
     cleanup_mock.side_effect = Exception("foo")
 
-    @get("/", dependencies={"dep": Provide(dependency)})
+    @get("/", dependencies={"dep": Provide(dependency, sync_to_thread=False)})
     def handler(dep: str) -> Dict[str, str]:
         return {"value": dep}
 
@@ -169,9 +169,9 @@ def test_generator_dependency_nested(
     @get(
         "/",
         dependencies={
-            "generator_dep": Provide(dependency),
-            "nested_one": Provide(nested_dependency_one),
-            "nested_two": Provide(nested_dependency_two),
+            "generator_dep": Provide(dependency, sync_to_thread=False),
+            "nested_one": Provide(nested_dependency_one, sync_to_thread=False),
+            "nested_two": Provide(nested_dependency_two, sync_to_thread=False),
         },
     )
     def handler(nested_two: str) -> Dict[str, str]:
@@ -207,8 +207,8 @@ def test_generator_dependency_nested_error_during_cleanup(
     @get(
         "/",
         dependencies={
-            "generator_dep": Provide(dependency),
-            "other": Provide(other_dependency),
+            "generator_dep": Provide(dependency, sync_to_thread=False),
+            "other": Provide(other_dependency, sync_to_thread=False),
         },
     )
     def handler(other: str) -> Dict[str, str]:

--- a/tests/kwargs/test_query_params.py
+++ b/tests/kwargs/test_query_params.py
@@ -210,7 +210,7 @@ def test_query_parsing_of_escaped_values(values: Tuple[Tuple[str, str], Tuple[st
 
 
 def test_query_param_dependency_with_alias() -> None:
-    def qp_dependency(page_size: int = Parameter(query="pageSize", gt=0, le=100)) -> int:
+    async def qp_dependency(page_size: int = Parameter(query="pageSize", gt=0, le=100)) -> int:
         return page_size
 
     @get("/", media_type=MediaType.TEXT)

--- a/tests/kwargs/test_validations.py
+++ b/tests/kwargs/test_validations.py
@@ -12,7 +12,7 @@ from litestar.handlers.http_handlers import HTTPRouteHandler
 from litestar.params import Body, Parameter
 
 
-def my_dependency() -> int:
+async def my_dependency() -> int:
     return 1
 
 
@@ -106,13 +106,13 @@ def json_dependency(data: Dict[str, Any] = Body()) -> Dict[str, Any]:
     return data
 
 
-@post("/", dependencies={"first": Provide(json_dependency)})
+@post("/", dependencies={"first": Provide(json_dependency, sync_to_thread=True)})
 def accepted_json_handler(data: Dict[str, Any], first: Dict[str, Any]) -> None:
     assert data
     assert first
 
 
-@post("/", dependencies={"first": Provide(url_encoded_dependency)})
+@post("/", dependencies={"first": Provide(url_encoded_dependency, sync_to_thread=True)})
 def accepted_url_encoded_handler(
     first: Dict[str, Any],
     data: Dict[str, Any] = Body(media_type=RequestEncodingType.URL_ENCODED),
@@ -121,7 +121,7 @@ def accepted_url_encoded_handler(
     assert first
 
 
-@post("/", dependencies={"first": Provide(multi_part_dependency)})
+@post("/", dependencies={"first": Provide(multi_part_dependency, sync_to_thread=True)})
 def accepted_multi_part_handler(
     first: Dict[str, Any],
     data: Dict[str, Any] = Body(media_type=RequestEncodingType.MULTI_PART),
@@ -147,7 +147,7 @@ def test_dependency_data_kwarg_validation_success_scenarios(handler: HTTPRouteHa
     ],
 )
 def test_dependency_data_kwarg_validation_failure_scenarios(body: FieldInfo, dependency: Callable) -> None:
-    @post("/", dependencies={"first": Provide(dependency)})
+    @post("/", dependencies={"first": Provide(dependency, sync_to_thread=False)})
     def handler(first: Dict[str, Any], data: Any = body) -> None:
         assert first
         assert data

--- a/tests/openapi/test_parameters.py
+++ b/tests/openapi/test_parameters.py
@@ -145,13 +145,21 @@ def test_deduplication_for_param_where_key_and_type_are_equal() -> None:
     class BDep(BaseDep):
         ...
 
-    def c_dep(other_param: float) -> float:
+    async def c_dep(other_param: float) -> float:
         return other_param
 
-    def d_dep(other_param: float) -> float:
+    async def d_dep(other_param: float) -> float:
         return other_param
 
-    @get("/test", dependencies={"a": Provide(ADep), "b": Provide(BDep), "c": Provide(c_dep), "d": Provide(d_dep)})
+    @get(
+        "/test",
+        dependencies={
+            "a": Provide(ADep, sync_to_thread=False),
+            "b": Provide(BDep, sync_to_thread=False),
+            "c": Provide(c_dep),
+            "d": Provide(d_dep),
+        },
+    )
     def handler(a: ADep, b: BDep, c: float, d: float) -> str:
         return "OK"
 
@@ -164,10 +172,10 @@ def test_deduplication_for_param_where_key_and_type_are_equal() -> None:
 
 
 def test_raise_for_multiple_parameters_of_same_name_and_differing_types() -> None:
-    def a_dep(query_param: int) -> int:
+    async def a_dep(query_param: int) -> int:
         return query_param
 
-    def b_dep(query_param: str) -> int:
+    async def b_dep(query_param: str) -> int:
         return 1
 
     @get("/test", dependencies={"a": Provide(a_dep), "b": Provide(b_dep)})
@@ -181,7 +189,7 @@ def test_raise_for_multiple_parameters_of_same_name_and_differing_types() -> Non
 
 
 def test_dependency_params_in_docs_if_dependency_provided() -> None:
-    def produce_dep(param: str) -> int:
+    async def produce_dep(param: str) -> int:
         return 13
 
     @get(dependencies={"dep": Provide(produce_dep)})

--- a/tests/openapi/test_schema.py
+++ b/tests/openapi/test_schema.py
@@ -69,13 +69,13 @@ def test_process_schema_result() -> None:
 
 
 def test_dependency_schema_generation() -> None:
-    def top_dependency(query_param: int) -> int:
+    async def top_dependency(query_param: int) -> int:
         return query_param
 
-    def mid_level_dependency(header_param: str = Parameter(header="header_param", required=False)) -> int:
+    async def mid_level_dependency(header_param: str = Parameter(header="header_param", required=False)) -> int:
         return 5
 
-    def local_dependency(path_param: int, mid_level: int, top_level: int) -> int:
+    async def local_dependency(path_param: int, mid_level: int, top_level: int) -> int:
         return path_param + mid_level + top_level
 
     class MyController(Controller):

--- a/tests/security/test_security.py
+++ b/tests/security/test_security.py
@@ -41,7 +41,7 @@ def test_abstract_security_config_sets_dependencies(session_backend_config_memor
     security_config = SessionAuth[Any, ServerSideSessionBackend](
         retrieve_user_handler=retrieve_user_handler,
         session_backend_config=session_backend_config_memory,
-        dependencies={"value": Provide(lambda: 13)},
+        dependencies={"value": Provide(lambda: 13, sync_to_thread=False)},
     )
 
     with create_test_client([], on_app_init=[security_config.on_app_init]) as client:

--- a/tests/signature/test_parsing.py
+++ b/tests/signature/test_parsing.py
@@ -134,7 +134,7 @@ def test_dependency_validation_failure_raises_500(
     preferred_validation_backend: Literal["attrs", "pydantic"],
     error_extra: Any,
 ) -> None:
-    dependencies = {"dep": Provide(lambda: "thirteen")}
+    dependencies = {"dep": Provide(lambda: "thirteen", sync_to_thread=False)}
 
     @get("/")
     def test(dep: int, param: int, optional_dep: Optional[int] = Dependency()) -> None:
@@ -159,7 +159,7 @@ def test_dependency_validation_failure_raises_500(
 def test_validation_failure_raises_400(
     preferred_validation_backend: Literal["attrs", "pydantic"], error_extra: Any
 ) -> None:
-    dependencies = {"dep": Provide(lambda: 13)}
+    dependencies = {"dep": Provide(lambda: 13, sync_to_thread=False)}
 
     @get("/")
     def test(dep: int, param: int, optional_dep: Optional[int] = Dependency()) -> None:
@@ -178,7 +178,10 @@ def test_validation_failure_raises_400(
 
 
 def test_client_pydantic_backend_error_precedence_over_server_error() -> None:
-    dependencies = {"dep": Provide(lambda: "thirteen"), "optional_dep": Provide(lambda: "thirty-one")}
+    dependencies = {
+        "dep": Provide(lambda: "thirteen", sync_to_thread=False),
+        "optional_dep": Provide(lambda: "thirty-one", sync_to_thread=False),
+    }
 
     @get("/")
     def test(dep: int, param: int, optional_dep: Optional[int] = Dependency()) -> None:

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -39,7 +39,7 @@ def test_non_optional_with_default() -> None:
 
 
 def test_no_default_dependency_provided() -> None:
-    @get(dependencies={"value": Provide(lambda: 13)})
+    @get(dependencies={"value": Provide(lambda: 13, sync_to_thread=False)})
     def test(value: int = Dependency()) -> Dict[str, int]:
         return {"value": value}
 
@@ -64,7 +64,7 @@ def test_dependency_provided_on_controller() -> None:
 
     class C(Controller):
         path = ""
-        dependencies = {"value": Provide(lambda: 13)}
+        dependencies = {"value": Provide(lambda: 13, sync_to_thread=False)}
 
         @get()
         def test(self, value: int = Dependency()) -> Dict[str, int]:
@@ -85,7 +85,7 @@ def test_dependency_skip_validation() -> None:
         return {"value": value}
 
     with create_test_client(
-        route_handlers=[validated, skipped], dependencies={"value": Provide(lambda: "str")}
+        route_handlers=[validated, skipped], dependencies={"value": Provide(lambda: "str", sync_to_thread=False)}
     ) as client:
         validated_resp = client.get("/validated")
         assert validated_resp.status_code == HTTP_500_INTERNAL_SERVER_ERROR
@@ -110,7 +110,7 @@ def test_nested_sequence_dependency() -> None:
         def __init__(self, seq: List[str]) -> None:
             self.seq = seq
 
-    def provides_obj(seq: List[str]) -> Obj:
+    async def provides_obj(seq: List[str]) -> Obj:
         return Obj(seq)
 
     @get("/obj")

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -68,7 +68,7 @@ def test_parsing_of_body_as_default_value(backend: Any) -> None:
 
 @pytest.mark.parametrize("backend", ("pydantic", "attrs"))
 def test_parsing_of_dependency_as_annotated(backend: Any) -> None:
-    @get(path="/", dependencies={"dep": Provide(lambda: None)})
+    @get(path="/", dependencies={"dep": Provide(lambda: None, sync_to_thread=False)})
     def handler(dep: Annotated[int, Dependency(skip_validation=True)]) -> int:
         return dep
 
@@ -79,7 +79,7 @@ def test_parsing_of_dependency_as_annotated(backend: Any) -> None:
 
 @pytest.mark.parametrize("backend", ("pydantic", "attrs"))
 def test_parsing_of_dependency_as_default_value(backend: Any) -> None:
-    @get(path="/", dependencies={"dep": Provide(lambda: None)})
+    @get(path="/", dependencies={"dep": Provide(lambda: None, sync_to_thread=False)})
     def handler(dep: int = Dependency(skip_validation=True)) -> int:
         return dep
 

--- a/tests/test_provide.py
+++ b/tests/test_provide.py
@@ -77,10 +77,10 @@ async def test_run_in_thread(anyio_backend: str) -> None:
 
 
 def test_provider_equality_check() -> None:
-    first_provider = Provide(dependency=sync_fn)
-    second_provider = Provide(dependency=sync_fn)
+    first_provider = Provide(dependency=sync_fn, sync_to_thread=False)
+    second_provider = Provide(dependency=sync_fn, sync_to_thread=False)
     assert first_provider == second_provider
-    third_provider = Provide(dependency=sync_fn, use_cache=True)
+    third_provider = Provide(dependency=sync_fn, use_cache=True, sync_to_thread=False)
     assert first_provider != third_provider
     second_provider.value = True
     assert first_provider != second_provider
@@ -102,7 +102,7 @@ def test_provider_equality_check() -> None:
     ],
 )
 async def test_provide_for_callable(fn: Any, exp: Any, anyio_backend: str) -> None:
-    assert await Provide(fn)() == exp
+    assert await Provide(fn, sync_to_thread=False)() == exp
 
 
 @pytest.fixture

--- a/tests/test_provide.py
+++ b/tests/test_provide.py
@@ -6,6 +6,7 @@ import pytest
 
 from litestar._kwargs.cleanup import DependencyCleanupGroup
 from litestar.di import Provide
+from litestar.exceptions import LitestarWarning
 from litestar.types import Empty
 from litestar.utils.compat import async_next
 
@@ -186,3 +187,11 @@ async def test_cleanup_group_add_on_closed_raises(
 
     with pytest.raises(RuntimeError):
         group.add(async_generator)
+
+
+def test_sync_callable_without_sync_to_thread_warns() -> None:
+    def func() -> None:
+        pass
+
+    with pytest.warns(LitestarWarning):
+        Provide(func)


### PR DESCRIPTION
As discussed in https://github.com/litestar-org/litestar/pull/1638#discussion_r1188482488, this changes the functionality of `Provide` to issue a warning if used with a synchronous callable without setting `sync_to_thread` explicitly. 

This is meant to prevent pitfalls where a user might pass a synchronous dependency which is blocking and inadvertently blocks their whole application. Since the other option would be to use `sync_to_thread` by default, which would introduce a performance loss in cases where this isn't needed, simply issuing a warning is seen as a reasonable approach.

