### PR TITLE
SQLAlchemyDTO: Improved handling of `hybrid_property`.

### DIFF
--- a/litestar/contrib/msgspec.py
+++ b/litestar/contrib/msgspec.py
@@ -51,6 +51,7 @@ class MsgspecDTO(AbstractDTOFactory[T], Generic[T]):
                 default_factory=default_or_empty(msgspec_field.default_factory),
                 dto_field=dto_field,
                 unique_model_name=get_fully_qualified_class_name(model_type),
+                dto_for=None,
             )
 
             yield field_def

--- a/litestar/contrib/pydantic.py
+++ b/litestar/contrib/pydantic.py
@@ -55,6 +55,7 @@ class PydanticDTO(AbstractDTOFactory[T], Generic[T]):
                 default_factory=model_field.default_factory or Empty,
                 dto_field=dto_field,
                 unique_model_name=get_fully_qualified_class_name(model_type),
+                dto_for=None,
             )
 
             yield field_def

--- a/litestar/contrib/sqlalchemy/dto.py
+++ b/litestar/contrib/sqlalchemy/dto.py
@@ -96,6 +96,7 @@ class SQLAlchemyDTO(AbstractDTOFactory[T], Generic[T]):
                 default_factory=default_factory,
                 dto_field=elem.info.get(DTO_FIELD_META_KEY),
                 unique_model_name=model_name,
+                dto_for=None,
             )
         ]
 
@@ -125,6 +126,7 @@ class SQLAlchemyDTO(AbstractDTOFactory[T], Generic[T]):
                 default_factory=None,
                 dto_field=orm_descriptor.info.get(DTO_FIELD_META_KEY, DTOField(mark=Mark.READ_ONLY)),
                 unique_model_name=model_name,
+                dto_for=None,
             )
         ]
 
@@ -151,6 +153,7 @@ class SQLAlchemyDTO(AbstractDTOFactory[T], Generic[T]):
                 default_factory=None,
                 dto_field=orm_descriptor.info.get(DTO_FIELD_META_KEY, DTOField(mark=Mark.READ_ONLY)),
                 unique_model_name=model_name,
+                dto_for="return",
             )
         ]
 
@@ -164,6 +167,7 @@ class SQLAlchemyDTO(AbstractDTOFactory[T], Generic[T]):
                     default_factory=None,
                     dto_field=orm_descriptor.info.get(DTO_FIELD_META_KEY, DTOField(mark=Mark.WRITE_ONLY)),
                     unique_model_name=model_name,
+                    dto_for="data",
                 )
             )
 

--- a/litestar/dto/factory/_backends/abc.py
+++ b/litestar/dto/factory/_backends/abc.py
@@ -26,6 +26,7 @@ from .utils import (
     RenameStrategies,
     build_annotation_for_backend,
     should_exclude_field,
+    should_ignore_field,
     transfer_data,
 )
 
@@ -158,6 +159,9 @@ class AbstractDTOBackend(ABC, Generic[BackendT]):
         """
         defined_fields = []
         for field_definition in self.context.field_definition_generator(model_type):
+            if should_ignore_field(field_definition, self.context.dto_for):
+                continue
+
             try:
                 transfer_type = self._create_transfer_type(
                     field_definition.parsed_type,

--- a/litestar/dto/factory/_backends/types.py
+++ b/litestar/dto/factory/_backends/types.py
@@ -127,6 +127,7 @@ class TransferFieldDefinition(FieldDefinition):
             dto_field=field_definition.dto_field,
             is_partial=is_partial,
             is_excluded=is_excluded,
+            dto_for=field_definition.dto_for,
         )
 
 

--- a/litestar/dto/factory/_backends/utils.py
+++ b/litestar/dto/factory/_backends/utils.py
@@ -73,8 +73,9 @@ def should_exclude_field(field_definition: FieldDefinition, exclude: AbstractSet
     dto_field = field_definition.dto_field
     excluded = field_name in exclude
     private = dto_field and dto_field.mark is Mark.PRIVATE
-    read_only_for_write = dto_for == "data" and dto_field and dto_field.mark is Mark.READ_ONLY
-    return bool(excluded or private or read_only_for_write)
+    read_only_for_data = dto_for == "data" and dto_field and dto_field.mark is Mark.READ_ONLY
+    write_only_for_return = dto_for == "return" and dto_field and dto_field.mark is Mark.WRITE_ONLY
+    return bool(excluded or private or read_only_for_data or write_only_for_return)
 
 
 class RenameStrategies:

--- a/litestar/dto/factory/_backends/utils.py
+++ b/litestar/dto/factory/_backends/utils.py
@@ -33,6 +33,7 @@ __all__ = (
     "build_annotation_for_backend",
     "create_transfer_model_type_annotation",
     "should_exclude_field",
+    "should_ignore_field",
     "transfer_data",
 )
 
@@ -76,6 +77,21 @@ def should_exclude_field(field_definition: FieldDefinition, exclude: AbstractSet
     read_only_for_data = dto_for == "data" and dto_field and dto_field.mark is Mark.READ_ONLY
     write_only_for_return = dto_for == "return" and dto_field and dto_field.mark is Mark.WRITE_ONLY
     return bool(excluded or private or read_only_for_data or write_only_for_return)
+
+
+def should_ignore_field(field_definition: FieldDefinition, dto_for: ForType) -> bool:
+    """Returns ``True`` where a field should be ignored.
+
+    An ignored field is different to an excluded one in that we do not produce a
+    ``TransferFieldDefinition`` for it at all.
+
+    This allows ``AbstractDTOFactory`` concrete types to generate multiple field definitions
+    for the same field name, each for a different transfer direction.
+
+    One example of this is the :class:`sqlalchemy.ext.hybrid.hybrid_property` which, might have
+    a different type accepted by its setter method, than is returned by its getter method.
+    """
+    return field_definition.dto_for is not None and field_definition.dto_for != dto_for
 
 
 class RenameStrategies:

--- a/litestar/dto/factory/field.py
+++ b/litestar/dto/factory/field.py
@@ -20,6 +20,8 @@ class Mark(str, Enum):
 
     READ_ONLY = "read-only"
     """To mark a field that can be read, but not updated by clients."""
+    WRITE_ONLY = "write-only"
+    """To mark a field that can be written to, but not read by clients."""
     PRIVATE = "private"
     """To mark a field that can neither be read or updated by clients."""
 

--- a/litestar/dto/factory/stdlib/dataclass.py
+++ b/litestar/dto/factory/stdlib/dataclass.py
@@ -47,6 +47,7 @@ class DataclassDTO(AbstractDTOFactory[T], Generic[T]):
                 default_factory=default_factory,
                 dto_field=dc_field.metadata.get(DTO_FIELD_META_KEY),
                 unique_model_name=get_fully_qualified_class_name(model_type),
+                dto_for=None,
             )
 
             yield field_def

--- a/litestar/dto/factory/types.py
+++ b/litestar/dto/factory/types.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
 
     from typing_extensions import TypeAlias
 
+    from litestar.dto.types import ForType
+
     from .field import DTOField
 
 __all__ = ("FieldDefinition", "RenameStrategy")
@@ -19,7 +21,12 @@ __all__ = ("FieldDefinition", "RenameStrategy")
 class FieldDefinition(ParsedParameter):
     """A model field representation for purposes of generating a DTO backend model type."""
 
-    __slots__ = ("unique_model_name", "default_factory", "dto_field")
+    __slots__ = (
+        "default_factory",
+        "dto_field",
+        "dto_for",
+        "unique_model_name",
+    )
 
     unique_model_name: str
     """Unique identifier of model that owns the field."""
@@ -27,6 +34,19 @@ class FieldDefinition(ParsedParameter):
     """Default factory of the field."""
     dto_field: DTOField | None
     """DTO field configuration."""
+    dto_for: ForType | None
+    """Direction of transfer for field.
+
+    Specify if the field definition should only be added to models for only the request (``"data"``) or response
+    (``"return"``). If there should be no such distinction, set to ``None``.
+
+    This is to support special cases where the type to set an attribute may be different to the type received when
+    retrieving its value. For example, a :class:`sqlalchemy.ext.hybrid.hybrid_property` may be set with a ``str`` but
+    retrieved as some other type.
+
+    The difference between this, and marking a field as read-only or private, is that it cannot be overridden by the end
+    user.
+    """
 
     def unique_name(self) -> str:
         return f"{self.unique_model_name}.{self.name}"

--- a/tests/contrib/conftest.py
+++ b/tests/contrib/conftest.py
@@ -29,6 +29,7 @@ def expected_field_defs(int_factory: Callable[[], int]) -> list[FieldDefinition]
             unique_model_name=ANY,
             default_factory=Empty,
             dto_field=None,
+            dto_for=None,
         ),
         FieldDefinition(
             name="b",
@@ -37,6 +38,7 @@ def expected_field_defs(int_factory: Callable[[], int]) -> list[FieldDefinition]
             unique_model_name=ANY,
             default_factory=Empty,
             dto_field=DTOField(mark="read-only"),
+            dto_for=None,
         ),
         FieldDefinition(
             name="c",
@@ -45,6 +47,7 @@ def expected_field_defs(int_factory: Callable[[], int]) -> list[FieldDefinition]
             unique_model_name=ANY,
             default_factory=Empty,
             dto_field=None,
+            dto_for=None,
         ),
         FieldDefinition(
             name="d",
@@ -53,6 +56,7 @@ def expected_field_defs(int_factory: Callable[[], int]) -> list[FieldDefinition]
             unique_model_name=ANY,
             default_factory=Empty,
             dto_field=None,
+            dto_for=None,
         ),
         FieldDefinition(
             name="e",
@@ -61,5 +65,6 @@ def expected_field_defs(int_factory: Callable[[], int]) -> list[FieldDefinition]
             unique_model_name=ANY,
             default_factory=int_factory,
             dto_field=None,
+            dto_for=None,
         ),
     ]

--- a/tests/contrib/sqlalchemy/test_dto_integration.py
+++ b/tests/contrib/sqlalchemy/test_dto_integration.py
@@ -310,7 +310,6 @@ class Circle(Base):
 
     @radius.inplace.setter
     def _radius_setter(self, value: float) -> None:
-        # for example only
         self.diameter = value * 2
 
 dto = SQLAlchemyDTO[Circle]

--- a/tests/dto/factory/backends/test_backends.py
+++ b/tests/dto/factory/backends/test_backends.py
@@ -194,6 +194,7 @@ def test_backend_model_name_uniqueness(backend_type: type[AbstractDTOBackend], b
             transfer_type=transfer_type,
             is_partial=False,
             is_excluded=False,
+            dto_for=None,
         ),
     )
     for i in range(100):

--- a/tests/dto/factory/test_stdlib.py
+++ b/tests/dto/factory/test_stdlib.py
@@ -37,6 +37,7 @@ def test_dataclass_field_definitions(dto_type: type[DataclassDTO[Model]]) -> Non
             default_factory=None,
             dto_field=None,
             unique_model_name=fqdn,
+            dto_for=None,
         ),
         FieldDefinition(
             name="b",
@@ -45,6 +46,7 @@ def test_dataclass_field_definitions(dto_type: type[DataclassDTO[Model]]) -> Non
             default_factory=None,
             dto_field=None,
             unique_model_name=fqdn,
+            dto_for=None,
         ),
         FieldDefinition(
             name="c",
@@ -53,6 +55,7 @@ def test_dataclass_field_definitions(dto_type: type[DataclassDTO[Model]]) -> Non
             default_factory=list,
             dto_field=None,
             unique_model_name=fqdn,
+            dto_for=None,
         ),
     ]
 
@@ -67,6 +70,7 @@ def test_dataclass_field_definitions_38(dto_type: type[DataclassDTO[Model]]) -> 
             default_factory=None,
             dto_field=None,
             unique_model_name=fqdn,
+            dto_for=None,
         ),
         FieldDefinition(
             name="b",
@@ -75,6 +79,7 @@ def test_dataclass_field_definitions_38(dto_type: type[DataclassDTO[Model]]) -> 
             default_factory=None,
             dto_field=None,
             unique_model_name=fqdn,
+            dto_for=None,
         ),
         FieldDefinition(
             name="c",
@@ -83,6 +88,7 @@ def test_dataclass_field_definitions_38(dto_type: type[DataclassDTO[Model]]) -> 
             default_factory=list,
             unique_model_name=fqdn,
             dto_field=None,
+            dto_for=None,
         ),
     ]
 


### PR DESCRIPTION
In addition to the read-only `FieldDefinition` generated for the getter method of the hybrid property, if a setter method is defined an additional write-only `FieldDefinition` is generated that is typed to the argument of the setter callable.

Fixes issue where expression method names were being added to the DTO fields as field types (closes #1769).

Adds the `Mark.WRITE_ONLY` field mark for write-only fields.

Adds `FieldDefinition.dto_for`. This property allows the field definitions to declare whether they should be used for inbound or outbound transfer, and is intended to support cases where inbound data transfer may accept a different type than is delivered
by outbound data transfer.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
