### PR TITLE
`ParsedType.is_subclass_of(X)` true for union if all union types are subtypes of X.

### DIFF
--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -417,14 +417,12 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
                 handler_return_type = before_request_handler.parsed_signature.return_type
                 if not handler_return_type.is_subclass_of((Empty, NoneType)):
                     return_annotation = handler_return_type.annotation
-            self._response_handler_mapping["response_type_handler"] = create_response_handler(
+            self._response_handler_mapping["response_type_handler"] = response_type_handler = create_response_handler(
                 cookies=cookies, after_request=after_request
             )
 
             if return_type.is_subclass_of(Response):
-                self._response_handler_mapping["default_handler"] = self._response_handler_mapping[
-                    "response_type_handler"
-                ]
+                self._response_handler_mapping["default_handler"] = response_type_handler
             elif return_type.is_subclass_of(ResponseContainer):
                 self._response_handler_mapping["default_handler"] = create_response_container_handler(
                     after_request=after_request,

--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -124,8 +124,8 @@ class ParsedType:
     def is_subclass_of(self, cl: type[Any] | tuple[type[Any], ...]) -> bool:
         """Whether the annotation is a subclass of the given type.
 
-        Where ``self.annotation`` is a union type, this method will always return ``False``. While this is not
-        strictly correct, we intend on revisiting this once a concrete use-case is to hand.
+        Where ``self.annotation`` is a union type, this method will return ``True`` when all members of the union are
+        a subtype of ``cl``, otherwise, ``False``.
 
         Args:
             cl: The type to check, or tuple of types. Passed as 2nd argument to ``issubclass()``.

--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -134,7 +134,11 @@ class ParsedType:
             Whether the annotation is a subtype of the given type(s).
         """
         if self.origin:
+            if self.origin in UNION_TYPES:
+                return all(t.is_subclass_of(cl) for t in self.inner_types)
+
             return self.origin not in UNION_TYPES and issubclass(self.origin, cl)
+
         if self.annotation is AnyStr:
             return issubclass(str, cl) or issubclass(bytes, cl)
         return self.annotation is not Any and not self.is_type_var and issubclass(self.annotation, cl)

--- a/tests/utils/test_signature.py
+++ b/tests/utils/test_signature.py
@@ -308,6 +308,7 @@ def test_parsed_type_is_subclass_of() -> None:
     assert ParsedType(List[int]).is_subclass_of(list) is True
     assert ParsedType(List[int]).is_subclass_of(int) is False
     assert ParsedType(Optional[int]).is_subclass_of(int) is False
+    assert ParsedType(Union[bool, int]).is_subclass_of(int) is True
 
 
 def test_parsed_type_has_inner_subclass_of() -> None:


### PR DESCRIPTION
When `ParsedType` was introduced, `is_subclass_of()` any union was deliberately left to return `False` with the intention of waiting for some use-cases to arrive.

This PR closes #1652 where a handler may be typed to return a union of multiple response types. If all response types are `Response` subtypes then the correct response handler will be applied.

If any of the union types are not response subtypes then behavior is still incorrect, but we should either handle that with validation or a special union response handler.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
