### PR TITLE
Add missing marker to SQLA oracle JSON tests

### DIFF
--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_sqlalchemy_oracledb_json.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_sqlalchemy_oracledb_json.py
@@ -12,7 +12,7 @@ from tests.unit.test_contrib.test_sqlalchemy.models_uuid import UUIDEventLog
 
 pytestmark = [
     pytest.mark.skipif(platform.uname()[4] != "x86_64", reason="oracle not available on this platform"),
-    pytest.mark.sqlalchemy_integration
+    pytest.mark.sqlalchemy_integration,
 ]
 
 

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_sqlalchemy_oracledb_json.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_sqlalchemy_oracledb_json.py
@@ -12,6 +12,7 @@ from tests.unit.test_contrib.test_sqlalchemy.models_uuid import UUIDEventLog
 
 pytestmark = [
     pytest.mark.skipif(platform.uname()[4] != "x86_64", reason="oracle not available on this platform"),
+    pytest.mark.sqlalchemy_integration
 ]
 
 


### PR DESCRIPTION
Add a missing `sqlalchemy_integration` marker to the SQLA repository tests for oracledb