### PR TITLE
feat: exclude unloaded columns on `to_dict`

### DIFF
--- a/litestar/contrib/sqlalchemy/base.py
+++ b/litestar/contrib/sqlalchemy/base.py
@@ -137,7 +137,7 @@ class CommonTableAttributes:
         Returns:
             dict[str, Any]: A dict representation of the model
         """
-        exclude = {"_sentinel"}.union(self._sa_instance_state.unloaded).union(exclude or []) # type: ignore[attr-defined]
+        exclude = {"_sentinel"}.union(self._sa_instance_state.unloaded).union(exclude or [])  # type: ignore[attr-defined]
         return {field.name: getattr(self, field.name) for field in self.__table__.columns if field.name not in exclude}
 
 

--- a/litestar/contrib/sqlalchemy/base.py
+++ b/litestar/contrib/sqlalchemy/base.py
@@ -137,11 +137,7 @@ class CommonTableAttributes:
         Returns:
             dict[str, Any]: A dict representation of the model
         """
-        exclude = (
-            exclude.union({"_sentinel"}.union(self._sa_instance_state.unloaded))  # type: ignore[attr-defined]
-            if exclude
-            else {"_sentinel"}.union(self._sa_instance_state.unloaded)  # type: ignore[attr-defined]
-        )
+        exclude = {"_sentinel"}.union(self._sa_instance_state.unloaded).union(exclude or []) # type: ignore[attr-defined]
         return {field.name: getattr(self, field.name) for field in self.__table__.columns if field.name not in exclude}
 
 

--- a/litestar/contrib/sqlalchemy/base.py
+++ b/litestar/contrib/sqlalchemy/base.py
@@ -137,7 +137,11 @@ class CommonTableAttributes:
         Returns:
             dict[str, Any]: A dict representation of the model
         """
-        exclude = exclude.union("_sentinel") if exclude else {"_sentinel"}
+        exclude = (
+            exclude.union({"_sentinel"}.union(self._sa_instance_state.unloaded))  # type: ignore[attr-defined]
+            if exclude
+            else {"_sentinel"}.union(self._sa_instance_state.unloaded)  # type: ignore[attr-defined]
+        )
         return {field.name: getattr(self, field.name) for field in self.__table__.columns if field.name not in exclude}
 
 

--- a/tests/contrib/sqlalchemy/repository/test_sqlalchemy_async.py
+++ b/tests/contrib/sqlalchemy/repository/test_sqlalchemy_async.py
@@ -75,17 +75,17 @@ async def test_sqlalchemy_sentinel(monkeypatch: MonkeyPatch) -> None:
         """Inheriting from UUIDAuditBase gives the model 'created' and 'updated'
         columns."""
 
-        the_extra_col: Mapped[str | None] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
+        the_extra_col: Mapped[str] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
 
     class TheTestModel(base.UUIDBase):
         """Inheriting from DeclarativeBase gives the model 'id'  columns."""
 
-        the_extra_col: Mapped[str | None] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
+        the_extra_col: Mapped[str] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
 
     class TheBigIntModel(base.BigIntBase):
         """Inheriting from DeclarativeBase gives the model 'id'  columns."""
 
-        the_extra_col: Mapped[str | None] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
+        the_extra_col: Mapped[str] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
 
     unloaded_cols = {"the_extra_col"}
     sa_instance_mock = MagicMock()

--- a/tests/contrib/sqlalchemy/repository/test_sqlalchemy_async.py
+++ b/tests/contrib/sqlalchemy/repository/test_sqlalchemy_async.py
@@ -7,11 +7,12 @@ from unittest.mock import AsyncMock, MagicMock, call
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import String
 from sqlalchemy.exc import IntegrityError, InvalidRequestError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
 )
-from sqlalchemy.orm import MappedColumn
+from sqlalchemy.orm import Mapped, MappedColumn, mapped_column
 
 from litestar.contrib.repository.exceptions import ConflictError, RepositoryError
 from litestar.contrib.repository.filters import (
@@ -74,26 +75,35 @@ async def test_sqlalchemy_sentinel(monkeypatch: MonkeyPatch) -> None:
         """Inheriting from UUIDAuditBase gives the model 'created' and 'updated'
         columns."""
 
-        ...
+        the_extra_col: Mapped[str | None] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
 
     class TheTestModel(base.UUIDBase):
         """Inheriting from DeclarativeBase gives the model 'id'  columns."""
 
-        ...
+        the_extra_col: Mapped[str | None] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
 
     class TheBigIntModel(base.BigIntBase):
         """Inheriting from DeclarativeBase gives the model 'id'  columns."""
 
-        ...
+        the_extra_col: Mapped[str | None] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
+
+    unloaded_cols = {"the_extra_col"}
+    sa_instance_mock = MagicMock()
+    sa_instance_mock.unloaded = unloaded_cols
 
     assert isinstance(AnotherModel._sentinel, MappedColumn)
     assert isinstance(TheTestModel._sentinel, MappedColumn)
     assert not hasattr(TheBigIntModel, "_sentinel")
     model1, model2, model3 = AnotherModel(), TheTestModel(), TheBigIntModel()
+    monkeypatch.setattr(model1, "_sa_instance_state", sa_instance_mock)
+    monkeypatch.setattr(model2, "_sa_instance_state", sa_instance_mock)
+    monkeypatch.setattr(model3, "_sa_instance_state", sa_instance_mock)
     assert "created" not in model1.to_dict(exclude={"created"}).keys()
+    assert "the_extra_col" not in model1.to_dict(exclude={"created"}).keys()
     assert "_sentinel" not in model1.to_dict().keys()
     assert "_sentinel" not in model2.to_dict().keys()
     assert "_sentinel" not in model3.to_dict().keys()
+    assert "the_extra_col" not in model1.to_dict().keys()
 
 
 def test_wrap_sqlalchemy_integrity_error() -> None:

--- a/tests/contrib/sqlalchemy/repository/test_sqlalchemy_sync.py
+++ b/tests/contrib/sqlalchemy/repository/test_sqlalchemy_sync.py
@@ -72,17 +72,17 @@ def test_sqlalchemy_sentinel(monkeypatch: MonkeyPatch) -> None:
         """Inheriting from UUIDAuditBase gives the model 'created' and 'updated'
         columns."""
 
-        the_extra_col: Mapped[str | None] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
+        the_extra_col: Mapped[str] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
 
     class TheTestModel(base.UUIDBase):
         """Inheriting from DeclarativeBase gives the model 'id'  columns."""
 
-        the_extra_col: Mapped[str | None] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
+        the_extra_col: Mapped[str] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
 
     class TheBigIntModel(base.BigIntBase):
         """Inheriting from DeclarativeBase gives the model 'id'  columns."""
 
-        the_extra_col: Mapped[str | None] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
+        the_extra_col: Mapped[str] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
 
     unloaded_cols = {"the_extra_col"}
     sa_instance_mock = MagicMock()

--- a/tests/contrib/sqlalchemy/repository/test_sqlalchemy_sync.py
+++ b/tests/contrib/sqlalchemy/repository/test_sqlalchemy_sync.py
@@ -7,8 +7,9 @@ from unittest.mock import MagicMock, Mock, call
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import String
 from sqlalchemy.exc import IntegrityError, InvalidRequestError, SQLAlchemyError
-from sqlalchemy.orm import MappedColumn, Session
+from sqlalchemy.orm import Mapped, MappedColumn, Session, mapped_column
 
 from litestar.contrib.repository.exceptions import ConflictError, RepositoryError
 from litestar.contrib.repository.filters import (
@@ -71,26 +72,34 @@ def test_sqlalchemy_sentinel(monkeypatch: MonkeyPatch) -> None:
         """Inheriting from UUIDAuditBase gives the model 'created' and 'updated'
         columns."""
 
-        ...
+        the_extra_col: Mapped[str | None] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
 
     class TheTestModel(base.UUIDBase):
         """Inheriting from DeclarativeBase gives the model 'id'  columns."""
 
-        ...
+        the_extra_col: Mapped[str | None] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
 
     class TheBigIntModel(base.BigIntBase):
         """Inheriting from DeclarativeBase gives the model 'id'  columns."""
 
-        ...
+        the_extra_col: Mapped[str | None] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
 
+    unloaded_cols = {"the_extra_col"}
+    sa_instance_mock = MagicMock()
+    sa_instance_mock.unloaded = unloaded_cols
     assert isinstance(AnotherModel._sentinel, MappedColumn)
     assert isinstance(TheTestModel._sentinel, MappedColumn)
     assert not hasattr(TheBigIntModel, "_sentinel")
     model1, model2, model3 = AnotherModel(), TheTestModel(), TheBigIntModel()
+    monkeypatch.setattr(model1, "_sa_instance_state", sa_instance_mock)
+    monkeypatch.setattr(model2, "_sa_instance_state", sa_instance_mock)
+    monkeypatch.setattr(model3, "_sa_instance_state", sa_instance_mock)
     assert "created" not in model1.to_dict(exclude={"created"}).keys()
+    assert "the_extra_col" not in model1.to_dict(exclude={"created"}).keys()
     assert "_sentinel" not in model1.to_dict().keys()
     assert "_sentinel" not in model2.to_dict().keys()
     assert "_sentinel" not in model3.to_dict().keys()
+    assert "the_extra_col" not in model1.to_dict().keys()
 
 
 def test_wrap_sqlalchemy_integrity_error() -> None:


### PR DESCRIPTION
### Pull Request Checklist

Currently, when calling `to_dict` on a model, it includes all columns that haven't been excluded.  If a column has been excluded with `load_only` it will cause an exception to be raised on an `AsyncSession`.  This PR excludes any column that hasn't been loaded.

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
