### PR TITLE
Feature: add `--reload-dir` to `litestar run`

### DIFF
--- a/docs/usage/cli.rst
+++ b/docs/usage/cli.rst
@@ -107,7 +107,7 @@ Options
 +-------------------------------------+---------------------------+-----------------------------------------------------------------+
 | Flag                                | Environment variable      | Description                                                     |
 +========================+============+=========+=================+=================================================================+
-| ``-r``\ , ``--reload``              | ``LITESTAR_RELOAD``       |  Reload the application when files in its directory are changed |
+| ``-r``\ , ``--reload``              | ``LITESTAR_RELOAD``       | Reload the application when files in its directory are changed  |
 +-------------------------------------+---------------------------+-----------------------------------------------------------------+
 | ``-p``\ , ``--port``                | ``LITESTAR_PORT``         | Bind the the server to this port [default: 8000]                |
 +-------------------------------------+---------------------------+-----------------------------------------------------------------+
@@ -117,7 +117,24 @@ Options
 +-------------------------------------+---------------------------+-----------------------------------------------------------------+
 | ``--debug``                         | ``LITESTAR_DEBUG``        | Run the application in debug mode                               |
 +-------------------------------------+---------------------------+-----------------------------------------------------------------+
+| ``--reload-dir``                    | ``LITESTAR_RELOAD_DIRS``  | Specify directories to watch for reload.                        |
++-------------------------------------+---------------------------+-----------------------------------------------------------------+
 
+``--reload-dir``
+++++++++++++++++
+
+The ``--reload-dir`` flag can be used to specify directories to watch for changes. If specified, the ``--reload`` flag
+is implied. Multiple directories can be specified by passing the flag multiple times:
+
+.. code-block:: shell
+
+   litestar run --reload-dir=. --reload-dir=../other-library/src
+
+To set via environment variable, use a comma-separated list:
+
+.. code-block:: shell
+
+   LITESTAR_RELOAD_DIRS=.,../other-library/src
 
 info
 ^^^^

--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -67,6 +67,7 @@ class LitestarEnv:
     host: str | None = None
     port: int | None = None
     reload: bool | None = None
+    reload_dirs: tuple[str, ...] | None = None
     web_concurrency: int | None = None
     is_app_factory: bool = False
 
@@ -97,6 +98,7 @@ class LitestarEnv:
 
         port = getenv("LITESTAR_PORT")
         web_concurrency = getenv("WEB_CONCURRENCY")
+        reload_dirs = tuple(s.strip() for s in getenv("LITESTAR_RELOAD_DIRS", "").split(",") if s) or None
 
         return cls(
             app_path=loaded_app.app_path,
@@ -105,6 +107,7 @@ class LitestarEnv:
             host=getenv("LITESTAR_HOST"),
             port=int(port) if port else None,
             reload=_bool_from_env("LITESTAR_RELOAD"),
+            reload_dirs=reload_dirs,
             web_concurrency=int(web_concurrency) if web_concurrency else None,
             is_app_factory=loaded_app.is_factory,
             cwd=cwd,


### PR DESCRIPTION
This PR facilitates a command such as:

```sh
$ litestar run --reload-dir=. --reload-dir=../litestar/litestar
```

If `--reload-dir` is provided, `--reload` is implied.

If `--reload` is provided, and `--reload-dir` is not provided the behavior is same as before.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [x] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
