### PR TITLE
fix serialization.py

### DIFF
--- a/litestar/serialization.py
+++ b/litestar/serialization.py
@@ -26,6 +26,7 @@ from pydantic import (
 )
 from pydantic.color import Color
 from pydantic.json import decimal_encoder
+from uuid import UUID
 
 from litestar.enums import MediaType
 from litestar.exceptions import SerializationException
@@ -84,6 +85,7 @@ DEFAULT_TYPE_ENCODERS: TypeEncodersMap = {
     IPv6Address: str,
     IPv6Interface: str,
     IPv6Network: str,
+    UUID: str,
     # pydantic compatibility
     deque: list,
     Decimal: decimal_encoder,


### PR DESCRIPTION
fix litestar.exceptions.base_exceptions.SerializationException: Unsupported type: <class 'asyncpg.pgproto.pgproto.UUID'>
Some one forgot to add UUID to DEFAULT_TYPE_ENCODERS

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
