### PR TITLE
DTO handling for handlers that return Response.

### DIFF
--- a/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_init_plugin.py
+++ b/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_init_plugin.py
@@ -57,7 +57,7 @@ async def get_todo_list(done: Optional[bool], session: AsyncSession) -> List[Tod
 
 @get("/")
 async def get_list(transaction: AsyncSession, done: Optional[bool] = None) -> List[TodoItem]:
-    return get_todo_list(done, transaction)
+    return await get_todo_list(done, transaction)
 
 
 @post("/")

--- a/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_plugin.py
+++ b/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_plugin.py
@@ -53,7 +53,7 @@ async def get_todo_list(done: Optional[bool], session: AsyncSession) -> List[Tod
 
 @get("/")
 async def get_list(transaction: AsyncSession, done: Optional[bool] = None) -> List[TodoItem]:
-    return get_todo_list(done, transaction)
+    return await get_todo_list(done, transaction)
 
 
 @post("/")

--- a/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_serialization_plugin.py
+++ b/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_serialization_plugin.py
@@ -72,7 +72,7 @@ async def get_todo_list(done: Optional[bool], session: AsyncSession) -> List[Tod
 
 @get("/")
 async def get_list(transaction: AsyncSession, done: Optional[bool] = None) -> List[TodoItem]:
-    return get_todo_list(done, transaction)
+    return await get_todo_list(done, transaction)
 
 
 @post("/")
@@ -94,4 +94,5 @@ app = Litestar(
     dependencies={"transaction": provide_transaction},
     lifespan=[db_connection],
     plugins=[SQLAlchemySerializationPlugin()],
+    debug=True,
 )

--- a/litestar/contrib/msgspec.py
+++ b/litestar/contrib/msgspec.py
@@ -40,9 +40,10 @@ class MsgspecDTO(AbstractDTOFactory[T], Generic[T]):
         for key, parsed_type in get_model_type_hints(model_type).items():
             msgspec_field = msgspec_fields[key]
 
-            dto_field: DTOField | None = None
             if isinstance(msgspec_field.type, inspect.Metadata):
-                dto_field = (msgspec_field.type.extra or {}).get(DTO_FIELD_META_KEY)
+                dto_field = (msgspec_field.type.extra or {}).get(DTO_FIELD_META_KEY, DTOField())
+            else:
+                dto_field = DTOField()
 
             field_def = FieldDefinition(
                 name=key,

--- a/litestar/contrib/pydantic.py
+++ b/litestar/contrib/pydantic.py
@@ -36,7 +36,7 @@ class PydanticDTO(AbstractDTOFactory[T], Generic[T]):
         for key, model_field in model_type.__fields__.items():
             parsed_type = model_parsed_types[key]
             model_field = model_type.__fields__[key]
-            dto_field: DTOField | None = model_field.field_info.extra.get(DTO_FIELD_META_KEY)
+            dto_field = model_field.field_info.extra.get(DTO_FIELD_META_KEY, DTOField())
 
             def determine_default(_parsed_type: ParsedType, _model_field: ModelField) -> Any:
                 if (

--- a/litestar/contrib/sqlalchemy/dto.py
+++ b/litestar/contrib/sqlalchemy/dto.py
@@ -94,7 +94,7 @@ class SQLAlchemyDTO(AbstractDTOFactory[T], Generic[T]):
                 default=default,
                 parsed_type=parsed_type,
                 default_factory=default_factory,
-                dto_field=elem.info.get(DTO_FIELD_META_KEY),
+                dto_field=elem.info.get(DTO_FIELD_META_KEY, DTOField()),
                 unique_model_name=model_name,
                 dto_for=None,
             )

--- a/litestar/dto/factory/_backends/abc.py
+++ b/litestar/dto/factory/_backends/abc.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Final, Generic, TypeVar
 
 from litestar._openapi.schema_generation import create_schema
 from litestar._signature.field import SignatureField
-from litestar.dto.factory import DTOData
+from litestar.dto.factory import DTOData, Mark
 from litestar.utils.helpers import get_fully_qualified_class_name
 
 from .types import (
@@ -161,6 +161,13 @@ class AbstractDTOBackend(ABC, Generic[BackendT]):
         for field_definition in self.context.field_definition_generator(model_type):
             if should_ignore_field(field_definition, self.context.dto_for):
                 continue
+
+            if (
+                self.context.config.underscore_fields_private
+                and field_definition.name.startswith("_")
+                and field_definition.dto_field.mark is None
+            ):
+                field_definition.dto_field.mark = Mark.PRIVATE
 
             try:
                 transfer_type = self._create_transfer_type(

--- a/litestar/dto/factory/_backends/msgspec/utils.py
+++ b/litestar/dto/factory/_backends/msgspec/utils.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, NewType, TypeVar, Union
 
 from msgspec import UNSET, Struct, UnsetType, defstruct, field
 
-from litestar.dto.factory._backends.utils import create_transfer_model_type_annotation
+from litestar.dto.factory._backends.utils.transfer import create_transfer_model_type_annotation
 from litestar.types import Empty
 
 if TYPE_CHECKING:

--- a/litestar/dto/factory/_backends/pydantic/utils.py
+++ b/litestar/dto/factory/_backends/pydantic/utils.py
@@ -6,7 +6,7 @@ from msgspec import UNSET, UnsetType
 from pydantic import BaseModel, create_model
 from pydantic.fields import FieldInfo
 
-from litestar.dto.factory._backends.utils import create_transfer_model_type_annotation
+from litestar.dto.factory._backends.utils.transfer import create_transfer_model_type_annotation
 from litestar.types import Empty
 
 if TYPE_CHECKING:

--- a/litestar/dto/factory/_backends/utils/predicates.py
+++ b/litestar/dto/factory/_backends/utils/predicates.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from litestar.dto.factory import Mark
+
+if TYPE_CHECKING:
+    from typing import AbstractSet
+
+    from litestar.dto.factory._backends.types import TransferFieldDefinition
+    from litestar.dto.factory.data_structures import FieldDefinition
+    from litestar.dto.types import ForType
+
+__all__ = (
+    "should_exclude_field",
+    "should_ignore_field",
+    "should_mark_private",
+    "should_skip_transfer",
+)
+
+
+def should_exclude_field(field_definition: FieldDefinition, exclude: AbstractSet[str], dto_for: ForType) -> bool:
+    """Returns ``True`` where a field should be excluded from data transfer.
+
+    Args:
+        field_definition: defined DTO field
+        exclude: names of fields to exclude
+        dto_for: indicates whether the DTO is for the request body or response.
+
+    Returns:
+        ``True`` if the field should not be included in any data transfer.
+    """
+    field_name = field_definition.name
+    dto_field = field_definition.dto_field
+    excluded = field_name in exclude
+    private = dto_field and dto_field.mark is Mark.PRIVATE
+    read_only_for_data = dto_for == "data" and dto_field and dto_field.mark is Mark.READ_ONLY
+    write_only_for_return = dto_for == "return" and dto_field and dto_field.mark is Mark.WRITE_ONLY
+    return bool(excluded or private or read_only_for_data or write_only_for_return)
+
+
+def should_ignore_field(field_definition: FieldDefinition, dto_for: ForType) -> bool:
+    """Returns ``True`` where a field should be ignored.
+
+    An ignored field is different to an excluded one in that we do not produce a
+    ``TransferFieldDefinition`` for it at all.
+
+    This allows ``AbstractDTOFactory`` concrete types to generate multiple field definitions
+    for the same field name, each for a different transfer direction.
+
+    One example of this is the :class:`sqlalchemy.ext.hybrid.hybrid_property` which, might have
+    a different type accepted by its setter method, than is returned by its getter method.
+    """
+    return field_definition.dto_for is not None and field_definition.dto_for != dto_for
+
+
+def should_mark_private(field_definition: FieldDefinition, underscore_fields_private: bool) -> bool:
+    """Returns ``True`` where a field should be marked as private.
+
+    Args:
+        field_definition: defined DTO field
+        underscore_fields_private: whether fields prefixed with an underscore should be marked as private.
+    """
+    return (
+        underscore_fields_private and field_definition.dto_field.mark is None and field_definition.name.startswith("_")
+    )
+
+
+def should_skip_transfer(
+    dto_for: ForType,
+    field_definition: TransferFieldDefinition,
+    source_has_value: bool,
+) -> bool:
+    """Returns ``True`` where a field should be excluded from data transfer.
+
+    We should skip transfer when:
+    - the field is excluded and the DTO is for the return data.
+    - the DTO is for request data, and the field is not in the source instance.
+
+    Args:
+        dto_for: indicates whether the DTO is for the request body or response.
+        field_definition: model field definition.
+        source_has_value: indicates whether the source instance has a value for the field.
+    """
+    return (dto_for == "return" and field_definition.is_excluded) or (dto_for == "data" and not source_has_value)

--- a/litestar/dto/factory/_backends/utils/predicates.py
+++ b/litestar/dto/factory/_backends/utils/predicates.py
@@ -57,6 +57,11 @@ def should_ignore_field(field_definition: FieldDefinition, dto_for: ForType) -> 
 def should_mark_private(field_definition: FieldDefinition, underscore_fields_private: bool) -> bool:
     """Returns ``True`` where a field should be marked as private.
 
+    Fields should be marked as private when:
+    - the ``underscore_fields_private`` flag is set.
+    - the field is not already marked.
+    - the field name is prefixed with an underscore
+
     Args:
         field_definition: defined DTO field
         underscore_fields_private: whether fields prefixed with an underscore should be marked as private.

--- a/litestar/dto/factory/_backends/utils/renaming.py
+++ b/litestar/dto/factory/_backends/utils/renaming.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from litestar.dto.factory import DTOConfig
+    from litestar.dto.factory.data_structures import FieldDefinition
+    from litestar.dto.factory.types import RenameStrategy
+
+
+__all__ = ("determine_serialization_name",)
+
+
+class RenameStrategies:
+    """Useful renaming strategies than be used with :class:`DTOConfig`"""
+
+    def __init__(self, renaming_strategy: RenameStrategy) -> None:
+        self.renaming_strategy = renaming_strategy
+
+    def __call__(self, field_name: str) -> str:
+        if not isinstance(self.renaming_strategy, str):
+            return self.renaming_strategy(field_name)
+
+        return cast(str, getattr(self, self.renaming_strategy)(field_name))
+
+    @staticmethod
+    def upper(field_name: str) -> str:
+        return field_name.upper()
+
+    @staticmethod
+    def lower(field_name: str) -> str:
+        return field_name.lower()
+
+    @staticmethod
+    def camel(field_name: str) -> str:
+        return RenameStrategies._camelize(field_name)
+
+    @staticmethod
+    def pascal(field_name: str) -> str:
+        return RenameStrategies._camelize(field_name, capitalize_first_letter=True)
+
+    @staticmethod
+    def _camelize(string: str, capitalize_first_letter: bool = False) -> str:
+        """Convert a string to camel case.
+
+        Args:
+            string (str): The string to convert
+            capitalize_first_letter (bool): Default is False, a True value will convert to PascalCase
+        Returns:
+            str: The string converted to camel case or Pascal case
+        """
+        return "".join(
+            word if index == 0 and not capitalize_first_letter else word.capitalize()
+            for index, word in enumerate(string.split("_"))
+        )
+
+
+def determine_serialization_name(config: DTOConfig, field_definition: FieldDefinition) -> str:
+    """Determine the serialization name strategy to use.
+
+    Returns:
+        RenameStrategies: The serialization name strategy to use.
+    """
+    if rename := config.rename_fields.get(field_definition.name):
+        return rename
+    if config.rename_strategy:
+        return RenameStrategies(config.rename_strategy)(field_definition.name)
+    return field_definition.name

--- a/litestar/dto/factory/_backends/utils/transfer.py
+++ b/litestar/dto/factory/_backends/utils/transfer.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Collection, Mapping, TypeVar, cast
+from typing import TYPE_CHECKING, Mapping, TypeVar
 
 from msgspec import UNSET
-from typing_extensions import get_origin
 
-from litestar.dto.factory import Mark
-from litestar.types.protocols import InstantiableCollection
-
-from .types import (
+from litestar.dto.factory._backends.types import (
     CollectionType,
     CompositeType,
+    FieldDefinitionsType,
     MappingType,
     NestedFieldInfo,
     SimpleType,
@@ -18,125 +15,19 @@ from .types import (
     TupleType,
     UnionType,
 )
+from litestar.types.protocols import InstantiableCollection
+
+from .predicates import should_skip_transfer
 
 if TYPE_CHECKING:
-    from typing import AbstractSet, Any, Iterable
+    from typing import Any, Collection
 
-    from litestar.dto.factory.data_structures import FieldDefinition
-    from litestar.dto.factory.types import RenameStrategy
     from litestar.dto.types import ForType
     from litestar.typing import ParsedType
 
-    from .types import FieldDefinitionsType, TransferFieldDefinition
-
-__all__ = (
-    "RenameStrategies",
-    "build_annotation_for_backend",
-    "create_transfer_model_type_annotation",
-    "should_exclude_field",
-    "should_ignore_field",
-    "transfer_data",
-)
-
 T = TypeVar("T")
 
-
-def build_annotation_for_backend(annotation: Any, model: type[T]) -> type[T] | type[Iterable[T]]:
-    """A helper to re-build a generic outer type with new inner type.
-
-    Args:
-        annotation: The original annotation on the handler signature
-        model: The data container type
-
-    Returns:
-        Annotation with new inner type if applicable.
-    """
-    origin = get_origin(annotation)
-    if not origin:
-        return model
-    try:
-        return origin[model]  # type:ignore[no-any-return]
-    except TypeError:  # pragma: no cover
-        return annotation.copy_with((model,))  # type:ignore[no-any-return]
-
-
-def should_exclude_field(field_definition: FieldDefinition, exclude: AbstractSet[str], dto_for: ForType) -> bool:
-    """Returns ``True`` where a field should be excluded from data transfer.
-
-    Args:
-        field_definition: defined DTO field
-        exclude: names of fields to exclude
-        dto_for: indicates whether the DTO is for the request body or response.
-
-    Returns:
-        ``True`` if the field should not be included in any data transfer.
-    """
-    field_name = field_definition.name
-    dto_field = field_definition.dto_field
-    excluded = field_name in exclude
-    private = dto_field and dto_field.mark is Mark.PRIVATE
-    read_only_for_data = dto_for == "data" and dto_field and dto_field.mark is Mark.READ_ONLY
-    write_only_for_return = dto_for == "return" and dto_field and dto_field.mark is Mark.WRITE_ONLY
-    return bool(excluded or private or read_only_for_data or write_only_for_return)
-
-
-def should_ignore_field(field_definition: FieldDefinition, dto_for: ForType) -> bool:
-    """Returns ``True`` where a field should be ignored.
-
-    An ignored field is different to an excluded one in that we do not produce a
-    ``TransferFieldDefinition`` for it at all.
-
-    This allows ``AbstractDTOFactory`` concrete types to generate multiple field definitions
-    for the same field name, each for a different transfer direction.
-
-    One example of this is the :class:`sqlalchemy.ext.hybrid.hybrid_property` which, might have
-    a different type accepted by its setter method, than is returned by its getter method.
-    """
-    return field_definition.dto_for is not None and field_definition.dto_for != dto_for
-
-
-class RenameStrategies:
-    """Useful renaming strategies than be used with :class:`DTOConfig`"""
-
-    def __init__(self, renaming_strategy: RenameStrategy) -> None:
-        self.renaming_strategy = renaming_strategy
-
-    def __call__(self, field_name: str) -> str:
-        if not isinstance(self.renaming_strategy, str):
-            return self.renaming_strategy(field_name)
-
-        return cast(str, getattr(self, self.renaming_strategy)(field_name))
-
-    @staticmethod
-    def upper(field_name: str) -> str:
-        return field_name.upper()
-
-    @staticmethod
-    def lower(field_name: str) -> str:
-        return field_name.lower()
-
-    @staticmethod
-    def camel(field_name: str) -> str:
-        return RenameStrategies._camelize(field_name)
-
-    @staticmethod
-    def pascal(field_name: str) -> str:
-        return RenameStrategies._camelize(field_name, capitalize_first_letter=True)
-
-    @staticmethod
-    def _camelize(string: str, capitalize_first_letter: bool = False) -> str:
-        """Convert a string to camel case.
-
-        Args:
-            string (str): The string to convert
-            capitalize_first_letter (bool): Default is False, a True value will convert to PascalCase
-        Returns:
-            str: The string converted to camel case or Pascal case
-        """
-        return "".join(
-            word if index == 0 and not capitalize_first_letter else word.capitalize()
-            for index, word in enumerate(string.split("_"))
-        )
+__all__ = ("transfer_data",)
 
 
 def transfer_data(
@@ -223,25 +114,6 @@ def transfer_instance_data(
             source_value, transfer_type, dto_for, nested_as_dict=destination_type is dict
         )
     return destination_type(**unstructured_data)
-
-
-def should_skip_transfer(
-    dto_for: ForType,
-    field_definition: TransferFieldDefinition,
-    source_has_value: bool,
-) -> bool:
-    """Returns ``True`` where a field should be excluded from data transfer.
-
-    We should skip transfer when:
-    - the field is excluded and the DTO is for the return data.
-    - the DTO is for request data, and the field is not in the source instance.
-
-    Args:
-        dto_for: indicates whether the DTO is for the request body or response.
-        field_definition: model field definition.
-        source_has_value: indicates whether the source instance has a value for the field.
-    """
-    return (dto_for == "return" and field_definition.is_excluded) or (dto_for == "data" and not source_has_value)
 
 
 def transfer_type_data(

--- a/litestar/dto/factory/_backends/utils/typing.py
+++ b/litestar/dto/factory/_backends/utils/typing.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, TypeVar
+
+from typing_extensions import get_origin
+
+T = TypeVar("T")
+
+__all__ = ("build_annotation_for_backend",)
+
+
+def build_annotation_for_backend(annotation: Any, model: type[T]) -> type[T] | type[Iterable[T]]:
+    """A helper to re-build a generic outer type with new inner type.
+
+    Args:
+        annotation: The original annotation on the handler signature
+        model: The data container type
+
+    Returns:
+        Annotation with new inner type if applicable.
+    """
+    origin = get_origin(annotation)
+    if not origin:
+        return model
+    try:
+        return origin[model]  # type:ignore[no-any-return]
+    except TypeError:  # pragma: no cover
+        return annotation.copy_with((model,))  # type:ignore[no-any-return]

--- a/litestar/dto/factory/config.py
+++ b/litestar/dto/factory/config.py
@@ -38,3 +38,5 @@ class DTOConfig:
     """The maximum depth of nested items allowed for data transfer."""
     partial: bool = False
     """Allow transfer of partial data."""
+    underscore_fields_private: bool = True
+    """Fields starting with an underscore are considered private and excluded from data transfer."""

--- a/litestar/dto/factory/data_structures.py
+++ b/litestar/dto/factory/data_structures.py
@@ -3,13 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generic, TypeVar
 
-from litestar.typing import ParsedType
 from litestar.utils.signature import ParsedParameter
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, ClassVar
-
-    from typing_extensions import Self
+    from typing import Any, Callable
 
     from litestar.dto.factory import DTOField
     from litestar.dto.factory._backends.abc import AbstractDTOBackend
@@ -23,14 +20,9 @@ class DTOData(Generic[T]):
 
     __slots__ = ("_backend", "_data_as_builtins")
 
-    parsed_type: ClassVar[ParsedType]
-
     def __init__(self, backend: AbstractDTOBackend, data_as_builtins: Any) -> None:
         self._backend = backend
         self._data_as_builtins = data_as_builtins
-
-    def __class_getitem__(cls, item: T) -> type[Self]:
-        return type(cls.__name__, (cls,), {"parsed_type": ParsedType(item)})
 
     def create_instance(self, **kwargs: Any) -> T:
         """Create an instance of the DTO validated data.

--- a/litestar/dto/factory/data_structures.py
+++ b/litestar/dto/factory/data_structures.py
@@ -84,7 +84,7 @@ class FieldDefinition(ParsedParameter):
     """Unique identifier of model that owns the field."""
     default_factory: Callable[[], Any] | None
     """Default factory of the field."""
-    dto_field: DTOField | None
+    dto_field: DTOField
     """DTO field configuration."""
     dto_for: ForType | None
     """Direction of transfer for field.

--- a/litestar/dto/factory/field.py
+++ b/litestar/dto/factory/field.py
@@ -30,7 +30,7 @@ class Mark(str, Enum):
 class DTOField:
     """For configuring DTO behavior on model fields."""
 
-    mark: Mark | Literal["read-only", "private"] | None = None
+    mark: Mark | Literal["read-only", "write-only", "private"] | None = None
     """Mark the field as read-only, or private."""
 
 

--- a/litestar/dto/factory/stdlib/dataclass.py
+++ b/litestar/dto/factory/stdlib/dataclass.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 
 from litestar.dto.factory.abc import AbstractDTOFactory
 from litestar.dto.factory.data_structures import FieldDefinition
-from litestar.dto.factory.field import DTO_FIELD_META_KEY
+from litestar.dto.factory.field import DTO_FIELD_META_KEY, DTOField
 from litestar.dto.factory.utils import get_model_type_hints
 from litestar.types.empty import Empty
 from litestar.utils.helpers import get_fully_qualified_class_name
@@ -45,7 +45,7 @@ class DataclassDTO(AbstractDTOFactory[T], Generic[T]):
                 parsed_type=parsed_type,
                 default=default,
                 default_factory=default_factory,
-                dto_field=dc_field.metadata.get(DTO_FIELD_META_KEY),
+                dto_field=dc_field.metadata.get(DTO_FIELD_META_KEY, DTOField()),
                 unique_model_name=get_fully_qualified_class_name(model_type),
                 dto_for=None,
             )

--- a/litestar/dto/interface.py
+++ b/litestar/dto/interface.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from litestar.openapi.spec import Reference
+    from litestar.response import Response
     from litestar.types import LitestarEncodableType
     from litestar.types.internal_types import AnyConnection
     from litestar.typing import ParsedType
@@ -76,7 +77,7 @@ class DTOInterface(Protocol):
         self.connection_context = connection_context
 
     @abstractmethod
-    def data_to_encodable_type(self, data: Any) -> bytes | LitestarEncodableType:
+    def data_to_encodable_type(self, data: Any) -> bytes | LitestarEncodableType | Response:
         """Encode data to a type supported by litestar serialization.
 
         Can return either bytes or a type that Litestar can return to bytes.

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -430,6 +430,7 @@ class BaseRouteHandler(Generic[T]):
                 fn=cast("AnyCallable", self.fn.value),
                 preferred_validation_backend=app.preferred_validation_backend,
                 parsed_signature=self.parsed_fn_signature,
+                has_data_dto=bool(self.resolve_dto()),
             )
 
     def _create_provider_signature_models(self, app: Litestar) -> None:
@@ -443,6 +444,7 @@ class BaseRouteHandler(Generic[T]):
                     parsed_signature=ParsedSignature.from_fn(
                         unwrap_partial(provider.dependency.value), self.resolve_signature_namespace()
                     ),
+                    has_data_dto=bool(self.resolve_dto()),
                 )
 
     def _handle_serialization_plugins(self, plugins: list[SerializationPluginProtocol]) -> None:

--- a/litestar/handlers/http_handlers/_utils.py
+++ b/litestar/handlers/http_handlers/_utils.py
@@ -4,7 +4,6 @@ from functools import lru_cache
 from inspect import isawaitable
 from typing import TYPE_CHECKING, Any, Sequence, cast
 
-from litestar.dto.interface import ConnectionContext
 from litestar.enums import HttpMethod
 from litestar.exceptions import ValidationException
 from litestar.status_codes import HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT
@@ -14,7 +13,6 @@ if TYPE_CHECKING:
     from litestar.background_tasks import BackgroundTask, BackgroundTasks
     from litestar.connection import Request
     from litestar.datastructures import Cookie, ResponseHeader
-    from litestar.dto.interface import DTOInterface
     from litestar.response import Response
     from litestar.response_containers import ResponseContainer
     from litestar.types import (
@@ -85,18 +83,9 @@ def create_data_handler(
 
         return response
 
-    async def handler(
-        data: Any,
-        return_dto: type[DTOInterface] | None,
-        request: Request[Any, Any, Any],
-        **kwargs: Any,
-    ) -> ASGIApp:
+    async def handler(data: Any, **kwargs: Any) -> ASGIApp:
         if isawaitable(data):
             data = await data
-
-        if return_dto:
-            ctx = ConnectionContext.from_connection(request)
-            data = return_dto(ctx).data_to_encodable_type(data)
 
         return await create_response(data=data)
 

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, AnyStr, Mapping, TypedDict, cast
 from litestar._layers.utils import narrow_response_cookies, narrow_response_headers
 from litestar.datastructures.cookie import Cookie
 from litestar.datastructures.response_header import ResponseHeader
+from litestar.dto.interface import ConnectionContext
 from litestar.enums import HttpMethod, MediaType
 from litestar.exceptions import (
     HTTPException,
@@ -465,8 +466,13 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
         Returns:
             A Response instance
         """
+        if return_dto_type := self.resolve_return_dto():
+            ctx = ConnectionContext.from_connection(request)
+            data = return_dto_type(ctx).data_to_encodable_type(data)
+
         response_handler = self.get_response_handler(is_response_type_data=isinstance(data, Response))
-        return await response_handler(app=app, data=data, request=request, return_dto=self.resolve_return_dto())  # type: ignore
+
+        return await response_handler(app=app, data=data, request=request)  # type: ignore
 
     def on_registration(self, app: Litestar) -> None:
         super().on_registration(app)

--- a/tests/contrib/conftest.py
+++ b/tests/contrib/conftest.py
@@ -28,7 +28,7 @@ def expected_field_defs(int_factory: Callable[[], int]) -> list[FieldDefinition]
             parsed_type=ParsedType(int),
             unique_model_name=ANY,
             default_factory=Empty,
-            dto_field=None,
+            dto_field=DTOField(),
             dto_for=None,
         ),
         FieldDefinition(
@@ -46,7 +46,7 @@ def expected_field_defs(int_factory: Callable[[], int]) -> list[FieldDefinition]
             parsed_type=ParsedType(int),
             unique_model_name=ANY,
             default_factory=Empty,
-            dto_field=None,
+            dto_field=DTOField(),
             dto_for=None,
         ),
         FieldDefinition(
@@ -55,7 +55,7 @@ def expected_field_defs(int_factory: Callable[[], int]) -> list[FieldDefinition]
             parsed_type=ParsedType(int),
             unique_model_name=ANY,
             default_factory=Empty,
-            dto_field=None,
+            dto_field=DTOField(),
             dto_for=None,
         ),
         FieldDefinition(
@@ -64,7 +64,7 @@ def expected_field_defs(int_factory: Callable[[], int]) -> list[FieldDefinition]
             parsed_type=ParsedType(int),
             unique_model_name=ANY,
             default_factory=int_factory,
-            dto_field=None,
+            dto_field=DTOField(),
             dto_for=None,
         ),
     ]

--- a/tests/contrib/sqlalchemy/test_dto_integration.py
+++ b/tests/contrib/sqlalchemy/test_dto_integration.py
@@ -10,7 +10,7 @@ from typing_extensions import Annotated
 from litestar import get, post
 from litestar.contrib.sqlalchemy.dto import SQLAlchemyDTO
 from litestar.dto.factory import DTOConfig
-from litestar.dto.factory._backends.utils import RenameStrategies
+from litestar.dto.factory._backends.utils.renaming import RenameStrategies
 from litestar.dto.factory.types import RenameStrategy
 from litestar.testing import create_test_client
 

--- a/tests/dto/factory/backends/test_abc.py
+++ b/tests/dto/factory/backends/test_abc.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
 
 import pytest
 
-from litestar.dto.factory import DTOConfig
+from litestar.dto.factory import DTOConfig, DTOField
 from litestar.dto.factory._backends.abc import AbstractDTOBackend, BackendContext
 from litestar.dto.factory._backends.types import (
     CollectionType,
@@ -57,7 +57,7 @@ def fx_field_definitions(data_model_type: type[Model]) -> list[FieldDefinition]:
             default=Empty,
             parsed_type=ParsedType(int),
             default_factory=None,
-            dto_field=None,
+            dto_field=DTOField(),
             unique_model_name="some_module.SomeModel",
             dto_for=None,
         ),
@@ -66,7 +66,7 @@ def fx_field_definitions(data_model_type: type[Model]) -> list[FieldDefinition]:
             default=Empty,
             parsed_type=ParsedType(str),
             default_factory=None,
-            dto_field=None,
+            dto_field=DTOField(),
             unique_model_name="some_module.SomeModel",
             dto_for=None,
         ),

--- a/tests/dto/factory/backends/test_backends.py
+++ b/tests/dto/factory/backends/test_backends.py
@@ -9,7 +9,7 @@ import pytest
 from msgspec import Struct, to_builtins
 from pydantic import BaseModel
 
-from litestar.dto.factory import DTOConfig
+from litestar.dto.factory import DTOConfig, DTOField
 from litestar.dto.factory._backends import MsgspecDTOBackend, PydanticDTOBackend
 from litestar.dto.factory._backends.abc import BackendContext
 from litestar.dto.factory._backends.types import CollectionType, SimpleType, TransferFieldDefinition
@@ -188,7 +188,7 @@ def test_backend_model_name_uniqueness(backend_type: type[AbstractDTOBackend], b
             default=Empty,
             parsed_type=ParsedType(int),
             default_factory=None,
-            dto_field=None,
+            dto_field=DTOField(),
             unique_model_name="some_module.SomeModel",
             serialization_name="a",
             transfer_type=transfer_type,

--- a/tests/dto/factory/backends/test_utils.py
+++ b/tests/dto/factory/backends/test_utils.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Tuple, Union
 import pytest
 from msgspec import Struct
 
+from litestar.dto.factory import DTOField
 from litestar.dto.factory._backends.types import (
     CollectionType,
     CompositeType,
@@ -15,10 +16,12 @@ from litestar.dto.factory._backends.types import (
     TupleType,
     UnionType,
 )
+from litestar.dto.factory._backends.utils.predicates import should_mark_private
 from litestar.dto.factory._backends.utils.transfer import (
     create_transfer_model_type_annotation,
     transfer_nested_union_type_data,
 )
+from litestar.dto.factory.data_structures import FieldDefinition
 from litestar.typing import ParsedType
 
 
@@ -149,3 +152,99 @@ def test_create_transfer_model_type_annotation_unexpected_transfer_type() -> Non
     transfer_type = CompositeType(parsed_type=ParsedType(Union[str, int]), has_nested=False)
     with pytest.raises(RuntimeError):
         create_transfer_model_type_annotation(transfer_type=transfer_type)
+
+
+def test_should_mark_private_underscore_fields_private_true() -> None:
+    assert (
+        should_mark_private(
+            FieldDefinition(
+                name="a",
+                parsed_type=ParsedType(int),
+                unique_model_name="A",
+                default=1,
+                default_factory=None,
+                dto_field=DTOField(),
+                dto_for=None,
+            ),
+            True,
+        )
+        is False
+    )
+    assert (
+        should_mark_private(
+            FieldDefinition(
+                name="_a",
+                parsed_type=ParsedType(int),
+                unique_model_name="A",
+                default=1,
+                default_factory=None,
+                dto_field=DTOField(),
+                dto_for=None,
+            ),
+            True,
+        )
+        is True
+    )
+    assert (
+        should_mark_private(
+            FieldDefinition(
+                name="_a",
+                parsed_type=ParsedType(int),
+                unique_model_name="A",
+                default=1,
+                default_factory=None,
+                dto_field=DTOField(mark="read-only"),
+                dto_for=None,
+            ),
+            True,
+        )
+        is False
+    )
+
+
+def test_should_mark_private_underscore_fields_private_false() -> None:
+    assert (
+        should_mark_private(
+            FieldDefinition(
+                name="a",
+                parsed_type=ParsedType(int),
+                unique_model_name="A",
+                default=1,
+                default_factory=None,
+                dto_field=DTOField(),
+                dto_for=None,
+            ),
+            False,
+        )
+        is False
+    )
+    assert (
+        should_mark_private(
+            FieldDefinition(
+                name="_a",
+                parsed_type=ParsedType(int),
+                unique_model_name="A",
+                default=1,
+                default_factory=None,
+                dto_field=DTOField(),
+                dto_for=None,
+            ),
+            False,
+        )
+        is False
+    )
+    assert (
+        should_mark_private(
+            FieldDefinition(
+                name="_a",
+                parsed_type=ParsedType(int),
+                unique_model_name="A",
+                default=1,
+                default_factory=None,
+                dto_field=DTOField(mark="read-only"),
+                dto_for=None,
+            ),
+            False,
+        )
+        is False
+    )

--- a/tests/dto/factory/backends/test_utils.py
+++ b/tests/dto/factory/backends/test_utils.py
@@ -15,7 +15,10 @@ from litestar.dto.factory._backends.types import (
     TupleType,
     UnionType,
 )
-from litestar.dto.factory._backends.utils import create_transfer_model_type_annotation, transfer_nested_union_type_data
+from litestar.dto.factory._backends.utils.transfer import (
+    create_transfer_model_type_annotation,
+    transfer_nested_union_type_data,
+)
 from litestar.typing import ParsedType
 
 

--- a/tests/dto/factory/test_stdlib.py
+++ b/tests/dto/factory/test_stdlib.py
@@ -6,6 +6,7 @@ from typing import ClassVar, List
 
 import pytest
 
+from litestar.dto.factory import DTOField
 from litestar.dto.factory.data_structures import FieldDefinition
 from litestar.dto.factory.stdlib.dataclass import DataclassDTO
 from litestar.types.empty import Empty
@@ -35,8 +36,8 @@ def test_dataclass_field_definitions(dto_type: type[DataclassDTO[Model]]) -> Non
             parsed_type=ParsedType(int),
             default=Empty,
             default_factory=None,
-            dto_field=None,
             unique_model_name=fqdn,
+            dto_field=DTOField(),
             dto_for=None,
         ),
         FieldDefinition(
@@ -44,8 +45,8 @@ def test_dataclass_field_definitions(dto_type: type[DataclassDTO[Model]]) -> Non
             parsed_type=ParsedType(str),
             default="b",
             default_factory=None,
-            dto_field=None,
             unique_model_name=fqdn,
+            dto_field=DTOField(),
             dto_for=None,
         ),
         FieldDefinition(
@@ -53,8 +54,8 @@ def test_dataclass_field_definitions(dto_type: type[DataclassDTO[Model]]) -> Non
             parsed_type=ParsedType(list[int]),
             default=Empty,
             default_factory=list,
-            dto_field=None,
             unique_model_name=fqdn,
+            dto_field=DTOField(),
             dto_for=None,
         ),
     ]
@@ -68,8 +69,8 @@ def test_dataclass_field_definitions_38(dto_type: type[DataclassDTO[Model]]) -> 
             parsed_type=ParsedType(int),
             default=Empty,
             default_factory=None,
-            dto_field=None,
             unique_model_name=fqdn,
+            dto_field=DTOField(),
             dto_for=None,
         ),
         FieldDefinition(
@@ -77,8 +78,8 @@ def test_dataclass_field_definitions_38(dto_type: type[DataclassDTO[Model]]) -> 
             parsed_type=ParsedType(str),
             default="b",
             default_factory=None,
-            dto_field=None,
             unique_model_name=fqdn,
+            dto_field=DTOField(),
             dto_for=None,
         ),
         FieldDefinition(
@@ -87,7 +88,7 @@ def test_dataclass_field_definitions_38(dto_type: type[DataclassDTO[Model]]) -> 
             default=Empty,
             default_factory=list,
             unique_model_name=fqdn,
-            dto_field=None,
+            dto_field=DTOField(),
             dto_for=None,
         ),
     ]

--- a/tests/response/test_serialization.py
+++ b/tests/response/test_serialization.py
@@ -87,7 +87,7 @@ def test_response_validation_of_unknown_media_types(
 ) -> None:
     if should_raise:
         with pytest.raises(ImproperlyConfiguredException):
-            Response[response_type](content, media_type=media_type, status_code=HTTP_200_OK)
+            Response[response_type](content, media_type=media_type, status_code=HTTP_200_OK).body
     else:
         response = Response[response_type](content, media_type=media_type, status_code=HTTP_200_OK)
         assert response.body == (content.encode("utf-8") if not isinstance(content, bytes) else content)


### PR DESCRIPTION
- Delays rendering response content to bytes until the "response.start" message is sent. Previously, this occurred on instantiation of the response object, however, that did not give the DTO opportunity to overwrite the content.
- Moves call of the return dto into the `HTTPRouteHandler.to_response()` method. This removes the need for duplicated code in the response handlers.
- Modifies `DTOInterface.to_encodable_type()` return type to include `Response`.

Closes #1631

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
