### PR TITLE
Tests: Add missing aiosqlite marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,7 +216,8 @@ filterwarnings = [
 markers = [
     "sqlalchemy_asyncmy: SQLAlchemy MySQL (asyncmy) Tests",
     "sqlalchemy_asyncpg: SQLAlchemy Postgres (asyncpg) Tests",
-    "sqlalchemy_psycopg_async: SQLAlchemy Postgres (psycopg async) Tests"
+    "sqlalchemy_psycopg_async: SQLAlchemy Postgres (psycopg async) Tests",
+    "sqlalchemy_aiosqlite: SQLAlchemy SQLite (aiosqlite) Tests"
 ]
 
 [tool.pyright]


### PR DESCRIPTION
Add a missing `sqlalchemy_aiosqlite` marker to the pytest configuration.
