### PR TITLE
SQLAlchemyDTO: column/relationship type inference.

### DIFF
--- a/litestar/dto/factory/_backends/utils.py
+++ b/litestar/dto/factory/_backends/utils.py
@@ -279,7 +279,7 @@ def transfer_type_data(
     if isinstance(transfer_type, CollectionType):
         if transfer_type.has_nested:
             return transfer_nested_collection_type_data(
-                transfer_type.parsed_type.origin, transfer_type, dto_for, source_value
+                transfer_type.parsed_type.instantiable_origin, transfer_type, dto_for, source_value
             )
         return transfer_type.parsed_type.instantiable_origin(source_value)
     return source_value


### PR DESCRIPTION
If type annotations aren't available for a given column/relationship we make an effort to infer a type annotation from the relevant SQLAlchemy object.

For columns, we use the `Column.type.python_type` attribute as the type of the column, and the `Column.nullable` property to determine if the field should have a `None` union.

For relationships, where the `RelationshipProperty.direction` is `ONETOMANY` or `MANYTOMANY`, we use the `RelationshipProperty.collection_class` and the `RelationshipProperty.mapper.class_` attribute to construct an annotation for the collection.

For `ONETOONE` relationships, we use the `RelationshipProperty.mapper.class_` to get the type annotation, and make the type a union with `None` if all of the foreign key columns are nullable.

Closes #1853

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
