### PR TITLE
Enhancement: DTO Factory computed fields.

### DIFF
--- a/docs/examples/data_transfer_objects/factory/computed_fields.py
+++ b/docs/examples/data_transfer_objects/factory/computed_fields.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import binascii
+import hashlib
+import os
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
+
+from litestar import Litestar, post
+from litestar.dto.factory import DTOConfig, DTOData, dto_field
+from litestar.dto.factory.stdlib.dataclass import DataclassDTO
+
+
+@dataclass
+class Person:
+    id: UUID
+    name: str
+    age: int
+    hashed_password: str = field(metadata=dto_field("write-only"))
+
+
+def hash_password(password: str) -> bytes:
+    """Hash password."""
+    salt = os.urandom(16)
+    dk = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, 100000)
+    hashed_password = binascii.hexlify(dk)
+    return salt + hashed_password
+
+
+class WriteDTO(DataclassDTO[Person]):
+    """Don't allow client to set the id."""
+
+    config = DTOConfig(
+        exclude={"id"},
+        computed_fields={"hashed_password": hash_password},
+    )
+
+
+@post("/person", dto=WriteDTO, return_dto=DataclassDTO[Person], sync_to_thread=False)
+def create_person(data: DTOData[Person]) -> Person:
+    """Create a person."""
+    return data.create_instance(id=uuid4())
+
+
+app = Litestar(route_handlers=[create_person])
+
+# run: /person -H "Content-Type: application/json" -d '{"name":"Peter","age":41,"password":"secret"}'

--- a/docs/examples/data_transfer_objects/factory/computed_fields.py
+++ b/docs/examples/data_transfer_objects/factory/computed_fields.py
@@ -16,7 +16,7 @@ class Person:
     id: UUID
     name: str
     age: int
-    hashed_password: str = field(metadata=dto_field("write-only"))
+    hashed_password: bytes = field(metadata=dto_field("write-only"))
 
 
 def hash_password(password: str) -> bytes:

--- a/docs/usage/dto/1-dto-factory.rst
+++ b/docs/usage/dto/1-dto-factory.rst
@@ -195,3 +195,15 @@ to update the instance of ``Person`` before returning it.
 
 In our request, we set only the ``name`` property of the ``Person``, from ``"Peter"`` to ``"Peter Pan"`` and received
 the full object - with the modified name - back in the response.
+
+Computed Fields
+---------------
+
+Sometimes, a field that we store on our model is something that is calculated from other inputs. For example, we might
+have a ``Person`` model that has a ``hashed_password`` field. We want clients to be able to set the ``password`` field
+when creating a new ``Person``, but we don't want to store the plain text password in the database.
+
+.. literalinclude:: /examples/data_transfer_objects/factory/computed_fields.py
+    :language: python
+    :emphasize-lines: 1
+    :linenos:

--- a/litestar/dto/factory/_backends/msgspec/backend.py
+++ b/litestar/dto/factory/_backends/msgspec/backend.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, NewType, TypeVar
 from msgspec import Struct, from_builtins
 
 from litestar.dto.factory._backends.abc import AbstractDTOBackend
+from litestar.dto.factory._backends.utils import gen_unique_name_id
 from litestar.serialization import decode_media_type
 
 from .utils import _create_struct_for_field_definitions
@@ -26,7 +27,7 @@ class MsgspecDTOBackend(AbstractDTOBackend[Struct]):
     __slots__ = ()
 
     def create_transfer_model_type(self, unique_name: str, field_definitions: FieldDefinitionsType) -> type[Struct]:
-        fqn_uid: str = self._gen_unique_name_id(unique_name)
+        fqn_uid: str = gen_unique_name_id(unique_name)
         return _create_struct_for_field_definitions(fqn_uid, field_definitions)
 
     def parse_raw(self, raw: bytes, connection_context: ConnectionContext) -> Struct | Collection[Struct]:

--- a/litestar/dto/factory/_backends/msgspec/utils.py
+++ b/litestar/dto/factory/_backends/msgspec/utils.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
     from typing import Any
 
     from litestar.dto.factory._backends.types import FieldDefinitionsType
-    from litestar.dto.factory.types import FieldDefinition
 
 
 MsgspecField = NewType("MsgspecField", type)
@@ -19,13 +18,13 @@ StructT = TypeVar("StructT", bound=Struct)
 T = TypeVar("T")
 
 
-def _create_msgspec_field(field_definition: FieldDefinition) -> MsgspecField | None:
+def _create_msgspec_field(default: Any, default_factory: Any) -> MsgspecField | None:
     kws: dict[str, Any] = {}
-    if field_definition.default is not Empty:
-        kws["default"] = field_definition.default
+    if default is not Empty:
+        kws["default"] = default
 
-    if field_definition.default_factory is not None:
-        kws["default_factory"] = field_definition.default_factory
+    if default_factory is not None:
+        kws["default_factory"] = default_factory
 
     if not kws:
         return None
@@ -45,11 +44,21 @@ def _create_struct_for_field_definitions(model_name: str, field_definitions: Fie
     struct_fields: list[tuple[str, type] | tuple[str, type, MsgspecField]] = []
     for field_def in field_definitions:
         field_name = field_def.serialization_name or field_def.name
+
+        if field_def.computed_field_info:
+            for parsed_param in field_def.computed_field_info.parsed_signature.parameters.values():
+                struct_fields.append(
+                    _create_struct_field_def(
+                        parsed_param.name, parsed_param.annotation, _create_msgspec_field(parsed_param.default, None)
+                    )
+                )
+            continue
+
         struct_fields.append(
             _create_struct_field_def(
                 field_name,
                 create_transfer_model_type_annotation(field_def.transfer_type),
-                _create_msgspec_field(field_def),
+                _create_msgspec_field(field_def.default, field_def.default_factory),
             )
         )
     return defstruct(model_name, struct_fields, frozen=True, kw_only=True)

--- a/litestar/dto/factory/_backends/pydantic/backend.py
+++ b/litestar/dto/factory/_backends/pydantic/backend.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, TypeVar
 from pydantic import BaseModel, parse_obj_as
 
 from litestar.dto.factory._backends.abc import AbstractDTOBackend
+from litestar.dto.factory._backends.utils import gen_unique_name_id
 from litestar.serialization import decode_media_type
 
 from .utils import _create_model_for_field_definitions
@@ -25,7 +26,7 @@ class PydanticDTOBackend(AbstractDTOBackend[BaseModel]):
     __slots__ = ()
 
     def create_transfer_model_type(self, unique_name: str, field_definitions: FieldDefinitionsType) -> type[BaseModel]:
-        fqn_uid: str = self._gen_unique_name_id(unique_name)
+        fqn_uid: str = gen_unique_name_id(unique_name)
         return _create_model_for_field_definitions(fqn_uid, field_definitions)
 
     def parse_raw(self, raw: bytes, connection_context: ConnectionContext) -> BaseModel | Collection[BaseModel]:

--- a/litestar/dto/factory/config.py
+++ b/litestar/dto/factory/config.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import AbstractSet
 
+    from litestar.types import AnyCallable
+
     from .types import RenameStrategy
 
 
@@ -38,3 +40,9 @@ class DTOConfig:
     """The maximum depth of nested items allowed for data transfer."""
     partial: bool = False
     """Allow transfer of partial data."""
+    computed_fields: dict[str, AnyCallable] = field(default_factory=dict)
+    """Callables to compute field values.
+
+    The callable's parameters and return type must be fully annotated, and the return type of the callable must match
+    the type of the field.
+    """

--- a/litestar/dto/factory/field.py
+++ b/litestar/dto/factory/field.py
@@ -20,6 +20,8 @@ class Mark(str, Enum):
 
     READ_ONLY = "read-only"
     """To mark a field that can be read, but not updated by clients."""
+    WRITE_ONLY = "write-only"
+    """To mark a field that can be updated, but not read by clients."""
     PRIVATE = "private"
     """To mark a field that can neither be read or updated by clients."""
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2272,6 +2272,7 @@ files = [
 
 [package.dependencies]
 "backports.zoneinfo" = {version = ">=0.2.0", markers = "python_version < \"3.9\""}
+psycopg-binary = {version = "3.1.9", optional = true, markers = "extra == \"binary\""}
 typing-extensions = ">=4.1"
 tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 
@@ -2282,6 +2283,70 @@ dev = ["black (>=23.1.0)", "dnspython (>=2.1)", "flake8 (>=4.0)", "mypy (>=1.2)"
 docs = ["Sphinx (>=5.0)", "furo (==2022.6.21)", "sphinx-autobuild (>=2021.3.14)", "sphinx-autodoc-typehints (>=1.12)"]
 pool = ["psycopg-pool"]
 test = ["anyio (>=3.6.2)", "mypy (>=1.2)", "pproxy (>=2.7)", "pytest (>=6.2.5)", "pytest-cov (>=3.0)", "pytest-randomly (>=3.5)"]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.1.9"
+description = "PostgreSQL database adapter for Python -- C optimisation distribution"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "psycopg_binary-3.1.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:284038cbe3f5a0f3de417af9b5eaa2a9524a3a06211523cf245111c71b566506"},
+    {file = "psycopg_binary-3.1.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d2cea4bb0b19245c83486868d7c66f73238c4caa266b5b3c3d664d10dab2ab56"},
+    {file = "psycopg_binary-3.1.9-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dfe5c5c31f59ccb1d1f473466baa93d800138186286e80e251f930e49c80d208"},
+    {file = "psycopg_binary-3.1.9-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:82704a899d57c29beba5399d41eab5ef5c238b810d7e25e2d1916d2b34c4b1a3"},
+    {file = "psycopg_binary-3.1.9-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eab449e39db1c429cac79b7aa27e6827aad4995f32137e922db7254f43fed7b5"},
+    {file = "psycopg_binary-3.1.9-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87e0c97733b11eeca3d24e56df70f3f9d792b2abd46f48be2fb2348ffc3e7e39"},
+    {file = "psycopg_binary-3.1.9-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:81e34d6df54329424944d5ca91b1cc77df6b8a9130cb5480680d56f53d4e485c"},
+    {file = "psycopg_binary-3.1.9-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e2f463079d99568a343ed0b766150b30627e9ed41de99fd82e945e7e2bec764a"},
+    {file = "psycopg_binary-3.1.9-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:f2cbdef6568da21c39dfd45c2074e85eabbd00e1b721832ba94980f01f582dd4"},
+    {file = "psycopg_binary-3.1.9-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:53afb0cc2ebe74651f339e22d05ec082a0f44939715d9138d357852f074fcf55"},
+    {file = "psycopg_binary-3.1.9-cp310-cp310-win_amd64.whl", hash = "sha256:09167f106e7685591b4cdf58eff0191fb7435d586f384133a0dd30df646cf409"},
+    {file = "psycopg_binary-3.1.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a8aaa47c1791fc05c0229ec1003dd49e13238fba9434e1fc3b879632f749c3c4"},
+    {file = "psycopg_binary-3.1.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3d91ee0d33ac7b42d0488a9be2516efa2ec00901b81d69566ff34a7a94b66c0b"},
+    {file = "psycopg_binary-3.1.9-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5e36504373e5bcdc954b1da1c6fe66379007fe1e329790e8fb72b879a01e097"},
+    {file = "psycopg_binary-3.1.9-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c1def6c2d28e257325b3b208cf1966343b498282a0f4d390fda7b7e0577da64"},
+    {file = "psycopg_binary-3.1.9-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:055537a9c20efe9bf17cb72bd879602eda71de6f737ebafa1953e017c6a37fbe"},
+    {file = "psycopg_binary-3.1.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5b164355d023a91b23dcc4bb3112bc7d6e9b9c938fb5abcb6e54457d2da1f317"},
+    {file = "psycopg_binary-3.1.9-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:03b08545ce1c627f4d5e6384eda2946660c4ba6ceb0a09ae47de07419f725669"},
+    {file = "psycopg_binary-3.1.9-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:1e31bac3d2d41e6446b20b591f638943328c958f4d1ce13d6f1c5db97c3a8dee"},
+    {file = "psycopg_binary-3.1.9-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:a274c63c8fb9d419509bed2ef72befc1fd04243972e17e7f5afc5725cb13a560"},
+    {file = "psycopg_binary-3.1.9-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:98d9d156b9ada08c271a79662fc5fcc1731b4d7c1f651ef5843d818d35f15ba0"},
+    {file = "psycopg_binary-3.1.9-cp311-cp311-win_amd64.whl", hash = "sha256:c3a13aa022853891cadbc7256a9804e5989def760115c82334bddf0d19783b0b"},
+    {file = "psycopg_binary-3.1.9-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b1a321ef3579a8de0545ade6ff1edfde0c88b8847d58c5615c03751c76054796"},
+    {file = "psycopg_binary-3.1.9-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5833bda4c14f24c6a8ac08d3c5712acaa4f35aab31f9ccd2265e9e9a7d0151c8"},
+    {file = "psycopg_binary-3.1.9-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a207d5a7f4212443b7452851c9ccd88df9c6d4d58fa2cea2ead4dd9cb328e578"},
+    {file = "psycopg_binary-3.1.9-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:07414daa86662f7657e9fabe49af85a32a975e92e6568337887d9c9ffedc224f"},
+    {file = "psycopg_binary-3.1.9-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17c5d4936c746f5125c6ef9eb43655e27d4d0c9ffe34c3073878b43c3192511d"},
+    {file = "psycopg_binary-3.1.9-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:5cdc13c8ec1437240801e43d07e27ff6479ac9dd8583ecf647345bfd2e8390e4"},
+    {file = "psycopg_binary-3.1.9-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:3836bdaf030a5648bd5f5b452e4b068b265e28f9199060c5b70dbf4a218cde6e"},
+    {file = "psycopg_binary-3.1.9-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:96725d9691a84a21eb3e81c884a2e043054e33e176801a57a05e9ac38d142c6e"},
+    {file = "psycopg_binary-3.1.9-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:dade344aa90bb0b57d1cfc13304ed83ab9a36614b8ddd671381b2de72fe1483d"},
+    {file = "psycopg_binary-3.1.9-cp37-cp37m-win_amd64.whl", hash = "sha256:db866cc557d9761036771d666d17fa4176c537af7e6098f42a6bf8f64217935f"},
+    {file = "psycopg_binary-3.1.9-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3b62545cc64dd69ea0ae5ffe18d7c97e03660ab8244aa8c5172668a21c41daa0"},
+    {file = "psycopg_binary-3.1.9-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:058ab0d79be0b229338f0e61fec6f475077518cba63c22c593645a69f01c3e23"},
+    {file = "psycopg_binary-3.1.9-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2340ca2531f69e5ebd9d18987362ba57ed6ab6a271511d8026814a46a2a87b59"},
+    {file = "psycopg_binary-3.1.9-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3b816ce0e27a2a8786d34b61d3e36e01029245025879d64b88554326b794a4f0"},
+    {file = "psycopg_binary-3.1.9-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7b36fe4314a784fbe45c9fd71c902b9bf57341aff9b97c0cbd22f8409a271e2f"},
+    {file = "psycopg_binary-3.1.9-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b246fed629482b06f938b23e9281c4af592329daa3ec2cd4a6841ccbfdeb4d68"},
+    {file = "psycopg_binary-3.1.9-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:90787ac05b932c0fc678cbf470ccea9c385b8077583f0490136b4569ed3fb652"},
+    {file = "psycopg_binary-3.1.9-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:9c114f678e8f4a96530fa79cfd84f65f26358ecfc6cca70cfa2d5e3ae5ef217a"},
+    {file = "psycopg_binary-3.1.9-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:3a82e77400d1ef6c5bbcf3e600e8bdfacf1a554512f96c090c43ceca3d1ce3b6"},
+    {file = "psycopg_binary-3.1.9-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c7d990f14a37345ca05a5192cd5ac938c9cbedca9c929872af6ae311158feb0e"},
+    {file = "psycopg_binary-3.1.9-cp38-cp38-win_amd64.whl", hash = "sha256:e0ca74fd85718723bb9f08e0c6898e901a0c365aef20b3c3a4ef8709125d6210"},
+    {file = "psycopg_binary-3.1.9-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ce8f4dea5934aa6c4933e559c74bef4beb3413f51fbcf17f306ce890216ac33a"},
+    {file = "psycopg_binary-3.1.9-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f41a9e0de4db194c053bcc7c00c35422a4d19d92a8187e8065b1c560626efe35"},
+    {file = "psycopg_binary-3.1.9-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f94a7985135e084e122b143956c6f589d17aef743ecd0a434a3d3a222631d5a"},
+    {file = "psycopg_binary-3.1.9-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bb86d58b90faefdc0bbedf08fdea4cc2afcb1cfa4340f027d458bfd01d8b812"},
+    {file = "psycopg_binary-3.1.9-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c696dc84f9ff155761df15779181d8e4af7746b98908e130add8259912e4bb7"},
+    {file = "psycopg_binary-3.1.9-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4213953da44324850c8f789301cf665f46fb94301ba403301e7af58546c3a428"},
+    {file = "psycopg_binary-3.1.9-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:25e3ce947aaaa1bd9f1920fca76d7281660646304f9ea5bc036b201dd8790655"},
+    {file = "psycopg_binary-3.1.9-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9c75be2a9b986139e3ff6bc0a2852081ac00811040f9b82d3aa539821311122e"},
+    {file = "psycopg_binary-3.1.9-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:63e8d1dbe253657c70dbfa9c59423f4654d82698fc5ed6868b8dc0765abe20b6"},
+    {file = "psycopg_binary-3.1.9-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f4da4ca9b2365fc1d3fc741c3bbd3efccd892ce813444b884c8911a1acf1c932"},
+    {file = "psycopg_binary-3.1.9-cp39-cp39-win_amd64.whl", hash = "sha256:c0b8d6bbeff1dba760a208d8bc205a05b745e6cee02b839f969f72cf56a8b80d"},
+]
 
 [[package]]
 name = "pyasn1"
@@ -3650,4 +3715,4 @@ tortoise-orm = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "df9b05fbcfef62d4f05659f2a86e85976d46ead6450c299ea0d8694f88bbb865"
+content-hash = "f5533c22c0b316aff8a1cc48f34df1f25a14fce2197421121067673efb8ac3d5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ opentelemetry-sdk = "*"
 piccolo = "*"
 picologging = "*"
 pre-commit = "*"
-psycopg = "*"
+psycopg = { version = "*", extras = ["binary"] }
 pytest = "*"
 pytest-asyncio = "*"
 pytest-cov = "*"

--- a/tests/dto/factory/backends/test_backends.py
+++ b/tests/dto/factory/backends/test_backends.py
@@ -193,9 +193,10 @@ def test_backend_model_name_uniqueness(backend_type: type[AbstractDTOBackend], b
             serialization_name="a",
             transfer_type=transfer_type,
             is_partial=False,
+            computed_field_info=None,
         ),
     )
-    for i in range(100):
+    for _ in range(100):
         model_class = backend.create_transfer_model_type("some_module.SomeModel", fd)
         model_name = model_class.__name__
         assert model_name not in unique_names


### PR DESCRIPTION
Only applies to DTO for inbound data, not return dto.

Compute the value for a model attribute with a callable with an arbitrary number of args.

The transfer model is produced with attributes that represent the args of the callable, not the model attribute.

Values are validated by the transfer model and passed to the callable to retrieve a value for instantiation of the model.

We validate that the return annotation of the callable is consistent with the model attribute that it is to populate.

```py
from __future__ import annotations

import binascii
import hashlib
import os
from dataclasses import dataclass, field
from uuid import UUID, uuid4

from litestar import Litestar, post
from litestar.dto.factory import DTOConfig, DTOData, dto_field
from litestar.dto.factory.stdlib.dataclass import DataclassDTO


@dataclass
class Person:
    id: UUID
    name: str
    age: int
    hashed_password: bytes = field(metadata=dto_field("write-only"))


def hash_password(password: str) -> bytes:
    """Hash password."""
    salt = os.urandom(16)
    dk = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, 100000)
    hashed_password = binascii.hexlify(dk)
    return salt + hashed_password


class WriteDTO(DataclassDTO[Person]):
    """Don't allow client to set the id."""

    config = DTOConfig(
        exclude={"id"},
        computed_fields={"hashed_password": hash_password},
    )


@post("/person", dto=WriteDTO, return_dto=DataclassDTO[Person], sync_to_thread=False)
def create_person(data: DTOData[Person]) -> Person:
    """Create a person."""
    return data.create_instance(id=uuid4())


app = Litestar(route_handlers=[create_person])

# run: /person -H "Content-Type: application/json" -d '{"name":"Peter","age":41,"password":"secret"}'

```

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
