### PR TITLE
fix handling of pydantic field info in openapi schema

### DIFF
--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -550,7 +550,9 @@ def create_schema_for_pydantic_model(
         required=sorted([field.alias or field.name for field in field_type.__fields__.values() if field.required]),
         properties={
             (f.alias or f.name): create_schema(
-                field=SignatureField.create(field_type=field_type_hints[f.name], name=f.alias or f.name),
+                field=SignatureField.create(
+                    field_type=field_type_hints[f.name], name=f.alias or f.name, default_value=f.field_info
+                ),
                 generate_examples=generate_examples,
                 plugins=plugins,
                 schemas=schemas,

--- a/tests/openapi/test_schema.py
+++ b/tests/openapi/test_schema.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Dict, Literal
 
 import msgspec
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing_extensions import Annotated
 
 from litestar import Controller, MediaType, get
@@ -260,4 +260,22 @@ def test_create_schema_from_msgspec_annotated_type() -> None:
         plugins=[],
         schemas=schemas,
     )
-    assert schemas["Lookup"]
+    schema = schemas["Lookup"]
+    assert schema.properties["id"].type == OpenAPIType.STRING  # type: ignore
+
+
+def test_create_schema_for_pydantic_field() -> None:
+    class Model(BaseModel):
+        value: str = Field(title="title", description="description")
+
+    schemas: Dict[str, Schema] = {}
+    create_schema(
+        field=SignatureField.create(name="Model", field_type=Model),
+        generate_examples=False,
+        plugins=[],
+        schemas=schemas,
+    )
+    schema = schemas["Model"]
+
+    assert schema.properties["value"].description == "description"  # type: ignore
+    assert schema.properties["value"].title == "title"  # type: ignore


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

Fixes #1541 