### PR TITLE
Docs: Fix "about" section links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,12 +185,12 @@ html_theme_options = {
         "About": {
             "Litestar Organization": {
                 "description": "Details about the Litestar organization",
-                "link": "about/organization",
+                "link": "https://litestar.dev/about/organization",
                 "icon": "org",
             },
             "Releases": {
                 "description": "Details about the Litestar release process",
-                "link": "about/litestar-releases",
+                "link": "https://litestar.dev/about/litestar-releases",
                 "icon": "releases",
             },
         },


### PR DESCRIPTION
Fix links in the "About" menu, which currently lead to non-existing pages