### PR TITLE
Infra: Set a timout for test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,7 @@ on:
 jobs:
   test:
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 10
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Recently we've been introducing more integration tests that might hang indefinitely (behaviour observed multiple times already) due to a misconfigured tests, resource cleanup issues, issues with the docker containers being used etc. This PR introduces a hard limit of 10 minutes for the tests workflow, after which it will be cancelled.