### PR TITLE
Data transfer for non-generic builtin collection annotations.

### DIFF
--- a/litestar/dto/factory/_backends/utils.py
+++ b/litestar/dto/factory/_backends/utils.py
@@ -281,7 +281,7 @@ def transfer_type_data(
             return transfer_nested_collection_type_data(
                 transfer_type.parsed_type.origin, transfer_type, dto_for, source_value
             )
-        return transfer_type.parsed_type.origin(source_value)
+        return transfer_type.parsed_type.instantiable_origin(source_value)
     return source_value
 
 

--- a/tests/dto/factory/test_integration.py
+++ b/tests/dto/factory/test_integration.py
@@ -358,3 +358,22 @@ def test_dto_private_fields_disabled() -> None:
         response = client.post("/", json={"bar": "hello", "_baz": 42})
         assert response.status_code == 201
         assert response.json() == {"bar": "hello", "_baz": 42}
+
+
+def test_dto_concrete_builtin_collection_types() -> None:
+    @dataclass
+    class Foo:
+        bar: dict
+        baz: list
+
+    @post(
+        dto=DataclassDTO[Annotated[Foo, DTOConfig(underscore_fields_private=False)]],
+        signature_namespace={"Foo": Foo},
+    )
+    def handler(data: Foo) -> Foo:
+        return data
+
+    with create_test_client(route_handlers=[handler], debug=True) as client:
+        response = client.post("/", json={"bar": {"a": 1, "b": [1, 2, 3]}, "baz": [4, 5, 6]})
+        assert response.status_code == 201
+        assert response.json() == {"bar": {"a": 1, "b": [1, 2, 3]}, "baz": [4, 5, 6]}


### PR DESCRIPTION
DTO would fail where a builtin collection type was used as an annotation without any generic arguments, e.g., `a: dict`.

This PR corrects this by inferring the inner types as `Any` if they don't otherwise exist.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
