### PR TITLE
Fix deserialization of PydanticObjectID

### DIFF
--- a/litestar/serialization.py
+++ b/litestar/serialization.py
@@ -135,9 +135,7 @@ def dec_hook(type_: Any, value: Any) -> Any:  # pragma: no cover
     """
     if issubclass(type_, BaseModel):
         return type_.parse_obj(value)
-    if issubclass(type_, (Path, PurePath)):
-        return type_(value)
-    raise TypeError(f"Unsupported type: {type(value)!r}")
+    return type_(value)
 
 
 _msgspec_json_encoder = msgspec.json.Encoder(enc_hook=default_serializer)


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

This allows for handling of types other than just Pydantic models and `pathlib` objects to be handled by the `msgspec` decoder hook. It came up when dealing with beanie's `PydanticObjectId` in a data DTO context.

### Close Issue(s)

Fixes #1765 
