### PR TITLE
Refactor: remove generic base from BaseRouteHandler.

### DIFF
--- a/litestar/handlers/asgi_handlers.py
+++ b/litestar/handlers/asgi_handlers.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     )
 
 
-class ASGIRouteHandler(BaseRouteHandler["ASGIRouteHandler"]):
+class ASGIRouteHandler(BaseRouteHandler):
     """ASGI Route Handler decorator.
 
     Use this decorator to decorate ASGI applications.

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from copy import copy
 from functools import partial
-from typing import TYPE_CHECKING, Any, Generic, Mapping, Sequence, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Mapping, Sequence, cast
 
 from litestar._signature import create_signature_model
 from litestar._signature.field import SignatureField
@@ -32,10 +32,8 @@ if TYPE_CHECKING:
 
 __all__ = ("BaseRouteHandler",)
 
-T = TypeVar("T", bound="BaseRouteHandler")
 
-
-class BaseRouteHandler(Generic[T]):
+class BaseRouteHandler:
     """Base route handler.
 
     Serves as a subclass for all route handlers
@@ -186,7 +184,7 @@ class BaseRouteHandler(Generic[T]):
         return {name for layer in layered_dependencies for name in layer}  # pyright: ignore
 
     @property
-    def ownership_layers(self) -> list[T | Controller | Router]:
+    def ownership_layers(self) -> list[Self | Controller | Router]:
         """Return the handler layers from the app down to the route handler.
 
         ``app -> ... -> route handler``

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -71,7 +71,7 @@ class ResponseHandlerMap(TypedDict):
     response_type_handler: Callable[[Any], Awaitable[ASGIApp]] | EmptyType
 
 
-class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
+class HTTPRouteHandler(BaseRouteHandler):
     """HTTP Route Decorator.
 
     Use this decorator to decorate an HTTP handler with multiple methods.

--- a/litestar/handlers/websocket_handlers/route_handler.py
+++ b/litestar/handlers/websocket_handlers/route_handler.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from litestar.types import Dependencies, ExceptionHandler, Guard, Middleware
 
 
-class WebsocketRouteHandler(BaseRouteHandler["WebsocketRouteHandler"]):
+class WebsocketRouteHandler(BaseRouteHandler):
     """Websocket route handler decorator.
 
     Use this decorator to decorate websocket handler functions.

--- a/tests/handlers/base/test_validations.py
+++ b/tests/handlers/base/test_validations.py
@@ -5,7 +5,7 @@ from litestar.handlers.base import BaseRouteHandler
 
 
 def test_raise_no_fn_validation() -> None:
-    handler = BaseRouteHandler[BaseRouteHandler](path="/")
+    handler = BaseRouteHandler(path="/")
 
     with pytest.raises(ImproperlyConfiguredException):
         handler.fn


### PR DESCRIPTION
It appears this pattern was to support annotation of the `ownership_layers` property, but this would more conventionally be done with `Self`.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
