### PR TITLE
Refactor: Move all util predicates to utils.predicates.py

### DIFF
--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -48,9 +48,9 @@ from litestar.openapi.spec.schema import Schema, SchemaDataContainer
 from litestar.pagination import ClassicPagination, CursorPagination, OffsetPagination
 from litestar.serialization import encode_json
 from litestar.types import DataclassProtocol, Empty, TypedDictClass
-from litestar.utils.dataclass import is_dataclass_class
 from litestar.utils.predicates import (
     is_attrs_class,
+    is_dataclass_class,
     is_optional_union,
     is_pydantic_constrained_field,
     is_pydantic_model_class,

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -39,8 +39,9 @@ from litestar.static_files.base import StaticFiles
 from litestar.stores.registry import StoreRegistry
 from litestar.types import Empty
 from litestar.types.internal_types import PathParameterDefinition
-from litestar.utils import AsyncCallable, is_async_callable, join_paths, unique
+from litestar.utils import AsyncCallable, join_paths, unique
 from litestar.utils.dataclass import extract_dataclass_items
+from litestar.utils.predicates import is_async_callable
 from litestar.utils.warnings import warn_pdb_on_exception
 
 if TYPE_CHECKING:

--- a/litestar/di.py
+++ b/litestar/di.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Any
 
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types import Empty
-from litestar.utils import Ref, is_async_callable
-from litestar.utils.predicates import is_sync_or_async_generator
+from litestar.utils import Ref
+from litestar.utils.predicates import is_async_callable, is_sync_or_async_generator
 from litestar.utils.warnings import (
     warn_implicit_sync_to_thread,
     warn_sync_to_thread_with_async_callable,

--- a/litestar/file_system.py
+++ b/litestar/file_system.py
@@ -8,7 +8,7 @@ from anyio.to_thread import run_sync
 
 from litestar.exceptions import InternalServerException, NotAuthorizedException
 from litestar.types.file_types import FileSystemProtocol
-from litestar.utils.sync import is_async_callable
+from litestar.utils.predicates import is_async_callable
 
 __all__ = ("BaseLocalFileSystem", "FileSystemAdapter")
 

--- a/litestar/handlers/asgi_handlers.py
+++ b/litestar/handlers/asgi_handlers.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Sequence
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.handlers.base import BaseRouteHandler
 from litestar.types.builtin_types import NoneType
-from litestar.utils import is_async_callable
+from litestar.utils.predicates import is_async_callable
 
 __all__ = ("ASGIRouteHandler", "asgi")
 

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -10,8 +10,9 @@ from litestar.di import Provide
 from litestar.dto.interface import HandlerContext
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types import Dependencies, Empty, ExceptionHandlersMap, Guard, Middleware, TypeEncodersMap
-from litestar.utils import AsyncCallable, Ref, async_partial, get_name, is_async_callable, normalize_path
+from litestar.utils import AsyncCallable, Ref, async_partial, get_name, normalize_path
 from litestar.utils.helpers import unwrap_partial
+from litestar.utils.predicates import is_async_callable
 from litestar.utils.signature import ParsedSignature, infer_request_encoding_from_parameter
 
 if TYPE_CHECKING:

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -43,7 +43,8 @@ from litestar.types import (
     TypeEncodersMap,
 )
 from litestar.types.builtin_types import NoneType
-from litestar.utils import AsyncCallable, async_partial, is_async_callable
+from litestar.utils import AsyncCallable, async_partial
+from litestar.utils.predicates import is_async_callable
 from litestar.utils.warnings import warn_implicit_sync_to_thread, warn_sync_to_thread_with_async_callable
 
 if TYPE_CHECKING:

--- a/litestar/handlers/websocket_handlers/route_handler.py
+++ b/litestar/handlers/websocket_handlers/route_handler.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Mapping
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.handlers import BaseRouteHandler
 from litestar.types.builtin_types import NoneType
-from litestar.utils import is_async_callable
+from litestar.utils.predicates import is_async_callable
 
 if TYPE_CHECKING:
     from litestar.types import Dependencies, ExceptionHandler, Guard, Middleware

--- a/litestar/partial.py
+++ b/litestar/partial.py
@@ -17,10 +17,10 @@ from typing_extensions import TypeAlias, TypedDict
 
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types.builtin_types import NoneType
-from litestar.utils.dataclass import is_dataclass_class
 from litestar.utils.predicates import (
     is_attrs_class,
     is_class_var,
+    is_dataclass_class,
     is_pydantic_model_class,
     is_struct_class,
     is_typed_dict,

--- a/litestar/utils/__init__.py
+++ b/litestar/utils/__init__.py
@@ -1,13 +1,15 @@
 from litestar.utils.deprecation import deprecated, warn_deprecation
 
-from .dataclass import is_dataclass_class, is_dataclass_instance
 from .helpers import Ref, get_enum_string_value, get_name
 from .path import join_paths, normalize_path
 from .predicates import (
     is_any,
+    is_async_callable,
     is_attrs_class,
     is_class_and_subclass,
     is_class_var,
+    is_dataclass_class,
+    is_dataclass_instance,
     is_generic,
     is_mapping,
     is_non_string_iterable,
@@ -26,7 +28,7 @@ from .scope import (
     set_litestar_scope_state,
 )
 from .sequence import compact, find_index, unique
-from .sync import AsyncCallable, AsyncIteratorWrapper, async_partial, is_async_callable
+from .sync import AsyncCallable, AsyncIteratorWrapper, async_partial
 from .typing import annotation_is_iterable_of_type, get_origin_or_inner_type, make_non_optional_union
 
 __all__ = (

--- a/litestar/utils/dataclass.py
+++ b/litestar/utils/dataclass.py
@@ -1,52 +1,21 @@
 from __future__ import annotations
 
-from dataclasses import Field, fields, is_dataclass
-from inspect import isclass
+from dataclasses import Field, fields
 from typing import TYPE_CHECKING
 
 from litestar.types import Empty
+from litestar.utils.predicates import is_dataclass_instance
 
 if TYPE_CHECKING:
     from typing import AbstractSet, Any, Iterable
-
-    from typing_extensions import TypeGuard
 
     from litestar.types.protocols import DataclassProtocol
 
 __all__ = (
     "extract_dataclass_fields",
     "extract_dataclass_items",
-    "is_dataclass_class",
-    "is_dataclass_instance",
     "simple_asdict",
 )
-
-
-def is_dataclass_instance(obj: Any) -> TypeGuard[DataclassProtocol]:
-    """Check if an object is a dataclass instance.
-
-    Args:
-        obj: An object to check.
-
-    Returns:
-        True if the object is a dataclass instance.
-    """
-    return hasattr(type(obj), "__dataclass_fields__")
-
-
-def is_dataclass_class(annotation: Any) -> TypeGuard[type[DataclassProtocol]]:
-    """Wrap :func:`is_dataclass <dataclasses.is_dataclass>` in a :data:`typing.TypeGuard`.
-
-    Args:
-        annotation: tested to determine if instance or type of :class:`dataclasses.dataclass`.
-
-    Returns:
-        ``True`` if instance or type of ``dataclass``.
-    """
-    try:
-        return isclass(annotation) and is_dataclass(annotation)
-    except TypeError:  # pragma: no cover
-        return False
 
 
 def extract_dataclass_fields(

--- a/litestar/utils/predicates.py
+++ b/litestar/utils/predicates.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+from asyncio import iscoroutinefunction
 from collections import defaultdict, deque
 from collections.abc import Iterable as CollectionsIterable
+from dataclasses import is_dataclass
+from functools import partial
 from inspect import isasyncgenfunction, isclass, isgeneratorfunction
 from typing import (
     TYPE_CHECKING,
     Any,
+    Awaitable,
+    Callable,
     ClassVar,
     DefaultDict,
     Deque,
@@ -37,6 +42,8 @@ from litestar.utils.typing import get_origin_or_inner_type
 if TYPE_CHECKING:
     from litestar.types.builtin_types import TypedDictClass
     from litestar.types.callable_types import AnyGenerator
+    from litestar.types.protocols import DataclassProtocol
+
 
 try:
     import pydantic
@@ -49,10 +56,13 @@ except ImportError:  # pragma: no cover
     attrs = Empty  # type: ignore
 
 __all__ = (
+    "is_async_callable",
     "is_any",
     "is_attrs_class",
     "is_class_and_subclass",
     "is_class_var",
+    "is_dataclass_class",
+    "is_dataclass_instance",
     "is_generic",
     "is_mapping",
     "is_non_string_iterable",
@@ -68,6 +78,51 @@ __all__ = (
 
 P = ParamSpec("P")
 T = TypeVar("T")
+
+
+def is_async_callable(value: Callable[P, T]) -> TypeGuard[Callable[P, Awaitable[T]]]:
+    """Extend :func:`asyncio.iscoroutinefunction` to additionally detect async :func:`functools.partial` objects and
+    class instances with ``async def __call__()`` defined.
+
+    Args:
+        value: Any
+
+    Returns:
+        Bool determining if type of ``value`` is an awaitable.
+    """
+    while isinstance(value, partial):
+        value = value.func  # type: ignore[unreachable]
+
+    return iscoroutinefunction(value) or (
+        callable(value) and iscoroutinefunction(value.__call__)  #  type: ignore[operator]
+    )
+
+
+def is_dataclass_instance(obj: Any) -> TypeGuard[DataclassProtocol]:
+    """Check if an object is a dataclass instance.
+
+    Args:
+        obj: An object to check.
+
+    Returns:
+        True if the object is a dataclass instance.
+    """
+    return hasattr(type(obj), "__dataclass_fields__")
+
+
+def is_dataclass_class(annotation: Any) -> TypeGuard[type[DataclassProtocol]]:
+    """Wrap :func:`is_dataclass <dataclasses.is_dataclass>` in a :data:`typing.TypeGuard`.
+
+    Args:
+        annotation: tested to determine if instance or type of :class:`dataclasses.dataclass`.
+
+    Returns:
+        ``True`` if instance or type of ``dataclass``.
+    """
+    try:
+        return isclass(annotation) and is_dataclass(annotation)
+    except TypeError:  # pragma: no cover
+        return False
 
 
 def is_class_and_subclass(annotation: Any, t_type: type[T]) -> TypeGuard[type[T]]:

--- a/litestar/utils/sync.py
+++ b/litestar/utils/sync.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from asyncio import iscoroutinefunction
 from functools import partial
 from inspect import getfullargspec, ismethod
 from typing import (
@@ -17,11 +16,12 @@ from typing import (
 )
 
 from anyio.to_thread import run_sync
-from typing_extensions import ParamSpec, TypeGuard
+from typing_extensions import ParamSpec
 
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types import Empty
 from litestar.utils.helpers import Ref
+from litestar.utils.predicates import is_async_callable
 
 if TYPE_CHECKING:
     from litestar.types.empty import EmptyType
@@ -32,24 +32,6 @@ __all__ = ("AsyncCallable", "AsyncIteratorWrapper", "async_partial", "is_async_c
 
 P = ParamSpec("P")
 T = TypeVar("T")
-
-
-def is_async_callable(value: Callable[P, T]) -> TypeGuard[Callable[P, Awaitable[T]]]:
-    """Extend :func:`asyncio.iscoroutinefunction` to additionally detect async :func:`functools.partial` objects and
-    class instances with ``async def __call__()`` defined.
-
-    Args:
-        value: Any
-
-    Returns:
-        Bool determining if type of ``value`` is an awaitable.
-    """
-    while isinstance(value, partial):
-        value = value.func  # type: ignore[unreachable]
-
-    return iscoroutinefunction(value) or (
-        callable(value) and iscoroutinefunction(value.__call__)  #  type: ignore[operator]
-    )
 
 
 class AsyncCallable(Generic[P, T]):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ from typing import AsyncGenerator, Callable
 
 import pytest
 
-from litestar.utils import is_async_callable
+from litestar.utils.predicates import is_async_callable
 
 
 class AsyncTestCallable:

--- a/tests/utils/test_dataclass.py
+++ b/tests/utils/test_dataclass.py
@@ -8,9 +8,11 @@ from litestar.types import DataclassProtocol, Empty, EmptyType
 from litestar.utils.dataclass import (
     extract_dataclass_fields,
     extract_dataclass_items,
+    simple_asdict,
+)
+from litestar.utils.predicates import (
     is_dataclass_class,
     is_dataclass_instance,
-    simple_asdict,
 )
 
 


### PR DESCRIPTION
Moved predicates in `utils/` to `utils.predicates.py` for consistency

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [X] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description
This PR moves predicates from `utils/sync.py` and `utils/dataclass.py` to `utils.predicates.py` for consistency

### Close Issue(s)
This PR closes #1730 
