### PR TITLE
Fix: Documentation for Authentication middleware has wrong imports

### DIFF
--- a/docs/usage/security/abstract-authentication-middleware.rst
+++ b/docs/usage/security/abstract-authentication-middleware.rst
@@ -8,7 +8,7 @@ To add authentication to your app using this class as a basis, subclass it and i
 
 .. code-block:: python
 
-   from litestar.authentication import (
+   from litestar.middleware import (
        AbstractAuthenticationMiddleware,
        AuthenticationResult,
    )
@@ -122,7 +122,7 @@ We can now create our authentication middleware:
 
     from sqlalchemy import select
     from sqlalchemy.ext.asyncio import AsyncSession
-    from litestar.authentication import (
+    from litestar.middleware import (
         AbstractAuthenticationMiddleware,
         AuthenticationResult,
     )


### PR DESCRIPTION
The documentation for the v2 contains
```python
from litestar.authentication import (
    AbstractAuthenticationMiddleware,
    AuthenticationResult,
)
```

which is not existing.

The correct imports are `from litestar.middleware`.

AbstractAuthenticationMiddleware,  AuthenticationResult are imported in : https://github.com/litestar-org/litestar/blob/main/litestar/middleware/__init__.py