### PR TITLE
feat: create JSON check constraint for Oracle dialect.

### DIFF
--- a/tests/contrib/sqlalchemy/repository/oracledb/test_sqlalchemy_oracledb_json.py
+++ b/tests/contrib/sqlalchemy/repository/oracledb/test_sqlalchemy_oracledb_json.py
@@ -7,6 +7,7 @@ import sys
 import pytest
 from sqlalchemy import Engine, NullPool, create_engine
 from sqlalchemy.dialects import oracle
+from sqlalchemy.schema import CreateTable
 
 from tests.contrib.sqlalchemy.models_uuid import (
     UUIDEventLog,
@@ -47,7 +48,9 @@ def fx_engine(docker_ip: str) -> Engine:
     )
 
 
-@pytest.mark.xfail
 def test_json_constraint_generation(engine: Engine) -> None:
-    _ddl = UUIDEventLog.__table__.compile(engine, dialect=oracle.dialect())  # type: ignore
-    assert "BLOB" in str(_ddl)
+    ddl = str(CreateTable(UUIDEventLog.__table__).compile(engine, dialect=oracle.dialect()))  # type: ignore
+    assert "BLOB" in ddl.upper()
+    assert "JSON" in ddl.upper()
+    with engine.begin() as conn:
+        UUIDEventLog.metadata.create_all(conn)


### PR DESCRIPTION
This change is an Oracle specific enhancement that ensures a JSON check constraint is created when creating a JSON column.

Co-authored-by: Alc-Alc <45509143+Alc-Alc@users.noreply.github.com>

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
