### PR TITLE
Chore: exclude repository modules from sonar duplication checks.

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,14 @@
 sonar.coverage.exclusions=**/__init__.py, **/*.js, litestar/contrib/sqlalchemy_1/*
-sonar.cpd.exclusions=litestar/params.py, litestar/handlers/**/*, litestar/testing/*, litestar/connection.py, litestar/contrib/jwt/*, litestar/middleware/session/*, litestar/security/*
+sonar.cpd.exclusions=\
+  litestar/connection.py, \
+  litestar/contrib/jwt/*, \
+  litestar/contrib/repository/testing/generic_mock_repository.py, \
+  litestar/contrib/sqlalchemy/repository.py, \
+  litestar/handlers/**/*, \
+  litestar/middleware/session/*, \
+  litestar/params.py, \
+  litestar/security/*, \
+  litestar/testing/*
 sonar.exclusions=litestar/middleware/exceptions/templates/*
 sonar.organization=litestar-api
 sonar.projectKey=litestar-org_litestar


### PR DESCRIPTION
The reason for this duplication is due to having sync and async versions of the same code. We've discussed using tools to autogenerate one from the other in discord, but in the meantime this feels reasonable to exclude from checks.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
