### PR TITLE
Refactor: moves `Response.get_serializer()` to `serialization.get_serializer()`.

### DIFF
--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -18,7 +18,7 @@ from litestar.data_extractors import (
 from litestar.enums import ScopeType
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.middleware.base import AbstractMiddleware, DefineMiddleware
-from litestar.serialization import default_serializer, encode_json
+from litestar.serialization import encode_json
 from litestar.utils import (
     get_litestar_scope_state,
     get_serializer_from_scope,
@@ -195,7 +195,7 @@ class LoggingMiddleware(AbstractMiddleware):
             An dict.
         """
         data: dict[str, Any] = {"message": self.config.response_log_message}
-        serializer = get_serializer_from_scope(scope) or default_serializer
+        serializer = get_serializer_from_scope(scope)
         extracted_data = self.response_extractor(
             messages=(
                 get_litestar_scope_state(scope, HTTP_RESPONSE_START, pop=True),

--- a/litestar/serialization.py
+++ b/litestar/serialization.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import deque
 from decimal import Decimal
+from functools import partial
 from ipaddress import (
     IPv4Address,
     IPv4Interface,
@@ -29,7 +30,7 @@ from pydantic.json import decimal_encoder
 
 from litestar.enums import MediaType
 from litestar.exceptions import SerializationException
-from litestar.types import Empty
+from litestar.types import Empty, Serializer
 
 if TYPE_CHECKING:
     from litestar.types import TypeEncodersMap
@@ -42,6 +43,7 @@ __all__ = (
     "default_serializer",
     "encode_json",
     "encode_msgpack",
+    "get_serializer",
 )
 
 T = TypeVar("T")
@@ -271,3 +273,12 @@ def decode_media_type(raw: bytes, media_type: MediaType | str, type_: Any) -> An
         return decode_msgpack(raw, type_=type_)
 
     raise SerializationException(f"Unsupported media type: '{media_type}'")
+
+
+def get_serializer(type_encoders: TypeEncodersMap | None = None) -> Serializer:
+    """Get the serializer for the given type encoders."""
+
+    if type_encoders:
+        return partial(default_serializer, type_encoders={**DEFAULT_TYPE_ENCODERS, **type_encoders})
+
+    return default_serializer

--- a/tests/response/test_base_response.py
+++ b/tests/response/test_base_response.py
@@ -188,11 +188,11 @@ def test_get_serializer() -> None:
     class FooResponse(Response):
         type_encoders = foo_encoder
 
-    assert Response.get_serializer() is default_serializer
-    assert CustomResponse.get_serializer() is default_serializer
+    assert Response(None)._enc_hook is default_serializer
+    assert CustomResponse(None)._enc_hook is default_serializer
 
-    assert Response.get_serializer(type_encoders=foo_encoder)(Foo()) == "it's a foo"
-    assert Response.get_serializer(type_encoders=path_encoder)(PurePosixPath()) == "it's a path"
+    assert Response(None, type_encoders=foo_encoder)._enc_hook(Foo()) == "it's a foo"
+    assert Response(None, type_encoders=path_encoder)._enc_hook(PurePosixPath()) == "it's a path"
 
-    assert FooResponse.get_serializer()(Foo()) == "it's a foo"
-    assert FooResponse.get_serializer(type_encoders={Foo: lambda f: "foo"})(Foo()) == "foo"
+    assert FooResponse(None)._enc_hook(Foo()) == "it's a foo"
+    assert FooResponse(None, type_encoders={Foo: lambda f: "foo"})._enc_hook(Foo()) == "foo"

--- a/tests/utils/test_scope.py
+++ b/tests/utils/test_scope.py
@@ -2,12 +2,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from litestar import Litestar
 from litestar.constants import SCOPE_STATE_NAMESPACE
-from litestar.handlers.base import BaseRouteHandler
 from litestar.utils import (
     get_litestar_scope_state,
-    get_serializer_from_scope,
     set_litestar_scope_state,
 )
 
@@ -18,10 +15,6 @@ if TYPE_CHECKING:
 @pytest.fixture()
 def scope() -> "HTTPScope":
     return {"state": {}}  # type:ignore[typeddict-item]
-
-
-def test_get_serializer_from_scope() -> None:
-    assert get_serializer_from_scope({"app": Litestar([]), "route_handler": BaseRouteHandler()}) is None  # type: ignore
 
 
 def test_get_litestar_scope_state_without_default_does_not_set_key_in_scope_state(scope: "HTTPScope") -> None:


### PR DESCRIPTION
This is prep for #1790, I've split the change out for clearer discussion.

The PR removes the `Response.get_serializer()` method in favor of a `get_serializer()` function in `serialization.py`.

In the current `Response` implementation, `get_serializer()` is called on the response inside `Response.__init__()`, and the merging of class-level `type_encoders` with `Response` argument `type_encoders` is done inside the `get_serializer()` method.

In the #1790 version of `Response`, the response body is not encoded until after the response object has been returned from the handler, and it is converted into a low-level `ASGIResponse` object. Due to this, there is still opportunity for the handler layer resolved `type_encoders` object to be merged with the `Response` defined `type_encoders` - hence I've removed the logic to merge the `Response` class and arg defined type encoders from within the `Response.get_serializer()` method in that PR.

By splitting out the `get_serializer()` method from the response class, this also seemed to clean up a bit of logic for the logging middleware, where we can non-optionally return a `Serializer` instance from the `get_serializer_from_scope()` method.

Finally, having the function in the `serialization.py` module improves encapsulation of the serialization logic, evidenced by the fact that it removes import of `DEFAULT_TYPE_ENCODERS` from the module in one instance, and `default_serializer` in two instances.

So, long story short, I felt this was a decent enough tidy up to warrant a PR independent of #1790.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
