### PR TITLE
Unify hook handler signatures

### DIFF
--- a/docs/examples/application_hooks/after_exception_hook.py
+++ b/docs/examples/application_hooks/after_exception_hook.py
@@ -8,7 +8,6 @@ from litestar.status_codes import HTTP_400_BAD_REQUEST
 logger = logging.getLogger()
 
 if TYPE_CHECKING:
-    from litestar.datastructures import State
     from litestar.types import Scope
 
 
@@ -18,8 +17,9 @@ def my_handler() -> None:
     raise HTTPException(detail="bad request", status_code=HTTP_400_BAD_REQUEST)
 
 
-async def after_exception_handler(exc: Exception, scope: "Scope", state: "State") -> None:
+async def after_exception_handler(exc: Exception, scope: "Scope") -> None:
     """Hook function that will be invoked after each exception."""
+    state = scope["app"].state
     if not hasattr(state, "error_count"):
         state.error_count = 1
     else:

--- a/docs/examples/application_hooks/before_send_hook.py
+++ b/docs/examples/application_hooks/before_send_hook.py
@@ -8,7 +8,6 @@ from litestar.datastructures import MutableScopeHeaders
 if TYPE_CHECKING:
     from typing import Dict
 
-    from litestar.datastructures import State
     from litestar.types import Message, Scope
 
 
@@ -18,14 +17,14 @@ def handler() -> Dict[str, str]:
     return {"key": "value"}
 
 
-async def before_send_hook_handler(message: Message, state: State, scope: Scope) -> None:
+async def before_send_hook_handler(message: Message, scope: Scope) -> None:
     """The function will be called on each ASGI message.
 
     We therefore ensure it runs only on the message start event.
     """
     if message["type"] == "http.response.start":
         headers = MutableScopeHeaders.from_message(message=message)
-        headers["My Header"] = state.message
+        headers["My Header"] = scope["app"].state.message
 
 
 def on_startup(app: Litestar) -> None:

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -40,12 +40,7 @@ from litestar.static_files.base import StaticFiles
 from litestar.stores.registry import StoreRegistry
 from litestar.types import Empty
 from litestar.types.internal_types import PathParameterDefinition
-from litestar.utils import (
-    as_async_callable_list,
-    is_async_callable,
-    join_paths,
-    unique,
-)
+from litestar.utils import AsyncCallable, is_async_callable, join_paths, unique
 from litestar.utils.dataclass import extract_dataclass_items
 
 if TYPE_CHECKING:
@@ -362,9 +357,9 @@ class Litestar(Router):
         self.asgi_router = ASGIRouter(app=self)
 
         self.allowed_hosts = cast("AllowedHostsConfig | None", config.allowed_hosts)
-        self.after_exception = as_async_callable_list(config.after_exception)
+        self.after_exception = [AsyncCallable(h) for h in config.after_exception]
         self.allowed_hosts = cast("AllowedHostsConfig | None", config.allowed_hosts)
-        self.before_send = as_async_callable_list(config.before_send)
+        self.before_send = [AsyncCallable(h) for h in config.before_send]
         self.compression_config = config.compression_config
         self.cors_config = config.cors_config
         self.csrf_config = config.csrf_config
@@ -741,7 +736,7 @@ class Litestar(Router):
 
             async def wrapped_send(message: Message) -> None:
                 for hook in self.before_send:
-                    await hook(message, self.state, scope)
+                    await hook(message, scope)
                 await send(message)
 
             return wrapped_send

--- a/litestar/contrib/sqlalchemy/plugins/init/config/asyncio.py
+++ b/litestar/contrib/sqlalchemy/plugins/init/config/asyncio.py
@@ -16,13 +16,12 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from litestar import Litestar
-    from litestar.datastructures.state import State
     from litestar.types import BeforeMessageSendHookHandler, EmptyType, Message, Scope
 
 __all__ = ("SQLAlchemyAsyncConfig", "AsyncSessionConfig")
 
 
-async def default_before_send_handler(message: Message, _: State, scope: Scope) -> None:
+async def default_before_send_handler(message: Message, scope: Scope) -> None:
     """Handle closing and cleaning up sessions before sending.
 
     Args:

--- a/litestar/contrib/sqlalchemy/plugins/init/config/sync.py
+++ b/litestar/contrib/sqlalchemy/plugins/init/config/sync.py
@@ -14,13 +14,12 @@ if TYPE_CHECKING:
     from typing import Any, Callable
 
     from litestar import Litestar
-    from litestar.datastructures.state import State
     from litestar.types import BeforeMessageSendHookHandler, Message, Scope
 
 __all__ = ("SQLAlchemySyncConfig", "SyncSessionConfig")
 
 
-async def default_before_send_handler(message: Message, _: State, scope: Scope) -> None:
+async def default_before_send_handler(message: Message, scope: Scope) -> None:
     """Handle closing and cleaning up sessions before sending.
 
     Args:

--- a/litestar/middleware/exceptions/middleware.py
+++ b/litestar/middleware/exceptions/middleware.py
@@ -154,7 +154,7 @@ class ExceptionHandlerMiddleware:
                 self.handle_exception_logging(logger=logger, logging_config=litestar_app.logging_config, scope=scope)
 
             for hook in litestar_app.after_exception:
-                await hook(e, scope, litestar_app.state)
+                await hook(e, scope)
 
             if scope["type"] == ScopeType.HTTP:
                 await self.handle_request_exception(

--- a/litestar/types/callable_types.py
+++ b/litestar/types/callable_types.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from litestar.handlers.http_handlers import HTTPRouteHandler
     from litestar.response.base import Response
     from litestar.types.protocols import Logger
+
 else:
     AppConfig = Any
     BaseRouteHandler = Any
@@ -34,7 +35,7 @@ else:
     HTTPRouteHandler = Any
 
 ExceptionT = TypeVar("ExceptionT", bound=Exception)
-AfterExceptionHookHandler = Callable[[Exception, Scope, State], SyncOrAsyncUnion[None]]
+AfterExceptionHookHandler = Callable[[Exception, Scope], SyncOrAsyncUnion[None]]
 AfterRequestHookHandler = Union[
     Callable[[ASGIApp], SyncOrAsyncUnion[ASGIApp]], Callable[[Response], SyncOrAsyncUnion[Response]]
 ]
@@ -42,7 +43,7 @@ AfterResponseHookHandler = Callable[[Request], SyncOrAsyncUnion[None]]
 AsyncAnyCallable = Callable[..., Awaitable[Any]]
 AnyCallable = Callable[..., Any]
 AnyGenerator = Union[Generator[Any, Any, Any], AsyncGenerator[Any, Any]]
-BeforeMessageSendHookHandler = Callable[[Message, State, Scope], SyncOrAsyncUnion[None]]
+BeforeMessageSendHookHandler = Callable[[Message, Scope], SyncOrAsyncUnion[None]]
 BeforeRequestHookHandler = Callable[[Request], Union[Any, Awaitable[Any]]]
 CacheKeyBuilder = Callable[[Request], str]
 ExceptionHandler = Callable[[Request, ExceptionT], Response]

--- a/litestar/utils/__init__.py
+++ b/litestar/utils/__init__.py
@@ -26,13 +26,7 @@ from .scope import (
     set_litestar_scope_state,
 )
 from .sequence import compact, find_index, unique
-from .sync import (
-    AsyncCallable,
-    AsyncIteratorWrapper,
-    as_async_callable_list,
-    async_partial,
-    is_async_callable,
-)
+from .sync import AsyncCallable, AsyncIteratorWrapper, async_partial, is_async_callable
 from .typing import annotation_is_iterable_of_type, get_origin_or_inner_type, make_non_optional_union
 
 __all__ = (
@@ -40,7 +34,6 @@ __all__ = (
     "AsyncIteratorWrapper",
     "Ref",
     "annotation_is_iterable_of_type",
-    "as_async_callable_list",
     "async_partial",
     "compact",
     "delete_litestar_scope_state",

--- a/litestar/utils/sync.py
+++ b/litestar/utils/sync.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from litestar.types.empty import EmptyType
     from litestar.utils.signature import ParsedSignature
 
-__all__ = ("AsyncCallable", "AsyncIteratorWrapper", "as_async_callable_list", "async_partial", "is_async_callable")
+__all__ = ("AsyncCallable", "AsyncIteratorWrapper", "async_partial", "is_async_callable")
 
 
 P = ParamSpec("P")
@@ -100,20 +100,6 @@ class AsyncCallable(Generic[P, T]):
         from litestar.utils.signature import ParsedSignature
 
         self._parsed_signature = ParsedSignature.from_fn(self.ref.value, namespace)
-
-
-def as_async_callable_list(value: Callable | list[Callable]) -> list[AsyncCallable]:
-    """Wrap callables in ``AsyncCallable`` s.
-
-    Args:
-        value: A callable or list of callables.
-
-    Returns:
-        A list of AsyncCallable instances
-    """
-    if not isinstance(value, list):
-        return [AsyncCallable(value)]
-    return [AsyncCallable(v) for v in value]
 
 
 def async_partial(fn: Callable) -> Callable:

--- a/tests/app/test_before_send.py
+++ b/tests/app/test_before_send.py
@@ -11,7 +11,6 @@ from litestar.testing import create_test_client
 if TYPE_CHECKING:
     from typing import Dict
 
-    from litestar.datastructures import State
     from litestar.types import Message, Scope
 
 
@@ -20,10 +19,10 @@ def test_before_send() -> None:
     def handler() -> Dict[str, str]:
         return {"key": "value"}
 
-    async def before_send_hook_handler(message: Message, state: State, scope: Scope) -> None:
+    async def before_send_hook_handler(message: Message, scope: Scope) -> None:
         if message["type"] == "http.response.start":
             headers = MutableScopeHeaders(message)
-            headers.add("My Header", state.message)
+            headers.add("My Header", scope["app"].state.message)
 
     def on_startup(app: Litestar) -> None:
         app.state.message = "value injected during send"

--- a/tests/middleware/test_exception_handler_middleware.py
+++ b/tests/middleware/test_exception_handler_middleware.py
@@ -22,7 +22,6 @@ from litestar.types import ExceptionHandlersMap
 if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
 
-    from litestar.datastructures import State
     from litestar.types import Scope
     from litestar.types.callable_types import GetLogger
 
@@ -120,11 +119,12 @@ def test_exception_handler_middleware_calls_app_level_after_exception_hook() -> 
     def handler() -> None:
         raise RuntimeError()
 
-    async def after_exception_hook_handler(exc: Exception, scope: "Scope", state: "State") -> None:
+    async def after_exception_hook_handler(exc: Exception, scope: "Scope") -> None:
+        app = scope.get("app")
         assert isinstance(exc, RuntimeError)
-        assert scope["app"]
-        assert not state.called
-        state.called = True
+        assert app
+        assert not app.state.called
+        app.state.called = True
 
     with create_test_client(handler, after_exception=[after_exception_hook_handler]) as client:
         setattr(client.app.state, "called", False)


### PR DESCRIPTION
Remove the `state` paremeter from `AfterExceptionHookHandler` and `BeforeMessageSendHookHandler`.

This was largely unnecessary, as both already receive the `scope`, via which the state is accessible. It also makes them conform to the rest of the handler signatures, from which the `state` has been removed either in favour of `scope` or `app`, both of which make it possible t access the application's state.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
