### PR TITLE
Simplify SQLA repo imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,9 +19,10 @@ repos:
       - id: poetry-lock
         args: ["--no-update"]
   - repo: https://github.com/provinzkraut/unasyncd
-    rev: "v0.2.1"
+    rev: "v0.4.0"
     hooks:
       - id: unasyncd
+        additional_dependencies: ["ruff"]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: "v0.0.272"
     hooks:

--- a/litestar/contrib/sqlalchemy/repository/_async.py
+++ b/litestar/contrib/sqlalchemy/repository/_async.py
@@ -5,11 +5,7 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, cast
 from sqlalchemy import Result, Select, delete, over, select, text, update
 from sqlalchemy import func as sql_func
 
-from litestar.contrib.repository import (  # noqa: RUF100, F401
-    AbstractAsyncRepository,
-    AbstractSyncRepository,
-    RepositoryError,
-)
+from litestar.contrib.repository import AbstractAsyncRepository, RepositoryError
 from litestar.contrib.repository.filters import (
     BeforeAfter,
     CollectionFilter,
@@ -27,8 +23,7 @@ if TYPE_CHECKING:
     from datetime import datetime
 
     from sqlalchemy.engine.interfaces import _CoreSingleExecuteParams
-    from sqlalchemy.ext.asyncio import AsyncSession  # noqa: RUF100, F401
-    from sqlalchemy.orm import Session  # noqa: RUF100, F401
+    from sqlalchemy.ext.asyncio import AsyncSession
 
 
 class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]):

--- a/litestar/contrib/sqlalchemy/repository/_sync.py
+++ b/litestar/contrib/sqlalchemy/repository/_sync.py
@@ -7,11 +7,7 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, cast
 from sqlalchemy import Result, Select, delete, over, select, text, update
 from sqlalchemy import func as sql_func
 
-from litestar.contrib.repository import (  # noqa: RUF100, F401
-    AbstractAsyncRepository,
-    AbstractSyncRepository,
-    RepositoryError,
-)
+from litestar.contrib.repository import AbstractSyncRepository, RepositoryError
 from litestar.contrib.repository.filters import (
     BeforeAfter,
     CollectionFilter,
@@ -29,8 +25,7 @@ if TYPE_CHECKING:
     from datetime import datetime
 
     from sqlalchemy.engine.interfaces import _CoreSingleExecuteParams
-    from sqlalchemy.ext.asyncio import AsyncSession  # noqa: RUF100, F401
-    from sqlalchemy.orm import Session  # noqa: RUF100, F401
+    from sqlalchemy.orm import Session
 
 
 class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -426,6 +426,7 @@ known-first-party = ["litestar", "tests", "examples"]
 
 [tool.unasyncd]
 add_editors_note = true
+ruff_fix = true
 
 
 [tool.unasyncd.files]


### PR DESCRIPTION
Remove some unnecessary imports from the SQLA repositories, which were needed to a previous limitation of unasyncd.