### PR TITLE
Make `preferred_validation_backend` private

### DIFF
--- a/docs/usage/the-litestar-app.rst
+++ b/docs/usage/the-litestar-app.rst
@@ -26,23 +26,6 @@ and Route Handlers should be registered on it.
     :ref:`usage/routing:Registering Routes`
 
 
-Validation Backends
--------------------
-
-Litestar supports both `attrs <https://www.attrs.org/en/stable/>`_ and `pydantic <https://docs.pydantic.dev/>`_ as
-validation backends. If you have one of these libraries installed alongside Litestar, it will be used automatically.
-If you have both of these installed though, Litestar will default to using attrs unless a handler uses a pydantic-specific
-type or a custom class that has the pydantic ``__get_validators__`` dunder defined. You can change this behaviour by
-setting the ``preferred_validation_backend`` kwarg to ``pydantic``:
-
-
-.. code-block:: python
-
-   from litestar import Litestar
-
-   app = Litestar(route_handlers=..., preferred_validation_backend="pydantic")
-
-
 Startup and Shutdown
 --------------------
 

--- a/litestar/config/app.py
+++ b/litestar/config/app.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 from litestar.config.allowed_hosts import AllowedHostsConfig
 from litestar.config.response_cache import ResponseCacheConfig
@@ -148,8 +148,6 @@ class AppConfig:
     """Drop into the PDB on an exception"""
     plugins: list[PluginProtocol] = field(default_factory=list)
     """List of :class:`SerializationPluginProtocol <.plugins.SerializationPluginProtocol>`."""
-    preferred_validation_backend: Literal["pydantic", "attrs"] = field(default="attrs")
-    """Validation backend to use, if multiple are installed."""
     request_class: type[Request] | None = field(default=None)
     """An optional subclass of :class:`Request <.connection.Request>` to use for http connections."""
     response_class: ResponseType | None = field(default=None)

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -428,7 +428,7 @@ class BaseRouteHandler(Generic[T]):
             self.signature_model = create_signature_model(
                 dependency_name_set=self.dependency_name_set,
                 fn=cast("AnyCallable", self.fn.value),
-                preferred_validation_backend=app.preferred_validation_backend,
+                preferred_validation_backend=app._preferred_validation_backend,
                 parsed_signature=self.parsed_fn_signature,
                 has_data_dto=bool(self.resolve_dto()),
             )
@@ -440,7 +440,7 @@ class BaseRouteHandler(Generic[T]):
                 provider.signature_model = create_signature_model(
                     dependency_name_set=self.dependency_name_set,
                     fn=provider.dependency.value,
-                    preferred_validation_backend=app.preferred_validation_backend,
+                    preferred_validation_backend=app._preferred_validation_backend,
                     parsed_signature=ParsedSignature.from_fn(
                         unwrap_partial(provider.dependency.value), self.resolve_signature_namespace()
                     ),

--- a/litestar/handlers/websocket_handlers/listener.py
+++ b/litestar/handlers/websocket_handlers/listener.py
@@ -282,7 +282,7 @@ class websocket_listener(WebsocketRouteHandler):
             self.signature_model = create_signature_model(
                 dependency_name_set=self.dependency_name_set,
                 fn=cast("AnyCallable", self.fn.value),
-                preferred_validation_backend=app.preferred_validation_backend,
+                preferred_validation_backend=app._preferred_validation_backend,
                 parsed_signature=ParsedSignature.from_signature(new_signature, self.resolve_signature_namespace()),
             )
 

--- a/litestar/testing/helpers.py
+++ b/litestar/testing/helpers.py
@@ -87,7 +87,6 @@ def create_test_client(
     parameters: ParametersMap | None = None,
     plugins: OptionalSequence[PluginProtocol] = None,
     lifespan: list[Callable[[Litestar], AbstractAsyncContextManager] | AbstractAsyncContextManager] | None = None,
-    preferred_validation_backend: Literal["pydantic", "attrs"] | None = None,
     raise_server_exceptions: bool = True,
     pdb_on_exception: bool | None = None,
     request_class: type[Request] | None = None,
@@ -107,6 +106,7 @@ def create_test_client(
     template_config: TemplateConfig | None = None,
     type_encoders: TypeEncodersMap | None = None,
     websocket_class: type[WebSocket] | None = None,
+    _preferred_validation_backend: Literal["pydantic", "attrs"] | None = None,
 ) -> TestClient[Litestar]:
     """Create a Litestar app instance and initializes it.
 
@@ -132,7 +132,6 @@ def create_test_client(
                     assert response.json() == {"hello": "world"}
 
     Args:
-        preferred_validation_backend:
         route_handlers: A single handler or a sequence of route handlers, which can include instances of
             :class:`Router <litestar.router.Router>`, subclasses of :class:`Controller <.controller.Controller>` or
             any function decorated by the route handler decorators.
@@ -198,7 +197,6 @@ def create_test_client(
             paths.
         pdb_on_exception: Drop into the PDB when an exception occurs.
         plugins: Sequence of plugins.
-        preferred_validation_backend: Validation backend to use, if multiple are installed.
         request_class: An optional subclass of :class:`Request <.connection.Request>` to use for http connections.
         response_class: A custom subclass of :class:`Response <.response.Response>` to be used as the app's default
             response.
@@ -265,7 +263,6 @@ def create_test_client(
         parameters=parameters,
         pdb_on_exception=pdb_on_exception,
         plugins=plugins,
-        preferred_validation_backend=preferred_validation_backend,
         request_class=request_class,
         response_cache_config=response_cache_config,
         response_class=response_class,
@@ -282,6 +279,7 @@ def create_test_client(
         template_config=template_config,
         type_encoders=type_encoders,
         websocket_class=websocket_class,
+        _preferred_validation_backend=_preferred_validation_backend,
     )
 
     return TestClient[Litestar](
@@ -331,7 +329,6 @@ def create_async_test_client(
     parameters: ParametersMap | None = None,
     pdb_on_exception: bool | None = None,
     plugins: OptionalSequence[PluginProtocol] = None,
-    preferred_validation_backend: Literal["pydantic", "attrs"] | None = None,
     raise_server_exceptions: bool = True,
     request_class: type[Request] | None = None,
     response_cache_config: ResponseCacheConfig | None = None,
@@ -350,6 +347,7 @@ def create_async_test_client(
     template_config: TemplateConfig | None = None,
     type_encoders: TypeEncodersMap | None = None,
     websocket_class: type[WebSocket] | None = None,
+    _preferred_validation_backend: Literal["pydantic", "attrs"] | None = None,
 ) -> AsyncTestClient[Litestar]:
     """Create a Litestar app instance and initializes it.
 
@@ -440,7 +438,6 @@ def create_async_test_client(
             paths.
         pdb_on_exception: Drop into the PDB when an exception occurs.
         plugins: Sequence of plugins.
-        preferred_validation_backend: Validation backend to use, if multiple are installed.
         request_class: An optional subclass of :class:`Request <.connection.Request>` to use for http connections.
         response_class: A custom subclass of :class:`Response <.response.Response>` to be used as the app's default
             response.
@@ -507,7 +504,6 @@ def create_async_test_client(
         parameters=parameters,
         pdb_on_exception=pdb_on_exception,
         plugins=plugins,
-        preferred_validation_backend=preferred_validation_backend,
         request_class=request_class,
         response_cache_config=response_cache_config,
         response_class=response_class,
@@ -524,6 +520,7 @@ def create_async_test_client(
         template_config=template_config,
         type_encoders=type_encoders,
         websocket_class=websocket_class,
+        _preferred_validation_backend=_preferred_validation_backend,
     )
 
     return AsyncTestClient[Litestar](

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,6 +252,7 @@ filterwarnings = [
     "ignore::DeprecationWarning:google.iam",
     "ignore::DeprecationWarning:google",
     "ignore::DeprecationWarning:sphinxcontrib",
+    "ignore::DeprecationWarning:litestar.*",
 ]
 markers = [
     "sqlalchemy_integration: SQLAlchemy integration tests",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,8 @@ sonar.cpd.exclusions=\
   litestar/testing/* \
   litestar/contrib/repository/testing/generic_mock_repository.py, \
   litestar/contrib/repository/abc/_sync.py, \
-  litestar/contrib/sqlalchemy/repository/_sync.py
+  litestar/contrib/sqlalchemy/repository/_sync.py, \
+  litestar/testing/helpers.py
 sonar.exclusions=litestar/middleware/exceptions/templates/*
 sonar.organization=litestar-api
 sonar.projectKey=litestar-org_litestar

--- a/tests/app/test_app_config.py
+++ b/tests/app/test_app_config.py
@@ -62,7 +62,7 @@ def test_app_params_defined_on_app_config_object() -> None:
     litestar_signature = inspect.signature(Litestar)
     app_config_fields = {f.name for f in fields(AppConfig)}
     for name in litestar_signature.parameters:
-        if name in ("on_app_init", "initial_state"):
+        if name in {"on_app_init", "initial_state", "_preferred_validation_backend"}:
             continue
         assert name in app_config_fields
     # ensure there are not fields defined on AppConfig that aren't in the Litestar signature

--- a/tests/dto/test_attrs_fail.py
+++ b/tests/dto/test_attrs_fail.py
@@ -14,7 +14,7 @@ def test_dto_defined_on_handler() -> None:
         assert data == Model(a=1, b="2")
         return data
 
-    with create_test_client(route_handlers=handler, preferred_validation_backend="attrs") as client:
+    with create_test_client(route_handlers=handler, _preferred_validation_backend="attrs") as client:
         response = client.post("/", json={"what": "ever"})
         assert response.status_code == 201
         assert response.json() == {"a": 1, "b": "2"}

--- a/tests/dto/test_integration.py
+++ b/tests/dto/test_integration.py
@@ -14,7 +14,7 @@ def test_dto_defined_on_handler() -> None:
         assert data == Model(a=1, b="2")
         return data
 
-    with create_test_client(route_handlers=handler, preferred_validation_backend="pydantic") as client:
+    with create_test_client(route_handlers=handler, _preferred_validation_backend="pydantic") as client:
         response = client.post("/", json={"what": "ever"})
         assert response.status_code == 201
         assert response.json() == {"a": 1, "b": "2"}

--- a/tests/openapi/test_parameters.py
+++ b/tests/openapi/test_parameters.py
@@ -30,7 +30,7 @@ def _create_parameters(app: Litestar, path: str) -> List["OpenAPIParameter"]:
     handler_fields = create_signature_model(
         fn=handler,
         dependency_name_set=set(),
-        preferred_validation_backend=app.preferred_validation_backend,
+        preferred_validation_backend=app._preferred_validation_backend,
         parsed_signature=route_handler.parsed_fn_signature,
     ).fields
 

--- a/tests/signature/test_parsing.py
+++ b/tests/signature/test_parsing.py
@@ -141,7 +141,7 @@ def test_dependency_validation_failure_raises_500(
         ...
 
     with create_test_client(
-        route_handlers=[test], dependencies=dependencies, preferred_validation_backend=preferred_validation_backend
+        route_handlers=[test], dependencies=dependencies, _preferred_validation_backend=preferred_validation_backend
     ) as client:
         response = client.get("/?param=13")
 
@@ -166,7 +166,7 @@ def test_validation_failure_raises_400(
         ...
 
     with create_test_client(
-        route_handlers=[test], dependencies=dependencies, preferred_validation_backend=preferred_validation_backend
+        route_handlers=[test], dependencies=dependencies, _preferred_validation_backend=preferred_validation_backend
     ) as client:
         response = client.get("/?param=thirteen")
 
@@ -188,7 +188,7 @@ def test_client_pydantic_backend_error_precedence_over_server_error() -> None:
         ...
 
     with create_test_client(
-        route_handlers=[test], dependencies=dependencies, preferred_validation_backend="pydantic"
+        route_handlers=[test], dependencies=dependencies, _preferred_validation_backend="pydantic"
     ) as client:
         response = client.get("/?param=thirteen")
 
@@ -280,7 +280,7 @@ def test_query_param_bool(query: str, expected: bool, signature_backend: Literal
     def handler(param: bool) -> None:
         mock(param)
 
-    with create_test_client(route_handlers=[handler], preferred_validation_backend=signature_backend) as client:
+    with create_test_client(route_handlers=[handler], _preferred_validation_backend=signature_backend) as client:
         response = client.get(f"/?param={query}")
         assert response.status_code == HTTP_200_OK, response.json()
         mock.assert_called_once_with(expected)

--- a/tests/signature/test_utils.py
+++ b/tests/signature/test_utils.py
@@ -6,7 +6,7 @@ import attrs
 import pytest
 from pydantic import BaseModel
 
-from litestar._signature.utils import _any_attrs_annotation, _any_pydantic_annotation
+from litestar._signature.utils import _any_attrs_annotation
 from litestar.utils.signature import ParsedSignature
 
 
@@ -25,11 +25,3 @@ def test_any_attrs_annotation(annotation: Any) -> None:
         ...
 
     assert _any_attrs_annotation(ParsedSignature.from_fn(fn, {"annotation": annotation})) is True
-
-
-@pytest.mark.parametrize("annotation", [Bar, List[Bar], Optional[Bar]])
-def test_any_pydantic_annotation(annotation: Any) -> None:
-    def fn(bar: annotation) -> None:
-        ...
-
-    assert _any_pydantic_annotation(ParsedSignature.from_fn(fn, {"annotation": annotation})) is True

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -16,7 +16,7 @@ def test_parsing_of_parameter_as_annotated(backend: Any) -> None:
     def handler(param: Annotated[str, Parameter(min_length=1)]) -> str:
         return param
 
-    with create_test_client(handler, preferred_validation_backend=backend) as client:
+    with create_test_client(handler, _preferred_validation_backend=backend) as client:
         response = client.get("/")
         assert response.status_code == HTTP_400_BAD_REQUEST
 
@@ -30,7 +30,7 @@ def test_parsing_of_parameter_as_default_value(backend: Any) -> None:
     def handler(param: str = Parameter(min_length=1)) -> str:
         return param
 
-    with create_test_client(handler, preferred_validation_backend=backend) as client:
+    with create_test_client(handler, _preferred_validation_backend=backend) as client:
         response = client.get("/?param=")
         assert response.status_code == HTTP_400_BAD_REQUEST
 
@@ -44,7 +44,7 @@ def test_parsing_of_body_as_annotated(backend: Any) -> None:
     def handler(data: Annotated[List[str], Body(min_items=1)]) -> List[str]:
         return data
 
-    with create_test_client(handler, preferred_validation_backend=backend) as client:
+    with create_test_client(handler, _preferred_validation_backend=backend) as client:
         response = client.post("/", json=[])
         assert response.status_code == HTTP_400_BAD_REQUEST
 
@@ -58,7 +58,7 @@ def test_parsing_of_body_as_default_value(backend: Any) -> None:
     def handler(data: List[str] = Body(min_items=1)) -> List[str]:
         return data
 
-    with create_test_client(handler, preferred_validation_backend=backend) as client:
+    with create_test_client(handler, _preferred_validation_backend=backend) as client:
         response = client.post("/", json=[])
         assert response.status_code == HTTP_400_BAD_REQUEST
 
@@ -72,7 +72,7 @@ def test_parsing_of_dependency_as_annotated(backend: Any) -> None:
     def handler(dep: Annotated[int, Dependency(skip_validation=True)]) -> int:
         return dep
 
-    with create_test_client(handler, preferred_validation_backend=backend) as client:
+    with create_test_client(handler, _preferred_validation_backend=backend) as client:
         response = client.get("/")
         assert response.text == "null"
 
@@ -83,6 +83,6 @@ def test_parsing_of_dependency_as_default_value(backend: Any) -> None:
     def handler(dep: int = Dependency(skip_validation=True)) -> int:
         return dep
 
-    with create_test_client(handler, preferred_validation_backend=backend) as client:
+    with create_test_client(handler, _preferred_validation_backend=backend) as client:
         response = client.get("/")
         assert response.text == "null"


### PR DESCRIPTION
- Make the `preferred_validation_backend` parameter private
- Make the `Litestar.preferred_validation_backend` attribute private
- Remove the `preferred_validation_backend` from `AppConfig`
- Simplify logic for selecting a validation backend: If the preferred backend is set to `attrs`, or the signature contains attrs types, `attrs` is selected. In all other cases, Pydantic will be used.

This exposes less of the implementation details to the user, so that we can more easily implement the proposed changes in preparation of the 2.0 release, while keeping current functionality intact. 