### PR TITLE
Channels plugin signature namespace population.

### DIFF
--- a/litestar/channels/plugin.py
+++ b/litestar/channels/plugin.py
@@ -111,6 +111,7 @@ class ChannelsPlugin(InitPluginProtocol, AbstractAsyncContextManager):
         """Plugin hook. Set up a ``channels`` dependency, add route handlers and register application hooks"""
         app_config.dependencies["channels"] = Provide(lambda: self, use_cache=True, sync_to_thread=False)
         app_config.lifespan.append(self)
+        app_config.signature_namespace.update(ChannelsPlugin=ChannelsPlugin)
 
         if self._create_route_handlers:
             if self._arbitrary_channels_allowed:

--- a/tests/channels/test_plugin.py
+++ b/tests/channels/test_plugin.py
@@ -69,6 +69,12 @@ def test_plugin_dependency(mock: MagicMock, memory_backend: MemoryChannelsBacken
     assert mock.call_args[0][0] is channels_plugin
 
 
+def test_plugin_dependency_signature_namespace(memory_backend: MemoryChannelsBackend) -> None:
+    channels_plugin = ChannelsPlugin(backend=memory_backend, arbitrary_channels_allowed=True)
+    app = Litestar(plugins=[channels_plugin])
+    assert app.signature_namespace["ChannelsPlugin"] is ChannelsPlugin
+
+
 @pytest.mark.flaky(reruns=5)
 async def test_pub_sub_wait_published(channels_backend: ChannelsBackend) -> None:
     async with ChannelsPlugin(backend=channels_backend, channels=["something"]) as plugin:


### PR DESCRIPTION
Adds `ChannelsPlugin` name to signature namespace when plugin inits the app.

Closes #1691

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
