### PR TITLE
Add `--use-tuple` arg to dunder-all check.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,7 @@ repos:
     hooks:
       - id: ensure-dunder-all
         exclude: "test*|examples*|tools"
+        args: ["--use-tuple"]
   - repo: https://github.com/ariebovenberg/slotscheck
     rev: v0.16.5
     hooks:
@@ -104,7 +105,7 @@ repos:
             uvicorn,
           ]
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.310
+    rev: v1.1.311
     hooks:
       - id: pyright
         exclude: "test_apps|tools|docs|_openapi"

--- a/litestar/contrib/repository/filters.py
+++ b/litestar/contrib/repository/filters.py
@@ -8,7 +8,13 @@ from typing import Generic, Literal, TypeVar
 
 T = TypeVar("T")
 
-__all__ = ["BeforeAfter", "CollectionFilter", "LimitOffset", "OrderBy", "SearchFilter"]
+__all__ = (
+    "BeforeAfter",
+    "CollectionFilter",
+    "LimitOffset",
+    "OrderBy",
+    "SearchFilter",
+)
 
 
 @dataclass

--- a/litestar/dto/exceptions.py
+++ b/litestar/dto/exceptions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from litestar.exceptions import ImproperlyConfiguredException
 
-__all__ = ["DTOException", "UnsupportedType"]
+__all__ = ("DTOException", "UnsupportedType")
 
 
 class DTOException(ImproperlyConfiguredException):

--- a/litestar/dto/factory/abc.py
+++ b/litestar/dto/factory/abc.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from ._backends import AbstractDTOBackend
     from .types import FieldDefinition
 
-__all__ = ["AbstractDTOFactory"]
+__all__ = ("AbstractDTOFactory",)
 
 T = TypeVar("T")
 


### PR DESCRIPTION
Ref: https://flake8-dunder-all.readthedocs.io/en/latest/usage.html#cmdoption-ensure-dunder-all-use-tuple

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
