### PR TITLE
Enhancement: Trio compatible channels

### DIFF
--- a/tests/unit/test_channels/test_plugin.py
+++ b/tests/unit/test_channels/test_plugin.py
@@ -361,7 +361,7 @@ async def test_backlog(
         async with subscriber.run_in_background(async_mock):
             for message in messages:
                 await plugin.wait_published(message, channels=["something"])
-            await plugin._exit_stack.aclose()  # type: ignore[union-attr]  # force a flush of all buffers here
+            await plugin.__aexit__(None, None, None)  # force a flush of all buffers here
 
     expected_messages = messages[:-1] if backlog_strategy == "backoff" else messages[1:]
 

--- a/tests/unit/test_channels/test_plugin.py
+++ b/tests/unit/test_channels/test_plugin.py
@@ -361,7 +361,7 @@ async def test_backlog(
         async with subscriber.run_in_background(async_mock):
             for message in messages:
                 await plugin.wait_published(message, channels=["something"])
-            await plugin._on_shutdown()  # force a flush of all buffers here
+            await plugin._exit_stack.aclose()  # type: ignore[union-attr]  # force a flush of all buffers here
 
     expected_messages = messages[:-1] if backlog_strategy == "backoff" else messages[1:]
 


### PR DESCRIPTION
The changes introduced in #1635 allow a refactoring of channels to be trio-compatible, by removing `asyncio.Task` and `asyncio.Queue` and replacing them with task groups and streams.

**todo**

- [ ] Figure out a way to replace `Queue` and `AsyncDeque` in `Subscriber`