### PR TITLE
Fix: premature transfer to nested models with DTOData

### DIFF
--- a/tests/dto/factory/test_integration.py
+++ b/tests/dto/factory/test_integration.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Optional
-from unittest.mock import MagicMock
 
 import pytest
 from typing_extensions import Annotated
@@ -18,8 +17,8 @@ from litestar.params import Body
 from litestar.testing import create_test_client
 
 if TYPE_CHECKING:
-    from typing import Callable
     from types import ModuleType
+    from typing import Callable
 
 
 def test_url_encoded_form_data() -> None:
@@ -144,7 +143,6 @@ def test_dto_data_injection() -> None:
         assert response.json() == {"bar": "hello"}
 
 
-@pytest.mark.xfail(reason="working on it")
 def test_dto_data_injection_with_nested_model(create_module: Callable[[str], ModuleType]) -> None:
     module = create_module(
         """


### PR DESCRIPTION
This PR fixes an issue where data that should be transferred to builtin types on instantiation of `DTOData` was being instantiated into a model type for nested models.

Closes #1726 

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
