### PR TITLE
Fix OpenAPI schema generation for aliased Pydantic field in responses

### DIFF
--- a/litestar/_openapi/parameters.py
+++ b/litestar/_openapi/parameters.py
@@ -48,6 +48,7 @@ def create_path_parameter_schema(
         generate_examples=generate_examples,
         plugins=[],
         schemas=schemas,
+        prefer_alias=True,
     )
 
 
@@ -128,7 +129,9 @@ def create_parameter(
         parameter_name = kwargs_model.query if kwargs_model and kwargs_model.query else parameter_name
 
     if not result:
-        result = create_schema(field=signature_field, generate_examples=generate_examples, plugins=[], schemas=schemas)
+        result = create_schema(
+            field=signature_field, generate_examples=generate_examples, plugins=[], schemas=schemas, prefer_alias=True
+        )
 
     schema = result if isinstance(result, Schema) else schemas[result.value]
 

--- a/litestar/_openapi/request_body.py
+++ b/litestar/_openapi/request_body.py
@@ -31,7 +31,7 @@ def create_request_body(
         media_type = field.kwarg_model.media_type
 
     if dto := route_handler.resolve_dto():
-        schema = dto.create_openapi_schema("data", str(route_handler), generate_examples, schemas)
+        schema = dto.create_openapi_schema("data", str(route_handler), generate_examples, schemas, True)
     else:
         schema = create_schema(
             field=field, generate_examples=generate_examples, plugins=plugins, schemas=schemas, prefer_alias=True

--- a/litestar/_openapi/request_body.py
+++ b/litestar/_openapi/request_body.py
@@ -33,6 +33,8 @@ def create_request_body(
     if dto := route_handler.resolve_dto():
         schema = dto.create_openapi_schema("data", str(route_handler), generate_examples, schemas)
     else:
-        schema = create_schema(field=field, generate_examples=generate_examples, plugins=plugins, schemas=schemas)
+        schema = create_schema(
+            field=field, generate_examples=generate_examples, plugins=plugins, schemas=schemas, prefer_alias=True
+        )
 
     return RequestBody(required=True, content={media_type: OpenAPIMediaType(schema=schema)})

--- a/litestar/_openapi/responses.py
+++ b/litestar/_openapi/responses.py
@@ -89,7 +89,7 @@ def create_success_response(  # noqa: C901
             return_annotation = get_args(return_annotation)[0] or Any
 
         if dto := route_handler.resolve_return_dto():
-            result = dto.create_openapi_schema("return", str(route_handler), generate_examples, schemas)
+            result = dto.create_openapi_schema("return", str(route_handler), generate_examples, schemas, False)
         else:
             result = create_schema(
                 field=SignatureField.create(field_type=return_annotation),

--- a/litestar/_openapi/responses.py
+++ b/litestar/_openapi/responses.py
@@ -96,6 +96,7 @@ def create_success_response(  # noqa: C901
                 generate_examples=generate_examples,
                 plugins=plugins,
                 schemas=schemas,
+                prefer_alias=False,
             )
 
         schema = result if isinstance(result, Schema) else schemas[result.value]
@@ -104,11 +105,7 @@ def create_success_response(  # noqa: C901
         schema.content_media_type = route_handler.content_media_type
 
         response = OpenAPIResponse(
-            content={
-                route_handler.media_type: OpenAPIMediaType(
-                    schema=result,
-                )
-            },
+            content={route_handler.media_type: OpenAPIMediaType(schema=result)},
             description=description,
         )
 
@@ -165,6 +162,7 @@ def create_success_response(  # noqa: C901
                     generate_examples=False,
                     plugins=plugins,
                     schemas=schemas,
+                    prefer_alias=False,
                 )
 
             elif attribute_name != "documentation_only":
@@ -231,6 +229,7 @@ def create_additional_responses(
             generate_examples=additional_response.generate_examples,
             plugins=plugins,
             schemas=schemas,
+            prefer_alias=False,
         )
         yield str(status_code), OpenAPIResponse(
             description=additional_response.description,

--- a/litestar/_openapi/schema_generation/constrained_fields.py
+++ b/litestar/_openapi/schema_generation/constrained_fields.py
@@ -103,6 +103,7 @@ def create_collection_constrained_field_schema(
     kwargs_model: ParameterKwarg | BodyKwarg,
     plugins: list[OpenAPISchemaPluginProtocol],
     schemas: dict[str, Schema],
+    prefer_alias: bool,
 ) -> Schema:
     """Create Schema from Constrained List/Set field.
 
@@ -112,6 +113,7 @@ def create_collection_constrained_field_schema(
         kwargs_model:  A constrained field model.
         plugins: A list of plugins.
         schemas: A mapping of namespaces to schemas - this mapping is used in the OA components section.
+        prefer_alias: Whether to prefer the alias name for the schema.
 
     Returns:
         A schema instance.
@@ -128,7 +130,9 @@ def create_collection_constrained_field_schema(
         schema.unique_items = True
     if children:
         items = [
-            create_schema(field=sub_field, generate_examples=False, plugins=plugins, schemas=schemas)
+            create_schema(
+                field=sub_field, generate_examples=False, plugins=plugins, schemas=schemas, prefer_alias=prefer_alias
+            )
             for sub_field in children
         ]
         if len(items) > 1:
@@ -143,6 +147,7 @@ def create_collection_constrained_field_schema(
             generate_examples=False,
             plugins=plugins,
             schemas=schemas,
+            prefer_alias=prefer_alias,
         )
     return schema
 
@@ -153,6 +158,7 @@ def create_constrained_field_schema(
     kwargs_model: ParameterKwarg | BodyKwarg,
     plugins: list[OpenAPISchemaPluginProtocol],
     schemas: dict[str, Schema],
+    prefer_alias: bool,
 ) -> Schema:
     """Create Schema for Pydantic Constrained fields (created using constr(), conint() and so forth, or by subclassing
     Constrained*)
@@ -163,6 +169,7 @@ def create_constrained_field_schema(
         kwargs_model:  A constrained field model.
         plugins: A list of plugins.
         schemas: A mapping of namespaces to schemas - this mapping is used in the OA components section.
+        prefer_alias: Whether to prefer the alias name for the schema.
 
     Returns:
         A schema instance.
@@ -179,5 +186,6 @@ def create_constrained_field_schema(
         children=tuple(children) if children else None,
         plugins=plugins,
         schemas=schemas,
+        prefer_alias=prefer_alias,
         kwargs_model=kwargs_model,
     )

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -858,7 +858,7 @@ def create_schema(
     generate_examples: bool,
     plugins: list[OpenAPISchemaPluginProtocol],
     schemas: dict[str, Schema],
-    prefer_alias: bool = True,
+    prefer_alias: bool,
 ) -> Schema | Reference:
     """Create a Schema for a given SignatureField.
 

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -78,6 +78,7 @@ if TYPE_CHECKING:
             ConstrainedSet,
             ConstrainedStr,
         )
+        from pydantic.fields import ModelField
     except ImportError:
         BaseModel = Any  # type: ignore
         ConstrainedBytes = Any  # type: ignore
@@ -89,6 +90,7 @@ if TYPE_CHECKING:
         ConstrainedList = Any  # type: ignore
         ConstrainedSet = Any  # type: ignore
         ConstrainedStr = Any  # type: ignore
+        ModelField = Any  # type: ignore
 
     try:
         from attrs import AttrsInstance
@@ -343,6 +345,7 @@ def create_schema_for_optional_field(
     generate_examples: bool,
     plugins: list[OpenAPISchemaPluginProtocol],
     schemas: dict[str, Schema],
+    prefer_alias: bool,
 ) -> Schema:
     """Create a Schema for an optional SignatureField.
 
@@ -351,6 +354,7 @@ def create_schema_for_optional_field(
         generate_examples: Whether to generate examples if none are given.
         plugins: A list of plugins.
         schemas: A mapping of namespaces to schemas - this mapping is used in the OA components section.
+        prefer_alias: Whether to prefer the alias name for the schema.
 
     Returns:
         A schema instance.
@@ -364,6 +368,7 @@ def create_schema_for_optional_field(
         generate_examples=generate_examples,
         plugins=plugins,
         schemas=schemas,
+        prefer_alias=prefer_alias,
     )
 
     if isinstance(schema_or_reference, Schema) and isinstance(schema_or_reference.one_of, list):
@@ -384,6 +389,7 @@ def create_schema_for_union_field(
     generate_examples: bool,
     plugins: list[OpenAPISchemaPluginProtocol],
     schemas: dict[str, Schema],
+    prefer_alias: bool,
 ) -> Schema:
     """Create a Schema for a union SignatureField.
 
@@ -392,6 +398,7 @@ def create_schema_for_union_field(
         generate_examples: Whether to generate examples if none are given.
         plugins: A list of plugins.
         schemas: A mapping of namespaces to schemas - this mapping is used in the OA components section.
+        prefer_alias: Whether to prefer the alias name for the schema.
 
     Returns:
         A schema instance.
@@ -399,7 +406,13 @@ def create_schema_for_union_field(
     return Schema(
         one_of=sort_schemas_and_references(
             [
-                create_schema(field=sub_field, generate_examples=generate_examples, plugins=plugins, schemas=schemas)
+                create_schema(
+                    field=sub_field,
+                    generate_examples=generate_examples,
+                    plugins=plugins,
+                    schemas=schemas,
+                    prefer_alias=prefer_alias,
+                )
                 for sub_field in field.children or []
             ]
         )
@@ -411,6 +424,7 @@ def create_schema_for_object_type(
     generate_examples: bool,
     plugins: list[OpenAPISchemaPluginProtocol],
     schemas: dict[str, Schema],
+    prefer_alias: bool,
 ) -> Schema:
     """Create schema for object types (dict, Mapping, list, Sequence etc.) types.
 
@@ -419,6 +433,7 @@ def create_schema_for_object_type(
         generate_examples: Whether to generate examples if none are given.
         plugins: A list of plugins.
         schemas: A mapping of namespaces to schemas - this mapping is used in the OA components section.
+        prefer_alias: Whether to prefer the alias name for the schema.
 
     Returns:
         A schema instance.
@@ -428,7 +443,13 @@ def create_schema_for_object_type(
 
     if field.is_non_string_sequence or field.is_non_string_iterable:
         items = [
-            create_schema(field=sub_field, generate_examples=generate_examples, plugins=plugins, schemas=schemas)
+            create_schema(
+                field=sub_field,
+                generate_examples=generate_examples,
+                plugins=plugins,
+                schemas=schemas,
+                prefer_alias=prefer_alias,
+            )
             for sub_field in (field.children or ())
         ]
 
@@ -453,6 +474,7 @@ def create_schema_for_builtin_generics(
     generate_examples: bool,
     plugins: list[OpenAPISchemaPluginProtocol],
     schemas: dict[str, Schema],
+    prefer_alias: bool,
 ) -> Schema:
     """Handle builtin generic types.
 
@@ -461,6 +483,7 @@ def create_schema_for_builtin_generics(
         generate_examples: Whether to generate examples if none are given.
         plugins: A list of plugins.
         schemas: A mapping of namespaces to schemas - this mapping is used in the OA components section.
+        prefer_alias: Whether to prefer the alias name for the schema.
 
     Returns:
         A schema instance.
@@ -478,6 +501,7 @@ def create_schema_for_builtin_generics(
                         generate_examples=generate_examples,
                         plugins=plugins,
                         schemas=schemas,
+                        prefer_alias=prefer_alias,
                     ),
                 ),
                 "page_size": Schema(type=OpenAPIType.INTEGER, description="Number of items per page."),
@@ -497,6 +521,7 @@ def create_schema_for_builtin_generics(
                         generate_examples=generate_examples,
                         plugins=plugins,
                         schemas=schemas,
+                        prefer_alias=prefer_alias,
                     ),
                 ),
                 "limit": Schema(type=OpenAPIType.INTEGER, description="Maximal number of items to send."),
@@ -506,7 +531,11 @@ def create_schema_for_builtin_generics(
         )
 
     cursor_schema = create_schema(
-        field=field.children[0], generate_examples=False, plugins=plugins, schemas=schemas  # type: ignore[index]
+        field=field.children[0],  # type: ignore[index]
+        generate_examples=False,
+        plugins=plugins,
+        schemas=schemas,
+        prefer_alias=prefer_alias,
     )
     cursor_schema.description = "Unique ID, designating the last identifier in the given data set. This value can be used to request the 'next' batch of records."
 
@@ -520,6 +549,7 @@ def create_schema_for_builtin_generics(
                     generate_examples=generate_examples,
                     plugins=plugins,
                     schemas=schemas,
+                    prefer_alias=prefer_alias,
                 ),
             ),
             "cursor": cursor_schema,
@@ -533,6 +563,7 @@ def create_schema_for_pydantic_model(
     generate_examples: bool,
     plugins: list[OpenAPISchemaPluginProtocol],
     schemas: dict[str, Schema],
+    prefer_alias: bool,
 ) -> Schema:
     """Create a schema object for a given pydantic model class.
 
@@ -541,6 +572,7 @@ def create_schema_for_pydantic_model(
         generate_examples: Whether to generate examples if none are given.
         plugins: A list of plugins.
         schemas: A mapping of namespaces to schemas - this mapping is used in the OA components section.
+        prefer_alias: Whether to prefer the alias over the field name.
 
     Returns:
         A schema instance.
@@ -553,16 +585,20 @@ def create_schema_for_pydantic_model(
         getattr(model_config, "example", None) if not isinstance(model_config, dict) else model_config.get("example")
     )
 
+    def get_name(f: ModelField) -> str:
+        return (f.alias or f.name) if prefer_alias else f.name
+
     return Schema(
-        required=sorted([field.alias or field.name for field in field_type.__fields__.values() if field.required]),
+        required=sorted(get_name(field) for field in field_type.__fields__.values() if field.required),
         properties={
-            (f.alias or f.name): create_schema(
+            get_name(f): create_schema(
                 field=SignatureField.create(
-                    field_type=field_type_hints[f.name], name=f.alias or f.name, default_value=f.field_info
+                    field_type=field_type_hints[f.name], name=get_name(f), default_value=f.field_info
                 ),
                 generate_examples=generate_examples,
                 plugins=plugins,
                 schemas=schemas,
+                prefer_alias=prefer_alias,
             )
             for f in field_type.__fields__.values()
         },
@@ -577,6 +613,7 @@ def create_schema_for_attrs_class(
     generate_examples: bool,
     plugins: list[OpenAPISchemaPluginProtocol],
     schemas: dict[str, Schema],
+    prefer_alias: bool,
 ) -> Schema:
     """Create a schema object for a given attrs class.
 
@@ -585,6 +622,7 @@ def create_schema_for_attrs_class(
         generate_examples: Whether to generate examples if none are given.
         plugins: A list of plugins.
         schemas: A mapping of namespaces to schemas - this mapping is used in the OA components section.
+        prefer_alias: Whether to prefer the alias name for the schema.
 
     Returns:
         A schema instance.
@@ -607,6 +645,7 @@ def create_schema_for_attrs_class(
                 generate_examples=generate_examples,
                 plugins=plugins,
                 schemas=schemas,
+                prefer_alias=prefer_alias,
             )
             for k, v in field_type_hints.items()
         },
@@ -620,6 +659,7 @@ def create_schema_for_struct_class(
     generate_examples: bool,
     plugins: list[OpenAPISchemaPluginProtocol],
     schemas: dict[str, Schema],
+    prefer_alias: bool,
 ) -> Schema:
     """Create a schema object for a given msgspec.Struct class.
 
@@ -628,6 +668,7 @@ def create_schema_for_struct_class(
         generate_examples: Whether to generate examples if none are given.
         plugins: A list of plugins.
         schemas: A mapping of namespaces to schemas - this mapping is used in the OA components section.
+        prefer_alias: Whether to prefer the alias name for the schema.
 
     Returns:
         A schema instance.
@@ -647,6 +688,7 @@ def create_schema_for_struct_class(
                 generate_examples=generate_examples,
                 plugins=plugins,
                 schemas=schemas,
+                prefer_alias=prefer_alias,
             )
             for field in msgspec_struct_fields(field_type)
         },
@@ -660,6 +702,7 @@ def create_schema_for_dataclass(
     generate_examples: bool,
     plugins: list[OpenAPISchemaPluginProtocol],
     schemas: dict[str, Schema],
+    prefer_alias: bool,
 ) -> Schema:
     """Create a schema object for a given dataclass class.
 
@@ -668,6 +711,7 @@ def create_schema_for_dataclass(
         generate_examples: Whether to generate examples if none are given.
         plugins: A list of plugins.
         schemas: A mapping of namespaces to schemas - this mapping is used in the OA components section.
+        prefer_alias: Whether to prefer the alias name for the schema.
 
     Returns:
         A schema instance.
@@ -691,6 +735,7 @@ def create_schema_for_dataclass(
                 generate_examples=generate_examples,
                 plugins=plugins,
                 schemas=schemas,
+                prefer_alias=prefer_alias,
             )
             for k, v in field_type_hints.items()
         },
@@ -704,6 +749,7 @@ def create_schema_for_typed_dict(
     generate_examples: bool,
     plugins: list[OpenAPISchemaPluginProtocol],
     schemas: dict[str, Schema],
+    prefer_alias: bool,
 ) -> Schema:
     """Create a schema object for a given typed dict.
 
@@ -712,6 +758,7 @@ def create_schema_for_typed_dict(
         generate_examples: Whether to generate examples if none are given.
         plugins: A list of plugins.
         schemas: A mapping of namespaces to schemas - this mapping is used in the OA components section.
+        prefer_alias: Whether to prefer the alias name for the schema.
 
     Returns:
         A schema instance.
@@ -724,6 +771,7 @@ def create_schema_for_typed_dict(
                 generate_examples=generate_examples,
                 plugins=plugins,
                 schemas=schemas,
+                prefer_alias=prefer_alias,
             )
             for k, v in get_type_hints(field_type).items()
         },
@@ -737,6 +785,7 @@ def create_schema_for_plugin(
     generate_examples: bool,
     plugins: list[OpenAPISchemaPluginProtocol],
     schemas: dict[str, Schema],
+    prefer_alias: bool,
     plugin: OpenAPISchemaPluginProtocol,
 ) -> Schema | Reference:
     """Create a schema using a plugin.
@@ -746,6 +795,7 @@ def create_schema_for_plugin(
         generate_examples: Whether to generate examples if none are given.
         plugins: A list of plugins.
         schemas: A mapping of namespaces to schemas - this mapping is used in the OA components section.
+        prefer_alias: Whether to prefer the alias name for the schema.
         plugin: A plugin for the field type.
 
     Returns:
@@ -765,6 +815,7 @@ def create_schema_for_plugin(
             generate_examples=generate_examples,
             plugins=plugins,
             schemas=schemas,
+            prefer_alias=prefer_alias,
         )
     return schema  # pragma: no cover
 
@@ -807,6 +858,7 @@ def create_schema(
     generate_examples: bool,
     plugins: list[OpenAPISchemaPluginProtocol],
     schemas: dict[str, Schema],
+    prefer_alias: bool = True,
 ) -> Schema | Reference:
     """Create a Schema for a given SignatureField.
 
@@ -815,43 +867,72 @@ def create_schema(
         generate_examples: Whether to generate examples if none are given.
         plugins: A list of plugins.
         schemas: A mapping of namespaces to schemas - this mapping is used in the OA components section.
+        prefer_alias: Whether to prefer the alias name for the schema.
 
     Returns:
         A schema instance.
     """
     if field.is_optional:
         result: Schema | Reference = create_schema_for_optional_field(
-            field=field, generate_examples=generate_examples, plugins=plugins, schemas=schemas
+            field=field,
+            generate_examples=generate_examples,
+            plugins=plugins,
+            schemas=schemas,
+            prefer_alias=prefer_alias,
         )
 
     elif field.is_union:
         result = create_schema_for_union_field(
-            field=field, generate_examples=generate_examples, plugins=plugins, schemas=schemas
+            field=field,
+            generate_examples=generate_examples,
+            plugins=plugins,
+            schemas=schemas,
+            prefer_alias=prefer_alias,
         )
 
     elif is_pydantic_model_class(annotation=field.field_type):
         result = create_schema_for_pydantic_model(
-            field_type=field.field_type, generate_examples=generate_examples, plugins=plugins, schemas=schemas
+            field_type=field.field_type,
+            generate_examples=generate_examples,
+            plugins=plugins,
+            schemas=schemas,
+            prefer_alias=prefer_alias,
         )
 
     elif is_attrs_class(annotation=field.field_type):
         result = create_schema_for_attrs_class(
-            field_type=field.field_type, generate_examples=generate_examples, plugins=plugins, schemas=schemas
+            field_type=field.field_type,
+            generate_examples=generate_examples,
+            plugins=plugins,
+            schemas=schemas,
+            prefer_alias=prefer_alias,
         )
 
     elif is_struct_class(annotation=field.field_type):
         result = create_schema_for_struct_class(
-            field_type=field.field_type, generate_examples=generate_examples, plugins=plugins, schemas=schemas
+            field_type=field.field_type,
+            generate_examples=generate_examples,
+            plugins=plugins,
+            schemas=schemas,
+            prefer_alias=prefer_alias,
         )
 
     elif is_dataclass_class(annotation=field.field_type):
         result = create_schema_for_dataclass(
-            field_type=field.field_type, generate_examples=generate_examples, plugins=plugins, schemas=schemas
+            field_type=field.field_type,
+            generate_examples=generate_examples,
+            plugins=plugins,
+            schemas=schemas,
+            prefer_alias=prefer_alias,
         )
 
     elif is_typed_dict(annotation=field.field_type):
         result = create_schema_for_typed_dict(
-            field_type=field.field_type, generate_examples=generate_examples, plugins=plugins, schemas=schemas
+            field_type=field.field_type,
+            generate_examples=generate_examples,
+            plugins=plugins,
+            schemas=schemas,
+            prefer_alias=prefer_alias,
         )
 
     elif plugins_for_annotation := [plugin for plugin in plugins if plugin.is_plugin_supported_type(field.field_type)]:
@@ -860,6 +941,7 @@ def create_schema(
             generate_examples=generate_examples,
             plugins=plugins,
             schemas=schemas,
+            prefer_alias=prefer_alias,
             plugin=plugins_for_annotation[0],
         )
 
@@ -871,19 +953,28 @@ def create_schema(
             children=field.children,
             plugins=plugins,
             schemas=schemas,
+            prefer_alias=prefer_alias,
             kwargs_model=field.kwarg_model,  # type: ignore[arg-type]
         )
 
     elif field.children and not field.is_generic:
         result = create_schema_for_object_type(
-            field=field, generate_examples=generate_examples, plugins=plugins, schemas=schemas
+            field=field,
+            generate_examples=generate_examples,
+            plugins=plugins,
+            schemas=schemas,
+            prefer_alias=prefer_alias,
         )
 
     elif field.is_generic and (
         get_origin_or_inner_type(field.field_type) in (ClassicPagination, CursorPagination, OffsetPagination)
     ):
         result = create_schema_for_builtin_generics(
-            field=field, generate_examples=generate_examples, plugins=plugins, schemas=schemas
+            field=field,
+            generate_examples=generate_examples,
+            plugins=plugins,
+            schemas=schemas,
+            prefer_alias=prefer_alias,
         )
     else:
         result = create_schema_for_annotation(annotation=field.field_type) or Schema()

--- a/litestar/dto/factory/_backends/abc.py
+++ b/litestar/dto/factory/_backends/abc.py
@@ -313,10 +313,14 @@ class AbstractDTOBackend(ABC, Generic[BackendT]):
             parsed_type=self.context.parsed_type,
         )
 
-    def create_openapi_schema(self, generate_examples: bool, schemas: dict[str, Schema]) -> Reference | Schema:
+    def create_openapi_schema(
+        self, generate_examples: bool, schemas: dict[str, Schema], prefer_alias: bool
+    ) -> Reference | Schema:
         """Create a RequestBody model for the given RouteHandler or return None."""
         field = SignatureField.create(self.annotation)
-        return create_schema(field=field, generate_examples=generate_examples, plugins=[], schemas=schemas)
+        return create_schema(
+            field=field, generate_examples=generate_examples, plugins=[], schemas=schemas, prefer_alias=prefer_alias
+        )
 
     def _create_transfer_type(
         self, parsed_type: ParsedType, exclude: AbstractSet[str], field_name: str, unique_name: str, nested_depth: int

--- a/litestar/dto/factory/abc.py
+++ b/litestar/dto/factory/abc.py
@@ -172,11 +172,7 @@ class AbstractDTOFactory(DTOInterface, Generic[T], metaclass=ABCMeta):
 
     @classmethod
     def create_openapi_schema(
-        cls,
-        dto_for: ForType,
-        handler_id: str,
-        generate_examples: bool,
-        schemas: dict[str, Schema],
+        cls, dto_for: ForType, handler_id: str, generate_examples: bool, schemas: dict[str, Schema], prefer_alias: bool
     ) -> Reference | Schema:
         """Create an OpenAPI request body.
 
@@ -184,7 +180,7 @@ class AbstractDTOFactory(DTOInterface, Generic[T], metaclass=ABCMeta):
             OpenAPI request body.
         """
         backend = cls._get_backend(dto_for, handler_id)
-        return backend.create_openapi_schema(generate_examples, schemas)
+        return backend.create_openapi_schema(generate_examples, schemas, prefer_alias)
 
     @classmethod
     def _get_backend(cls, dto_for: ForType, handler_id: str) -> AbstractDTOBackend:

--- a/litestar/dto/interface.py
+++ b/litestar/dto/interface.py
@@ -114,6 +114,7 @@ class DTOInterface(Protocol):
         handler_id: str,
         generate_examples: bool,
         schemas: dict[str, Schema],
+        prefer_alias: bool,
     ) -> Reference | Schema:
         """Create an OpenAPI request body for the DTO.
 

--- a/tests/dto/factory/backends/test_backends.py
+++ b/tests/dto/factory/backends/test_backends.py
@@ -163,7 +163,7 @@ def test_backend_populate_data_from_builtins(
 def test_backend_create_openapi_schema(backend_type: type[AbstractDTOBackend], backend_context: BackendContext) -> None:
     backend = backend_type(backend_context)
     schemas: dict[str, Any] = {}
-    ref = backend.create_openapi_schema(False, schemas)
+    ref = backend.create_openapi_schema(False, schemas, True)
     assert isinstance(ref, Reference)
     schema = schemas[ref.value]
     assert schema.properties["a"].type == "integer"

--- a/tests/dto/factory/test_abc.py
+++ b/tests/dto/factory/test_abc.py
@@ -180,5 +180,5 @@ def test_create_openapi_schema(monkeypatch: MonkeyPatch) -> None:
     dto_type.on_registration(HandlerContext(handler_id="handler", dto_for="data", parsed_type=ParsedType(Model)))
 
     with patch("litestar.dto.factory._backends.abc.AbstractDTOBackend.create_openapi_schema") as mock:
-        dto_type.create_openapi_schema("data", "handler", True, {})
-        mock.assert_called_once_with(True, {})
+        dto_type.create_openapi_schema("data", "handler", True, {}, True)
+        mock.assert_called_once_with(True, {}, True)

--- a/tests/dto/test_interface.py
+++ b/tests/dto/test_interface.py
@@ -8,4 +8,4 @@ from . import MockDTO
 
 
 def test_dto_interface_create_openapi_schema_default_implementation() -> None:
-    assert MockDTO.create_openapi_schema("data", MagicMock(), False, {}) == Schema()
+    assert MockDTO.create_openapi_schema("data", MagicMock(), False, {}, True) == Schema()

--- a/tests/openapi/test_constrained_fields.py
+++ b/tests/openapi/test_constrained_fields.py
@@ -30,6 +30,7 @@ def test_create_collection_constrained_field_schema(field_type: Any) -> None:
         kwargs_model=signature_field.kwarg_model,  # type: ignore[arg-type]
         plugins=[],
         schemas={},
+        prefer_alias=True,
     )
     assert schema.type == OpenAPIType.ARRAY
     assert schema.items.type == OpenAPIType.INTEGER  # type: ignore
@@ -46,6 +47,7 @@ def test_create_collection_constrained_field_schema_sub_fields() -> None:
             kwargs_model=signature_field.kwarg_model,  # type: ignore[arg-type]
             plugins=[],
             schemas={},
+            prefer_alias=True,
         )
         assert schema.type == OpenAPIType.ARRAY
         expected = {
@@ -117,5 +119,6 @@ def test_create_constrained_field_schema(field_type: Any) -> None:
         kwargs_model=signature_field.kwarg_model,  # type: ignore[arg-type]
         plugins=[],
         schemas={},
+        prefer_alias=True,
     )
     assert schema

--- a/tests/openapi/test_request_body.py
+++ b/tests/openapi/test_request_body.py
@@ -105,4 +105,4 @@ def test_request_body_generation_with_dto() -> None:
         schemas={},
     )
 
-    mock_dto.create_openapi_schema.assert_called_once_with("data", str(handler), False, {})
+    mock_dto.create_openapi_schema.assert_called_once_with("data", str(handler), False, {}, True)

--- a/tests/openapi/test_responses.py
+++ b/tests/openapi/test_responses.py
@@ -436,4 +436,4 @@ def test_response_generation_with_dto() -> None:
         schemas={},
     )
 
-    mock_dto.create_openapi_schema.assert_called_once_with("return", str(handler), False, {})
+    mock_dto.create_openapi_schema.assert_called_once_with("return", str(handler), False, {}, False)

--- a/tests/openapi/test_schema.py
+++ b/tests/openapi/test_schema.py
@@ -204,7 +204,9 @@ class Foo(BaseModel):
     foo: Annotated[int, "Foo description"]
 """
     )
-    schema = create_schema_for_pydantic_model(module.Foo, generate_examples=False, plugins=[], schemas={})
+    schema = create_schema_for_pydantic_model(
+        module.Foo, generate_examples=False, plugins=[], schemas={}, prefer_alias=True
+    )
     assert schema.properties and "foo" in schema.properties
 
 
@@ -224,7 +226,7 @@ class Foo:
     foo: Annotated[int, "Foo description"]
 """
     )
-    schema = create_schema_for_dataclass(module.Foo, generate_examples=False, plugins=[], schemas={})
+    schema = create_schema_for_dataclass(module.Foo, generate_examples=False, plugins=[], schemas={}, prefer_alias=True)
     assert schema.properties and "foo" in schema.properties
 
 
@@ -245,7 +247,9 @@ class Foo(TypedDict):
     baz: Annotated[NotRequired[int], "Baz description"]
 """
     )
-    schema = create_schema_for_typed_dict(module.Foo, generate_examples=False, plugins=[], schemas={})
+    schema = create_schema_for_typed_dict(
+        module.Foo, generate_examples=False, plugins=[], schemas={}, prefer_alias=True
+    )
     assert schema.properties and all(key in schema.properties for key in ("foo", "bar", "baz"))
 
 

--- a/tests/openapi/test_schema.py
+++ b/tests/openapi/test_schema.py
@@ -136,6 +136,7 @@ def test_handling_of_literals() -> None:
         generate_examples=False,
         plugins=[],
         schemas=schemas,
+        prefer_alias=True,
     )
     assert isinstance(result, Reference)
     schema = schemas["DataclassWithLiteral"]
@@ -168,6 +169,7 @@ def test_title_validation() -> None:
         generate_examples=False,
         plugins=[],
         schemas=schemas,
+        prefer_alias=True,
     )
     assert schemas.get("Person")
 
@@ -176,6 +178,7 @@ def test_title_validation() -> None:
         generate_examples=False,
         plugins=[],
         schemas=schemas,
+        prefer_alias=True,
     )
 
     assert schemas.get("Pet")
@@ -186,6 +189,7 @@ def test_title_validation() -> None:
             generate_examples=False,
             plugins=[],
             schemas=schemas,
+            prefer_alias=True,
         )
 
 
@@ -263,6 +267,7 @@ def test_create_schema_from_msgspec_annotated_type() -> None:
         generate_examples=False,
         plugins=[],
         schemas=schemas,
+        prefer_alias=True,
     )
     schema = schemas["Lookup"]
     assert schema.properties["id"].type == OpenAPIType.STRING  # type: ignore
@@ -282,6 +287,7 @@ def test_create_schema_for_pydantic_field() -> None:
         generate_examples=False,
         plugins=[],
         schemas=schemas,
+        prefer_alias=True,
     )
     schema = schemas["Model"]
 


### PR DESCRIPTION
### Description

- Add a `prefer_alias` parameter to `litestar._openapi.schema_generation.create_schema` & friends
- Set it to False for response schemas and True otherwise.

### Close Issue(s)

Fixes #1809 
