### PR TITLE
Refactor: openapi handler media types

### DIFF
--- a/litestar/_openapi/responses.py
+++ b/litestar/_openapi/responses.py
@@ -91,13 +91,13 @@ def create_success_response(  # noqa: C901
     if return_annotation is not Signature.empty and not return_type.is_subclass_of(
         (NoneType, File, Redirect, Stream, ASGIResponse)
     ):
+        media_type = route_handler.media_type
         if return_annotation is Template:
             return_annotation = str
-            route_handler.media_type = get_enum_string_value(MediaType.HTML)
+            media_type = media_type or MediaType.HTML
         elif return_type.is_subclass_of(LitestarResponse):
             return_annotation = return_type.inner_types[0].annotation if return_type.inner_types else Any
-            if not route_handler.media_type:
-                route_handler.media_type = get_enum_string_value(MediaType.JSON)
+            media_type = media_type or MediaType.JSON
 
         if dto := route_handler.resolve_return_dto():
             result = dto.create_openapi_schema("return", str(route_handler), generate_examples, schemas, False)
@@ -116,8 +116,7 @@ def create_success_response(  # noqa: C901
         schema.content_media_type = route_handler.content_media_type
 
         response = OpenAPIResponse(
-            content={route_handler.media_type: OpenAPIMediaType(schema=result)},
-            description=description,
+            content={get_enum_string_value(media_type): OpenAPIMediaType(schema=result)}, description=description
         )
 
     elif return_type.is_subclass_of(Redirect):


### PR DESCRIPTION
This PR introduces two behavioural differences:

1. template response media types aren't necessarily always HTML.
2. don't mutate the state of the handler media type configuration during schema generation.

Regarding the first change. If the return annotation of the handler is a `Template` response, currently we use `MediaType.HTML` for the response content, ignoring what may have already been defined on the handler. This PR only defaults to `MediaType.HTML` if it isn't already defined. I believe this is correct, as template documents don't have to be HTML, although that would be the most common.

Regards the 2nd change, instead of mutating the handler inside the openapi generation, this PR introduces a local variable to carry the media type for the function. This is not fixing a known issue, I just noticed the behavior while working on an earlier PR and think that unnecessarily mutating the configuration of the handler might be a source of confusion.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
