### PR TITLE
Feature: SQLAlchemyDTO support for hybrid properties and association proxies.

### DIFF
--- a/litestar/contrib/sqlalchemy/dto.py
+++ b/litestar/contrib/sqlalchemy/dto.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
+from functools import singledispatchmethod
 from typing import TYPE_CHECKING, Generic, TypeVar
 
-from sqlalchemy import inspect, orm, sql
-from sqlalchemy.orm import DeclarativeBase, Mapped
+from sqlalchemy import Column, inspect, orm, sql
+from sqlalchemy.ext.associationproxy import AssociationProxy, AssociationProxyExtensionType
+from sqlalchemy.orm import (
+    ColumnProperty,
+    DeclarativeBase,
+    InspectionAttr,
+    Mapped,
+    NotExtension,
+    QueryableAttribute,
+    RelationshipProperty,
+)
 
 from litestar.dto.factory.abc import AbstractDTOFactory
-from litestar.dto.factory.field import DTO_FIELD_META_KEY
+from litestar.dto.factory.field import DTO_FIELD_META_KEY, DTOField, Mark
 from litestar.dto.factory.types import FieldDefinition
 from litestar.dto.factory.utils import get_model_type_hints
 from litestar.types.empty import Empty
@@ -15,8 +25,6 @@ from litestar.utils.helpers import get_fully_qualified_class_name
 if TYPE_CHECKING:
     from typing import Any, ClassVar, Collection, Generator
 
-    from sqlalchemy import Column
-    from sqlalchemy.orm import RelationshipProperty
     from typing_extensions import TypeAlias
 
     from litestar.typing import ParsedType
@@ -26,6 +34,8 @@ __all__ = ("SQLAlchemyDTO",)
 T = TypeVar("T", bound="DeclarativeBase | Collection[DeclarativeBase]")
 ElementType: TypeAlias = "Column[Any] | RelationshipProperty[Any]"
 
+SQLA_NS = {**vars(orm), **vars(sql)}
+
 
 class SQLAlchemyDTO(AbstractDTOFactory[T], Generic[T]):
     """Support for domain modelling with SQLAlchemy."""
@@ -34,40 +44,98 @@ class SQLAlchemyDTO(AbstractDTOFactory[T], Generic[T]):
 
     model_type: ClassVar[type[DeclarativeBase]]
 
+    @singledispatchmethod
+    @classmethod
+    def handle_orm_descriptor(
+        cls,
+        extension_type: NotExtension | AssociationProxyExtensionType,
+        orm_descriptor: InspectionAttr,
+        key: str,
+        parsed_type: ParsedType,
+        model_name: str,
+    ) -> FieldDefinition:
+        raise NotImplementedError(f"Unsupported extension type: {extension_type}")
+
+    @handle_orm_descriptor.register(NotExtension)
+    @classmethod
+    def _(
+        cls,
+        extension_type: NotExtension,
+        key: str,
+        orm_descriptor: InspectionAttr,
+        parsed_type: ParsedType,
+        model_name: str,
+    ) -> FieldDefinition:
+        if not isinstance(orm_descriptor, QueryableAttribute):
+            raise NotImplementedError(f"Unexpected descriptor type for '{extension_type}': '{orm_descriptor}'")
+
+        elem: ElementType
+        if isinstance(orm_descriptor.property, ColumnProperty):
+            if not isinstance(orm_descriptor.property.expression, Column):
+                raise NotImplementedError(f"Expected 'Column', got: '{orm_descriptor.property.expression}'")
+            elem = orm_descriptor.property.expression
+        elif isinstance(orm_descriptor.property, RelationshipProperty):
+            elem = orm_descriptor.property
+        else:
+            raise NotImplementedError(f"Unhandled property type: '{orm_descriptor.property}'")
+
+        default, default_factory = _detect_defaults(elem)
+
+        if parsed_type.origin is Mapped:
+            (parsed_type,) = parsed_type.inner_types
+        else:
+            raise NotImplementedError(f"Expected 'Mapped' origin, got: '{parsed_type.origin}'")
+
+        return FieldDefinition(
+            name=key,
+            default=default,
+            parsed_type=parsed_type,
+            default_factory=default_factory,
+            dto_field=elem.info.get(DTO_FIELD_META_KEY),
+            unique_model_name=model_name,
+        )
+
+    @handle_orm_descriptor.register(AssociationProxyExtensionType)
+    @classmethod
+    def _(
+        cls,
+        extension_type: AssociationProxyExtensionType,
+        key: str,
+        orm_descriptor: InspectionAttr,
+        parsed_type: ParsedType,
+        model_name: str,
+    ) -> FieldDefinition:
+        if not isinstance(orm_descriptor, AssociationProxy):
+            raise NotImplementedError(f"Unexpected descriptor type '{orm_descriptor}' for '{extension_type}'")
+
+        if parsed_type.origin is AssociationProxy:
+            (parsed_type,) = parsed_type.inner_types
+        else:
+            raise NotImplementedError(f"Expected 'AssociationProxy' origin, got: '{parsed_type.origin}'")
+
+        return FieldDefinition(
+            name=key,
+            default=Empty,
+            parsed_type=parsed_type,
+            default_factory=None,
+            dto_field=orm_descriptor.info.get(DTO_FIELD_META_KEY, DTOField(mark=Mark.READ_ONLY)),
+            unique_model_name=model_name,
+        )
+
     @classmethod
     def generate_field_definitions(cls, model_type: type[DeclarativeBase]) -> Generator[FieldDefinition, None, None]:
         if (mapper := inspect(model_type)) is None:  # pragma: no cover
             raise RuntimeError("Unexpected `None` value for mapper.")
 
-        columns = mapper.columns
-        relationships = mapper.relationships
-
         # includes SQLAlchemy names and other mapped class names in the forward reference resolution namespace
-        namespace = dict(vars(orm))
-        namespace.update(vars(sql))
-        namespace.update({m.class_.__name__: m.class_ for m in mapper.registry.mappers if m is not mapper})
+        namespace = {**SQLA_NS, **{m.class_.__name__: m.class_ for m in mapper.registry.mappers if m is not mapper}}
+        model_type_hints = get_model_type_hints(model_type, namespace=namespace)
+        model_name = get_fully_qualified_class_name(model_type)
 
-        for key, parsed_type in get_model_type_hints(model_type, namespace=namespace).items():
-            elem: ElementType | None
-            elem = columns.get(key, relationships.get(key))  # pyright:ignore
-            if elem is None:
-                continue
+        for key, orm_descriptor in mapper.all_orm_descriptors.items():
+            parsed_type = model_type_hints[key]
 
-            if parsed_type.origin is Mapped:
-                (parsed_type,) = parsed_type.inner_types
-
-            default, default_factory = _detect_defaults(elem)
-
-            field_def = FieldDefinition(
-                name=key,
-                default=default,
-                parsed_type=parsed_type,
-                default_factory=default_factory,
-                dto_field=elem.info.get(DTO_FIELD_META_KEY),
-                unique_model_name=get_fully_qualified_class_name(model_type),
-            )
-
-            yield field_def
+            yield cls.handle_orm_descriptor(orm_descriptor.extension_type, key, orm_descriptor, parsed_type, model_name)
 
     @classmethod
     def detect_nested_field(cls, parsed_type: ParsedType) -> bool:

--- a/litestar/dto/factory/_backends/utils.py
+++ b/litestar/dto/factory/_backends/utils.py
@@ -232,10 +232,12 @@ def transfer_type_data(
         return transfer_nested_simple_type_data(dest_type, transfer_type.nested_field_info, dto_for, source_value)
     if isinstance(transfer_type, UnionType) and transfer_type.has_nested:
         return transfer_nested_union_type_data(transfer_type, dto_for, source_value)
-    if isinstance(transfer_type, CollectionType) and transfer_type.has_nested:
-        return transfer_nested_collection_type_data(
-            transfer_type.parsed_type.origin, transfer_type, dto_for, source_value
-        )
+    if isinstance(transfer_type, CollectionType):
+        if transfer_type.has_nested:
+            return transfer_nested_collection_type_data(
+                transfer_type.parsed_type.origin, transfer_type, dto_for, source_value
+            )
+        return transfer_type.parsed_type.origin(source_value)
     return source_value
 
 


### PR DESCRIPTION
This PR adds support for SQLAlchemyDTO field generation to recognize hybrid properties and association proxies.

In either case, the generated `FieldDefinition` is marked read-only.

Closes #1752 

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
