### PR TITLE
Enhancement: Warn about sync handler functions without an explicit `sync_to_thread` value

### DIFF
--- a/docs/admonitions/sync-to-thread-info.rst
+++ b/docs/admonitions/sync-to-thread-info.rst
@@ -1,0 +1,18 @@
+.. admonition:: Synchronous and asynchronous callables
+    :class: important
+
+    Both synchronous and asynchronous callables are supported. One important aspect of
+    this is that using a synchronous function which perform blocking operations, such
+    as I/O or computationally intensive tasks, can potentially block the main thread
+    running the event loop, and in turn block the whole application.
+
+    To mitigate this, the ``sync_to_thread`` parameter can be set to ``True``, which
+    will result in the function being run in a thread pool. Should the function be
+    non-blocking, ``sync_to_thread`` should be set to ``False`` instead.
+
+    If a synchronous function is passed, without setting an explicit ``sync_to_thread``
+    value, a warning will be raised.
+
+    .. seealso::
+
+        :doc:`/topics/sync-vs-async`

--- a/docs/examples/application_hooks/after_exception_hook.py
+++ b/docs/examples/application_hooks/after_exception_hook.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from litestar.types import Scope
 
 
-@get("/some-path")
+@get("/some-path", sync_to_thread=False)
 def my_handler() -> None:
     """Route handler that raises an exception."""
     raise HTTPException(detail="bad request", status_code=HTTP_400_BAD_REQUEST)

--- a/docs/examples/application_hooks/before_send_hook.py
+++ b/docs/examples/application_hooks/before_send_hook.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from litestar.types import Message, Scope
 
 
-@get("/test")
+@get("/test", sync_to_thread=False)
 def handler() -> Dict[str, str]:
     """Example Handler function."""
     return {"key": "value"}

--- a/docs/examples/application_state/passing_initial_state.py
+++ b/docs/examples/application_state/passing_initial_state.py
@@ -2,7 +2,7 @@ from litestar import Litestar, get
 from litestar.datastructures import State
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def handler(state: State) -> dict:
     return state.dict()
 

--- a/docs/examples/application_state/using_application_state.py
+++ b/docs/examples/application_state/using_application_state.py
@@ -32,7 +32,7 @@ async def my_dependency(state: State) -> Any:
     logger.info("state value in dependency: %s", state.value)
 
 
-@get("/", dependencies={"dep": Provide(my_dependency)}, middleware=[middleware_factory])
+@get("/", dependencies={"dep": Provide(my_dependency)}, middleware=[middleware_factory], sync_to_thread=False)
 def get_handler(state: State, request: Request, dep: Any) -> None:
     """Handlers can receive state via injection."""
     logger.info("state value in handler from `State`: %s", state.value)

--- a/docs/examples/application_state/using_custom_state.py
+++ b/docs/examples/application_state/using_custom_state.py
@@ -9,7 +9,7 @@ class MyState(State):
         self.count += 1
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def handler(state: MyState) -> dict:
     state.increment()
     return state.dict()

--- a/docs/examples/application_state/using_immutable_state.py
+++ b/docs/examples/application_state/using_immutable_state.py
@@ -2,7 +2,7 @@ from litestar import Litestar, get
 from litestar.datastructures import ImmutableState
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def handler(state: ImmutableState) -> dict:
     setattr(state, "count", 1)  # raises AttributeError
     return state.dict()

--- a/docs/examples/conftest.py
+++ b/docs/examples/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Generator
 
 import pytest
@@ -12,3 +13,13 @@ def reset_httpx_logging() -> Generator[None, None, None]:
     httpx_logger.setLevel(logging.WARNING)
     yield
     httpx_logger.setLevel(initial_level)
+
+
+# the monkeypatch fixture does not work with session scoped dependencies
+@pytest.fixture(autouse=True, scope="session")
+def disable_warn_implicit_sync_to_thread() -> Generator[None, None, None]:
+    old_value = os.getenv("LITESTAR_WARN_IMPLICIT_SYNC_TO_THREAD")
+    os.environ["LITESTAR_WARN_IMPLICIT_SYNC_TO_THREAD"] = "0"
+    yield
+    if old_value is not None:
+        os.environ["LITESTAR_WARN_IMPLICIT_SYNC_TO_THREAD"] = old_value

--- a/docs/examples/contrib/jwt/using_jwt_auth.py
+++ b/docs/examples/contrib/jwt/using_jwt_auth.py
@@ -55,7 +55,7 @@ async def login_handler(data: User) -> Response[User]:
 
 
 # We also have some other routes, for example:
-@get("/some-path")
+@get("/some-path", sync_to_thread=False)
 def some_route_handler(request: "Request[User, Token, Any]") -> Any:
     # request.user is set to the instance of user returned by the middleware
     assert isinstance(request.user, User)

--- a/docs/examples/contrib/jwt/using_jwt_cookie_auth.py
+++ b/docs/examples/contrib/jwt/using_jwt_cookie_auth.py
@@ -57,7 +57,7 @@ async def login_handler(data: "User") -> "Response[User]":
 
 
 # We also have some other routes, for example:
-@get("/some-path")
+@get("/some-path", sync_to_thread=False)
 def some_route_handler(request: "Request[User, Token, Any]") -> Any:
     # request.user is set to the instance of user returned by the middleware
     assert isinstance(request.user, User)

--- a/docs/examples/contrib/jwt/using_oauth2_password_bearer.py
+++ b/docs/examples/contrib/jwt/using_oauth2_password_bearer.py
@@ -71,7 +71,7 @@ async def login_custom_response_handler(data: "User") -> "Response[User]":
 
 
 # We also have some other routes, for example:
-@get("/some-path")
+@get("/some-path", sync_to_thread=False)
 def some_route_handler(request: "Request[User, Token, Any]") -> Any:
     # request.user is set to the instance of user returned by the middleware
     assert isinstance(request.user, User)

--- a/docs/examples/data_transfer_objects/factory/excluding_fields.py
+++ b/docs/examples/data_transfer_objects/factory/excluding_fields.py
@@ -32,7 +32,7 @@ config = DTOConfig(exclude={"id", "address.id", "address.street"})
 ReadUserDTO = SQLAlchemyDTO[Annotated[User, config]]
 
 
-@post("/users", dto=UserDTO, return_dto=ReadUserDTO)
+@post("/users", dto=UserDTO, return_dto=ReadUserDTO, sync_to_thread=False)
 def create_user(data: User) -> User:
     data.created_at = datetime.min
     data.address = Address(street="123 Main St", city="Anytown", state="NY", zip="12345")

--- a/docs/examples/data_transfer_objects/factory/marking_fields.py
+++ b/docs/examples/data_transfer_objects/factory/marking_fields.py
@@ -18,7 +18,7 @@ class User(Base):
 UserDTO = SQLAlchemyDTO[User]
 
 
-@post("/users", dto=UserDTO)
+@post("/users", dto=UserDTO, sync_to_thread=False)
 def create_user(data: User) -> User:
     # even though the client sent the password and created_at field, it is not in the data object
     assert "password" not in vars(data)

--- a/docs/examples/data_transfer_objects/factory/related_items.py
+++ b/docs/examples/data_transfer_objects/factory/related_items.py
@@ -29,7 +29,7 @@ DataDTO = SQLAlchemyDTO[Annotated[A, data_config]]
 ReturnDTO = SQLAlchemyDTO[A]
 
 
-@put("/a", dto=DataDTO, return_dto=ReturnDTO)
+@put("/a", dto=DataDTO, return_dto=ReturnDTO, sync_to_thread=False)
 def update_a(data: A) -> A:
     # this shows that "b" was not parsed out of the inbound data
     assert "b" not in vars(data)

--- a/docs/examples/data_transfer_objects/factory/renaming_all_fields.py
+++ b/docs/examples/data_transfer_objects/factory/renaming_all_fields.py
@@ -22,7 +22,7 @@ config = DTOConfig(rename_strategy="camel")
 UserDTO = SQLAlchemyDTO[Annotated[User, config]]
 
 
-@post("/users", dto=UserDTO)
+@post("/users", dto=UserDTO, sync_to_thread=False)
 def create_user(data: User) -> User:
     assert data.first_name == "Litestar User"
     data.created_at = datetime.min

--- a/docs/examples/data_transfer_objects/factory/renaming_fields.py
+++ b/docs/examples/data_transfer_objects/factory/renaming_fields.py
@@ -20,7 +20,7 @@ config = DTOConfig(rename_fields={"name": "userName"})
 UserDTO = SQLAlchemyDTO[Annotated[User, config]]
 
 
-@post("/users", dto=UserDTO)
+@post("/users", dto=UserDTO, sync_to_thread=False)
 def create_user(data: User) -> User:
     assert data.name == "Litestar User"
     data.created_at = datetime.min

--- a/docs/examples/data_transfer_objects/factory/simple_dto_factory_example.py
+++ b/docs/examples/data_transfer_objects/factory/simple_dto_factory_example.py
@@ -17,7 +17,7 @@ class User(Base):
 UserDTO = SQLAlchemyDTO[User]
 
 
-@post("/users", dto=UserDTO)
+@post("/users", dto=UserDTO, sync_to_thread=False)
 def create_user(data: User) -> User:
     return data
 

--- a/docs/examples/datastructures/headers/cache_control.py
+++ b/docs/examples/datastructures/headers/cache_control.py
@@ -7,18 +7,18 @@ from litestar.datastructures import CacheControlHeader
 class MyController(Controller):
     cache_control = CacheControlHeader(max_age=86_400, public=True)
 
-    @get("/chance_of_rain")
+    @get("/chance_of_rain", sync_to_thread=False)
     def get_chance_of_rain(self) -> float:
         """This endpoint uses the cache control value defined in the controller which overrides the app value."""
         return 0.5
 
-    @get("/timestamp", cache_control=CacheControlHeader(no_store=True))
+    @get("/timestamp", cache_control=CacheControlHeader(no_store=True), sync_to_thread=False)
     def get_server_time(self) -> float:
         """This endpoint overrides the cache control value defined in the controller."""
         return time.time()
 
 
-@get("/population")
+@get("/population", sync_to_thread=False)
 def get_population_count() -> int:
     """This endpoint will use the cache control defined in the app."""
     return 100000

--- a/docs/examples/dependency_injection/dependency_default_value_no_dependency_fn.py
+++ b/docs/examples/dependency_injection/dependency_default_value_no_dependency_fn.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 from litestar import Litestar, get
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def hello_world(optional_dependency: int = 3) -> Dict[str, Any]:
     """Notice we haven't provided the dependency to the route.
 

--- a/docs/examples/dependency_injection/dependency_default_value_with_dependency_fn.py
+++ b/docs/examples/dependency_injection/dependency_default_value_with_dependency_fn.py
@@ -6,7 +6,7 @@ from litestar import Litestar, get
 from litestar.params import Dependency
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def hello_world(optional_dependency: Annotated[int, Dependency(default=3)]) -> Dict[str, Any]:
     """Notice we haven't provided the dependency to the route.
 

--- a/docs/examples/dependency_injection/dependency_skip_validation.py
+++ b/docs/examples/dependency_injection/dependency_skip_validation.py
@@ -12,7 +12,7 @@ async def provide_str() -> str:
     return "whoops"
 
 
-@get("/", dependencies={"injected": Provide(provide_str)})
+@get("/", dependencies={"injected": Provide(provide_str)}, sync_to_thread=False)
 def hello_world(injected: Annotated[int, Dependency(skip_validation=True)]) -> Dict[str, Any]:
     """Handler expects an `int`, but we've provided a `str`."""
     return {"hello": injected}

--- a/docs/examples/dependency_injection/dependency_validation_error.py
+++ b/docs/examples/dependency_injection/dependency_validation_error.py
@@ -9,7 +9,7 @@ async def provide_str() -> str:
     return "whoops"
 
 
-@get("/", dependencies={"injected": Provide(provide_str)})
+@get("/", dependencies={"injected": Provide(provide_str)}, sync_to_thread=False)
 def hello_world(injected: int) -> Dict[str, Any]:
     """Handler expects and `int`, but we've provided a `str`."""
     return {"hello": injected}

--- a/docs/examples/hello_world.py
+++ b/docs/examples/hello_world.py
@@ -4,7 +4,7 @@ from litestar import Litestar, get
 
 
 @get("/")
-def hello_world() -> Dict[str, str]:
+async def hello_world() -> Dict[str, str]:
     """Handler function that returns a greeting dictionary."""
     return {"hello": "world"}
 

--- a/docs/examples/middleware/base.py
+++ b/docs/examples/middleware/base.py
@@ -44,25 +44,25 @@ async def websocket_handler(socket: "WebSocket") -> None:
     await socket.close()
 
 
-@get("/first_path")
+@get("/first_path", sync_to_thread=False)
 def first_handler() -> Dict[str, str]:
     """Handler is excluded due to regex pattern matching "first_path"."""
     return {"hello": "first"}
 
 
-@get("/second_path")
+@get("/second_path", sync_to_thread=False)
 def second_handler() -> Dict[str, str]:
     """Handler is excluded due to regex pattern matching "second_path"."""
     return {"hello": "second"}
 
 
-@get("/third_path", exclude_from_middleware=True)
+@get("/third_path", exclude_from_middleware=True, sync_to_thread=False)
 def third_handler() -> Dict[str, str]:
     """Handler is excluded due to the opt key 'exclude_from_middleware' matching the middleware 'exclude_opt_key'."""
     return {"hello": "second"}
 
 
-@get("/greet")
+@get("/greet", sync_to_thread=False)
 def not_excluded_handler() -> Dict[str, str]:
     """This handler is not excluded, and thus the middleware will execute on every incoming request to it."""
     return {"hello": "world"}

--- a/docs/examples/middleware/logging_middleware.py
+++ b/docs/examples/middleware/logging_middleware.py
@@ -7,7 +7,7 @@ from litestar.middleware.logging import LoggingMiddlewareConfig
 logging_middleware_config = LoggingMiddlewareConfig()
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def my_handler() -> Dict[str, str]:
     return {"hello": "world"}
 

--- a/docs/examples/middleware/rate_limit.py
+++ b/docs/examples/middleware/rate_limit.py
@@ -4,7 +4,7 @@ from litestar.middleware.rate_limit import RateLimitConfig
 rate_limit_config = RateLimitConfig(rate_limit=("minute", 1), exclude=["/schema"])
 
 
-@get("/", media_type=MediaType.TEXT)
+@get("/", media_type=MediaType.TEXT, sync_to_thread=False)
 def handler() -> str:
     """Handler which should not be accessed more than once per minute."""
     return "ok"

--- a/docs/examples/middleware/session/cookies_full_example.py
+++ b/docs/examples/middleware/session/cookies_full_example.py
@@ -9,13 +9,13 @@ from litestar.middleware.session.client_side import CookieBackendConfig
 session_config = CookieBackendConfig(secret=urandom(16))  # type: ignore[arg-type]
 
 
-@get("/session")
+@get("/session", sync_to_thread=False)
 def check_session_handler(request: Request) -> Dict[str, bool]:
     """Handler function that accesses request.session."""
     return {"has_session": request.session != {}}
 
 
-@post("/session")
+@post("/session", sync_to_thread=False)
 def create_session_handler(request: Request) -> None:
     """Handler to set the session."""
     if not request.session:
@@ -23,7 +23,7 @@ def create_session_handler(request: Request) -> None:
         request.set_session({"username": "moishezuchmir"})
 
 
-@delete("/session")
+@delete("/session", sync_to_thread=False)
 def delete_session_handler(request: Request) -> None:
     """Handler to clear the session."""
     if request.session:

--- a/docs/examples/openapi/customize_pydantic_model_name.py
+++ b/docs/examples/openapi/customize_pydantic_model_name.py
@@ -11,7 +11,7 @@ class IdModel(BaseModel):
     id: UUID
 
 
-@get("/id")
+@get("/id", sync_to_thread=False)
 def retrieve_id_handler() -> IdModel:
     """
 

--- a/docs/examples/pagination/using_classic_pagination.py
+++ b/docs/examples/pagination/using_classic_pagination.py
@@ -36,7 +36,7 @@ paginator = PersonClassicPaginator()
 
 # we now create a regular handler. The handler will receive two query parameters - 'page_size' and 'current_page', which
 # we will pass to the paginator.
-@get("/people")
+@get("/people", sync_to_thread=False)
 def people_handler(page_size: int, current_page: int) -> ClassicPagination[Person]:
     return paginator(page_size=page_size, current_page=current_page)
 

--- a/docs/examples/pagination/using_cursor_pagination.py
+++ b/docs/examples/pagination/using_cursor_pagination.py
@@ -33,7 +33,7 @@ paginator = PersonCursorPaginator()
 
 # we now create a regular handler. The handler will receive a single query parameter - 'cursor', which
 # we will pass to the paginator.
-@get("/people")
+@get("/people", sync_to_thread=False)
 def people_handler(cursor: Optional[str], results_per_page: int) -> CursorPagination[str, Person]:
     return paginator(cursor=cursor, results_per_page=results_per_page)
 

--- a/docs/examples/pagination/using_offset_pagination.py
+++ b/docs/examples/pagination/using_offset_pagination.py
@@ -37,7 +37,7 @@ paginator = PersonOffsetPaginator()
 
 # we now create a regular handler. The handler will receive two query parameters - 'limit' and 'offset', which
 # we will pass to the paginator.
-@get("/people")
+@get("/people", sync_to_thread=False)
 def people_handler(limit: int, offset: int) -> OffsetPagination[Person]:
     return paginator(limit=limit, offset=offset)
 

--- a/docs/examples/parameters/layered_parameters.py
+++ b/docs/examples/parameters/layered_parameters.py
@@ -12,7 +12,7 @@ class MyController(Controller):
         "controller_param": Parameter(int, lt=100),
     }
 
-    @get("/{path_param:int}")
+    @get("/{path_param:int}", sync_to_thread=False)
     def my_handler(
         self,
         path_param: int,

--- a/docs/examples/parameters/path_parameters_1.py
+++ b/docs/examples/parameters/path_parameters_1.py
@@ -10,7 +10,7 @@ class User(BaseModel):
     name: str
 
 
-@get("/user/{user_id:int}")
+@get("/user/{user_id:int}", sync_to_thread=False)
 def get_user(user_id: int) -> User:
     return User.parse_obj(USER_DB[user_id])
 

--- a/docs/examples/parameters/path_parameters_2.py
+++ b/docs/examples/parameters/path_parameters_2.py
@@ -19,7 +19,7 @@ ORDERS_BY_DATETIME = {
 }
 
 
-@get(path="/orders/{from_date:int}")
+@get(path="/orders/{from_date:int}", sync_to_thread=False)
 def get_orders(from_date: datetime) -> List[Order]:
     return ORDERS_BY_DATETIME[from_date]
 

--- a/docs/examples/parameters/path_parameters_3.py
+++ b/docs/examples/parameters/path_parameters_3.py
@@ -15,7 +15,7 @@ class Version(BaseModel):
 VERSIONS = {1: Version(id=1, specs='{"some": "value"}')}
 
 
-@get(path="/versions/{version:int}")
+@get(path="/versions/{version:int}", sync_to_thread=False)
 def get_product_version(
     version: Annotated[
         int,

--- a/docs/examples/parameters/query_params.py
+++ b/docs/examples/parameters/query_params.py
@@ -3,7 +3,7 @@ from typing import Dict
 from litestar import Litestar, get
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def index(param: str) -> Dict[str, str]:
     return {"param": param}
 

--- a/docs/examples/parameters/query_params_constraints.py
+++ b/docs/examples/parameters/query_params_constraints.py
@@ -6,7 +6,7 @@ from litestar import Litestar, get
 from litestar.params import Parameter
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def index(param: Annotated[int, Parameter(gt=5)]) -> Dict[str, int]:
     return {"param": param}
 

--- a/docs/examples/parameters/query_params_default.py
+++ b/docs/examples/parameters/query_params_default.py
@@ -3,7 +3,7 @@ from typing import Dict
 from litestar import Litestar, get
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def index(param: str = "hello") -> Dict[str, str]:
     return {"param": param}
 

--- a/docs/examples/parameters/query_params_optional.py
+++ b/docs/examples/parameters/query_params_optional.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 from litestar import Litestar, get
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def index(param: Optional[str] = None) -> Dict[str, Optional[str]]:
     return {"param": param}
 

--- a/docs/examples/parameters/query_params_remap.py
+++ b/docs/examples/parameters/query_params_remap.py
@@ -6,7 +6,7 @@ from litestar import Litestar, get
 from litestar.params import Parameter
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def index(snake_case: Annotated[str, Parameter(query="camelCase")]) -> Dict[str, str]:
     return {"param": snake_case}
 

--- a/docs/examples/parameters/query_params_types.py
+++ b/docs/examples/parameters/query_params_types.py
@@ -4,13 +4,8 @@ from typing import Any, Dict, List
 from litestar import Litestar, get
 
 
-@get("/")
-def index(
-    date: datetime,
-    number: int,
-    floating_number: float,
-    strings: List[str],
-) -> Dict[str, Any]:
+@get("/", sync_to_thread=False)
+def index(date: datetime, number: int, floating_number: float, strings: List[str]) -> Dict[str, Any]:
     return {
         "datetime": date + timedelta(days=1),
         "int": number,

--- a/docs/examples/plugins/sqlalchemy_init_plugin/sqlalchemy_sync.py
+++ b/docs/examples/plugins/sqlalchemy_init_plugin/sqlalchemy_sync.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
 
-@get(path="/sqlalchemy-app")
+@get(path="/sqlalchemy-app", sync_to_thread=True)
 def async_sqlalchemy_init(db_session: Session, db_engine: Engine) -> str:
     """Interact with SQLAlchemy engine and session."""
     one = db_session.execute(text("SELECT 1")).scalar_one()

--- a/docs/examples/request_data/msgpack_request.py
+++ b/docs/examples/request_data/msgpack_request.py
@@ -7,7 +7,7 @@ from litestar.enums import RequestEncodingType
 from litestar.params import Body
 
 
-@post(path="/")
+@post(path="/", sync_to_thread=False)
 def msgpack_handler(data: Annotated[dict, Body(media_type=RequestEncodingType.MESSAGEPACK)]) -> Dict:
     # This will try to parse the request body as `MessagePack` regardless of the
     # `Content-Type`

--- a/docs/examples/request_data/request_data_7.py
+++ b/docs/examples/request_data/request_data_7.py
@@ -6,7 +6,7 @@ from litestar.enums import RequestEncodingType
 from litestar.params import Body
 
 
-@post(path="/", media_type=MediaType.TEXT)
+@post(path="/", media_type=MediaType.TEXT, sync_to_thread=False)
 def handle_file_upload(
     data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)],
 ) -> str:

--- a/docs/examples/responses/background_tasks_1.py
+++ b/docs/examples/responses/background_tasks_1.py
@@ -11,7 +11,7 @@ async def logging_task(identifier: str, message: str) -> None:
     logger.info("%s: %s", identifier, message)
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def greeter(name: str) -> Response[Dict[str, str]]:
     return Response(
         {"hello": name},

--- a/docs/examples/responses/background_tasks_2.py
+++ b/docs/examples/responses/background_tasks_2.py
@@ -11,7 +11,7 @@ async def logging_task(identifier: str, message: str) -> None:
     logger.info("%s: %s", identifier, message)
 
 
-@get("/", background=BackgroundTask(logging_task, "greeter", message="was called"))
+@get("/", background=BackgroundTask(logging_task, "greeter", message="was called"), sync_to_thread=False)
 def greeter() -> Dict[str, str]:
     return {"hello": "world"}
 

--- a/docs/examples/responses/background_tasks_3.py
+++ b/docs/examples/responses/background_tasks_3.py
@@ -16,7 +16,7 @@ async def saving_task(name: str) -> None:
     greeted.add(name)
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def greeter(name: str) -> Response[Dict[str, str]]:
     return Response(
         {"hello": name},

--- a/docs/examples/responses/response_content.py
+++ b/docs/examples/responses/response_content.py
@@ -1,7 +1,7 @@
 from litestar import Litestar, MediaType, Request, Response, get
 
 
-@get("/resource")
+@get("/resource", sync_to_thread=False)
 def retrieve_resource(request: Request) -> Response[bytes]:
     provided_types = [MediaType.TEXT, MediaType.HTML, "application/xml"]
     preferred_type = request.accept.best_match(provided_types, default=MediaType.TEXT)

--- a/docs/examples/responses/response_cookies_1.py
+++ b/docs/examples/responses/response_cookies_1.py
@@ -22,6 +22,7 @@ class MyController(Controller):
             )
         ],
         media_type=MediaType.TEXT,
+        sync_to_thread=False,
     )
     def my_route_handler(self) -> str:
         return "hello world"

--- a/docs/examples/responses/response_cookies_2.py
+++ b/docs/examples/responses/response_cookies_2.py
@@ -10,6 +10,7 @@ class MyController(Controller):
         path="/",
         response_cookies=[Cookie(key="my-cookie", value="456")],
         media_type=MediaType.TEXT,
+        sync_to_thread=False,
     )
     def my_route_handler(self) -> str:
         return "hello world"

--- a/docs/examples/responses/response_cookies_3.py
+++ b/docs/examples/responses/response_cookies_3.py
@@ -20,6 +20,7 @@ class Resource(BaseModel):
             documentation_only=True,
         )
     ],
+    sync_to_thread=False,
 )
 def retrieve_resource() -> Response[Resource]:
     return Response(

--- a/docs/examples/responses/response_cookies_4.py
+++ b/docs/examples/responses/response_cookies_4.py
@@ -11,7 +11,7 @@ class Resource(BaseModel):
     name: str
 
 
-@get("/resources")
+@get("/resources", sync_to_thread=False)
 def retrieve_resource() -> Resource:
     return Resource(
         id=1,

--- a/docs/examples/responses/response_cookies_5.py
+++ b/docs/examples/responses/response_cookies_5.py
@@ -20,6 +20,7 @@ class Resource(BaseModel):
             documentation_only=True,
         )
     ],
+    sync_to_thread=False,
 )
 def retrieve_resource() -> Response[Resource]:
     return Response(

--- a/docs/examples/responses/response_headers_1.py
+++ b/docs/examples/responses/response_headers_1.py
@@ -14,6 +14,7 @@ class MyController(Controller):
             ResponseHeader(name="my-local-header", value="local header", description="local level header")
         ],
         media_type=MediaType.TEXT,
+        sync_to_thread=False,
     )
     def my_route_handler(self) -> str:
         return "hello world"

--- a/docs/examples/responses/response_headers_2.py
+++ b/docs/examples/responses/response_headers_2.py
@@ -18,6 +18,7 @@ class Resource(BaseModel):
             name="Random-Header", description="a random number in the range 1 - 100", documentation_only=True
         )
     ],
+    sync_to_thread=False,
 )
 def retrieve_resource() -> Response[Resource]:
     return Response(

--- a/docs/examples/responses/response_headers_3.py
+++ b/docs/examples/responses/response_headers_3.py
@@ -20,6 +20,7 @@ class Resource(BaseModel):
             documentation_only=True,
         )
     ],
+    sync_to_thread=False,
 )
 def retrieve_resource() -> Response[Resource]:
     return Response(

--- a/docs/examples/responses/response_headers_4.py
+++ b/docs/examples/responses/response_headers_4.py
@@ -20,6 +20,7 @@ class Resource(BaseModel):
             documentation_only=True,
         )
     ],
+    sync_to_thread=False,
 )
 def retrieve_resource() -> Response[Resource]:
     return Response(

--- a/docs/examples/responses/returning_responses.py
+++ b/docs/examples/responses/returning_responses.py
@@ -9,7 +9,7 @@ class Resource(BaseModel):
     name: str
 
 
-@get("/resources")
+@get("/resources", sync_to_thread=False)
 def retrieve_resource() -> Response[Resource]:
     return Response(
         Resource(

--- a/docs/examples/security/using_session_auth.py
+++ b/docs/examples/security/using_session_auth.py
@@ -111,7 +111,7 @@ async def signup(data: UserCreatePayload, request: Request[Any, Any, Any]) -> Us
 
 # the endpoint below requires the user to be already authenticated
 # to be able to access it.
-@get("/user")
+@get("/user", sync_to_thread=False)
 def get_user(request: Request[User, Dict[Literal["user_id"], str], Any]) -> Any:
     # because this route requires authentication, we can access
     # `request.user`, which is the authenticated user returned

--- a/docs/examples/signature_namespace/controller.py
+++ b/docs/examples/signature_namespace/controller.py
@@ -9,6 +9,6 @@ if TYPE_CHECKING:
 
 
 class MyController(Controller):
-    @post()
+    @post(sync_to_thread=False)
     def post_handler(self, data: Model) -> Model:
         return data

--- a/docs/examples/stores/registry_default_factory_namespacing.py
+++ b/docs/examples/stores/registry_default_factory_namespacing.py
@@ -7,7 +7,7 @@ from litestar.stores.registry import StoreRegistry
 root_store = RedisStore.with_client()
 
 
-@get(cache=True)
+@get(cache=True, sync_to_thread=False)
 def cached_handler() -> str:
     # this will use app.stores.get("response_cache")
     return "Hello, world!"

--- a/docs/examples/testing/test_get_session_data.py
+++ b/docs/examples/testing/test_get_session_data.py
@@ -5,7 +5,7 @@ from litestar.testing import TestClient
 session_config = ServerSideSessionConfig()
 
 
-@post(path="/test")
+@post(path="/test", sync_to_thread=False)
 def set_session_data(request: Request) -> None:
     request.session["foo"] = "bar"
 

--- a/docs/examples/testing/test_get_session_data_async.py
+++ b/docs/examples/testing/test_get_session_data_async.py
@@ -5,7 +5,7 @@ from litestar.testing import AsyncTestClient
 session_config = ServerSideSessionConfig()
 
 
-@post(path="/test")
+@post(path="/test", sync_to_thread=False)
 def set_session_data(request: Request) -> None:
     request.session["foo"] = "bar"
 

--- a/docs/examples/testing/test_health_check_async.py
+++ b/docs/examples/testing/test_health_check_async.py
@@ -5,7 +5,7 @@ from litestar.status_codes import HTTP_200_OK
 from litestar.testing import AsyncTestClient
 
 
-@get(path="/health-check", media_type=MediaType.TEXT)
+@get(path="/health-check", media_type=MediaType.TEXT, sync_to_thread=False)
 def health_check() -> str:
     return "healthy"
 

--- a/docs/examples/testing/test_health_check_sync.py
+++ b/docs/examples/testing/test_health_check_sync.py
@@ -5,7 +5,7 @@ from litestar.status_codes import HTTP_200_OK
 from litestar.testing import TestClient
 
 
-@get(path="/health-check", media_type=MediaType.TEXT)
+@get(path="/health-check", media_type=MediaType.TEXT, sync_to_thread=False)
 def health_check() -> str:
     return "healthy"
 

--- a/docs/examples/testing/test_set_session_data.py
+++ b/docs/examples/testing/test_set_session_data.py
@@ -7,7 +7,7 @@ from litestar.testing import TestClient
 session_config = ServerSideSessionConfig()
 
 
-@get(path="/test")
+@get(path="/test", sync_to_thread=False)
 def get_session_data(request: Request) -> Dict[str, Any]:
     return request.session
 

--- a/docs/examples/testing/test_set_session_data_async.py
+++ b/docs/examples/testing/test_set_session_data_async.py
@@ -7,7 +7,7 @@ from litestar.testing import AsyncTestClient
 session_config = ServerSideSessionConfig()
 
 
-@get(path="/test")
+@get(path="/test", sync_to_thread=False)
 def get_session_data(request: Request) -> Dict[str, Any]:
     return request.session
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -228,5 +228,6 @@ Example Applications
     tutorials/index
     usage/index
     reference/index
+    topics/index
     migration/index
     benchmarks

--- a/docs/topics/index.rst
+++ b/docs/topics/index.rst
@@ -1,7 +1,7 @@
 Topics
 ======
 
-A collection of articles talking about technical concepts, background information,
+A collection of articles about technical concepts, background information,
 design decisions and similar topics on a higher level.
 
 

--- a/docs/topics/index.rst
+++ b/docs/topics/index.rst
@@ -1,0 +1,10 @@
+Topics
+======
+
+A collection of articles talking about technical concepts, background information,
+design decisions and similar topics on a higher level.
+
+
+.. toctree::
+
+    sync-vs-async

--- a/docs/topics/sync-vs-async.rst
+++ b/docs/topics/sync-vs-async.rst
@@ -10,8 +10,7 @@ supported:
 - Running synchronous callables directly
 - Running synchronous callables in a thread pool
 
-There are a few important differences between those, which the following article tries
-to give an overview of.
+This article gives an overview of important differences between these modes.
 
 
 Blocking and non-blocking
@@ -33,7 +32,7 @@ would. More importantly, anything that happens inside an asynchronous function
 Technically speaking, this means that there are no non-blocking functions in Python,
 since async functions only "unblock" at each ``await``. As this is not a useful
 definition of the term, "blocking" usually refers to callables that *block for a long
-time*. long period of time*.
+time*.
 
 .. note::
 

--- a/docs/topics/sync-vs-async.rst
+++ b/docs/topics/sync-vs-async.rst
@@ -1,0 +1,147 @@
+Sync vs. Async
+==============
+
+
+Litestar supports synchronous as well as asynchronous callables in almost all places
+where it's possible to do so. In general, three different modes of execution are
+supported:
+
+- Running asynchronous callables directly
+- Running synchronous callables directly
+- Running synchronous callables in a thread pool
+
+There are a few important differences between those, which the following article tries
+to give an overview of.
+
+
+Blocking and non-blocking
+-------------------------
+
+In the context of asynchronous programming, the terms *blocking* and *non-blocking*
+are often used to describe a particular quality of a function: Blocking the flow of
+execution.
+
+Asynchronous functions are not inherently non-blocking. What they do instead is allow a
+programmer to control exactly *where* they unblock and return control to the main loop,
+allowing other asynchronous tasks to run, which is usually indicated by the use of the
+``await`` keyword.  This is a very important aspect to note, since an async function
+that never calls ``await`` and, for example, performs a computationally intensive task,
+*will* block the main thread for its entire runtime, just like a synchronous function
+would. More importantly, anything that happens inside an asynchronous function
+*between* the parts where it waits will also be blocked.
+
+Technically speaking, this means that there are no non-blocking functions in Python,
+since async functions only "unblock" at each ``await``. As this is not a useful
+definition of the term, "blocking" usually refers to callables that *block for a long
+time*. long period of time*.
+
+.. note::
+
+    Since "blocking" is about the flow of execution, one might think of ``await`` as
+    blocking as well; the execution will not proceed past it until the awaitable has
+    been resolved, which fits the definition of the term. However, since at the same
+    time *other parts of the program* (more precisely, other parts currently waiting at
+    an ``await``) are allowed to proceed, this is not considered blocking and usually
+    referred to as "waiting".
+
+
+I/O bound vs. CPU bound
+-----------------------
+
+Another important aspect to consider when trying to determine whether a function should
+be asynchronous or not is *why* it might block. In general, there are two different
+categories of blocking operations:
+
+I/O bound
+    Calls to the file system or network are typical examples of I/O-bound blocking.
+    Their execution speed is largely limited by the time it takes for the external
+    resource to complete, which makes them "bound" to that resource.
+
+    They are a good fit for async because most of the time is spent waiting for these
+    operations to complete. This means that other tasks can be executed during this
+    time, "waiting in parallel", greatly reducing the overall runtime.
+
+CPU bound
+    Operations that do not wait on I/O can be usually considered CPU bound. Since they
+    don't wait for external resources, their execution speed is bound to the CPU, i.e.
+    how fast it can execute the instructions given.
+
+    They do not benefit from asynchronous execution like I/O bound tasks, since they
+    don't spend a significant amount of time waiting.
+
+
+Asynchronous CPU-bound tasks
+++++++++++++++++++++++++++++
+
+In some cases, CPU bound tasks can be made asynchronous, by introducing points for the
+event loop to switch to other tasks. An example of this would be an inner loop which
+awaits :func:`asyncio.sleep(0) <asyncio.sleep>` at the beginning of each iteration.
+
+This technique is mostly useful for long-running tasks, where each individual step does
+not block for an extended period of time.
+
+
+When to use an asynchronous function
+------------------------------------
+
+Asynchronous functions should be used when they can benefit from a concurrent execution,
+that is, they themselves perform asynchronous operations, such as calling other
+asynchronous functions or iterating asynchronously, and do not perform any blocking
+operations, such as calling synchronous functions that are I/O bound.
+
+**Why not use async by default?**
+
+It might be tempting to look at this and think a function should be async by default,
+unless it's performing blocking operations synchronously, but this is not the case.
+Async itself has an overhead attached to it which, while very small, can in some
+situations become non negligible. An synchronous function performing non-blocking
+operations will outperform an asynchronous function doing the same.
+
+
+When to use a synchronous function
+----------------------------------
+
+As an inverse of the previous paragraph, it follows that synchronous functions should
+be used for non-blocking, non-computationally intensive tasks. The synchronous execution
+model allows for the smallest amount of overhead and should therefore be preferred in
+such situations where no asynchronous functionality is made use of.
+
+
+When to use a thread pool
+-------------------------
+
+If a function performs computationally intense or I/O bound operations, which can not be
+replaced by asynchronous equivalents, ``sync_to_thread=True`` can be used to run it in
+a thread pool.
+
+**Why not make this the default for synchronous functions?**
+
+Running in a thread pool has a very high overhead, greatly reducing an application's
+performance. Its use should therefore be restricted to cases where it's absolutely
+necessary.
+
+
+Limitations
++++++++++++
+
+While running a CPU bound function in a thread pool does allow it to be run in a
+non-blocking way, it does not speed up its execution. Computationally intensive tasks
+that are performed regularly should be offloaded into a different process, to make use
+of multiple CPU cores.
+
+This can for example be achieve by using :func:`anyio.to_process.run_sync`.
+
+
+Warnings about the mode of execution
+------------------------------------
+
+Since a synchronous function might be blocking, Litestar will raise a warning about its
+use in places where it might block the main event loop and impact the application's
+performance. If a synchronous function is non-blocking, setting ``sync_to_thread=False``
+will tell Litestar that the function can be treated as such.
+
+This warning was introduced to prevent accidentally using blocking functions, by having
+to make a deliberate decision about whether or not to run the function in a thread pool.
+
+The warning can be disabled globally by setting the environment variable
+``LITESTAR_WARN_IMPLICIT_SYNC_TO_THREAD=0``.

--- a/docs/usage/dependency-injection.rst
+++ b/docs/usage/dependency-injection.rst
@@ -62,18 +62,9 @@ Dependencies can be either callables - sync or async functions, methods or class
 :meth:`object.__call__` method, or classes. These are in turn wrapped inside an instance of the
 :class:`Provide <.di.Provide>` class.
 
-.. admonition:: Sync vs. Async dependencies
-    :class: important
 
-    Litestar supports both **synchronous** and **asynchronous** dependencies.
-    To ensure **synchronous** dependencies don't block the main thread
-    - *and therefore the entire application, for example when they perform blocking I/O* -
-    the parameter ``sync_to_thread`` will ensure they are run in a thread pool.
-    If a **synchronous** function is non-blocking, you should consider making it an async function instead.
+.. include:: /admonitions/sync-to-thread-info.rst
 
-.. tip::
-    Litestar will warn about the usage of synchronous dependency functions which do not
-    have ``sync_to_thread`` set.
 
 
 Pre-requisites and Scope

--- a/litestar/di.py
+++ b/litestar/di.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import warnings
 from inspect import isclass
 from typing import TYPE_CHECKING, Any
 
-from litestar.exceptions import ImproperlyConfiguredException, LitestarWarning
+from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types import Empty
 from litestar.utils import Ref, is_async_callable
 from litestar.utils.warnings import warn_implicit_sync_to_thread

--- a/litestar/di.py
+++ b/litestar/di.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 from litestar.exceptions import ImproperlyConfiguredException, LitestarWarning
 from litestar.types import Empty
 from litestar.utils import Ref, is_async_callable
+from litestar.utils.warnings import warn_implicit_sync_to_thread
 
 __all__ = ("Provide",)
 
@@ -51,15 +52,7 @@ class Provide:
         self.dependency = Ref["AnyCallable"](dependency)
         self.has_sync_callable = isclass(dependency) or not is_async_callable(dependency)
         if self.has_sync_callable and sync_to_thread is None:
-            warnings.warn(
-                "Using a synchronous callable with Provide might block the main thread "
-                "if the callable performs blocking operations and sync_to_thread is not "
-                "set to True. If the callable is non-blocking, either make it "
-                "asynchronous or set sync_to_thread=False explicitly to silence this "
-                "warning.",
-                category=LitestarWarning,
-                stacklevel=1,
-            )
+            warn_implicit_sync_to_thread(dependency, stacklevel=3)
         self.sync_to_thread = bool(sync_to_thread)
         self.use_cache = use_cache
         self.value: Any = Empty

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from enum import Enum
 from typing import TYPE_CHECKING, AnyStr, Mapping, cast
 
@@ -13,7 +12,6 @@ from litestar.enums import HttpMethod, MediaType
 from litestar.exceptions import (
     HTTPException,
     ImproperlyConfiguredException,
-    LitestarWarning,
 )
 from litestar.handlers.base import BaseRouteHandler
 from litestar.handlers.http_handlers._utils import (

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -48,6 +48,7 @@ from litestar.types import (
 )
 from litestar.types.builtin_types import NoneType
 from litestar.utils import AsyncCallable, async_partial, is_async_callable
+from litestar.utils.warnings import warn_implicit_sync_to_thread
 
 if TYPE_CHECKING:
     from typing import Any, Awaitable, Callable, Sequence
@@ -283,15 +284,7 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
     def __call__(self, fn: AnyCallable) -> HTTPRouteHandler:
         """Replace a function with itself."""
         if not is_async_callable(fn) and self.sync_to_thread is None:
-            warnings.warn(
-                "Using a synchronous callable in a route handler might block the "
-                "main thread if the callable performs blocking operations and "
-                "sync_to_thread is not set to True. If the callable is non-blocking,"
-                "either make it asynchronous or set sync_to_thread=False explicitly "
-                "to silence this warning.",
-                category=LitestarWarning,
-                stacklevel=1,
-            )
+            warn_implicit_sync_to_thread(fn, stacklevel=3)
         super().__call__(fn)
         return self
 

--- a/litestar/handlers/http_handlers/decorators.py
+++ b/litestar/handlers/http_handlers/decorators.py
@@ -75,7 +75,7 @@ class delete(HTTPRouteHandler):
         return_dto: type[DTOInterface] | None | EmptyType = Empty,
         signature_namespace: Mapping[str, Any] | None = None,
         status_code: int | None = None,
-        sync_to_thread: bool = False,
+        sync_to_thread: bool | None = None,
         # OpenAPI related attributes
         content_encoding: str | None = None,
         content_media_type: str | None = None,
@@ -236,7 +236,7 @@ class get(HTTPRouteHandler):
         return_dto: type[DTOInterface] | None | EmptyType = Empty,
         signature_namespace: Mapping[str, Any] | None = None,
         status_code: int | None = None,
-        sync_to_thread: bool = False,
+        sync_to_thread: bool | None = None,
         # OpenAPI related attributes
         content_encoding: str | None = None,
         content_media_type: str | None = None,
@@ -397,7 +397,7 @@ class head(HTTPRouteHandler):
         response_headers: ResponseHeaders | None = None,
         signature_namespace: Mapping[str, Any] | None = None,
         status_code: int | None = None,
-        sync_to_thread: bool = False,
+        sync_to_thread: bool | None = None,
         # OpenAPI related attributes
         content_encoding: str | None = None,
         content_media_type: str | None = None,
@@ -577,7 +577,7 @@ class patch(HTTPRouteHandler):
         return_dto: type[DTOInterface] | None | EmptyType = Empty,
         signature_namespace: Mapping[str, Any] | None = None,
         status_code: int | None = None,
-        sync_to_thread: bool = False,
+        sync_to_thread: bool | None = None,
         # OpenAPI related attributes
         content_encoding: str | None = None,
         content_media_type: str | None = None,
@@ -738,7 +738,7 @@ class post(HTTPRouteHandler):
         return_dto: type[DTOInterface] | None | EmptyType = Empty,
         signature_namespace: Mapping[str, Any] | None = None,
         status_code: int | None = None,
-        sync_to_thread: bool = False,
+        sync_to_thread: bool | None = None,
         # OpenAPI related attributes
         content_encoding: str | None = None,
         content_media_type: str | None = None,
@@ -899,7 +899,7 @@ class put(HTTPRouteHandler):
         return_dto: type[DTOInterface] | None | EmptyType = Empty,
         signature_namespace: Mapping[str, Any] | None = None,
         status_code: int | None = None,
-        sync_to_thread: bool = False,
+        sync_to_thread: bool | None = None,
         # OpenAPI related attributes
         content_encoding: str | None = None,
         content_media_type: str | None = None,

--- a/litestar/openapi/controller.py
+++ b/litestar/openapi/controller.py
@@ -160,6 +160,7 @@ class OpenAPIController(Controller):
         path="/openapi.yaml",
         media_type=OpenAPIMediaType.OPENAPI_YAML,
         include_in_schema=False,
+        sync_to_thread=False
     )
     def retrieve_schema_yaml(self, request: Request) -> Response:
         """Return the OpenAPI schema as YAML with an ``application/vnd.oai.openapi`` Content-Type header.
@@ -177,7 +178,8 @@ class OpenAPIController(Controller):
             )
         return Response(content={}, status_code=HTTP_404_NOT_FOUND)
 
-    @get(path="/openapi.json", media_type=OpenAPIMediaType.OPENAPI_JSON, include_in_schema=False)
+    @get(path="/openapi.json", media_type=OpenAPIMediaType.OPENAPI_JSON, include_in_schema=False,
+        sync_to_thread=False)
     def retrieve_schema_json(self, request: Request) -> Response:
         """Return the OpenAPI schema as JSON with an ``application/vnd.oai.openapi+json`` Content-Type header.
 
@@ -194,7 +196,8 @@ class OpenAPIController(Controller):
             )
         return Response(content={}, status_code=HTTP_404_NOT_FOUND)
 
-    @get(path="/", media_type=MediaType.HTML, include_in_schema=False)
+    @get(path="/", media_type=MediaType.HTML, include_in_schema=False,
+        sync_to_thread=False)
     def root(self, request: Request) -> Response:
         """Render a static documentation site.
 
@@ -226,7 +229,8 @@ class OpenAPIController(Controller):
             media_type=MediaType.HTML,
         )
 
-    @get(path="/swagger", media_type=MediaType.HTML, include_in_schema=False)
+    @get(path="/swagger", media_type=MediaType.HTML, include_in_schema=False,
+        sync_to_thread=False)
     def swagger_ui(self, request: Request) -> Response:
         """Route handler responsible for rendering Swagger-UI.
 
@@ -245,7 +249,8 @@ class OpenAPIController(Controller):
             media_type=MediaType.HTML,
         )
 
-    @get(path="/elements", media_type=MediaType.HTML, include_in_schema=False)
+    @get(path="/elements", media_type=MediaType.HTML, include_in_schema=False,
+        sync_to_thread=False)
     def stoplight_elements(self, request: Request) -> Response:
         """Route handler responsible for rendering StopLight Elements.
 
@@ -260,7 +265,8 @@ class OpenAPIController(Controller):
             return Response(content=self.render_stoplight_elements(request), media_type=MediaType.HTML)
         return Response(content=self.render_404_page(), status_code=HTTP_404_NOT_FOUND, media_type=MediaType.HTML)
 
-    @get(path="/redoc", media_type=MediaType.HTML, include_in_schema=False)
+    @get(path="/redoc", media_type=MediaType.HTML, include_in_schema=False,
+        sync_to_thread=False)
     def redoc(self, request: Request) -> Response:  # pragma: no cover
         """Route handler responsible for rendering Redoc.
 

--- a/litestar/openapi/controller.py
+++ b/litestar/openapi/controller.py
@@ -156,12 +156,7 @@ class OpenAPIController(Controller):
             "elements": self.render_stoplight_elements,
         }
 
-    @get(
-        path="/openapi.yaml",
-        media_type=OpenAPIMediaType.OPENAPI_YAML,
-        include_in_schema=False,
-        sync_to_thread=False
-    )
+    @get(path="/openapi.yaml", media_type=OpenAPIMediaType.OPENAPI_YAML, include_in_schema=False, sync_to_thread=False)
     def retrieve_schema_yaml(self, request: Request) -> Response:
         """Return the OpenAPI schema as YAML with an ``application/vnd.oai.openapi`` Content-Type header.
 
@@ -178,8 +173,7 @@ class OpenAPIController(Controller):
             )
         return Response(content={}, status_code=HTTP_404_NOT_FOUND)
 
-    @get(path="/openapi.json", media_type=OpenAPIMediaType.OPENAPI_JSON, include_in_schema=False,
-        sync_to_thread=False)
+    @get(path="/openapi.json", media_type=OpenAPIMediaType.OPENAPI_JSON, include_in_schema=False, sync_to_thread=False)
     def retrieve_schema_json(self, request: Request) -> Response:
         """Return the OpenAPI schema as JSON with an ``application/vnd.oai.openapi+json`` Content-Type header.
 
@@ -196,8 +190,7 @@ class OpenAPIController(Controller):
             )
         return Response(content={}, status_code=HTTP_404_NOT_FOUND)
 
-    @get(path="/", media_type=MediaType.HTML, include_in_schema=False,
-        sync_to_thread=False)
+    @get(path="/", media_type=MediaType.HTML, include_in_schema=False, sync_to_thread=False)
     def root(self, request: Request) -> Response:
         """Render a static documentation site.
 
@@ -229,8 +222,7 @@ class OpenAPIController(Controller):
             media_type=MediaType.HTML,
         )
 
-    @get(path="/swagger", media_type=MediaType.HTML, include_in_schema=False,
-        sync_to_thread=False)
+    @get(path="/swagger", media_type=MediaType.HTML, include_in_schema=False, sync_to_thread=False)
     def swagger_ui(self, request: Request) -> Response:
         """Route handler responsible for rendering Swagger-UI.
 
@@ -249,8 +241,7 @@ class OpenAPIController(Controller):
             media_type=MediaType.HTML,
         )
 
-    @get(path="/elements", media_type=MediaType.HTML, include_in_schema=False,
-        sync_to_thread=False)
+    @get(path="/elements", media_type=MediaType.HTML, include_in_schema=False, sync_to_thread=False)
     def stoplight_elements(self, request: Request) -> Response:
         """Route handler responsible for rendering StopLight Elements.
 
@@ -265,8 +256,7 @@ class OpenAPIController(Controller):
             return Response(content=self.render_stoplight_elements(request), media_type=MediaType.HTML)
         return Response(content=self.render_404_page(), status_code=HTTP_404_NOT_FOUND, media_type=MediaType.HTML)
 
-    @get(path="/redoc", media_type=MediaType.HTML, include_in_schema=False,
-        sync_to_thread=False)
+    @get(path="/redoc", media_type=MediaType.HTML, include_in_schema=False, sync_to_thread=False)
     def redoc(self, request: Request) -> Response:  # pragma: no cover
         """Route handler responsible for rendering Redoc.
 

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -328,6 +328,7 @@ class HTTPRoute(BaseRoute):
             path=path,
             http_method=[HttpMethod.OPTIONS],
             include_in_schema=False,
+            sync_to_thread=False,
         )(options_handler)
 
     @staticmethod

--- a/litestar/testing/request_factory.py
+++ b/litestar/testing/request_factory.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 
 def _create_default_route_handler() -> HTTPRouteHandler:
-    @get("/")
+    @get("/", sync_to_thread=False)
     def _default_route_handler() -> None:
         ...
 

--- a/litestar/utils/warnings.py
+++ b/litestar/utils/warnings.py
@@ -1,0 +1,21 @@
+import os
+import warnings
+
+from litestar.exceptions import LitestarWarning
+from litestar.types import AnyCallable
+
+
+def warn_implicit_sync_to_thread(source: AnyCallable, stacklevel: int = 2) -> None:
+    if os.getenv("LITESTAR_WARN_IMPLICIT_SYNC_TO_THREAD") == "0":
+        return
+
+    warnings.warn(
+        f"Use of a synchronous callable {source} without setting sync_to_thread is "
+        "discouraged. Since synchronous callables can block the main thread if they "
+        "perform blocking operations. If the callable is guaranteed to be non-blocking, "
+        "you can set sync_to_thread=False to skip this warning, or set the environment"
+        "variable LITESTAR_WARN_IMPLICIT_SYNC_TO_THREAD=0 to disable warnings of this "
+        "type entirely.",
+        category=LitestarWarning,
+        stacklevel=stacklevel,
+    )

--- a/litestar/utils/warnings.py
+++ b/litestar/utils/warnings.py
@@ -11,7 +11,7 @@ def warn_implicit_sync_to_thread(source: AnyCallable, stacklevel: int = 2) -> No
 
     warnings.warn(
         f"Use of a synchronous callable {source} without setting sync_to_thread is "
-        "discouraged. Since synchronous callables can block the main thread if they "
+        "discouraged since synchronous callables can block the main thread if they "
         "perform blocking operations. If the callable is guaranteed to be non-blocking, "
         "you can set sync_to_thread=False to skip this warning, or set the environment"
         "variable LITESTAR_WARN_IMPLICIT_SYNC_TO_THREAD=0 to disable warnings of this "

--- a/test_apps/openapi_test_app/main.py
+++ b/test_apps/openapi_test_app/main.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
 from litestar import Litestar, get
-from tests.openapi.utils import PersonController, PetController
+from tests.openapi.conftest import create_person_controller, create_pet_controller
 
 
 @get("/")
@@ -10,7 +10,7 @@ async def greet() -> Dict[str, str]:
 
 
 app = Litestar(
-    route_handlers=[greet, PersonController, PetController],
+    route_handlers=[greet, create_person_controller(), create_pet_controller()],
 )
 
 

--- a/tests/cli/test_schema_commands.py
+++ b/tests/cli/test_schema_commands.py
@@ -2,7 +2,6 @@ from json import dumps as json_dumps
 from typing import TYPE_CHECKING
 
 import pytest
-from test_apps.openapi_test_app.main import app as openapi_test_app
 from yaml import dump as dump_yaml
 
 from litestar.cli.main import litestar_group as cli_command
@@ -20,6 +19,8 @@ def test_openapi_schema_command(
     monkeypatch.setenv("LITESTAR_APP", "test_apps.openapi_test_app.main:app")
     mock_path_write_text = mocker.patch("pathlib.Path.write_text")
     command = "schema openapi"
+
+    from test_apps.openapi_test_app.main import app as openapi_test_app
 
     assert openapi_test_app.openapi_schema
     schema = openapi_test_app.openapi_schema.to_schema()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -490,5 +490,5 @@ def disable_warn_implicit_sync_to_thread() -> Generator[None, None, None]:
 
 
 @pytest.fixture()
-def enable_warn_implicit_sync_to_thread(monkeypatch) -> None:
+def enable_warn_implicit_sync_to_thread(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("LITESTAR_WARN_IMPLICIT_SYNC_TO_THREAD", "1")

--- a/tests/dependency_injection/test_injection_of_generic_models.py
+++ b/tests/dependency_injection/test_injection_of_generic_models.py
@@ -31,17 +31,16 @@ class DictStore(Store[Item]):
         return None
 
 
-@get("/")
-def root(store: DictStore) -> Optional[Item]:
-    assert isinstance(store, DictStore)
-    return store.get("0")
-
-
 async def get_item_store() -> DictStore:
     return DictStore(model=Item)  # type: ignore
 
 
 def test_generic_model_injection() -> None:
+    @get("/")
+    def root(store: DictStore) -> Optional[Item]:
+        assert isinstance(store, DictStore)
+        return store.get("0")
+
     with create_test_client(root, dependencies={"store": Provide(get_item_store, use_cache=True)}) as client:
         response = client.get("/")
         assert response.status_code == HTTP_200_OK

--- a/tests/handlers/http/test_sync.py
+++ b/tests/handlers/http/test_sync.py
@@ -1,6 +1,7 @@
 import pytest
 
 from litestar import MediaType, get
+from litestar.exceptions import LitestarWarning
 from litestar.handlers.http_handlers import HTTPRouteHandler
 from litestar.testing import create_test_client
 
@@ -13,10 +14,15 @@ def sync_handler() -> str:
     "handler",
     [
         get("/", media_type=MediaType.TEXT, sync_to_thread=True)(sync_handler),
-        get("/", media_type=MediaType.TEXT)(sync_handler),
+        get("/", media_type=MediaType.TEXT, sync_to_thread=False)(sync_handler),
     ],
 )
 def test_sync_to_thread(handler: HTTPRouteHandler) -> None:
     with create_test_client(handler) as client:
         response = client.get("/")
         assert response.text == "Hello World"
+
+
+def test_sync_to_thread_not_set_warns() -> None:
+    with pytest.warns(LitestarWarning):
+        get("/")(sync_handler)

--- a/tests/handlers/http/test_sync.py
+++ b/tests/handlers/http/test_sync.py
@@ -11,7 +11,6 @@ def sync_handler() -> str:
 
 @pytest.mark.parametrize("sync_to_thread", [True, False])
 def test_sync_to_thread(sync_to_thread: bool) -> None:
-
     handler = get("/", media_type=MediaType.TEXT, sync_to_thread=sync_to_thread)(sync_handler)
 
     with create_test_client(handler) as client:

--- a/tests/middleware/test_base_authentication_middleware.py
+++ b/tests/middleware/test_base_authentication_middleware.py
@@ -49,13 +49,12 @@ class AuthMiddleware(AbstractAuthenticationMiddleware):
         raise PermissionDeniedException("unauthenticated")
 
 
-@get(path="/")
-def http_route_handler(request: Request[User, Auth, Any]) -> None:
-    assert isinstance(request.user, User)
-    assert isinstance(request.auth, Auth)
-
-
 def test_authentication_middleware_http_routes() -> None:
+    @get(path="/")
+    def http_route_handler(request: Request[User, Auth, Any]) -> None:
+        assert isinstance(request.user, User)
+        assert isinstance(request.auth, Auth)
+
     client = create_test_client(route_handlers=[http_route_handler], middleware=[AuthMiddleware])
     token = "abc"
     error_response = client.get("/", headers={"Authorization": token})

--- a/tests/middleware/test_middleware_handling.py
+++ b/tests/middleware/test_middleware_handling.py
@@ -52,11 +52,6 @@ class MiddlewareWithArgsAndKwargs(BaseHTTPMiddleware):
         ...
 
 
-@get(path="/")
-def handler() -> None:
-    ...
-
-
 @pytest.mark.parametrize(
     "middleware",
     [
@@ -68,6 +63,10 @@ def handler() -> None:
     ],
 )
 def test_custom_middleware_processing(middleware: Any) -> None:
+    @get(path="/")
+    def handler() -> None:
+        ...
+
     with create_test_client(route_handlers=[handler], middleware=[middleware]) as client:
         app = client.app
         assert app.middleware == [middleware]
@@ -103,12 +102,11 @@ class JSONRequest(BaseModel):
     programmer: bool
 
 
-@post(path="/")
-def post_handler(data: JSONRequest) -> JSONRequest:
-    return data
-
-
 def test_request_body_logging_middleware(caplog: "LogCaptureFixture") -> None:
+    @post(path="/")
+    def post_handler(data: JSONRequest) -> JSONRequest:
+        return data
+
     with caplog.at_level(logging.INFO):
         client = create_test_client(
             route_handlers=[post_handler], middleware=[MiddlewareProtocolRequestLoggingMiddleware]

--- a/tests/openapi/conftest.py
+++ b/tests/openapi/conftest.py
@@ -1,0 +1,134 @@
+from datetime import date, datetime
+from typing import Any, Dict, List, Optional, Type, Union
+
+import pytest
+from pydantic import (
+    conint,
+)
+
+from litestar import Controller, MediaType, delete, get, patch, post, put
+from litestar.datastructures import ResponseHeader, State
+from litestar.openapi.spec.example import Example
+from litestar.params import Parameter
+from litestar.partial import Partial
+from tests import Person, PersonFactory, Pet, VanillaDataClassPerson
+from tests.openapi.utils import Gender, PetException
+
+
+def create_person_controller() -> Type[Controller]:
+    class PersonController(Controller):
+        path = "/{service_id:int}/person"
+
+        @get()
+        def get_persons(
+            self,
+            # expected to be ignored
+            headers: Any,
+            request: Any,
+            state: State,
+            query: Dict[str, Any],
+            cookies: Dict[str, Any],
+            # required query parameters below
+            page: int,
+            name: Optional[Union[str, List[str]]],  # intentionally without default
+            page_size: int = Parameter(
+                query="pageSize",
+                description="Page Size Description",
+                title="Page Size Title",
+                examples=[Example(description="example value", value=1)],
+            ),
+            # path parameter
+            service_id: int = conint(gt=0),  # type: ignore
+            # non-required query parameters below
+            from_date: Optional[Union[int, datetime, date]] = None,
+            to_date: Optional[Union[int, datetime, date]] = None,
+            gender: Optional[Union[Gender, List[Gender]]] = Parameter(
+                examples=[Example(value="M"), Example(value=["M", "O"])]
+            ),
+            # header parameter
+            secret_header: str = Parameter(header="secret"),
+            # cookie parameter
+            cookie_value: int = Parameter(cookie="value"),
+        ) -> List[Person]:
+            return []
+
+        @post(media_type=MediaType.TEXT)
+        def create_person(self, data: Person, secret_header: str = Parameter(header="secret")) -> Person:
+            return data
+
+        @post(path="/bulk")
+        def bulk_create_person(
+            self, data: List[Person], secret_header: str = Parameter(header="secret")
+        ) -> List[Person]:
+            return []
+
+        @put(path="/bulk")
+        def bulk_update_person(
+            self, data: List[Person], secret_header: str = Parameter(header="secret")
+        ) -> List[Person]:
+            return []
+
+        @patch(path="/bulk")
+        def bulk_partial_update_person(
+            self, data: List[Partial[Person]], secret_header: str = Parameter(header="secret")
+        ) -> List[Person]:
+            return []
+
+        @get(path="/{person_id:str}")
+        def get_person_by_id(self, person_id: str) -> Person:
+            """Description in docstring."""
+            return PersonFactory.build(id=person_id)
+
+        @patch(path="/{person_id:str}", description="Description in decorator")
+        def partial_update_person(self, person_id: str, data: Partial[Person]) -> Person:
+            """Description in docstring."""
+            return PersonFactory.build(id=person_id)
+
+        @put(path="/{person_id:str}")
+        def update_person(self, person_id: str, data: Person) -> Person:
+            """Multiline docstring example.
+
+            Line 3.
+            """
+            return data
+
+        @delete(path="/{person_id:str}")
+        def delete_person(self, person_id: str) -> None:
+            return None
+
+        @get(path="/dataclass")
+        def get_person_dataclass(self) -> VanillaDataClassPerson:
+            return VanillaDataClassPerson(
+                first_name="Moishe", last_name="zuchmir", id="1", optional=None, complex={}, pets=None
+            )
+
+    return PersonController
+
+
+def create_pet_controller() -> Type[Controller]:
+    class PetController(Controller):
+        path = "/pet"
+
+        @get()
+        def pets(self) -> List[Pet]:
+            return []
+
+        @get(
+            path="/owner-or-pet", response_headers=[ResponseHeader(name="x-my-tag", value="123")], raises=[PetException]
+        )
+        def get_pets_or_owners(self) -> List[Union[Person, Pet]]:
+            return []
+
+    return PetController
+
+
+@pytest.fixture
+@pytest.mark.usefixtures("disable_warn_implicit_sync_to_thread")
+def person_controller() -> Type[Controller]:
+    return create_person_controller()
+
+
+@pytest.fixture
+@pytest.mark.usefixtures("disable_warn_implicit_sync_to_thread")
+def pet_controller() -> Type[Controller]:
+    return create_pet_controller()

--- a/tests/openapi/test_controller.py
+++ b/tests/openapi/test_controller.py
@@ -1,20 +1,20 @@
-from typing import List
+from typing import List, Type
 
 import pytest
 
+from litestar import Controller
 from litestar.app import DEFAULT_OPENAPI_CONFIG
 from litestar.enums import MediaType
 from litestar.openapi.config import OpenAPIConfig
 from litestar.openapi.controller import OpenAPIController
 from litestar.status_codes import HTTP_200_OK, HTTP_404_NOT_FOUND
 from litestar.testing import create_test_client
-from tests.openapi.utils import PersonController, PetController
 
 root_paths: List[str] = ["", "/part1", "/part1/part2"]
 
 
-def test_default_redoc_cdn_urls() -> None:
-    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+def test_default_redoc_cdn_urls(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
+    with create_test_client([person_controller, pet_controller], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
         response = client.get("/schema/redoc")
         default_redoc_version = "next"
         default_redoc_js_bundle = (
@@ -25,8 +25,8 @@ def test_default_redoc_cdn_urls() -> None:
         assert default_redoc_js_bundle in response.text
 
 
-def test_default_swagger_ui_cdn_urls() -> None:
-    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+def test_default_swagger_ui_cdn_urls(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
+    with create_test_client([person_controller, pet_controller], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
         response = client.get("/schema/swagger")
         default_swagger_bundles = [
             f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{OpenAPIController.swagger_ui_version}/swagger-ui.css",
@@ -42,8 +42,10 @@ def test_default_swagger_ui_cdn_urls() -> None:
         assert all(cdn_url in response.text for cdn_url in default_swagger_bundles)
 
 
-def test_default_stoplight_elements_cdn_urls() -> None:
-    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+def test_default_stoplight_elements_cdn_urls(
+    person_controller: Type[Controller], pet_controller: Type[Controller]
+) -> None:
+    with create_test_client([person_controller, pet_controller], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
         response = client.get("/schema/elements")
         default_stoplight_elements_bundles = [
             f"https://unpkg.com/@stoplight/elements@{OpenAPIController.stoplight_elements_version}/styles.min.css",
@@ -60,8 +62,8 @@ def test_default_stoplight_elements_cdn_urls() -> None:
         assert all(cdn_url in response.text for cdn_url in default_stoplight_elements_bundles)
 
 
-def test_redoc_with_google_fonts() -> None:
-    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+def test_redoc_with_google_fonts(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
+    with create_test_client([person_controller, pet_controller], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
         response = client.get("/schema/redoc")
         google_font_cdn = "https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700"
         assert client.app.openapi_config is not None
@@ -69,31 +71,31 @@ def test_redoc_with_google_fonts() -> None:
         assert google_font_cdn in response.text
 
 
-def test_redoc_without_google_fonts() -> None:
+def test_redoc_without_google_fonts(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
     class OfflineOpenAPIController(OpenAPIController):
         """test class for usage in a couple "offline" tests and for without Google fonts test."""
 
         redoc_google_fonts = False
 
     offline_config = OpenAPIConfig(title="Litestar API", version="1.0.0", openapi_controller=OfflineOpenAPIController)
-    with create_test_client([PersonController, PetController], openapi_config=offline_config) as client:
+    with create_test_client([person_controller, pet_controller], openapi_config=offline_config) as client:
         response = client.get("/schema/redoc")
         assert "fonts.googleapis.com" not in response.text
 
 
-def test_openapi_redoc_offline() -> None:
+def test_openapi_redoc_offline(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
     class OfflineOpenAPIController(OpenAPIController):
         """test class for usage in a couple "offline" tests and for without Google fonts test."""
 
         redoc_js_url = "https://offline_location/redoc.standalone.js"
 
     offline_config = OpenAPIConfig(title="Litestar API", version="1.0.0", openapi_controller=OfflineOpenAPIController)
-    with create_test_client([PersonController, PetController], openapi_config=offline_config) as client:
+    with create_test_client([person_controller, pet_controller], openapi_config=offline_config) as client:
         response = client.get("/schema/redoc")
         assert OfflineOpenAPIController.redoc_js_url in response.text
 
 
-def test_openapi_swagger_offline() -> None:
+def test_openapi_swagger_offline(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
     class OfflineOpenAPIController(OpenAPIController):
         """test class for usage in a couple "offline" tests and for without Google fonts test."""
 
@@ -102,14 +104,16 @@ def test_openapi_swagger_offline() -> None:
         swagger_ui_standalone_preset_js_url = "https://offline_location/swagger-ui-standalone-preset.js"
 
     offline_config = OpenAPIConfig(title="Litestar API", version="1.0.0", openapi_controller=OfflineOpenAPIController)
-    with create_test_client([PersonController, PetController], openapi_config=offline_config) as client:
+    with create_test_client([person_controller, pet_controller], openapi_config=offline_config) as client:
         response = client.get("/schema/swagger")
         assert OfflineOpenAPIController.swagger_css_url in response.text
         assert OfflineOpenAPIController.swagger_ui_bundle_js_url in response.text
         assert OfflineOpenAPIController.swagger_ui_standalone_preset_js_url in response.text
 
 
-def test_openapi_stoplight_elements_offline() -> None:
+def test_openapi_stoplight_elements_offline(
+    person_controller: Type[Controller], pet_controller: Type[Controller]
+) -> None:
     class OfflineOpenAPIController(OpenAPIController):
         """test class for usage in a couple "offline" tests and for without Google fonts test."""
 
@@ -117,16 +121,16 @@ def test_openapi_stoplight_elements_offline() -> None:
         stoplight_elements_js_url = "https://offline_location/spotlight-web-components.min.js"
 
     offline_config = OpenAPIConfig(title="Litestar API", version="1.0.0", openapi_controller=OfflineOpenAPIController)
-    with create_test_client([PersonController, PetController], openapi_config=offline_config) as client:
+    with create_test_client([person_controller, pet_controller], openapi_config=offline_config) as client:
         response = client.get("/schema/elements")
         assert OfflineOpenAPIController.stoplight_elements_css_url in response.text
         assert OfflineOpenAPIController.stoplight_elements_js_url in response.text
 
 
 @pytest.mark.parametrize("root_path", root_paths)
-def test_openapi_root(root_path: str) -> None:
+def test_openapi_root(root_path: str, person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
     with create_test_client(
-        [PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG, root_path=root_path
+        [person_controller, pet_controller], openapi_config=DEFAULT_OPENAPI_CONFIG, root_path=root_path
     ) as client:
         response = client.get("/schema")
         assert response.status_code == HTTP_200_OK
@@ -134,9 +138,9 @@ def test_openapi_root(root_path: str) -> None:
 
 
 @pytest.mark.parametrize("root_path", root_paths)
-def test_openapi_redoc(root_path: str) -> None:
+def test_openapi_redoc(root_path: str, person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
     with create_test_client(
-        [PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG, root_path=root_path
+        [person_controller, pet_controller], openapi_config=DEFAULT_OPENAPI_CONFIG, root_path=root_path
     ) as client:
         response = client.get("/schema/redoc")
         assert response.status_code == HTTP_200_OK
@@ -144,9 +148,9 @@ def test_openapi_redoc(root_path: str) -> None:
 
 
 @pytest.mark.parametrize("root_path", root_paths)
-def test_openapi_swagger(root_path: str) -> None:
+def test_openapi_swagger(root_path: str, person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
     with create_test_client(
-        [PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG, root_path=root_path
+        [person_controller, pet_controller], openapi_config=DEFAULT_OPENAPI_CONFIG, root_path=root_path
     ) as client:
         response = client.get("/schema/swagger")
         assert response.status_code == HTTP_200_OK
@@ -154,9 +158,11 @@ def test_openapi_swagger(root_path: str) -> None:
 
 
 @pytest.mark.parametrize("root_path", root_paths)
-def test_openapi_swagger_caching_schema(root_path: str) -> None:
+def test_openapi_swagger_caching_schema(
+    root_path: str, person_controller: Type[Controller], pet_controller: Type[Controller]
+) -> None:
     with create_test_client(
-        [PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG, root_path=root_path
+        [person_controller, pet_controller], openapi_config=DEFAULT_OPENAPI_CONFIG, root_path=root_path
     ) as client:
         # Make sure that the schema is tweaked for swagger as the openapi version is changed.
         # Because schema can get cached, make sure that getting a different schema type before works.
@@ -169,18 +175,20 @@ def test_openapi_swagger_caching_schema(root_path: str) -> None:
 
 
 @pytest.mark.parametrize("root_path", root_paths)
-def test_openapi_stoplight_elements(root_path: str) -> None:
+def test_openapi_stoplight_elements(
+    root_path: str, person_controller: Type[Controller], pet_controller: Type[Controller]
+) -> None:
     with create_test_client(
-        [PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG, root_path=root_path
+        [person_controller, pet_controller], openapi_config=DEFAULT_OPENAPI_CONFIG, root_path=root_path
     ) as client:
         response = client.get("/schema/elements/")
         assert response.status_code == HTTP_200_OK
         assert response.headers["content-type"].startswith(MediaType.HTML.value)
 
 
-def test_openapi_root_not_allowed() -> None:
+def test_openapi_root_not_allowed(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
     with create_test_client(
-        [PersonController, PetController],
+        [person_controller, pet_controller],
         openapi_config=OpenAPIConfig(
             title="Litestar API",
             version="1.0.0",
@@ -192,9 +200,9 @@ def test_openapi_root_not_allowed() -> None:
         assert response.headers["content-type"].startswith(MediaType.HTML.value)
 
 
-def test_openapi_redoc_not_allowed() -> None:
+def test_openapi_redoc_not_allowed(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
     with create_test_client(
-        [PersonController, PetController],
+        [person_controller, pet_controller],
         openapi_config=OpenAPIConfig(
             title="Litestar API",
             version="1.0.0",
@@ -206,9 +214,9 @@ def test_openapi_redoc_not_allowed() -> None:
         assert response.headers["content-type"].startswith(MediaType.HTML.value)
 
 
-def test_openapi_swagger_not_allowed() -> None:
+def test_openapi_swagger_not_allowed(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
     with create_test_client(
-        [PersonController, PetController],
+        [person_controller, pet_controller],
         openapi_config=OpenAPIConfig(
             title="Litestar API",
             version="1.0.0",
@@ -220,9 +228,11 @@ def test_openapi_swagger_not_allowed() -> None:
         assert response.headers["content-type"].startswith(MediaType.HTML.value)
 
 
-def test_openapi_stoplight_elements_not_allowed() -> None:
+def test_openapi_stoplight_elements_not_allowed(
+    person_controller: Type[Controller], pet_controller: Type[Controller]
+) -> None:
     with create_test_client(
-        [PersonController, PetController],
+        [person_controller, pet_controller],
         openapi_config=OpenAPIConfig(
             title="Litestar API",
             version="1.0.0",

--- a/tests/openapi/test_integration.py
+++ b/tests/openapi/test_integration.py
@@ -1,14 +1,16 @@
+from typing import Type
+
 import yaml
 
+from litestar import Controller
 from litestar.app import DEFAULT_OPENAPI_CONFIG
 from litestar.enums import OpenAPIMediaType
 from litestar.status_codes import HTTP_200_OK, HTTP_404_NOT_FOUND
 from litestar.testing import create_test_client
-from tests.openapi.utils import PersonController, PetController
 
 
-def test_openapi_yaml() -> None:
-    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+def test_openapi_yaml(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
+    with create_test_client([person_controller, pet_controller], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
         assert client.app.openapi_schema
         openapi_schema = client.app.openapi_schema
         assert openapi_schema.paths
@@ -19,8 +21,8 @@ def test_openapi_yaml() -> None:
         assert yaml.unsafe_load(response.content) == client.app.openapi_schema.to_schema()
 
 
-def test_openapi_json() -> None:
-    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+def test_openapi_json(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
+    with create_test_client([person_controller, pet_controller], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
         assert client.app.openapi_schema
         openapi_schema = client.app.openapi_schema
         assert openapi_schema.paths
@@ -31,11 +33,11 @@ def test_openapi_json() -> None:
         assert response.json() == client.app.openapi_schema.to_schema()
 
 
-def test_openapi_yaml_not_allowed() -> None:
+def test_openapi_yaml_not_allowed(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
     openapi_config = DEFAULT_OPENAPI_CONFIG
     openapi_config.enabled_endpoints.discard("openapi.yaml")
 
-    with create_test_client([PersonController, PetController], openapi_config=openapi_config) as client:
+    with create_test_client([person_controller, pet_controller], openapi_config=openapi_config) as client:
         assert client.app.openapi_schema
         openapi_schema = client.app.openapi_schema
         assert openapi_schema.paths
@@ -43,11 +45,11 @@ def test_openapi_yaml_not_allowed() -> None:
         assert response.status_code == HTTP_404_NOT_FOUND
 
 
-def test_openapi_json_not_allowed() -> None:
+def test_openapi_json_not_allowed(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
     openapi_config = DEFAULT_OPENAPI_CONFIG
     openapi_config.enabled_endpoints.discard("openapi.json")
 
-    with create_test_client([PersonController, PetController], openapi_config=openapi_config) as client:
+    with create_test_client([person_controller, pet_controller], openapi_config=openapi_config) as client:
         assert client.app.openapi_schema
         openapi_schema = client.app.openapi_schema
         assert openapi_schema.paths

--- a/tests/openapi/test_parameters.py
+++ b/tests/openapi/test_parameters.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional, cast
+from typing import TYPE_CHECKING, List, Optional, Type, cast
 
 import pytest
 from polyfactory import BaseFactory
@@ -14,7 +14,6 @@ from litestar.openapi.spec import OpenAPI
 from litestar.openapi.spec.enums import OpenAPIType
 from litestar.params import Dependency, Parameter
 from litestar.utils import find_index
-from tests.openapi.utils import PersonController
 
 if TYPE_CHECKING:
     from litestar.openapi.spec.parameter import Parameter as OpenAPIParameter
@@ -43,9 +42,9 @@ def _create_parameters(app: Litestar, path: str) -> List["OpenAPIParameter"]:
     )
 
 
-def test_create_parameters() -> None:
+def test_create_parameters(person_controller: Type[Controller]) -> None:
     BaseFactory.seed_random(1)
-    parameters = _create_parameters(app=Litestar(route_handlers=[PersonController]), path="/{service_id}/person")
+    parameters = _create_parameters(app=Litestar(route_handlers=[person_controller]), path="/{service_id}/person")
     assert len(parameters) == 9
     page, name, page_size, service_id, from_date, to_date, gender, secret_header, cookie_value = tuple(parameters)
 

--- a/tests/openapi/test_path_item.py
+++ b/tests/openapi/test_path_item.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Tuple, cast
+from typing import TYPE_CHECKING, Any, Tuple, Type, cast
 
 import pytest
 
@@ -8,25 +8,24 @@ from litestar._openapi.utils import default_operation_id_creator
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.handlers.http_handlers import HTTPRouteHandler
 from litestar.utils import find_index
-from tests.openapi.utils import PersonController
 
 if TYPE_CHECKING:
     from litestar.routes import HTTPRoute
 
 
 @pytest.fixture()
-def route() -> "HTTPRoute":
-    app = Litestar(route_handlers=[PersonController], openapi_config=None)
+def route(person_controller: Type[Controller]) -> "HTTPRoute":
+    app = Litestar(route_handlers=[person_controller], openapi_config=None)
     index = find_index(app.routes, lambda x: x.path_format == "/{service_id}/person/{person_id}")
     return cast("HTTPRoute", app.routes[index])
 
 
 @pytest.fixture()
-def routes_with_router() -> Tuple["HTTPRoute", "HTTPRoute"]:
-    class PersonControllerV2(PersonController):
+def routes_with_router(person_controller: Type[Controller]) -> Tuple["HTTPRoute", "HTTPRoute"]:
+    class PersonControllerV2(person_controller):  # type: ignore
         pass
 
-    router_v1 = Router(path="/v1", route_handlers=[PersonController])
+    router_v1 = Router(path="/v1", route_handlers=[person_controller])
     router_v2 = Router(path="/v2", route_handlers=[PersonControllerV2])
     app = Litestar(route_handlers=[router_v1, router_v2], openapi_config=None)
     index_v1 = find_index(app.routes, lambda x: x.path_format == "/v1/{service_id}/person/{person_id}")

--- a/tests/openapi/test_request_body.py
+++ b/tests/openapi/test_request_body.py
@@ -1,16 +1,15 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Type
 from unittest.mock import MagicMock
 
 from pydantic import BaseConfig, BaseModel
 
-from litestar import Litestar, post
+from litestar import Controller, Litestar, post
 from litestar._openapi.request_body import create_request_body
 from litestar._signature.field import SignatureField
 from litestar.datastructures.upload_file import UploadFile
 from litestar.dto.interface import DTOInterface
 from litestar.enums import RequestEncodingType
 from litestar.params import Body
-from tests.openapi.utils import PersonController
 
 
 class FormData(BaseModel):
@@ -21,8 +20,8 @@ class FormData(BaseModel):
         arbitrary_types_allowed = True
 
 
-def test_create_request_body() -> None:
-    for route in Litestar(route_handlers=[PersonController]).routes:
+def test_create_request_body(person_controller: Type[Controller]) -> None:
+    for route in Litestar(route_handlers=[person_controller]).routes:
         for route_handler, _ in route.route_handler_map.values():  # type: ignore
             handler_fields = route_handler.signature_model.fields  # type: ignore
             if "data" in handler_fields:

--- a/tests/openapi/typescript_converter/test_converter.py
+++ b/tests/openapi/typescript_converter/test_converter.py
@@ -1,15 +1,16 @@
+from typing import Type
+
 from polyfactory import BaseFactory
 
-from litestar import Litestar
+from litestar import Controller, Litestar
 from litestar._openapi.typescript_converter.converter import (
     convert_openapi_to_typescript,
 )
-from tests.openapi.utils import PersonController, PetController
 
 
-def test_openapi_to_typescript_converter() -> None:
+def test_openapi_to_typescript_converter(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
     BaseFactory.seed_random(1)
-    app = Litestar(route_handlers=[PersonController, PetController])
+    app = Litestar(route_handlers=[person_controller, pet_controller])
     assert app.openapi_schema
 
     result = convert_openapi_to_typescript(openapi_schema=app.openapi_schema)

--- a/tests/openapi/utils.py
+++ b/tests/openapi/utils.py
@@ -1,7 +1,6 @@
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
 
 from pydantic import (
     conbytes,
@@ -14,13 +13,7 @@ from pydantic import (
     constr,
 )
 
-from litestar import Controller, MediaType, delete, get, patch, post, put
-from litestar.datastructures import ResponseHeader, State
 from litestar.exceptions import HTTPException
-from litestar.openapi.spec.example import Example
-from litestar.params import Parameter
-from litestar.partial import Partial
-from tests import Person, PersonFactory, Pet, VanillaDataClassPerson
 
 
 class PetException(HTTPException):
@@ -32,101 +25,6 @@ class Gender(str, Enum):
     FEMALE = "F"
     OTHER = "O"
     ANY = "A"
-
-
-class PersonController(Controller):
-    path = "/{service_id:int}/person"
-
-    @get()
-    def get_persons(
-        self,
-        # expected to be ignored
-        headers: Any,
-        request: Any,
-        state: State,
-        query: Dict[str, Any],
-        cookies: Dict[str, Any],
-        # required query parameters below
-        page: int,
-        name: Optional[Union[str, List[str]]],  # intentionally without default
-        page_size: int = Parameter(
-            query="pageSize",
-            description="Page Size Description",
-            title="Page Size Title",
-            examples=[Example(description="example value", value=1)],
-        ),
-        # path parameter
-        service_id: int = conint(gt=0),  # type: ignore
-        # non-required query parameters below
-        from_date: Optional[Union[int, datetime, date]] = None,
-        to_date: Optional[Union[int, datetime, date]] = None,
-        gender: Optional[Union[Gender, List[Gender]]] = Parameter(
-            examples=[Example(value="M"), Example(value=["M", "O"])]
-        ),
-        # header parameter
-        secret_header: str = Parameter(header="secret"),
-        # cookie parameter
-        cookie_value: int = Parameter(cookie="value"),
-    ) -> List[Person]:
-        return []
-
-    @post(media_type=MediaType.TEXT)
-    def create_person(self, data: Person, secret_header: str = Parameter(header="secret")) -> Person:
-        return data
-
-    @post(path="/bulk")
-    def bulk_create_person(self, data: List[Person], secret_header: str = Parameter(header="secret")) -> List[Person]:
-        return []
-
-    @put(path="/bulk")
-    def bulk_update_person(self, data: List[Person], secret_header: str = Parameter(header="secret")) -> List[Person]:
-        return []
-
-    @patch(path="/bulk")
-    def bulk_partial_update_person(
-        self, data: List[Partial[Person]], secret_header: str = Parameter(header="secret")
-    ) -> List[Person]:
-        return []
-
-    @get(path="/{person_id:str}")
-    def get_person_by_id(self, person_id: str) -> Person:
-        """Description in docstring."""
-        return PersonFactory.build(id=person_id)
-
-    @patch(path="/{person_id:str}", description="Description in decorator")
-    def partial_update_person(self, person_id: str, data: Partial[Person]) -> Person:
-        """Description in docstring."""
-        return PersonFactory.build(id=person_id)
-
-    @put(path="/{person_id:str}")
-    def update_person(self, person_id: str, data: Person) -> Person:
-        """Multiline docstring example.
-
-        Line 3.
-        """
-        return data
-
-    @delete(path="/{person_id:str}")
-    def delete_person(self, person_id: str) -> None:
-        return None
-
-    @get(path="/dataclass")
-    def get_person_dataclass(self) -> VanillaDataClassPerson:
-        return VanillaDataClassPerson(
-            first_name="Moishe", last_name="zuchmir", id="1", optional=None, complex={}, pets=None
-        )
-
-
-class PetController(Controller):
-    path = "/pet"
-
-    @get()
-    def pets(self) -> List[Pet]:
-        return []
-
-    @get(path="/owner-or-pet", response_headers=[ResponseHeader(name="x-my-tag", value="123")], raises=[PetException])
-    def get_pets_or_owners(self) -> List[Union[Person, Pet]]:
-        return []
 
 
 constrained_numbers = [

--- a/tests/response/test_response_class.py
+++ b/tests/response/test_response_class.py
@@ -13,21 +13,20 @@ handler_response = type("local_response", (Response,), {})
 test_path = "/test"
 
 
-class MyController(Controller):
-    path = test_path
-
-    @get(
-        path="/{path_param:str}",
-    )
-    def test_method(self) -> None:
-        pass
-
-
 @pytest.mark.parametrize(
     "layer, expected",
     [[0, handler_response], [1, controller_response], [2, router_response], [3, app_response], [None, Response]],
 )
 def test_response_class_resolution_of_layers(layer: Optional[int], expected: Response) -> None:
+    class MyController(Controller):
+        path = test_path
+
+        @get(
+            path="/{path_param:str}",
+        )
+        def test_method(self) -> None:
+            pass
+
     MyController.test_method._resolved_response_class = Empty if layer != 0 else expected  # type: ignore
     MyController.response_class = None if layer != 1 else expected  # type: ignore
     router = Router(path="/users", route_handlers=[MyController], response_class=None if layer != 2 else expected)  # type: ignore

--- a/tests/response/test_type_encoders.py
+++ b/tests/response/test_type_encoders.py
@@ -22,19 +22,17 @@ controller_type, controller_encoder = create_mock_encoder("ControllerType")
 app_type, app_encoder = create_mock_encoder("AppType")
 
 
-class MyController(Controller):
-    type_encoders = {controller_type: controller_encoder}
-
-    @get("/", type_encoders={handler_type: handler_encoder})
-    def handler(self) -> Any:
-        ...
-
-
-router = Router("/router", type_encoders={router_type: router_encoder}, route_handlers=[MyController])
-app = Litestar([router], type_encoders={app_type: app_encoder})
-
-
 def test_resolve_type_encoders() -> None:
+    class MyController(Controller):
+        type_encoders = {controller_type: controller_encoder}
+
+        @get("/", type_encoders={handler_type: handler_encoder})
+        def handler(self) -> Any:
+            ...
+
+    router = Router("/router", type_encoders={router_type: router_encoder}, route_handlers=[MyController])
+    app = Litestar([router], type_encoders={app_type: app_encoder})
+
     route_handler = app.routes[0].route_handler_map[HttpMethod.GET][0]  # type: ignore
     assert route_handler.resolve_type_encoders() == {
         handler_type: handler_encoder,

--- a/tests/routing/test_path_resolution.py
+++ b/tests/routing/test_path_resolution.py
@@ -14,7 +14,7 @@ from litestar.testing import create_test_client
 from tests import Person, PersonFactory
 
 
-@delete()
+@delete(sync_to_thread=False)
 def root_delete_handler() -> None:
     return None
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -11,12 +11,11 @@ if TYPE_CHECKING:
     from litestar.datastructures import State
 
 
-@get("/", media_type=MediaType.TEXT)
-def greet() -> str:
-    return "hello world"
-
-
 def test_plugin_on_app_init() -> None:
+    @get("/", media_type=MediaType.TEXT)
+    def greet() -> str:
+        return "hello world"
+
     tag = "on_app_init_called"
 
     def on_startup(state: State) -> None:

--- a/tests/test_provide.py
+++ b/tests/test_provide.py
@@ -189,6 +189,7 @@ async def test_cleanup_group_add_on_closed_raises(
         group.add(async_generator)
 
 
+@pytest.mark.usefixtures("enable_warn_implicit_sync_to_thread")
 def test_sync_callable_without_sync_to_thread_warns() -> None:
     def func() -> None:
         pass

--- a/tests/utils/test_predicates.py
+++ b/tests/utils/test_predicates.py
@@ -38,12 +38,12 @@ class C:
     pass
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def naive_handler() -> Dict[str, int]:
     return {}
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def response_handler() -> Response[Any]:
     return Response(content=b"")
 


### PR DESCRIPTION
As a continuation of #1648, which introduced a warning about the implicit usage of `sync_to_thread` in `Provide`, this adds the same warning for route handlers. 

Additionally this PR:

- Introduces an environment variable to toggle the emitted warnings: `LITESTAR_WARN_IMPLICIT_SYNC_TO_THREAD`
- Adds a new "topics" section to the documentation
- Adds a "Sync vs Async" article to the topics section, talking about basic considerations regarding the different modes of execution and when they are appropriate
- Adjusts the documentation of route handlers and `Provide` to reference that article
- Adjusts all examples to explicitly use `sync_to_thread=False` where appropriate
- Refactors a bunch of tests which did act on globally scoped objects and could therefore not be targeted by the setting of the `LITESTAR_WARN_IMPLICIT_SYNC_TO_THREAD` variable reliably

**Considerations**

Introducing this warning and including `sync_to_thread` by default in our documentation does not come without its downsides. The main concern is that it adds unnecessary noise, possibly making examples harder to follow. However, after a lengthy conversation with @peterschutt and weighing of the options, we agreed that handling it this way would be the best option overall.

The fact that Litestar does not implicitly run synchronous functions in a thread is a core design decision, and what allows us to be significantly faster for operations that are truly non-blocking, even being able to avoid async overhead. This is a detail that should be made explicit in the docs, and is simply the trade off being made in favour of more granular control over the mode of execution and better performance out of the box.

The impact of this on user code bases will be minimal, since this warning can be turned off at will. 


**Alternatives**

An alternative implementation would be to turn off the warning by default, which would then however place the burden of knowledge upon the user, making it easier to accidentally block their entire application by using a synchronous callable. Since this is exactly what the warning introduced here is trying to prevent, it was decided that this was not a viable option.