### PR TITLE
Add default modes for WebSocket `iter_` methods

### DIFF
--- a/litestar/connection/websocket.py
+++ b/litestar/connection/websocket.py
@@ -179,7 +179,7 @@ class WebSocket(Generic[UserT, AuthT, StateT], ASGIConnection["WebsocketRouteHan
     def iter_data(self, mode: Literal["binary"]) -> AsyncGenerator[bytes, None]:
         ...
 
-    async def iter_data(self, mode: WebSocketMode) -> AsyncGenerator[str | bytes, None]:
+    async def iter_data(self, mode: WebSocketMode = "text") -> AsyncGenerator[str | bytes, None]:
         """Continuously receive data and yield it
 
         Args:
@@ -231,7 +231,7 @@ class WebSocket(Generic[UserT, AuthT, StateT], ASGIConnection["WebsocketRouteHan
         data = await self.receive_data(mode="binary")
         return decode_msgpack(data)
 
-    async def iter_json(self, mode: WebSocketMode) -> AsyncGenerator[Any, None]:
+    async def iter_json(self, mode: WebSocketMode = "text") -> AsyncGenerator[Any, None]:
         """Continuously receive data and yield it, decoding it as JSON in the process.
 
         Args:

--- a/litestar/openapi/controller.py
+++ b/litestar/openapi/controller.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from copy import copy
 from functools import cached_property
-from typing import TYPE_CHECKING, Callable, Literal, cast
+from typing import TYPE_CHECKING, Callable, Literal
 
 from yaml import dump as dump_yaml
 
@@ -37,7 +37,7 @@ class OpenAPISchemaResponse(Response):
         """
         content_dict = content.to_schema()
         if self.media_type == OpenAPIMediaType.OPENAPI_YAML:
-            return cast("bytes", dump_yaml(content_dict, default_flow_style=False).encode("utf-8"))
+            return dump_yaml(content_dict, default_flow_style=False).encode("utf-8")
         return encode_json(content_dict)
 
 


### PR DESCRIPTION
Add a default `mode` for the `WebSocket.iter_json` and `WebSocket.iter_data` methods.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
