### PR TITLE
Feature: Partial dtos

### DIFF
--- a/docs/examples/data_transfer_objects/factory/patch_requests.py
+++ b/docs/examples/data_transfer_objects/factory/patch_requests.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from litestar import Litestar, patch
+from litestar.dto.factory import DTOConfig, DTOData
+from litestar.dto.factory.stdlib.dataclass import DataclassDTO
+
+
+@dataclass
+class Person:
+    id: UUID
+    name: str
+    age: int
+
+
+class WriteDTO(DataclassDTO[Person]):
+    """Don't allow client to set the id."""
+
+    config = DTOConfig(exclude={"id"}, partial=True)
+
+
+database = {
+    UUID("f32ff2ce-e32f-4537-9dc0-26e7599f1380"): Person(
+        id=UUID("f32ff2ce-e32f-4537-9dc0-26e7599f1380"), name="Peter", age=40
+    )
+}
+
+
+@patch("/person/{person_id:uuid}", dto=WriteDTO, return_dto=None)
+def update_person(person_id: UUID, data: DTOData[Person]) -> Person:
+    """Create a person."""
+    return data.update_instance(database.get(person_id))
+
+
+app = Litestar(route_handlers=[update_person])
+
+# run: /person/f32ff2ce-e32f-4537-9dc0-26e7599f1380 -X PATCH -H "Content-Type: application/json" -d '{"name":"Peter Pan"}'

--- a/docs/examples/tests/data_transfer_objects/factory/test_example_apps.py
+++ b/docs/examples/tests/data_transfer_objects/factory/test_example_apps.py
@@ -21,3 +21,19 @@ def test_dto_data_usage_app() -> None:
         response = client.post("/person", json={"name": "John", "age": 30})
         assert response.status_code == 201
         assert response.json() == {"id": ANY, "name": "John", "age": 30}
+
+
+def test_patch_requests_app() -> None:
+    from docs.examples.data_transfer_objects.factory.patch_requests import app
+
+    with TestClient(app) as client:
+        response = client.patch(
+            "/person/f32ff2ce-e32f-4537-9dc0-26e7599f1380",
+            json={"name": "Peter Pan"},
+        )
+        assert response.status_code == 200
+        assert response.json() == {
+            "id": "f32ff2ce-e32f-4537-9dc0-26e7599f1380",
+            "name": "Peter Pan",
+            "age": 40,
+        }

--- a/docs/usage/dto/1-dto-factory.rst
+++ b/docs/usage/dto/1-dto-factory.rst
@@ -154,7 +154,8 @@ data into a ``Person`` object and failed because it has no value for the require
 
 One way to handle this is to create different models, e.g., we might create a ``CreatePerson`` model that has no ``id``
 field, and decode the client data into that. However, this method can become quite cumbersome when we have a lot of
-variability in the data that we accept from clients, for example, PATCH requests.
+variability in the data that we accept from clients, for example,
+`PATCH <https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH>`_ requests.
 
 This is where the :class:`DTOData <litestar.dto.factory.DTOData>` class comes in. It is a generic class that accepts the
 type of the data that it will contain, and provides useful methods for interacting with that data.
@@ -169,3 +170,25 @@ and have used that to create our ``Person`` instance, after augmenting the clien
 value.
 
 Consult the :class:`Reference Docs <litestar.dto.factory.DTOData>` for more information on the methods available.
+
+DTO Factory and PATCH requests
+------------------------------
+
+`PATCH <https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH>`_ requests are a special case when it comes to
+data transfer objects. The reason for this is that we need to be able to accept and validate any subset of the model
+attributes in the client payload, which requires some special handling internally.
+
+.. literalinclude:: /examples/data_transfer_objects/factory/patch_requests.py
+    :language: python
+    :emphasize-lines: 7,21,32,34
+    :linenos:
+
+The ``PatchDTO`` class is defined for the Person class. The ``config`` attribute of ``WriteDTO`` is set to exclude the
+id field, preventing clients from setting it when updating a person, and the ``partial`` attribute is set to ``True``,
+which allows the DTO to accept a subset of the model attributes.
+
+Inside the handler, the :meth:`DTOData.update_instance <litestar.dto.factory.DTOData.update_instance>` method is called
+to update the instance of ``Person`` before returning it.
+
+In our request, we set only the ``name`` property of the ``Person``, from ``"Peter"`` to ``"Peter Pan"`` and received
+the full object - with the modified name - back in the response.

--- a/litestar/dto/factory/_backends/abc.py
+++ b/litestar/dto/factory/_backends/abc.py
@@ -4,17 +4,20 @@ back again, to bytes.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Final, Generic, TypeVar, Union
 
 from litestar._openapi.schema_generation import create_schema
 from litestar._signature.field import SignatureField
 from litestar.dto.factory import DTOData
 from litestar.utils.helpers import get_fully_qualified_class_name
+from litestar.utils.signature import ParsedType
 
 from .types import (
+    MISSING,
     CollectionType,
     CompositeType,
     MappingType,
+    Missing,
     NestedFieldInfo,
     SimpleType,
     TransferFieldDefinition,
@@ -29,7 +32,7 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
-    from typing import AbstractSet, Any, Callable, Final, Generator
+    from typing import AbstractSet, Any, Callable, Generator
 
     from litestar.dto.factory import DTOConfig
     from litestar.dto.factory.types import FieldDefinition
@@ -37,7 +40,6 @@ if TYPE_CHECKING:
     from litestar.dto.types import ForType
     from litestar.openapi.spec import Reference, Schema
     from litestar.types.serialization import LitestarEncodableType
-    from litestar.utils.signature import ParsedType
 
     from .types import FieldDefinitionsType
 
@@ -160,6 +162,11 @@ class AbstractDTOBackend(ABC, Generic[BackendT]):
             if should_exclude_field(field_definition, exclude, self.context.dto_for):
                 continue
 
+            if self.context.config.partial:
+                field_definition = field_definition.copy_with(  # noqa: PLW2901
+                    parsed_type=ParsedType(Union[field_definition.parsed_type.annotation, Missing]), default=MISSING
+                )
+
             try:
                 transfer_type = self._create_transfer_type(
                     field_definition.parsed_type,
@@ -182,6 +189,7 @@ class AbstractDTOBackend(ABC, Generic[BackendT]):
                 field_definition=field_definition,
                 serialization_name=serialization_name,
                 transfer_type=transfer_type,
+                is_partial=self.context.config.partial,
             )
             defined_fields.append(transfer_field_definition)
         return tuple(defined_fields)

--- a/litestar/dto/factory/_backends/abc.py
+++ b/litestar/dto/factory/_backends/abc.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Final, Generic, TypeVar, Union
 
+from msgspec import UNSET, UnsetType
+
 from litestar._openapi.schema_generation import create_schema
 from litestar._signature.field import SignatureField
 from litestar.dto.factory import DTOData
@@ -13,11 +15,9 @@ from litestar.utils.helpers import get_fully_qualified_class_name
 from litestar.utils.signature import ParsedType
 
 from .types import (
-    MISSING,
     CollectionType,
     CompositeType,
     MappingType,
-    Missing,
     NestedFieldInfo,
     SimpleType,
     TransferFieldDefinition,
@@ -164,7 +164,7 @@ class AbstractDTOBackend(ABC, Generic[BackendT]):
 
             if self.context.config.partial:
                 field_definition = field_definition.copy_with(  # noqa: PLW2901
-                    parsed_type=ParsedType(Union[field_definition.parsed_type.annotation, Missing]), default=MISSING
+                    parsed_type=ParsedType(Union[field_definition.parsed_type.annotation, UnsetType]), default=UNSET
                 )
 
             try:

--- a/litestar/dto/factory/_backends/types.py
+++ b/litestar/dto/factory/_backends/types.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Final
-from uuid import UUID
-
-from msgspec import Struct
+from typing import TYPE_CHECKING
 
 from litestar.dto.factory.types import FieldDefinition
 
@@ -126,12 +123,3 @@ class TransferFieldDefinition(FieldDefinition):
 
 FieldDefinitionsType: TypeAlias = "tuple[TransferFieldDefinition, ...]"
 """Generic representation of names and types."""
-
-
-class Missing(Struct, frozen=True):
-    """Sentinel value to indicate a missing value."""
-
-    missing: Final[UUID] = UUID("00000000-0000-0000-0000-000000000000")
-
-
-MISSING = Missing()

--- a/litestar/dto/factory/_backends/types.py
+++ b/litestar/dto/factory/_backends/types.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
+from uuid import UUID
+
+from msgspec import Struct
 
 from litestar.dto.factory.types import FieldDefinition
 
@@ -91,16 +94,22 @@ class MappingType(CompositeType):
 
 @dataclass(frozen=True)
 class TransferFieldDefinition(FieldDefinition):
-    __slots__ = ("transfer_type", "serialization_name")
+    __slots__ = (
+        "is_partial",
+        "serialization_name",
+        "transfer_type",
+    )
 
     transfer_type: TransferType
     """Type of the field for transfer."""
     serialization_name: str
     """Name of the field as it should feature on the transfer model."""
+    is_partial: bool
+    """Whether the field is optional for transfer."""
 
     @classmethod
     def from_field_definition(
-        cls, field_definition: FieldDefinition, transfer_type: TransferType, serialization_name: str
+        cls, field_definition: FieldDefinition, transfer_type: TransferType, serialization_name: str, is_partial: bool
     ) -> Self:
         return cls(
             name=field_definition.name,
@@ -111,8 +120,18 @@ class TransferFieldDefinition(FieldDefinition):
             unique_model_name=field_definition.unique_model_name,
             transfer_type=transfer_type,
             dto_field=field_definition.dto_field,
+            is_partial=is_partial,
         )
 
 
 FieldDefinitionsType: TypeAlias = "tuple[TransferFieldDefinition, ...]"
 """Generic representation of names and types."""
+
+
+class Missing(Struct, frozen=True):
+    """Sentinel value to indicate a missing value."""
+
+    missing: Final[UUID] = UUID("00000000-0000-0000-0000-000000000000")
+
+
+MISSING = Missing()

--- a/litestar/dto/factory/_backends/utils.py
+++ b/litestar/dto/factory/_backends/utils.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Collection, Mapping, TypeVar, cast
 
+from msgspec import UNSET
 from typing_extensions import get_origin
 
 from litestar.dto.factory import Mark
 
 from .types import (
-    MISSING,
     CollectionType,
     CompositeType,
     MappingType,
@@ -162,7 +162,7 @@ def transfer_instance_data(
     source_is_mapping = isinstance(source_instance, Mapping)
 
     def filter_missing(value: Any) -> bool:
-        return value is MISSING
+        return value is UNSET
 
     for field_definition in field_definitions:
         transfer_type = field_definition.transfer_type

--- a/litestar/dto/factory/config.py
+++ b/litestar/dto/factory/config.py
@@ -36,3 +36,5 @@ class DTOConfig:
     Fields defined in ``rename_fields`` are ignored."""
     max_nested_depth: int = 1
     """The maximum depth of nested items allowed for data transfer."""
+    partial: bool = False
+    """Allow transfer of partial data."""

--- a/litestar/dto/factory/data_structures.py
+++ b/litestar/dto/factory/data_structures.py
@@ -30,5 +30,17 @@ class DTOData(Generic[T]):
         data = {**self._data_as_builtins, **kwargs}
         return self.parsed_type.annotation(**data)  # type:ignore[no-any-return]
 
+    def update_instance(self, instance: T, **kwargs: Any) -> T:
+        """Update an instance with the DTO validated data.
+
+        Args:
+            instance: The instance to update.
+            **kwargs: Additional data to update the instance with. Takes precedence over DTO validated data.
+        """
+        data = {**self._data_as_builtins, **kwargs}
+        for k, v in data.items():
+            setattr(instance, k, v)
+        return instance
+
     def as_builtins(self) -> Any:
         return self._data_as_builtins

--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -17,6 +17,7 @@ from litestar.exceptions import ImproperlyConfiguredException
 from litestar.params import BodyKwarg, DependencyKwarg, ParameterKwarg
 from litestar.types import AnyCallable, Empty
 from litestar.types.builtin_types import UNION_TYPES, NoneType
+from litestar.utils.dataclass import simple_asdict
 from litestar.utils.typing import get_safe_generic_origin, unwrap_annotation
 
 _GLOBAL_NAMES = {
@@ -288,6 +289,18 @@ class ParsedParameter:
             default=Empty if parameter.default is Signature.empty else parameter.default,
             parsed_type=ParsedType(annotation),
         )
+
+    def copy_with(self, **kwargs: Any) -> Self:
+        """Create a copy of the parameter with the given attributes updated.
+
+        Args:
+            kwargs: Attributes to update.
+
+        Returns:
+            ParsedParameter
+        """
+        data = {**simple_asdict(self), **kwargs}
+        return type(self)(**data)
 
 
 @dataclass(frozen=True)

--- a/tests/dto/factory/test_integration.py
+++ b/tests/dto/factory/test_integration.py
@@ -7,7 +7,7 @@ from typing import Optional
 import pytest
 from typing_extensions import Annotated
 
-from litestar import post
+from litestar import patch, post
 from litestar.datastructures import UploadFile
 from litestar.dto.factory import DTOConfig, DTOData, dto_field
 from litestar.dto.factory.stdlib.dataclass import DataclassDTO
@@ -157,3 +157,22 @@ def test_dto_data_with_url_encoded_form_data() -> None:
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
         assert response.json() == {"name": "John", "age": 42, "read_only": "read-only"}
+
+
+def test_dto_data_with_patch_request() -> None:
+    @dataclass
+    class User:
+        name: str
+        age: int
+        read_only: str = field(default="read-only", metadata=dto_field("read-only"))
+
+    class PatchDTO(DataclassDTO[User]):
+        config = DTOConfig(partial=True)
+
+    @patch(dto=PatchDTO, return_dto=None, signature_namespace={"User": User})
+    def handler(data: DTOData[User]) -> User:
+        return data.update_instance(User(name="John", age=42))
+
+    with create_test_client(route_handlers=[handler], debug=True) as client:
+        response = client.patch("/", json={"age": 41, "read_only": "whoops"})
+        assert response.json() == {"name": "John", "age": 41, "read_only": "read-only"}


### PR DESCRIPTION
This allows a DTO to be configured to handle PATCH requests by creating a union of the field definition with an empty sentinel.

We filter any unset values when extracting data from transfer models.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [x] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [x] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
