### PR TITLE
Consistent template autoescape behavior.

### DIFF
--- a/litestar/contrib/mako.py
+++ b/litestar/contrib/mako.py
@@ -70,7 +70,9 @@ class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate]):
             directory: Direct path or list of directory paths from which to serve templates.
         """
         super().__init__(directory=directory)
-        self.engine = TemplateLookup(directories=directory if isinstance(directory, (list, tuple)) else [directory])
+        self.engine = TemplateLookup(
+            directories=directory if isinstance(directory, (list, tuple)) else [directory], default_filters=["h"]
+        )
         self._template_callables: list[tuple[str, Callable[[dict[str, Any]], Any]]] = []
         self.register_template_callable(key="url_for_static_asset", template_callable=url_for_static_asset)  # type: ignore
         self.register_template_callable(key="csrf_token", template_callable=csrf_token)  # type: ignore

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -51,6 +51,12 @@ def test_engine_passed_to_callback(template_dir: "Path") -> None:
 @pytest.mark.parametrize("engine", (JinjaTemplateEngine, MakoTemplateEngine))
 def test_engine_instance(engine: Type["TemplateEngineProtocol"], template_dir: "Path") -> None:
     engine_instance = engine(template_dir)
+    if isinstance(engine_instance, JinjaTemplateEngine):
+        assert engine_instance.engine.autoescape is True
+
+    if isinstance(engine_instance, MakoTemplateEngine):
+        assert engine_instance.engine.template_args["default_filters"] == ["h"]
+
     config = TemplateConfig(engine=engine_instance)
     assert config.engine_instance is engine_instance
 


### PR DESCRIPTION
This PR configures the mako template engine to autoescape expressions, making it consistent with config of jinja template engine.

Closes #1699

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
