### PR TITLE
fix: added `session.refresh` to sqla repository update

### DIFF
--- a/litestar/contrib/sqlalchemy/repository/_async.py
+++ b/litestar/contrib/sqlalchemy/repository/_async.py
@@ -286,6 +286,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
             # this will merge the inbound data to the instance we just put in the session
             instance = await self._attach_to_session(data, strategy="merge")
             await self.session.flush()
+            await self.session.refresh(instance)
             self.session.expunge(instance)
             return instance
 

--- a/litestar/contrib/sqlalchemy/repository/_sync.py
+++ b/litestar/contrib/sqlalchemy/repository/_sync.py
@@ -288,6 +288,7 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
             # this will merge the inbound data to the instance we just put in the session
             instance = self._attach_to_session(data, strategy="merge")
             self.session.flush()
+            self.session.refresh(instance)
             self.session.expunge(instance)
             return instance
 


### PR DESCRIPTION
I haven't opened an issue for this, but ran into it when updating a model attribute that changes when sent to the db. In my current case, it is a Geography object that uses a WKT formatted string when sent to the db, and comes back as a WKBElement wrapped by [GeoAlchemy2](https://geoalchemy-2.readthedocs.io/en/latest/orm_tutorial.html#add-new-objects) when queried. 

By refreshing the instance after merging and flushing, we get the newest values of the updated attributes instead of keeping values sent to the db. 