### PR TITLE
Store and reuse state `deep_copy` directive when copying state.

### DIFF
--- a/tests/datastructures/test_state.py
+++ b/tests/datastructures/test_state.py
@@ -1,4 +1,7 @@
-from typing import Any, Type
+from __future__ import annotations
+
+from copy import copy
+from typing import Any
 
 import pytest
 
@@ -7,7 +10,7 @@ from litestar.datastructures.state import ImmutableState
 
 
 @pytest.mark.parametrize("state_class", (ImmutableState, State))
-def test_state_immutable_mapping(state_class: Type[ImmutableState]) -> None:
+def test_state_immutable_mapping(state_class: type[ImmutableState]) -> None:
     state_dict = {"first": 1, "second": 2, "third": 3}
     state = state_class(state_dict, deep_copy=True)
     assert len(state) == 3
@@ -68,3 +71,17 @@ def test_state_copy() -> None:
     copy = state.copy()
     del state.key
     assert copy.key
+
+
+def test_state_copy_deep_copy_false() -> None:
+    state = State({}, deep_copy=False)
+    assert state.copy()._deep_copy is False
+
+
+def test_unpicklable_deep_copy_false() -> None:
+    # a module cannot be deep copied
+    import typing
+
+    state = ImmutableState({"module": typing}, deep_copy=False)
+    copy(state)
+    ImmutableState.validate(state)


### PR DESCRIPTION
App state can be created using `deep_copy=False`, however state is then deep copied again for dependency injection.

This PR memoizes the value of `deep_copy` when state is created, and reuses it when copying the state.

Closes #1674

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
