### PR TITLE
fix: correction for alembic generated migrations.

### DIFF
--- a/litestar/contrib/sqlalchemy/types.py
+++ b/litestar/contrib/sqlalchemy/types.py
@@ -35,19 +35,15 @@ class GUID(TypeDecorator):
     cache_ok = True
     python_type = type(uuid.UUID)
 
-    def __init__(self, length: int | None = None, binary: bool = True) -> None:
-        self.length = length
+    def __init__(self, *args: Any, binary: bool = True, **kwargs: Any) -> None:
         self.binary = binary
-        if self.binary and self.length is None:
-            self.length = 16
-        self.length = 32
 
     def load_dialect_impl(self, dialect: Dialect) -> Any:
         if dialect.name == "postgresql":
             return dialect.type_descriptor(PG_UUID())
         if self.binary:
-            return dialect.type_descriptor(BINARY(length=self.length))
-        return dialect.type_descriptor(CHAR(length=self.length))
+            return dialect.type_descriptor(BINARY(16))
+        return dialect.type_descriptor(CHAR(32))
 
     def process_bind_param(self, value: bytes | str | uuid.UUID | None, dialect: Dialect) -> bytes | str | None:
         if value is None:

--- a/litestar/contrib/sqlalchemy/types.py
+++ b/litestar/contrib/sqlalchemy/types.py
@@ -40,8 +40,7 @@ class GUID(TypeDecorator):
         self.binary = binary
         if self.binary and self.length is None:
             self.length = 16
-        elif not self.binary and self.length is None:
-            self.length = 32
+        self.length = 32
 
     def load_dialect_impl(self, dialect: Dialect) -> Any:
         if dialect.name == "postgresql":


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

When migrations are generated for models with a `GUID` type, it automatically adds in the `length=16` on the input.  However, we do not have this parameter on the `__init__` method.  This change adds that method so that migrations will execute properly.

The change also simplifies the JSON logic.  In the previous implementation, it was not reliably selecting JSONB in Postgres.  The new method is much each to manage and works better.

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
