### PR TITLE
Enhancement: Trio compatible event-emitters

### DIFF
--- a/docs/usage/events.rst
+++ b/docs/usage/events.rst
@@ -172,18 +172,20 @@ had ``**kwargs`` in both:
 Creating Event Emitters
 -----------------------
 
-An "event emitter" is a class that inherits from :class:`BaseEventEmitterBackend <litestar.events.BaseEventEmitterBackend>`
-and implements its abstract methods:
+An "event emitter" is a class that inherits from
+:class:`BaseEventEmitterBackend <litestar.events.BaseEventEmitterBackend>`, which
+itself inherits from :obj:`contextlib.AbstractAsyncContextManager`.
 
-- :meth:`on_startup <litestar.events.BaseEventEmitterBackend.on_startup>`: Called on application startup. This method
-  allows for performing any required async setup.
-- :meth:`on_shutdown <litestar.events.BaseEventEmitterBackend.on_shutdown>`: Called on application shutdown. This method
-  allows for performing any required async teardown and cleanup.
 - :meth:`emit <litestar.events.BaseEventEmitterBackend.emit>`: This is the method that performs the actual emitting
   logic.
 
-By default Litestar uses the :class:`SimpleEventEmitter <litestar.events.SimpleEventEmitter>`, which offers an in-memory
-based async queue.
+Additionally, the abstract ``__aenter__`` and ``__aexit__`` methods from
+:obj:`contextlib.AbstractAsyncContextManager` must be implemented, allowing the
+emitter to be used as an async context manager.
+
+By default Litestar uses the
+:class:`SimpleEventEmitter <litestar.events.SimpleEventEmitter>`, which offers an
+in-memory async queue.
 
 This solution works well if the system does not need to rely on complex behaviour, such as a retry
 mechanism, persistence, or scheduling/cron. For these more complex use cases, users should implement their own backend

--- a/docs/usage/events.rst
+++ b/docs/usage/events.rst
@@ -189,8 +189,3 @@ This solution works well if the system does not need to rely on complex behaviou
 mechanism, persistence, or scheduling/cron. For these more complex use cases, users should implement their own backend
 using either a DB/Key store that supports events (Redis, Postgres etc.), or a message broker, job queue or task queue
 technology.
-
-..  attention::
-    The :class:`SimpleEventEmitter <litestar.events.SimpleEventEmitter>` works only with ``asyncio`` due to the
-    limitation of ``trio`` (intentionally) not supporting "worker tasks" - i.e. tasks that run in a detached state. If
-    you want to use this functionality with ``trio``, you will need to create a custom implementation for your use case.

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -487,14 +487,12 @@ class Litestar(Router):
             for hook in self.on_shutdown[::-1]:
                 exit_stack.push_async_callback(partial(self._call_lifespan_hook, hook))
 
-            exit_stack.push_async_callback(self.event_emitter.on_shutdown)
+            await exit_stack.enter_async_context(self.event_emitter)
 
             for manager in self._lifespan_managers:
                 if not isinstance(manager, AbstractAsyncContextManager):
                     manager = manager(self)
                 await exit_stack.enter_async_context(manager)
-
-            await self.event_emitter.on_startup()
 
             for hook in self.on_startup:
                 await self._call_lifespan_hook(hook)

--- a/litestar/events/emitter.py
+++ b/litestar/events/emitter.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 import math
+import sys
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from contextlib import AbstractAsyncContextManager, AsyncExitStack
+from contextlib import AsyncExitStack
 from typing import TYPE_CHECKING, Any, DefaultDict, Sequence
+
+if sys.version_info < (3, 9):
+    from typing import AsyncContextManager
+else:
+    from contextlib import AbstractAsyncContextManager as AsyncContextManager
 
 import anyio
 
@@ -21,7 +27,7 @@ if TYPE_CHECKING:
     from litestar.events.listener import EventListener
 
 
-class BaseEventEmitterBackend(AbstractAsyncContextManager["BaseEventEmitterBackend"], ABC):
+class BaseEventEmitterBackend(AsyncContextManager["BaseEventEmitterBackend"], ABC):
     """Abstract class used to define event emitter backends."""
 
     __slots__ = ("listeners",)

--- a/tests/events/test_listener.py
+++ b/tests/events/test_listener.py
@@ -50,13 +50,9 @@ def test_event_listener(mock: MagicMock, listener: EventListener) -> None:
 
 
 async def test_shutdown_awaits_pending(async_listener: EventListener, mock: MagicMock) -> None:
-    emitter = SimpleEventEmitter([async_listener])
-    await emitter.on_startup()
-
-    for _ in range(100):
-        emitter.emit("test_event")
-
-    await emitter.on_shutdown()
+    async with SimpleEventEmitter([async_listener]) as emitter:
+        for _ in range(100):
+            emitter.emit("test_event")
 
     assert mock.call_count == 100
 
@@ -108,7 +104,6 @@ async def test_raises_when_not_initialized() -> None:
 async def test_raises_for_wrong_async_backend(async_listener: EventListener) -> None:
     with create_test_client([], listeners=[async_listener], backend="trio") as client:
         assert not client.app.event_emitter._queue
-        assert not client.app.event_emitter._worker_task
         with pytest.raises(ImproperlyConfiguredException):
             client.app.emit("test_event")
 

--- a/tests/events/test_listener.py
+++ b/tests/events/test_listener.py
@@ -11,6 +11,7 @@ from litestar.events.listener import EventListener, listener
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.status_codes import HTTP_200_OK
 from litestar.testing import create_test_client
+from litestar.types import AnyIOBackend
 
 
 @pytest.fixture()
@@ -37,12 +38,12 @@ def async_listener(mock: MagicMock) -> EventListener:
 
 
 @pytest.mark.parametrize("listener", [lazy_fixture("sync_listener"), lazy_fixture("async_listener")])
-def test_event_listener(mock: MagicMock, listener: EventListener) -> None:
+def test_event_listener(mock: MagicMock, listener: EventListener, anyio_backend: AnyIOBackend) -> None:
     @get("/")
     def route_handler(request: Request[Any, Any, Any]) -> None:
         request.app.emit("test_event", "positional", keyword="keyword-value")
 
-    with create_test_client(route_handlers=[route_handler], listeners=[listener]) as client:
+    with create_test_client(route_handlers=[route_handler], listeners=[listener], backend=anyio_backend) as client:
         response = client.get("/")
         assert response.status_code == HTTP_200_OK
         sleep(0.01)
@@ -57,19 +58,23 @@ async def test_shutdown_awaits_pending(async_listener: EventListener, mock: Magi
     assert mock.call_count == 100
 
 
-def test_multiple_event_listeners(async_listener: EventListener, sync_listener: EventListener, mock: MagicMock) -> None:
+def test_multiple_event_listeners(
+    async_listener: EventListener, sync_listener: EventListener, mock: MagicMock, anyio_backend: AnyIOBackend
+) -> None:
     @get("/")
     def route_handler(request: Request[Any, Any, Any]) -> None:
         request.app.emit("test_event")
 
-    with create_test_client(route_handlers=[route_handler], listeners=[async_listener, sync_listener]) as client:
+    with create_test_client(
+        route_handlers=[route_handler], listeners=[async_listener, sync_listener], backend=anyio_backend
+    ) as client:
         response = client.get("/")
         sleep(0.01)
         assert response.status_code == HTTP_200_OK
         assert mock.call_count == 2
 
 
-def test_multiple_event_ids(mock: MagicMock) -> None:
+def test_multiple_event_ids(mock: MagicMock, anyio_backend: AnyIOBackend) -> None:
     @listener("test_event_1", "test_event_2")
     def event_handler() -> None:
         mock()
@@ -78,7 +83,7 @@ def test_multiple_event_ids(mock: MagicMock) -> None:
     def route_handler(request: Request[Any, Any, Any], event_id: int) -> None:
         request.app.emit(f"test_event_{event_id}")
 
-    with create_test_client(route_handlers=[route_handler], listeners=[event_handler]) as client:
+    with create_test_client(route_handlers=[route_handler], listeners=[event_handler], backend=anyio_backend) as client:
         response = client.get("/1")
         sleep(0.01)
         assert response.status_code == HTTP_200_OK
@@ -97,15 +102,8 @@ async def test_raises_when_decorator_called_without_callable() -> None:
 async def test_raises_when_not_initialized() -> None:
     app = Litestar([])
 
-    with pytest.raises(ImproperlyConfiguredException):
+    with pytest.raises(RuntimeError):
         app.emit("x")
-
-
-async def test_raises_for_wrong_async_backend(async_listener: EventListener) -> None:
-    with create_test_client([], listeners=[async_listener], backend="trio") as client:
-        assert not client.app.event_emitter._queue
-        with pytest.raises(ImproperlyConfiguredException):
-            client.app.emit("test_event")
 
 
 async def test_raises_when_not_listener_are_registered_for_an_event_id(async_listener: EventListener) -> None:


### PR DESCRIPTION
The changes introduced in #1635 allow a refactoring of event emitters to be trio-compatible, by removing `asyncio.Task` and `asyncio.Queue` and replacing them with task groups and streams.

Additional changes:

- `BaseEventEmitterBackend` now inherits from `AbstractAsyncContextManager` to make use of the lifespan context manager. The `on_startup` and `on_shutdown` methods have been subsequently removed.