### PR TITLE
Fix `sync_to_thread` usage in generator dependency tests

### DIFF
--- a/tests/kwargs/test_generator_dependencies.py
+++ b/tests/kwargs/test_generator_dependencies.py
@@ -5,7 +5,6 @@ import pytest
 from pytest import FixtureRequest
 
 from litestar import WebSocket, get, websocket
-from litestar.di import Provide
 from litestar.testing import create_test_client
 
 
@@ -68,7 +67,7 @@ def test_generator_dependency(
 ) -> None:
     dependency = request.getfixturevalue(dependency_fixture)
 
-    @get("/", dependencies={"dep": Provide(dependency, sync_to_thread=False)}, cache=cache)
+    @get("/", dependencies={"dep": dependency}, cache=cache)
     def handler(dep: str) -> Dict[str, str]:
         return {"value": dep}
 
@@ -91,7 +90,7 @@ async def test_generator_dependency_websocket(
 ) -> None:
     dependency = request.getfixturevalue(dependency_fixture)
 
-    @websocket("/ws", dependencies={"dep": Provide(dependency, sync_to_thread=False)})
+    @websocket("/ws", dependencies={"dep": dependency})
     async def ws_handler(socket: WebSocket, dep: str) -> None:
         await socket.accept()
         await socket.send_json({"value": dep})
@@ -114,7 +113,7 @@ def test_generator_dependency_handle_exception(
 ) -> None:
     dependency = request.getfixturevalue(dependency_fixture)
 
-    @get("/", dependencies={"dep": Provide(dependency, sync_to_thread=False)})
+    @get("/", dependencies={"dep": dependency})
     def handler(dep: str) -> Dict[str, str]:
         raise ValueError("foo")
 
@@ -138,7 +137,7 @@ def test_generator_dependency_exception_during_cleanup(
     dependency = request.getfixturevalue(dependency_fixture)
     cleanup_mock.side_effect = Exception("foo")
 
-    @get("/", dependencies={"dep": Provide(dependency, sync_to_thread=False)})
+    @get("/", dependencies={"dep": dependency})
     def handler(dep: str) -> Dict[str, str]:
         return {"value": dep}
 
@@ -170,9 +169,9 @@ def test_generator_dependency_nested(
     @get(
         "/",
         dependencies={
-            "generator_dep": Provide(dependency, sync_to_thread=False),
-            "nested_one": Provide(nested_dependency_one, sync_to_thread=False),
-            "nested_two": Provide(nested_dependency_two, sync_to_thread=False),
+            "generator_dep": dependency,
+            "nested_one": nested_dependency_one,
+            "nested_two": nested_dependency_two,
         },
     )
     def handler(nested_two: str) -> Dict[str, str]:
@@ -207,10 +206,7 @@ def test_generator_dependency_nested_error_during_cleanup(
 
     @get(
         "/",
-        dependencies={
-            "generator_dep": Provide(dependency, sync_to_thread=False),
-            "other": Provide(other_dependency, sync_to_thread=False),
-        },
+        dependencies={"generator_dep": dependency, "other": other_dependency},
     )
     def handler(other: str) -> Dict[str, str]:
         return {"value": other}


### PR DESCRIPTION
Remove the `sync_to_thread` parameter from generator dependency tests.

Because of the warning introduced in #1716, these tests would raise a warning. 

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
