### PR TITLE
Add `TestClient` default timeout

### DIFF
--- a/litestar/testing/client/async_client.py
+++ b/litestar/testing/client/async_client.py
@@ -44,6 +44,7 @@ class AsyncTestClient(AsyncClient, BaseTestClient, Generic[T]):  # type: ignore[
         backend: AnyIOBackend = "asyncio",
         backend_options: Mapping[str, Any] | None = None,
         session_config: BaseBackendConfig | None = None,
+        timeout: float | None = None,
         cookies: CookieTypes | None = None,
     ):
         """An Async client implementation providing a context manager for testing applications asynchronously.
@@ -58,6 +59,7 @@ class AsyncTestClient(AsyncClient, BaseTestClient, Generic[T]):  # type: ignore[
             backend_options: 'anyio' options.
             session_config: Configuration for Session Middleware class to create raw session cookies for request to the
                 route handlers.
+            timeout: Request timeout
             cookies: Cookies to set on the client.
         """
         BaseTestClient.__init__(
@@ -81,6 +83,7 @@ class AsyncTestClient(AsyncClient, BaseTestClient, Generic[T]):  # type: ignore[
                 raise_server_exceptions=raise_server_exceptions,
                 root_path=root_path,
             ),
+            timeout=timeout,
         )
 
     async def __aenter__(self) -> AsyncTestClient[T]:

--- a/litestar/testing/client/sync_client.py
+++ b/litestar/testing/client/sync_client.py
@@ -47,6 +47,7 @@ class TestClient(Client, BaseTestClient, Generic[T]):  # type: ignore[misc]
         backend: AnyIOBackend = "asyncio",
         backend_options: Mapping[str, Any] | None = None,
         session_config: BaseBackendConfig | None = None,
+        timeout: float | None = None,
         cookies: CookieTypes | None = None,
     ) -> None:
         """A client implementation providing a context manager for testing applications.
@@ -61,6 +62,7 @@ class TestClient(Client, BaseTestClient, Generic[T]):  # type: ignore[misc]
             backend_options: ``anyio`` options.
             session_config: Configuration for Session Middleware class to create raw session cookies for request to the
                 route handlers.
+            timeout: Request timeout
             cookies: Cookies to set on the client.
         """
         BaseTestClient.__init__(
@@ -85,6 +87,7 @@ class TestClient(Client, BaseTestClient, Generic[T]):  # type: ignore[misc]
                 raise_server_exceptions=raise_server_exceptions,
                 root_path=root_path,
             ),
+            timeout=timeout,
         )
 
     def __enter__(self) -> TestClient[T]:

--- a/litestar/testing/helpers.py
+++ b/litestar/testing/helpers.py
@@ -104,6 +104,7 @@ def create_test_client(
     stores: StoreRegistry | dict[str, Store] | None = None,
     tags: Sequence[str] | None = None,
     template_config: TemplateConfig | None = None,
+    timeout: float | None = None,
     type_encoders: TypeEncodersMap | None = None,
     websocket_class: type[WebSocket] | None = None,
     _preferred_validation_backend: Literal["pydantic", "attrs"] | None = None,
@@ -221,6 +222,7 @@ def create_test_client(
         tags: A sequence of string tags that will be appended to the schema of all route handlers under the
             application.
         template_config: An instance of :class:`TemplateConfig <.template.TemplateConfig>`
+        timeout: Request timeout
         type_encoders: A mapping of types to callables that transform them into types supported for serialization.
         websocket_class: An optional subclass of :class:`WebSocket <.connection.WebSocket>` to use for websocket
             connections.
@@ -290,6 +292,7 @@ def create_test_client(
         raise_server_exceptions=raise_server_exceptions,
         root_path=root_path,
         session_config=session_config,
+        timeout=timeout,
     )
 
 
@@ -345,6 +348,7 @@ def create_async_test_client(
     stores: StoreRegistry | dict[str, Store] | None = None,
     tags: Sequence[str] | None = None,
     template_config: TemplateConfig | None = None,
+    timeout: float | None = None,
     type_encoders: TypeEncodersMap | None = None,
     websocket_class: type[WebSocket] | None = None,
     _preferred_validation_backend: Literal["pydantic", "attrs"] | None = None,
@@ -462,6 +466,7 @@ def create_async_test_client(
         tags: A sequence of string tags that will be appended to the schema of all route handlers under the
             application.
         template_config: An instance of :class:`TemplateConfig <.template.TemplateConfig>`
+        timeout: Request timeout
         type_encoders: A mapping of types to callables that transform them into types supported for serialization.
         websocket_class: An optional subclass of :class:`WebSocket <.connection.WebSocket>` to use for websocket
             connections.
@@ -531,4 +536,5 @@ def create_async_test_client(
         raise_server_exceptions=raise_server_exceptions,
         root_path=root_path,
         session_config=session_config,
+        timeout=timeout,
     )

--- a/litestar/testing/transport.py
+++ b/litestar/testing/transport.py
@@ -148,7 +148,7 @@ class TestClientTransport(Generic[T]):
             scope.update(
                 subprotocols=[value.strip() for value in request.headers.get("sec-websocket-protocol", "").split(",")]
             )
-            session = WebSocketTestSession(client=self.client, scope=cast("WebSocketScope", scope))  # type: ignore [arg-type]
+            session = WebSocketTestSession(client=self.client, scope=cast("WebSocketScope", scope))  # type: ignore[arg-type]
             raise ConnectionUpgradeExceptionError(session)
 
         scope.update(method=request.method, http_version="1.1", extensions={"http.response.template": {}})

--- a/tests/testing/test_sync_test_client.py
+++ b/tests/testing/test_sync_test_client.py
@@ -174,7 +174,7 @@ def test_websocket_accept_timeout(anyio_backend: AnyIOBackend) -> None:
     async def handler(socket: WebSocket) -> None:
         pass
 
-    with create_test_client(handler, backend=anyio_backend) as client, pytest.raises(Empty), client.websocket_connect(
-        "/"
-    ):
+    with create_test_client(handler, backend=anyio_backend, timeout=0.1) as client, pytest.raises(
+        Empty
+    ), client.websocket_connect("/"):
         pass


### PR DESCRIPTION
Add a `timeout` parameter to `TestClient`, `AsyncTestClient`, `create_test_client` and `create_async_test_client`. The value is passed down to the underlying HTTPX client and serves as a default timeout for all requests.
