### PR TITLE
Increase verbosity of validation error response keys

### DIFF
--- a/litestar/_signature/models/base.py
+++ b/litestar/_signature/models/base.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Sequence, TypedDict, cast
 
 from litestar.enums import ScopeType
 from litestar.exceptions import InternalServerException, ValidationException
+from litestar.params import ParameterKwarg
 
 if TYPE_CHECKING:
+    from typing_extensions import NotRequired
+
     from litestar._signature.field import SignatureField
     from litestar.connection import ASGIConnection
     from litestar.utils.signature import ParsedSignature
@@ -15,8 +18,12 @@ __all__ = ("SignatureModel",)
 
 
 class ErrorMessage(TypedDict):
-    key: str
+    # key may not be set in some cases, like when a query param is set but
+    # doesn't match the required length during `attrs` validation
+    # in this case, we don't show a key at all as it will be empty
+    key: NotRequired[str]
     message: str
+    source: NotRequired[Literal["cookie", "body", "header", "query"]]
 
 
 class SignatureModel(ABC):
@@ -40,12 +47,54 @@ class SignatureModel(ABC):
         """
         method = connection.method if hasattr(connection, "method") else ScopeType.WEBSOCKET  # pyright: ignore
         if client_errors := [
-            err_message for err_message in messages if err_message["key"] not in cls.dependency_name_set
+            err_message
+            for err_message in messages
+            if ("key" in err_message and err_message["key"] not in cls.dependency_name_set) or "key" not in err_message
         ]:
             return ValidationException(detail=f"Validation failed for {method} {connection.url}", extra=client_errors)
         return InternalServerException(
             detail=f"A dependency failed validation for {method} {connection.url}", extra=messages
         )
+
+    @classmethod
+    def _build_error_message(cls, keys: Sequence[str], exc_msg: str, connection: ASGIConnection) -> ErrorMessage:
+        """Build an error message.
+
+        Args:
+            keys: A list of keys.
+            exc_msg: A message.
+            connection: An ASGI connection instance.
+
+        Returns:
+            An ErrorMessage
+        """
+
+        message: ErrorMessage = {"message": exc_msg}
+
+        if len(keys) > 1:
+            key_start = 0
+
+            if keys[0] == "data":
+                key_start = 1
+                message["source"] = "body"
+
+            message["key"] = ".".join(keys[key_start:])
+        elif keys:
+            key = keys[0]
+            message["key"] = key
+
+            if key in connection.query_params:
+                message["source"] = "query"
+            elif key in cls.fields and isinstance(cls.fields[key].kwarg_model, ParameterKwarg):
+                message["source"] = (
+                    "cookie"
+                    if cast(ParameterKwarg, cls.fields[key].kwarg_model).cookie
+                    else "header"
+                    if cast(ParameterKwarg, cls.fields[key].kwarg_model).header
+                    else "query"
+                )
+
+        return message
 
     @classmethod
     @abstractmethod

--- a/litestar/_signature/utils.py
+++ b/litestar/_signature/utils.py
@@ -147,9 +147,7 @@ def _validate_dependencies(
 
     for parameter in parsed_signature.parameters.values():
         if isinstance(parameter.default, DependencyKwarg) and parameter.name not in dependency_name_set:
-            if not parameter.parsed_type.is_optional and (
-                isinstance(parameter.default, DependencyKwarg) and parameter.default.default is Empty
-            ):
+            if not parameter.parsed_type.is_optional and parameter.default.default is Empty:
                 raise ImproperlyConfiguredException(
                     f"Explicit dependency '{parameter.name}' for '{fn_name}' has no default value, "
                     f"or provided dependency."

--- a/tests/unit/test_signature/test_parsing.py
+++ b/tests/unit/test_signature/test_parsing.py
@@ -325,4 +325,5 @@ def test_validation_error_exception_key(preferred_validation_backend: Literal["a
     with pytest.raises(ValidationException) as exc_info:
         model.parse_values_from_connection_kwargs(connection=RequestFactory().get(), b={"a": {}})
 
+    assert isinstance(exc_info.value.extra, list)
     assert exc_info.value.extra[0]["key"] == "a.b"


### PR DESCRIPTION
### Pull Request Checklist

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description

This PR updates the keys in validation error responses to include the full path to the field with the issue. This gives the developer a better sense of where the failure happened.

It also adds an optional `source` key that designates whether the value is from the body, a cookie, a header, or a query param.

#### For example:

With the following controller

```python
from litestar import Controller
from pydantic import BaseModel, ValidationError


class Child(BaseModel):
    my_value: str


class Parent(BaseModel):
    child: Child


class SomeController(Controller):
    @post('/some-route')
    def some_route(
        self,
        data: Parent,
        int_param: int,
        int_header: int = Parameter(header="X-SOME-INT"),
        int_cookie: int = Parameter(cookie="int-cookie"), 
    ) -> Parent:
        return data
```

and the request

```bash
http POST localhost:8000/some-route child:='{}' int_param==asdf X-SOME-INT=asdf Cookie:int-cookie=asdf
```

the response would have previously been

```json
{
  "status_code": 400,
  "detail": "Validation failed for POST http://localhost:8000/some-route",
  "extra": [
    {"key": "int_param", "message": "value is not a valid integer"},
    {"key": "int_header", "message": "value is not a valid integer"},
    {"key": "int_cookie", "message": "value is not a valid integer"},
    {"key": "my_value", "message": "value is not a valid integer"}
  ]
}
```

This change will result in the following:

```json
{
  "status_code": 400,
  "detail": "Validation failed for POST http://localhost:8000/some-route",
  "extra": [
    {"key": "child.my_value", "message": "value is not a valid integer", "source": "body"},
    {"key": "int_param", "message": "value is not a valid integer", "source": "query"},
    {"key": "int_header", "message": "value is not a valid integer", "source": "header"},
    {"key": "int_cookie", "message": "value is not a valid integer", "source": "cookie"},
  ]
}
```

### Close Issue(s)

Fixes #1736
