### PR TITLE
Refactor: remove set-cookie ops on genric asgi responses.

### DIFF
--- a/litestar/handlers/http_handlers/_utils.py
+++ b/litestar/handlers/http_handlers/_utils.py
@@ -87,24 +87,17 @@ def create_data_handler(
     return handler
 
 
-def create_generic_asgi_response_handler(
-    after_request: AfterRequestHookHandler | None,
-    cookies: frozenset[Cookie],
-) -> AsyncAnyCallable:
+def create_generic_asgi_response_handler(after_request: AfterRequestHookHandler | None) -> AsyncAnyCallable:
     """Create a handler function for Responses.
 
     Args:
         after_request: An after request handler.
-        cookies: A set of pre-defined cookies.
 
     Returns:
         A handler function.
     """
 
     async def handler(data: ASGIApp, **kwargs: Any) -> ASGIApp:
-        if hasattr(data, "set_cookie"):
-            for cookie in cookies:
-                data.set_cookie(**cookie.dict)
         return await after_request(data) if after_request else data  # type: ignore
 
     return handler

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -435,7 +435,7 @@ class HTTPRouteHandler(BaseRouteHandler):
                 self._response_handler_mapping["default_handler"] = response_type_handler
             elif is_async_callable(return_annotation) or return_annotation is ASGIApp:
                 self._response_handler_mapping["default_handler"] = create_generic_asgi_response_handler(
-                    after_request=after_request, cookies=cookies
+                    after_request=after_request
                 )
             else:
                 self._response_handler_mapping["default_handler"] = create_data_handler(

--- a/tests/handlers/http/test_to_response.py
+++ b/tests/handlers/http/test_to_response.py
@@ -131,7 +131,7 @@ async def test_to_response_returning_litestar_response() -> None:
 async def test_to_response_returning_starlette_response(
     expected_response: StarletteResponse, anyio_backend: str
 ) -> None:
-    @get(path="/test", response_cookies=[Cookie(key="my-cookies", value="abc", path="/test")])
+    @get(path="/test")
     def test_function() -> StarletteResponse:
         return expected_response
 
@@ -143,7 +143,6 @@ async def test_to_response_returning_starlette_response(
         )
         assert isinstance(response, StarletteResponse)
         assert response is expected_response  # type: ignore[unreachable]
-        assert response.headers["set-cookie"] == "my-cookies=abc; Path=/test; SameSite=lax"
 
 
 async def test_to_response_returning_redirect_response(anyio_backend: str) -> None:


### PR DESCRIPTION
Current behavior is to set cookies on asgi responses from handlers if the response type has a `set_cookie()` method. This looks like it is specific handling for starlette responses, as they are the only tests that broke on its removal.

If we want to continue to explicitly support this for starlette response types, we can create a specific response handler for them that does set cookies, however, IMO we have diverged far enough from starlette to not warrant the specific logic.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
