### PR TITLE
Fix channels repeated unsubscribe bug

### DIFF
--- a/litestar/channels/plugin.py
+++ b/litestar/channels/plugin.py
@@ -230,7 +230,6 @@ class ChannelsPlugin(InitPluginProtocol):
                 continue
 
             if not channel_subscribers:
-                del self._channels[channel]
                 channels_to_unsubscribe.add(channel)
 
         if not any(subscriber in queues for queues in self._channels.values()):

--- a/tests/channels/test_plugin.py
+++ b/tests/channels/test_plugin.py
@@ -263,6 +263,14 @@ async def test_unsubscribe(
         assert subscriber_2 in plugin._channels[channel]
 
 
+async def test_subscribe_after_unsubscribe(memory_backend: MemoryChannelsBackend) -> None:
+    plugin = ChannelsPlugin(backend=memory_backend, channels=["foo"])
+    subscriber = await plugin.subscribe("foo")
+    await plugin.unsubscribe(subscriber)
+
+    await plugin.subscribe("foo")
+
+
 async def test_unsubscribe_last_subscriber_unsubscribes_backend(
     memory_backend: MemoryChannelsBackend, async_mock: AsyncMock
 ) -> None:


### PR DESCRIPTION
Fix a bug that would raise an error when repeatedly subscribing to and unsubscribing from the same channel while `arbitrary_channels_allowed=False`.