### PR TITLE
Infra: Fix run examples timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,6 +135,8 @@ jobs:
       - name: Install dependencies
         run: poetry install --no-interaction --with docs
       - name: Build docs
+        env:
+          LITESTAR_DOCS_IGNORE_MISSING_EXAMPLE_OUTPUT: 1
         run: poetry run make docs
       - name: Deploy docs preview
         uses: JamesIves/github-pages-deploy-action@v4

--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -27,7 +27,6 @@ REDIRECT_TEMPLATE = """
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--version", required=False)
-parser.add_argument("--ignore-missing-examples-output", action="store_true", default=False)
 parser.add_argument("output")
 
 
@@ -50,14 +49,11 @@ def load_version_spec() -> VersionSpec:
     return {"versions": [], "latest": ""}
 
 
-def build(output_dir: str, version: str | None, ignore_missing_output: bool) -> None:
+def build(output_dir: str, version: str | None) -> None:
     if version is None:
         version = importlib.metadata.version("litestar").rsplit(".")[0]
     else:
         os.environ["_LITESTAR_DOCS_BUILD_VERSION"] = version
-
-    if ignore_missing_output:
-        os.environ["_LITESTAR_DOCS_IGNORE_MISSING_EXAMPLE_OUTPUT"] = "1"
 
     subprocess.run(["make", "docs"], check=True)  # noqa: S603 S607
 
@@ -87,11 +83,7 @@ def build(output_dir: str, version: str | None, ignore_missing_output: bool) -> 
 
 def main() -> None:
     args = parser.parse_args()
-    build(
-        output_dir=args.output,
-        version=args.version,
-        ignore_missing_output=args.ignore_missing_examples_output,
-    )
+    build(output_dir=args.output, version=args.version)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Attempt to mitigate the various timeout related application example failures during the documentation building process.

1. Fix a bug that would lead to application servers not being killed properly
2. Cycle through ports rather than re-use them immediately
3. Ignore missing outputs when building the preview