### PR TITLE
fix: Cookie.expires field docstring

### DIFF
--- a/litestar/datastructures/cookie.py
+++ b/litestar/datastructures/cookie.py
@@ -26,7 +26,7 @@ class Cookie:
     max_age: int | None = field(default=None)
     """Maximal age of the cookie before its invalidated."""
     expires: int | None = field(default=None)
-    """Expiration date as unix MS timestamp."""
+    """Seconds from now until the cookie expires."""
     domain: str | None = field(default=None)
     """Domain for which the cookie is valid."""
     secure: bool | None = field(default=None)

--- a/litestar/response/base.py
+++ b/litestar/response/base.py
@@ -276,7 +276,7 @@ class Response(Generic[T]):
             key: Key for the cookie or a :class:`Cookie <.datastructures.Cookie>` instance.
             value: Value for the cookie, if none given defaults to empty string.
             max_age: Maximal age of the cookie before its invalidated.
-            expires: Expiration date as unix MS timestamp.
+            expires: Seconds from now until the cookie expires.
             path: Path fragment that must exist in the request url for the cookie to be valid. Defaults to ``/``.
             domain: Domain for which the cookie is valid.
             secure: Https is required for the cookie.


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

As shown in the [tests](https://github.com/litestar-org/litestar/blob/b204f8b9ca10b6f86feac6649c7976c91e38d182/tests/datastructures/test_cookie.py#L13-L31) the [Cookie.expires field](https://github.com/litestar-org/litestar/blob/b204f8b9ca10b6f86feac6649c7976c91e38d182/litestar/datastructures/cookie.py#L28-L29) takes seconds which will be added to the current datetime, therefore the current docstring is misleading.

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
