### PR TITLE
Enhancement: Warn about `sync_to_thread` with async callables

### DIFF
--- a/litestar/di.py
+++ b/litestar/di.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types import Empty
 from litestar.utils import Ref, is_async_callable
-from litestar.utils.warnings import warn_implicit_sync_to_thread
+from litestar.utils.warnings import warn_implicit_sync_to_thread, warn_sync_to_thread_with_async_callable
 
 __all__ = ("Provide",)
 
@@ -52,6 +52,10 @@ class Provide:
         self.has_sync_callable = isclass(dependency) or not is_async_callable(dependency)
         if self.has_sync_callable and sync_to_thread is None:
             warn_implicit_sync_to_thread(dependency, stacklevel=3)
+
+        if not self.has_sync_callable and sync_to_thread is not None:
+            warn_sync_to_thread_with_async_callable(dependency, stacklevel=3)
+
         self.sync_to_thread = bool(sync_to_thread)
         self.use_cache = use_cache
         self.value: Any = Empty

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -46,7 +46,7 @@ from litestar.types import (
 )
 from litestar.types.builtin_types import NoneType
 from litestar.utils import AsyncCallable, async_partial, is_async_callable
-from litestar.utils.warnings import warn_implicit_sync_to_thread
+from litestar.utils.warnings import warn_implicit_sync_to_thread, warn_sync_to_thread_with_async_callable
 
 if TYPE_CHECKING:
     from typing import Any, Awaitable, Callable, Sequence
@@ -281,8 +281,12 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
 
     def __call__(self, fn: AnyCallable) -> HTTPRouteHandler:
         """Replace a function with itself."""
-        if not is_async_callable(fn) and self.sync_to_thread is None:
-            warn_implicit_sync_to_thread(fn, stacklevel=3)
+        if not is_async_callable(fn):
+            if self.sync_to_thread is None:
+                warn_implicit_sync_to_thread(fn, stacklevel=3)
+        elif self.sync_to_thread is not None:
+            warn_sync_to_thread_with_async_callable(fn, stacklevel=3)
+
         super().__call__(fn)
         return self
 

--- a/litestar/utils/warnings.py
+++ b/litestar/utils/warnings.py
@@ -19,3 +19,16 @@ def warn_implicit_sync_to_thread(source: AnyCallable, stacklevel: int = 2) -> No
         category=LitestarWarning,
         stacklevel=stacklevel,
     )
+
+
+def warn_sync_to_thread_with_async_callable(source: AnyCallable, stacklevel: int = 2) -> None:
+    if os.getenv("LITESTAR_WARN_SYNC_TO_THREAD_WITH_ASYNC") == "0":
+        return
+
+    warnings.warn(
+        f"Use of an asynchronous callable {source} with sync_to_thread; sync_to_thread "
+        "has no effect on async callable. You can disable this warning by setting "
+        "LITESTAR_WARN_SYNC_TO_THREAD_WITH_ASYNC=0",
+        category=LitestarWarning,
+        stacklevel=stacklevel,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -490,5 +490,10 @@ def disable_warn_implicit_sync_to_thread() -> Generator[None, None, None]:
 
 
 @pytest.fixture()
+def disable_warn_sync_to_thread_with_async(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("LITESTAR_WARN_SYNC_TO_THREAD_WITH_ASYNC", "0")
+
+
+@pytest.fixture()
 def enable_warn_implicit_sync_to_thread(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("LITESTAR_WARN_IMPLICIT_SYNC_TO_THREAD", "1")

--- a/tests/dependency_injection/test_dependency_validation.py
+++ b/tests/dependency_injection/test_dependency_validation.py
@@ -20,7 +20,7 @@ def test_dependency_validation() -> None:
         path="/{path_param:int}",
         dependencies={
             "first": Provide(first_method),
-            "second": Provide(second_method, sync_to_thread=True),
+            "second": Provide(second_method),
         },
     )
     def test_function(first: int, second: str, third: int) -> None:
@@ -29,9 +29,7 @@ def test_dependency_validation() -> None:
     with pytest.raises(ImproperlyConfiguredException):
         Litestar(
             route_handlers=[test_function],
-            dependencies={
-                "third": Provide(first_method),
-            },
+            dependencies={"third": Provide(first_method)},
         )
 
 

--- a/tests/handlers/http/test_sync.py
+++ b/tests/handlers/http/test_sync.py
@@ -20,5 +20,14 @@ def test_sync_to_thread(sync_to_thread: bool) -> None:
 
 @pytest.mark.usefixtures("enable_warn_implicit_sync_to_thread")
 def test_sync_to_thread_not_set_warns() -> None:
-    with pytest.warns(LitestarWarning):
+    with pytest.warns(LitestarWarning, match="discouraged since synchronous callables"):
         get("/")(sync_handler)
+
+
+@pytest.mark.parametrize("sync_to_thread", [True, False])
+def test_async_callable_with_sync_to_thread_warns(sync_to_thread: bool) -> None:
+    with pytest.warns(LitestarWarning, match="asynchronous callable"):
+
+        @get(sync_to_thread=sync_to_thread)
+        async def handler() -> None:
+            pass

--- a/tests/kwargs/test_generator_dependencies.py
+++ b/tests/kwargs/test_generator_dependencies.py
@@ -151,6 +151,7 @@ def test_generator_dependency_exception_during_cleanup(
 
 
 @pytest.mark.parametrize("dependency_fixture", ["generator_dependency", "async_generator_dependency"])
+@pytest.mark.usefixtures("disable_warn_sync_to_thread_with_async")
 def test_generator_dependency_nested(
     request: FixtureRequest,
     dependency_fixture: str,

--- a/tests/test_provide.py
+++ b/tests/test_provide.py
@@ -101,6 +101,7 @@ def test_provider_equality_check() -> None:
         (sync_partial, "why-three-and-one"),
     ],
 )
+@pytest.mark.usefixtures("disable_warn_sync_to_thread_with_async")
 async def test_provide_for_callable(fn: Any, exp: Any, anyio_backend: str) -> None:
     assert await Provide(fn, sync_to_thread=False)() == exp
 
@@ -194,5 +195,14 @@ def test_sync_callable_without_sync_to_thread_warns() -> None:
     def func() -> None:
         pass
 
-    with pytest.warns(LitestarWarning):
+    with pytest.warns(LitestarWarning, match="discouraged since synchronous callables"):
         Provide(func)
+
+
+@pytest.mark.parametrize("sync_to_thread", [True, False])
+def test_async_callable_with_sync_to_thread_warns(sync_to_thread: bool) -> None:
+    async def func() -> None:
+        pass
+
+    with pytest.warns(LitestarWarning, match="asynchronous callable"):
+        Provide(func, sync_to_thread=sync_to_thread)

--- a/tests/test_response_caching.py
+++ b/tests/test_response_caching.py
@@ -36,7 +36,7 @@ def test_default_cache_response(sync_to_thread: bool, mock: MagicMock) -> None:
         cache=True,
         type_encoders={int: str},  # test pickling issues. see https://github.com/litestar-org/litestar/issues/1096
     )
-    async def handler() -> str:
+    def handler() -> str:
         return mock()  # type: ignore[no-any-return]
 
     with create_test_client([handler], after_request=after_request_handler) as client:
@@ -131,7 +131,7 @@ async def test_custom_cache_key(sync_to_thread: bool, anyio_backend: str, mock: 
         return request.url.path + ":::cached"
 
     @get("/cached", sync_to_thread=sync_to_thread, cache=True, cache_key_builder=custom_cache_key_builder)
-    async def handler() -> str:
+    def handler() -> str:
         return mock()  # type: ignore[no-any-return]
 
     app = Litestar([handler])


### PR DESCRIPTION
Add a warning when using `sync_to_thread=True` or `sync_to_thread=False` with asynchronous callables, as it will have no effect.