### PR TITLE
Make audit columns not always default to app startup time

### DIFF
--- a/litestar/contrib/sqlalchemy/base.py
+++ b/litestar/contrib/sqlalchemy/base.py
@@ -114,12 +114,12 @@ class AuditColumns:
 
     created_at: Mapped[datetime] = mapped_column(  # pyright: ignore
         DateTimeUTC(timezone=True),
-        default=datetime.now(timezone.utc),
+        default=lambda: datetime.now(timezone.utc),
     )
     """Date/time of instance creation."""
     updated_at: Mapped[datetime] = mapped_column(  # pyright: ignore
         DateTimeUTC(timezone=True),
-        default=datetime.now(timezone.utc),
+        default=lambda: datetime.now(timezone.utc),
     )
     """Date/time of instance last update."""
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] New code has 100% test coverage
- [x] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [x] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

This PR changes the `AuditColumns` mixin to the desired behavior. Currently, the default value is whatever `datetime.now(timezone.utc)` evaluates to when `AuditColumns` is first evaluated.

### Close Issue(s)

I can create one if you want.