### PR TITLE
Refactor: HTMX contrib tests

### DIFF
--- a/tests/contrib/htmx/test_htmx_request.py
+++ b/tests/contrib/htmx/test_htmx_request.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Any, Optional
 
 from litestar import MediaType, get
 from litestar.contrib.htmx._utils import HTMXHeaders
@@ -276,7 +276,7 @@ def test_triggering_event_bad_json() -> None:
 
 def test_triggering_event_good_json() -> None:
     @get("/")
-    def handler(request: HTMXRequest) -> Dict[str, None]:
+    def handler(request: HTMXRequest) -> Any:
         assert request.htmx.triggering_event == {"target": None}
         return request.htmx.triggering_event
 

--- a/tests/contrib/htmx/test_htmx_request.py
+++ b/tests/contrib/htmx/test_htmx_request.py
@@ -1,4 +1,6 @@
-from litestar import MediaType, Response, get
+from typing import Dict, Optional
+
+from litestar import MediaType, get
 from litestar.contrib.htmx._utils import HTMXHeaders
 from litestar.contrib.htmx.request import HTMXRequest
 from litestar.status_codes import HTTP_200_OK
@@ -17,9 +19,9 @@ def test_health_check() -> None:
 
 
 async def test_bool_default() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
-        return Response(content=bool(request.htmx))
+    @get("/")
+    def handler(request: HTMXRequest) -> bool:
+        return bool(request.htmx)
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/")
@@ -27,9 +29,9 @@ async def test_bool_default() -> None:
 
 
 async def test_bool_false() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
-        return Response(content=bool(request.htmx))
+    @get("/")
+    def handler(request: HTMXRequest) -> bool:
+        return bool(request.htmx)
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/", headers={HTMXHeaders.REQUEST.value: "false"})
@@ -37,9 +39,9 @@ async def test_bool_false() -> None:
 
 
 async def test_bool_true() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
-        return Response(content=bool(request.htmx))
+    @get("/")
+    def handler(request: HTMXRequest) -> bool:
+        return bool(request.htmx)
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/", headers={HTMXHeaders.REQUEST.value: "true"})
@@ -47,9 +49,9 @@ async def test_bool_true() -> None:
 
 
 async def test_boosted_default() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
-        return Response(content=request.htmx.boosted)
+    @get("/")
+    def handler(request: HTMXRequest) -> bool:
+        return request.htmx.boosted
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/")
@@ -57,9 +59,9 @@ async def test_boosted_default() -> None:
 
 
 async def test_boosted_set() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
-        return Response(content=request.htmx.boosted)
+    @get("/")
+    def handler(request: HTMXRequest) -> bool:
+        return request.htmx.boosted
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/", headers={HTMXHeaders.BOOSTED.value: "true"})
@@ -67,10 +69,10 @@ async def test_boosted_set() -> None:
 
 
 def test_current_url_default() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> Optional[str]:
         assert request.htmx.current_url is None
-        return Response(content=request.htmx.current_url)
+        return request.htmx.current_url
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/")
@@ -78,10 +80,10 @@ def test_current_url_default() -> None:
 
 
 def test_current_url_set() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> Optional[str]:
         assert request.htmx.current_url == "https://example.com"
-        return Response(content=request.htmx.current_url)
+        return request.htmx.current_url
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/", headers={HTMXHeaders.CURRENT_URL.value: "https://example.com"})
@@ -89,10 +91,10 @@ def test_current_url_set() -> None:
 
 
 def test_current_url_set_url_encoded() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> Optional[str]:
         assert request.htmx.current_url == "https://example.com/?"
-        return Response(content=request.htmx.current_url)
+        return request.htmx.current_url
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get(
@@ -106,10 +108,10 @@ def test_current_url_set_url_encoded() -> None:
 
 
 def test_current_url_abs_path_default() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> Optional[str]:
         assert request.htmx.current_url_abs_path is None
-        return Response(content=request.htmx.current_url_abs_path)
+        return request.htmx.current_url_abs_path
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/")
@@ -117,10 +119,10 @@ def test_current_url_abs_path_default() -> None:
 
 
 def test_current_url_abs_path_set() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> Optional[str]:
         assert request.htmx.current_url_abs_path == "/duck/?quack=true#h2"
-        return Response(content=request.htmx.current_url_abs_path)
+        return request.htmx.current_url_abs_path
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get(
@@ -130,10 +132,10 @@ def test_current_url_abs_path_set() -> None:
 
 
 def test_current_url_abs_path_set_other_domain() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> Optional[str]:
         assert request.htmx.current_url_abs_path is None
-        return Response(content=request.htmx.current_url_abs_path)
+        return request.htmx.current_url_abs_path
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/", headers={HTMXHeaders.CURRENT_URL.value: "http://example.com/duck/?quack=true#h2"})
@@ -141,10 +143,10 @@ def test_current_url_abs_path_set_other_domain() -> None:
 
 
 def test_history_restore_request_false() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> bool:
         assert request.htmx.history_restore_request is False
-        return Response(content=request.htmx.history_restore_request)
+        return request.htmx.history_restore_request
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/", headers={HTMXHeaders.HISTORY_RESTORE_REQUEST.value: "false"})
@@ -152,10 +154,10 @@ def test_history_restore_request_false() -> None:
 
 
 def test_history_restore_request_true() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> bool:
         assert request.htmx.history_restore_request is True
-        return Response(content=request.htmx.history_restore_request)
+        return request.htmx.history_restore_request
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/", headers={HTMXHeaders.HISTORY_RESTORE_REQUEST.value: "true"})
@@ -163,10 +165,10 @@ def test_history_restore_request_true() -> None:
 
 
 def test_prompt_default() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> Optional[str]:
         assert request.htmx.prompt is None
-        return Response(content=request.htmx.prompt)
+        return request.htmx.prompt
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/")
@@ -174,10 +176,10 @@ def test_prompt_default() -> None:
 
 
 def test_prompt_set() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> Optional[str]:
         assert request.htmx.prompt == "Yes"
-        return Response(content=request.htmx.prompt)
+        return request.htmx.prompt
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/", headers={HTMXHeaders.PROMPT.value: "Yes"})
@@ -185,10 +187,10 @@ def test_prompt_set() -> None:
 
 
 def test_target_default() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> Optional[str]:
         assert request.htmx.target is None
-        return Response(content=request.htmx.target)
+        return request.htmx.target
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/")
@@ -196,10 +198,10 @@ def test_target_default() -> None:
 
 
 def test_target_set() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> Optional[str]:
         assert request.htmx.target == "#element"
-        return Response(content=request.htmx.target)
+        return request.htmx.target
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/", headers={HTMXHeaders.TARGET.value: "#element"})
@@ -207,10 +209,10 @@ def test_target_set() -> None:
 
 
 def test_trigger_default() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> Optional[str]:
         assert request.htmx.trigger is None
-        return Response(content=request.htmx.trigger)
+        return request.htmx.trigger
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/")
@@ -218,10 +220,10 @@ def test_trigger_default() -> None:
 
 
 def test_trigger_set() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> Optional[str]:
         assert request.htmx.trigger == "#element"
-        return Response(content=request.htmx.trigger)
+        return request.htmx.trigger
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/", headers={HTMXHeaders.TRIGGER_ID.value: "#element"})
@@ -229,10 +231,10 @@ def test_trigger_set() -> None:
 
 
 def test_trigger_name_default() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> Optional[str]:
         assert request.htmx.trigger_name is None
-        return Response(content=request.htmx.trigger_name)
+        return request.htmx.trigger_name
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/")
@@ -240,10 +242,10 @@ def test_trigger_name_default() -> None:
 
 
 def test_trigger_name_set() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> Optional[str]:
         assert request.htmx.trigger_name == "name_of_element"
-        return Response(content=request.htmx.trigger_name)
+        return request.htmx.trigger_name
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/", headers={HTMXHeaders.TRIGGER_NAME.value: "name_of_element"})
@@ -251,10 +253,10 @@ def test_trigger_name_set() -> None:
 
 
 def test_triggering_event_none() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> None:
         assert request.htmx.triggering_event is None
-        return Response(content=request.htmx.triggering_event)
+        return request.htmx.triggering_event
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/")
@@ -262,10 +264,10 @@ def test_triggering_event_none() -> None:
 
 
 def test_triggering_event_bad_json() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> None:
         assert request.htmx.triggering_event is None
-        return Response(content=request.htmx.triggering_event)
+        return request.htmx.triggering_event
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get("/", headers={HTMXHeaders.TRIGGERING_EVENT.value: "{"})
@@ -273,10 +275,10 @@ def test_triggering_event_bad_json() -> None:
 
 
 def test_triggering_event_good_json() -> None:
-    @get("/", media_type=MediaType.TEXT)
-    def handler(request: HTMXRequest) -> Response:
+    @get("/")
+    def handler(request: HTMXRequest) -> Dict[str, None]:
         assert request.htmx.triggering_event == {"target": None}
-        return Response(content=request.htmx.triggering_event)
+        return request.htmx.triggering_event
 
     with create_test_client(route_handlers=[handler], request_class=HTMXRequest) as client:
         response = client.get(

--- a/tests/contrib/htmx/test_htmx_response.py
+++ b/tests/contrib/htmx/test_htmx_response.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import pytest
 
-from litestar import MediaType, get
+from litestar import get
 from litestar.contrib.htmx._utils import HTMXHeaders
 from litestar.contrib.htmx.request import HTMXRequest
 from litestar.contrib.htmx.response import (
@@ -59,7 +59,7 @@ async def test_client_refresh_response() -> None:
 
 
 async def test_push_url_false_response() -> None:
-    @get("/", media_type=MediaType.TEXT)
+    @get("/")
     def handler() -> PushUrl:
         return PushUrl(content="Success!", push_url=False)
 
@@ -70,7 +70,7 @@ async def test_push_url_false_response() -> None:
 
 
 async def test_push_url_response() -> None:
-    @get("/", media_type=MediaType.TEXT)
+    @get("/")
     def handler() -> PushUrl:
         return PushUrl(content="Success!", push_url="/index.html")
 
@@ -82,7 +82,7 @@ async def test_push_url_response() -> None:
 
 
 async def test_replace_url_false_response() -> None:
-    @get("/", media_type=MediaType.TEXT)
+    @get("/")
     def handler() -> ReplaceUrl:
         return ReplaceUrl(content="Success!", replace_url=False)
 
@@ -93,7 +93,7 @@ async def test_replace_url_false_response() -> None:
 
 
 async def test_replace_url_response() -> None:
-    @get("/", media_type=MediaType.TEXT)
+    @get("/")
     def handler() -> ReplaceUrl:
         return ReplaceUrl(content="Success!", replace_url="/index.html")
 
@@ -224,9 +224,9 @@ async def test_hx_location_response_with_all_parameters() -> None:
         spec = response.headers[HTMXHeaders.LOCATION]
         assert response.status_code == HTTP_200_OK
         assert "Location" not in response.headers
-        assert (
-            spec
-            == '{"path":"/contact-us","source":"#button","event":"click","target":"#content","swap":"innerHTML","values":{"action":"true"},"hx_headers":{"attribute":"value"}}'
+        assert spec == (
+            '{"path":"/contact-us","source":"#button","event":"click","target":"#content","swap":"innerHTML",'
+            '"values":{"action":"true"},"hx_headers":{"attribute":"value"}}'
         )
 
 
@@ -248,7 +248,7 @@ async def test_hx_location_response_with_all_parameters() -> None:
 def test_HTMXTemplate_response_success(engine: Any, template: str, expected: str, template_dir: Path) -> None:
     Path(template_dir / "abc.html").write_text(template)
 
-    @get(path="/", media_type=MediaType.HTML)
+    @get(path="/")
     def handler() -> HTMXTemplate:
         return HTMXTemplate(
             name="abc.html",
@@ -286,7 +286,7 @@ def test_HTMXTemplate_response_success(engine: Any, template: str, expected: str
 def test_HTMXTemplate_response_no_params(engine: Any, template: str, expected: str, template_dir: Path) -> None:
     Path(template_dir / "abc.html").write_text(template)
 
-    @get(path="/", media_type=MediaType.HTML)
+    @get(path="/")
     def handler() -> HTMXTemplate:
         return HTMXTemplate(
             name="abc.html",
@@ -320,7 +320,7 @@ def test_HTMXTemplate_response_push_url_set_to_false(
 ) -> None:
     Path(template_dir / "abc.html").write_text(template)
 
-    @get(path="/", media_type=MediaType.HTML)
+    @get(path="/")
     def handler() -> HTMXTemplate:
         return HTMXTemplate(
             name="abc.html",
@@ -355,7 +355,7 @@ def test_htmx_template_response_bad_trigger_params(
 ) -> None:
     Path(template_dir / "abc.html").write_text(template)
 
-    @get(path="/", media_type=MediaType.HTML)
+    @get(path="/")
     def handler() -> HTMXTemplate:
         return HTMXTemplate(
             name="abc.html",


### PR DESCRIPTION
- remove redundant `media_type` declarations on handlers. Handlers were
returning responses that have their own media type defaults.
- where appropriate, return values direct from handlers, without wrapping in `Response`.

I noticed these while doing some prep work for #1790.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
