### PR TITLE
feat: Make repository `refresh` and `expunge` optional, Adds `auto_commit` option.

### DIFF
--- a/litestar/contrib/sqlalchemy/repository/_async.py
+++ b/litestar/contrib/sqlalchemy/repository/_async.py
@@ -78,14 +78,14 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Returns:
             The added instance.
         """
-        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
-        _auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
+        auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
         with wrap_sqlalchemy_exception():
             instance = await self._attach_to_session(data)
-            await self._flush_or_commit(auto_commit=_auto_commit)
-            await self._refresh(instance, auto_refresh=_auto_refresh)
-            self._expunge(instance, auto_expunge=_auto_expunge)
+            await self._flush_or_commit(auto_commit=auto_commit)
+            await self._refresh(instance, auto_refresh=auto_refresh)
+            self._expunge(instance, auto_expunge=auto_expunge)
             return instance
 
     async def add_many(
@@ -102,13 +102,13 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Returns:
             The added instances.
         """
-        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             self.session.add_all(data)
-            await self._flush_or_commit(auto_commit=_auto_commit)
+            await self._flush_or_commit(auto_commit=auto_commit)
             for datum in data:
-                self._expunge(datum, auto_expunge=_auto_expunge)
+                self._expunge(datum, auto_expunge=auto_expunge)
             return data
 
     async def delete(
@@ -128,13 +128,13 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Raises:
             NotFoundError: If no instance found identified by ``item_id``.
         """
-        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             instance = await self.get(item_id)
             await self.session.delete(instance)
-            await self._flush_or_commit(auto_commit=_auto_commit)
-            self._expunge(instance, auto_expunge=_auto_expunge)
+            await self._flush_or_commit(auto_commit=auto_commit)
+            self._expunge(instance, auto_expunge=auto_expunge)
             return instance
 
     async def delete_many(
@@ -152,8 +152,8 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
             The deleted instances.
 
         """
-        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             instances: list[ModelT] = []
             chunk_size = 450
@@ -176,9 +176,9 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
                     await self.session.execute(
                         delete(self.model_type).where(getattr(self.model_type, self.id_attribute).in_(chunk))
                     )
-            await self._flush_or_commit(auto_commit=_auto_commit)
+            await self._flush_or_commit(auto_commit=auto_commit)
             for instance in instances:
-                self._expunge(instance, auto_expunge=_auto_expunge)
+                self._expunge(instance, auto_expunge=auto_expunge)
             return instances
 
     async def exists(self, **kwargs: Any) -> bool:
@@ -207,13 +207,13 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Raises:
             NotFoundError: If no instance found identified by `item_id`.
         """
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             statement = kwargs.pop("statement", self.statement)
             statement = self._filter_select_by_kwargs(statement=statement, **{self.id_attribute: item_id})
             instance = (await self._execute(statement)).scalar_one_or_none()
             instance = self.check_not_found(instance)
-            self._expunge(instance, auto_expunge=_auto_expunge)
+            self._expunge(instance, auto_expunge=auto_expunge)
             return instance
 
     async def get_one(self, **kwargs: Any) -> ModelT:
@@ -228,13 +228,13 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Raises:
             NotFoundError: If no instance found identified by `item_id`.
         """
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             statement = kwargs.pop("statement", self.statement)
             statement = self._filter_select_by_kwargs(statement=statement, **kwargs)
             instance = (await self._execute(statement)).scalar_one_or_none()
             instance = self.check_not_found(instance)
-            self._expunge(instance, auto_expunge=_auto_expunge)
+            self._expunge(instance, auto_expunge=auto_expunge)
             return instance
 
     async def get_one_or_none(self, **kwargs: Any) -> ModelT | None:
@@ -246,13 +246,13 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Returns:
             The retrieved instance or None
         """
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             statement = kwargs.pop("statement", self.statement)
             statement = self._filter_select_by_kwargs(statement=statement, **kwargs)
             instance = (await self._execute(statement)).scalar_one_or_none()
             if instance:
-                self._expunge(instance, auto_expunge=_auto_expunge)
+                self._expunge(instance, auto_expunge=auto_expunge)
             return instance  # type: ignore
 
     async def get_or_create(
@@ -275,9 +275,9 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Returns:
             a tuple that includes the instance and whether or not it needed to be created.  When using match_fields and actual model values differ from `kwargs`, the model value will be updated.
         """
-        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
-        _auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
+        auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
         match_fields = match_fields or self.match_fields
         if isinstance(match_fields, str):
             match_fields = [match_fields]
@@ -298,11 +298,11 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
                 if field and field != new_field_value:
                     setattr(existing, field_name, new_field_value)
             existing = await self._attach_to_session(existing, strategy="merge")
-            await self._flush_or_commit(auto_commit=_auto_commit)
+            await self._flush_or_commit(auto_commit=auto_commit)
             await self._refresh(
-                existing, attribute_names=attribute_names, with_for_update=with_for_update, auto_refresh=_auto_refresh
+                existing, attribute_names=attribute_names, with_for_update=with_for_update, auto_refresh=auto_refresh
             )
-            self._expunge(existing, auto_expunge=_auto_expunge)
+            self._expunge(existing, auto_expunge=auto_expunge)
         return existing, False
 
     async def count(self, *filters: FilterTypes, **kwargs: Any) -> int:
@@ -347,20 +347,20 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Raises:
             NotFoundError: If no instance found with same identifier as `data`.
         """
-        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
-        _auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
+        auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
         with wrap_sqlalchemy_exception():
             item_id = self.get_id_attribute_value(data)
             # this will raise for not found, and will put the item in the session
             await self.get(item_id)
             # this will merge the inbound data to the instance we just put in the session
             instance = await self._attach_to_session(data, strategy="merge")
-            await self._flush_or_commit(auto_commit=_auto_commit)
+            await self._flush_or_commit(auto_commit=auto_commit)
             await self._refresh(
-                instance, attribute_names=attribute_names, with_for_update=with_for_update, auto_refresh=_auto_refresh
+                instance, attribute_names=attribute_names, with_for_update=with_for_update, auto_refresh=auto_refresh
             )
-            self._expunge(instance, auto_expunge=_auto_expunge)
+            self._expunge(instance, auto_expunge=auto_expunge)
             return instance
 
     async def update_many(
@@ -385,8 +385,8 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Raises:
             NotFoundError: If no instance found with same identifier as `data`.
         """
-        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         data_to_update: list[dict[str, Any]] = [v.to_dict() if isinstance(v, self.model_type) else v for v in data]  # type: ignore
         with wrap_sqlalchemy_exception():
             if self._dialect.update_executemany_returning and self._dialect.name != "oracle":
@@ -398,15 +398,15 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
                         # https://github.com/sqlalchemy/sqlalchemy/discussions/9925
                     )
                 )
-                await self._flush_or_commit(auto_commit=_auto_commit)
+                await self._flush_or_commit(auto_commit=auto_commit)
                 for instance in instances:
-                    self._expunge(instance, auto_expunge=_auto_expunge)
+                    self._expunge(instance, auto_expunge=auto_expunge)
                 return instances
             await self.session.execute(
                 update(self.model_type),
                 data_to_update,
             )
-            await self._flush_or_commit(auto_commit=_auto_commit)
+            await self._flush_or_commit(auto_commit=auto_commit)
             return data
 
     async def list_and_count(
@@ -460,7 +460,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Returns:
             Count of records returned by query using an analytical window function, ignoring pagination.
         """
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         statement = kwargs.pop("statement", self.statement)
         statement = statement.add_columns(over(sql_func.count(self.get_id_attribute_value(self.model_type))))
         statement = self._apply_filters(*filters, statement=statement)
@@ -470,7 +470,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
             count: int = 0
             instances: list[ModelT] = []
             for i, (instance, count_value) in enumerate(result):
-                self._expunge(instance, auto_expunge=_auto_expunge)
+                self._expunge(instance, auto_expunge=auto_expunge)
                 instances.append(instance)
                 if i == 0:
                     count = count_value
@@ -490,7 +490,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Returns:
             Count of records returned by query using 2 queries, ignoring pagination.
         """
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         statement = kwargs.pop("statement", self.statement)
         statement = self._apply_filters(*filters, statement=statement)
         statement = self._filter_select_by_kwargs(statement, **kwargs)
@@ -504,7 +504,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
             result = await self._execute(statement)
             instances: list[ModelT] = []
             for (instance,) in result:
-                self._expunge(instance, auto_expunge=_auto_expunge)
+                self._expunge(instance, auto_expunge=auto_expunge)
                 instances.append(instance)
             return instances, count
 
@@ -518,7 +518,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Returns:
             The list of instances, after filtering applied.
         """
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         statement = kwargs.pop("statement", self.statement)
         statement = self._apply_filters(*filters, statement=statement)
         statement = self._filter_select_by_kwargs(statement, **kwargs)
@@ -527,7 +527,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
             result = await self._execute(statement)
             instances = list(result.scalars())
             for instance in instances:
-                self._expunge(instance, auto_expunge=_auto_expunge)
+                self._expunge(instance, auto_expunge=auto_expunge)
             return instances
 
     async def upsert(
@@ -556,16 +556,16 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Raises:
             NotFoundError: If no instance found with same identifier as `data`.
         """
-        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
-        _auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
+        auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
         with wrap_sqlalchemy_exception():
             instance = await self._attach_to_session(data, strategy="merge")
-            await self._flush_or_commit(auto_commit=_auto_commit)
+            await self._flush_or_commit(auto_commit=auto_commit)
             await self._refresh(
-                instance, attribute_names=attribute_names, with_for_update=with_for_update, auto_refresh=_auto_refresh
+                instance, attribute_names=attribute_names, with_for_update=with_for_update, auto_refresh=auto_refresh
             )
-            self._expunge(instance, auto_expunge=_auto_expunge)
+            self._expunge(instance, auto_expunge=auto_expunge)
             return instance
 
     def filter_collection_by_kwargs(  # type:ignore[override]

--- a/litestar/contrib/sqlalchemy/repository/_async.py
+++ b/litestar/contrib/sqlalchemy/repository/_async.py
@@ -36,8 +36,9 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         *,
         statement: Select[tuple[ModelT]] | None = None,
         session: AsyncSession,
-        auto_expunge: bool = False,
-        auto_refresh: bool = False,
+        auto_expunge: bool = True,
+        auto_refresh: bool = True,
+        auto_commit: bool = False,
         **kwargs: Any,
     ) -> None:
         """Repository pattern for SQLAlchemy models.
@@ -47,12 +48,14 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
             session: Session managing the unit-of-work for the operation.
             auto_expunge: Remove object from session before returning.
             auto_refresh: Refresh object from session before returning.
+            auto_commit: Commit objects before returning.
             **kwargs: Additional arguments.
 
         """
         super().__init__(**kwargs)
         self.auto_expunge = auto_expunge
         self.auto_refresh = auto_refresh
+        self.auto_commit = auto_commit
         self.session = session
         self.statement = statement if statement is not None else select(self.model_type)
         if not self.session.bind:
@@ -61,44 +64,63 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
             raise ValueError("Session improperly configure")
         self._dialect = self.session.bind.dialect
 
-    async def add(self, data: ModelT) -> ModelT:
+    async def add(
+        self,
+        data: ModelT,
+        **kwargs: Any,
+    ) -> ModelT:
         """Add `data` to the collection.
 
         Args:
             data: Instance to be added to the collection.
+            **kwargs: Additional arguments.
 
         Returns:
             The added instance.
         """
+        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        _auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
         with wrap_sqlalchemy_exception():
             instance = await self._attach_to_session(data)
-            await self.session.flush()
-            await self._refresh(instance)
-            self._expunge(instance)
+            await self._flush_or_commit(auto_commit=_auto_commit)
+            await self._refresh(instance, auto_refresh=_auto_refresh)
+            self._expunge(instance, auto_expunge=_auto_expunge)
             return instance
 
-    async def add_many(self, data: list[ModelT]) -> list[ModelT]:
+    async def add_many(
+        self,
+        data: list[ModelT],
+        **kwargs: Any,
+    ) -> list[ModelT]:
         """Add Many `data` to the collection.
 
         Args:
             data: list of Instances to be added to the collection.
-
+            **kwargs: Additional arguments.
 
         Returns:
             The added instances.
         """
+        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             self.session.add_all(data)
-            await self.session.flush()
+            await self._flush_or_commit(auto_commit=_auto_commit)
             for datum in data:
-                self._expunge(datum)
+                self._expunge(datum, auto_expunge=_auto_expunge)
             return data
 
-    async def delete(self, item_id: Any) -> ModelT:
+    async def delete(
+        self,
+        item_id: Any,
+        **kwargs: Any,
+    ) -> ModelT:
         """Delete instance identified by ``item_id``.
 
         Args:
             item_id: Identifier of instance to be deleted.
+            **kwargs: Additional arguments.
 
         Returns:
             The deleted instance.
@@ -106,23 +128,32 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Raises:
             NotFoundError: If no instance found identified by ``item_id``.
         """
+        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             instance = await self.get(item_id)
             await self.session.delete(instance)
-            await self.session.flush()
-            self._expunge(instance)
+            await self._flush_or_commit(auto_commit=_auto_commit)
+            self._expunge(instance, auto_expunge=_auto_expunge)
             return instance
 
-    async def delete_many(self, item_ids: list[Any]) -> list[ModelT]:
+    async def delete_many(
+        self,
+        item_ids: list[Any],
+        **kwargs: Any,
+    ) -> list[ModelT]:
         """Delete instance identified by `item_id`.
 
         Args:
             item_ids: Identifier of instance to be deleted.
+            **kwargs: Additional arguments.
 
         Returns:
             The deleted instances.
 
         """
+        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             instances: list[ModelT] = []
             chunk_size = 450
@@ -145,9 +176,9 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
                     await self.session.execute(
                         delete(self.model_type).where(getattr(self.model_type, self.id_attribute).in_(chunk))
                     )
-            await self.session.flush()
+            await self._flush_or_commit(auto_commit=_auto_commit)
             for instance in instances:
-                self._expunge(instance)
+                self._expunge(instance, auto_expunge=_auto_expunge)
             return instances
 
     async def exists(self, **kwargs: Any) -> bool:
@@ -176,12 +207,13 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Raises:
             NotFoundError: If no instance found identified by `item_id`.
         """
+        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             statement = kwargs.pop("statement", self.statement)
             statement = self._filter_select_by_kwargs(statement=statement, **{self.id_attribute: item_id})
             instance = (await self._execute(statement)).scalar_one_or_none()
             instance = self.check_not_found(instance)
-            self._expunge(instance)
+            self._expunge(instance, auto_expunge=_auto_expunge)
             return instance
 
     async def get_one(self, **kwargs: Any) -> ModelT:
@@ -196,12 +228,13 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Raises:
             NotFoundError: If no instance found identified by `item_id`.
         """
+        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             statement = kwargs.pop("statement", self.statement)
             statement = self._filter_select_by_kwargs(statement=statement, **kwargs)
             instance = (await self._execute(statement)).scalar_one_or_none()
             instance = self.check_not_found(instance)
-            self._expunge(instance)
+            self._expunge(instance, auto_expunge=_auto_expunge)
             return instance
 
     async def get_one_or_none(self, **kwargs: Any) -> ModelT | None:
@@ -213,12 +246,13 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Returns:
             The retrieved instance or None
         """
+        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             statement = kwargs.pop("statement", self.statement)
             statement = self._filter_select_by_kwargs(statement=statement, **kwargs)
             instance = (await self._execute(statement)).scalar_one_or_none()
             if instance:
-                self._expunge(instance)
+                self._expunge(instance, auto_expunge=_auto_expunge)
             return instance  # type: ignore
 
     async def get_or_create(
@@ -241,6 +275,9 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Returns:
             a tuple that includes the instance and whether or not it needed to be created.  When using match_fields and actual model values differ from `kwargs`, the model value will be updated.
         """
+        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        _auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
         match_fields = match_fields or self.match_fields
         if isinstance(match_fields, str):
             match_fields = [match_fields]
@@ -261,9 +298,11 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
                 if field and field != new_field_value:
                     setattr(existing, field_name, new_field_value)
             existing = await self._attach_to_session(existing, strategy="merge")
-            await self.session.flush()
-            await self._refresh(existing, attribute_names=attribute_names, with_for_update=with_for_update)
-            self._expunge(existing)
+            await self._flush_or_commit(auto_commit=_auto_commit)
+            await self._refresh(
+                existing, attribute_names=attribute_names, with_for_update=with_for_update, auto_refresh=_auto_refresh
+            )
+            self._expunge(existing, auto_expunge=_auto_expunge)
         return existing, False
 
     async def count(self, *filters: FilterTypes, **kwargs: Any) -> int:
@@ -291,6 +330,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         data: ModelT,
         attribute_names: Iterable[str] | None = None,
         with_for_update: bool | None = None,
+        **kwargs: Any,
     ) -> ModelT:
         """Update instance with the attribute values present on `data`.
 
@@ -299,25 +339,35 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
                 collection.
             attribute_names: an iterable of attribute names to pass into the ``update`` method.
             with_for_update: indicating FOR UPDATE should be used, or may be a dictionary containing flags to indicate a more specific set of FOR UPDATE flags for the SELECT
+            **kwargs: Additional arguments.
+
         Returns:
             The updated instance.
 
         Raises:
             NotFoundError: If no instance found with same identifier as `data`.
         """
-
+        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        _auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
         with wrap_sqlalchemy_exception():
             item_id = self.get_id_attribute_value(data)
             # this will raise for not found, and will put the item in the session
             await self.get(item_id)
             # this will merge the inbound data to the instance we just put in the session
             instance = await self._attach_to_session(data, strategy="merge")
-            await self.session.flush()
-            await self._refresh(instance, attribute_names=attribute_names, with_for_update=with_for_update)
-            self._expunge(instance)
+            await self._flush_or_commit(auto_commit=_auto_commit)
+            await self._refresh(
+                instance, attribute_names=attribute_names, with_for_update=with_for_update, auto_refresh=_auto_refresh
+            )
+            self._expunge(instance, auto_expunge=_auto_expunge)
             return instance
 
-    async def update_many(self, data: list[ModelT]) -> list[ModelT]:
+    async def update_many(
+        self,
+        data: list[ModelT],
+        **kwargs: Any,
+    ) -> list[ModelT]:
         """Update one or more instances with the attribute values present on `data`.
 
         This function has an optimized bulk insert based on the configured SQL dialect:
@@ -327,6 +377,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Args:
             data: A list of instances to update.  Each should have a value for `self.id_attribute` that exists in the
                 collection.
+            **kwargs: Additional arguments.
 
         Returns:
             The updated instances.
@@ -334,6 +385,8 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Raises:
             NotFoundError: If no instance found with same identifier as `data`.
         """
+        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         data_to_update: list[dict[str, Any]] = [v.to_dict() if isinstance(v, self.model_type) else v for v in data]  # type: ignore
         with wrap_sqlalchemy_exception():
             if self._dialect.update_executemany_returning and self._dialect.name != "oracle":
@@ -345,15 +398,15 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
                         # https://github.com/sqlalchemy/sqlalchemy/discussions/9925
                     )
                 )
-                await self.session.flush()
+                await self._flush_or_commit(auto_commit=_auto_commit)
                 for instance in instances:
-                    self._expunge(instance)
+                    self._expunge(instance, auto_expunge=_auto_expunge)
                 return instances
             await self.session.execute(
                 update(self.model_type),
                 data_to_update,
             )
-            await self.session.flush()
+            await self._flush_or_commit(auto_commit=_auto_commit)
             return data
 
     async def list_and_count(
@@ -374,18 +427,28 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
             return await self._list_and_count_basic(*filters, **kwargs)
         return await self._list_and_count_window(*filters, **kwargs)
 
-    def _expunge(self, instance: ModelT) -> None:
-        if self.auto_expunge:
-            self.session.expunge(instance)
+    def _expunge(self, instance: ModelT, auto_expunge: bool) -> None:
+        if auto_expunge:
+            return self.session.expunge(instance)
+        return None
+
+    async def _flush_or_commit(self, auto_commit: bool) -> None:
+        if auto_commit:
+            return await self.session.commit()
+        return await self.session.flush()
 
     async def _refresh(
         self,
         instance: ModelT,
+        auto_refresh: bool,
         attribute_names: Iterable[str] | None = None,
         with_for_update: bool | None = None,
     ) -> None:
-        if self.auto_refresh:
-            await self.session.refresh(instance, attribute_names=attribute_names, with_for_update=with_for_update)
+        if auto_refresh:
+            return await self.session.refresh(
+                instance, attribute_names=attribute_names, with_for_update=with_for_update
+            )
+        return None
 
     async def _list_and_count_window(
         self,
@@ -401,6 +464,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Returns:
             Count of records returned by query using an analytical window function, ignoring pagination.
         """
+        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         statement = kwargs.pop("statement", self.statement)
         statement = statement.add_columns(over(sql_func.count(self.get_id_attribute_value(self.model_type))))
         statement = self._apply_filters(*filters, statement=statement)
@@ -410,7 +474,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
             count: int = 0
             instances: list[ModelT] = []
             for i, (instance, count_value) in enumerate(result):
-                self._expunge(instance)
+                self._expunge(instance, auto_expunge=_auto_expunge)
                 instances.append(instance)
                 if i == 0:
                     count = count_value
@@ -430,6 +494,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Returns:
             Count of records returned by query using 2 queries, ignoring pagination.
         """
+        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         statement = kwargs.pop("statement", self.statement)
         statement = self._apply_filters(*filters, statement=statement)
         statement = self._filter_select_by_kwargs(statement, **kwargs)
@@ -443,7 +508,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
             result = await self._execute(statement)
             instances: list[ModelT] = []
             for (instance,) in result:
-                self._expunge(instance)
+                self._expunge(instance, auto_expunge=_auto_expunge)
                 instances.append(instance)
             return instances, count
 
@@ -457,6 +522,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         Returns:
             The list of instances, after filtering applied.
         """
+        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         statement = kwargs.pop("statement", self.statement)
         statement = self._apply_filters(*filters, statement=statement)
         statement = self._filter_select_by_kwargs(statement, **kwargs)
@@ -465,7 +531,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
             result = await self._execute(statement)
             instances = list(result.scalars())
             for instance in instances:
-                self._expunge(instance)
+                self._expunge(instance, auto_expunge=_auto_expunge)
             return instances
 
     async def upsert(
@@ -473,6 +539,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         data: ModelT,
         attribute_names: Iterable[str] | None = None,
         with_for_update: bool | None = None,
+        **kwargs: Any,
     ) -> ModelT:
         """Update or create instance.
 
@@ -485,17 +552,24 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
                 `self.id_attribute`.
             attribute_names: an iterable of attribute names to pass into the ``update`` method.
             with_for_update: indicating FOR UPDATE should be used, or may be a dictionary containing flags to indicate a more specific set of FOR UPDATE flags for the SELECT
+            **kwargs: Instance attribute value filters.
+
         Returns:
             The updated or created instance.
 
         Raises:
             NotFoundError: If no instance found with same identifier as `data`.
         """
+        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        _auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
         with wrap_sqlalchemy_exception():
             instance = await self._attach_to_session(data, strategy="merge")
-            await self.session.flush()
-            await self._refresh(instance, attribute_names=attribute_names, with_for_update=with_for_update)
-            self._expunge(instance)
+            await self._flush_or_commit(auto_commit=_auto_commit)
+            await self._refresh(
+                instance, attribute_names=attribute_names, with_for_update=with_for_update, auto_refresh=_auto_refresh
+            )
+            self._expunge(instance, auto_expunge=_auto_expunge)
             return instance
 
     def filter_collection_by_kwargs(  # type:ignore[override]

--- a/litestar/contrib/sqlalchemy/repository/_async.py
+++ b/litestar/contrib/sqlalchemy/repository/_async.py
@@ -36,7 +36,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         *,
         statement: Select[tuple[ModelT]] | None = None,
         session: AsyncSession,
-        auto_expunge: bool = True,
+        auto_expunge: bool = False,
         auto_refresh: bool = True,
         auto_commit: bool = False,
         **kwargs: Any,

--- a/litestar/contrib/sqlalchemy/repository/_async.py
+++ b/litestar/contrib/sqlalchemy/repository/_async.py
@@ -431,9 +431,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         return self.session.expunge(instance) if auto_expunge else None
 
     async def _flush_or_commit(self, auto_commit: bool) -> None:
-        if auto_commit:
-            return await self.session.commit()
-        return await self.session.flush()
+        return await self.session.commit() if auto_commit else await self.session.flush()
 
     async def _refresh(
         self,
@@ -442,11 +440,11 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         attribute_names: Iterable[str] | None = None,
         with_for_update: bool | None = None,
     ) -> None:
-        if auto_refresh:
-            return await self.session.refresh(
-                instance, attribute_names=attribute_names, with_for_update=with_for_update
-            )
-        return None
+        return (
+            await self.session.refresh(instance, attribute_names=attribute_names, with_for_update=with_for_update)
+            if auto_refresh
+            else None
+        )
 
     async def _list_and_count_window(
         self,

--- a/litestar/contrib/sqlalchemy/repository/_async.py
+++ b/litestar/contrib/sqlalchemy/repository/_async.py
@@ -428,9 +428,7 @@ class SQLAlchemyAsyncRepository(AbstractAsyncRepository[ModelT], Generic[ModelT]
         return await self._list_and_count_window(*filters, **kwargs)
 
     def _expunge(self, instance: ModelT, auto_expunge: bool) -> None:
-        if auto_expunge:
-            return self.session.expunge(instance)
-        return None
+        return self.session.expunge(instance) if auto_expunge else None
 
     async def _flush_or_commit(self, auto_commit: bool) -> None:
         if auto_commit:

--- a/litestar/contrib/sqlalchemy/repository/_sync.py
+++ b/litestar/contrib/sqlalchemy/repository/_sync.py
@@ -430,14 +430,10 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         return self._list_and_count_window(*filters, **kwargs)
 
     def _expunge(self, instance: ModelT, auto_expunge: bool) -> None:
-        if auto_expunge:
-            return self.session.expunge(instance)
-        return None
+        return self.session.expunge(instance) if auto_expunge else None
 
     def _flush_or_commit(self, auto_commit: bool) -> None:
-        if auto_commit:
-            return self.session.commit()
-        return self.session.flush()
+        return self.session.commit() if auto_commit else self.session.flush()
 
     def _refresh(
         self,

--- a/litestar/contrib/sqlalchemy/repository/_sync.py
+++ b/litestar/contrib/sqlalchemy/repository/_sync.py
@@ -80,14 +80,14 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         Returns:
             The added instance.
         """
-        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
-        _auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
+        auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
         with wrap_sqlalchemy_exception():
             instance = self._attach_to_session(data)
-            self._flush_or_commit(auto_commit=_auto_commit)
-            self._refresh(instance, auto_refresh=_auto_refresh)
-            self._expunge(instance, auto_expunge=_auto_expunge)
+            self._flush_or_commit(auto_commit=auto_commit)
+            self._refresh(instance, auto_refresh=auto_refresh)
+            self._expunge(instance, auto_expunge=auto_expunge)
             return instance
 
     def add_many(
@@ -104,13 +104,13 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         Returns:
             The added instances.
         """
-        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             self.session.add_all(data)
-            self._flush_or_commit(auto_commit=_auto_commit)
+            self._flush_or_commit(auto_commit=auto_commit)
             for datum in data:
-                self._expunge(datum, auto_expunge=_auto_expunge)
+                self._expunge(datum, auto_expunge=auto_expunge)
             return data
 
     def delete(
@@ -130,13 +130,13 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         Raises:
             NotFoundError: If no instance found identified by ``item_id``.
         """
-        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             instance = self.get(item_id)
             self.session.delete(instance)
-            self._flush_or_commit(auto_commit=_auto_commit)
-            self._expunge(instance, auto_expunge=_auto_expunge)
+            self._flush_or_commit(auto_commit=auto_commit)
+            self._expunge(instance, auto_expunge=auto_expunge)
             return instance
 
     def delete_many(
@@ -154,8 +154,8 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
             The deleted instances.
 
         """
-        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             instances: list[ModelT] = []
             chunk_size = 450
@@ -178,9 +178,9 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
                     self.session.execute(
                         delete(self.model_type).where(getattr(self.model_type, self.id_attribute).in_(chunk))
                     )
-            self._flush_or_commit(auto_commit=_auto_commit)
+            self._flush_or_commit(auto_commit=auto_commit)
             for instance in instances:
-                self._expunge(instance, auto_expunge=_auto_expunge)
+                self._expunge(instance, auto_expunge=auto_expunge)
             return instances
 
     def exists(self, **kwargs: Any) -> bool:
@@ -209,13 +209,13 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         Raises:
             NotFoundError: If no instance found identified by `item_id`.
         """
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             statement = kwargs.pop("statement", self.statement)
             statement = self._filter_select_by_kwargs(statement=statement, **{self.id_attribute: item_id})
             instance = (self._execute(statement)).scalar_one_or_none()
             instance = self.check_not_found(instance)
-            self._expunge(instance, auto_expunge=_auto_expunge)
+            self._expunge(instance, auto_expunge=auto_expunge)
             return instance
 
     def get_one(self, **kwargs: Any) -> ModelT:
@@ -230,13 +230,13 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         Raises:
             NotFoundError: If no instance found identified by `item_id`.
         """
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             statement = kwargs.pop("statement", self.statement)
             statement = self._filter_select_by_kwargs(statement=statement, **kwargs)
             instance = (self._execute(statement)).scalar_one_or_none()
             instance = self.check_not_found(instance)
-            self._expunge(instance, auto_expunge=_auto_expunge)
+            self._expunge(instance, auto_expunge=auto_expunge)
             return instance
 
     def get_one_or_none(self, **kwargs: Any) -> ModelT | None:
@@ -248,13 +248,13 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         Returns:
             The retrieved instance or None
         """
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         with wrap_sqlalchemy_exception():
             statement = kwargs.pop("statement", self.statement)
             statement = self._filter_select_by_kwargs(statement=statement, **kwargs)
             instance = (self._execute(statement)).scalar_one_or_none()
             if instance:
-                self._expunge(instance, auto_expunge=_auto_expunge)
+                self._expunge(instance, auto_expunge=auto_expunge)
             return instance  # type: ignore
 
     def get_or_create(
@@ -277,9 +277,9 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         Returns:
             a tuple that includes the instance and whether or not it needed to be created.  When using match_fields and actual model values differ from `kwargs`, the model value will be updated.
         """
-        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
-        _auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
+        auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
         match_fields = match_fields or self.match_fields
         if isinstance(match_fields, str):
             match_fields = [match_fields]
@@ -300,11 +300,11 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
                 if field and field != new_field_value:
                     setattr(existing, field_name, new_field_value)
             existing = self._attach_to_session(existing, strategy="merge")
-            self._flush_or_commit(auto_commit=_auto_commit)
+            self._flush_or_commit(auto_commit=auto_commit)
             self._refresh(
-                existing, attribute_names=attribute_names, with_for_update=with_for_update, auto_refresh=_auto_refresh
+                existing, attribute_names=attribute_names, with_for_update=with_for_update, auto_refresh=auto_refresh
             )
-            self._expunge(existing, auto_expunge=_auto_expunge)
+            self._expunge(existing, auto_expunge=auto_expunge)
         return existing, False
 
     def count(self, *filters: FilterTypes, **kwargs: Any) -> int:
@@ -349,20 +349,20 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         Raises:
             NotFoundError: If no instance found with same identifier as `data`.
         """
-        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
-        _auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
+        auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
         with wrap_sqlalchemy_exception():
             item_id = self.get_id_attribute_value(data)
             # this will raise for not found, and will put the item in the session
             self.get(item_id)
             # this will merge the inbound data to the instance we just put in the session
             instance = self._attach_to_session(data, strategy="merge")
-            self._flush_or_commit(auto_commit=_auto_commit)
+            self._flush_or_commit(auto_commit=auto_commit)
             self._refresh(
-                instance, attribute_names=attribute_names, with_for_update=with_for_update, auto_refresh=_auto_refresh
+                instance, attribute_names=attribute_names, with_for_update=with_for_update, auto_refresh=auto_refresh
             )
-            self._expunge(instance, auto_expunge=_auto_expunge)
+            self._expunge(instance, auto_expunge=auto_expunge)
             return instance
 
     def update_many(
@@ -387,8 +387,8 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         Raises:
             NotFoundError: If no instance found with same identifier as `data`.
         """
-        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         data_to_update: list[dict[str, Any]] = [v.to_dict() if isinstance(v, self.model_type) else v for v in data]  # type: ignore
         with wrap_sqlalchemy_exception():
             if self._dialect.update_executemany_returning and self._dialect.name != "oracle":
@@ -400,15 +400,15 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
                         # https://github.com/sqlalchemy/sqlalchemy/discussions/9925
                     )
                 )
-                self._flush_or_commit(auto_commit=_auto_commit)
+                self._flush_or_commit(auto_commit=auto_commit)
                 for instance in instances:
-                    self._expunge(instance, auto_expunge=_auto_expunge)
+                    self._expunge(instance, auto_expunge=auto_expunge)
                 return instances
             self.session.execute(
                 update(self.model_type),
                 data_to_update,
             )
-            self._flush_or_commit(auto_commit=_auto_commit)
+            self._flush_or_commit(auto_commit=auto_commit)
             return data
 
     def list_and_count(
@@ -462,7 +462,7 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         Returns:
             Count of records returned by query using an analytical window function, ignoring pagination.
         """
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         statement = kwargs.pop("statement", self.statement)
         statement = statement.add_columns(over(sql_func.count(self.get_id_attribute_value(self.model_type))))
         statement = self._apply_filters(*filters, statement=statement)
@@ -472,7 +472,7 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
             count: int = 0
             instances: list[ModelT] = []
             for i, (instance, count_value) in enumerate(result):
-                self._expunge(instance, auto_expunge=_auto_expunge)
+                self._expunge(instance, auto_expunge=auto_expunge)
                 instances.append(instance)
                 if i == 0:
                     count = count_value
@@ -492,7 +492,7 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         Returns:
             Count of records returned by query using 2 queries, ignoring pagination.
         """
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         statement = kwargs.pop("statement", self.statement)
         statement = self._apply_filters(*filters, statement=statement)
         statement = self._filter_select_by_kwargs(statement, **kwargs)
@@ -506,7 +506,7 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
             result = self._execute(statement)
             instances: list[ModelT] = []
             for (instance,) in result:
-                self._expunge(instance, auto_expunge=_auto_expunge)
+                self._expunge(instance, auto_expunge=auto_expunge)
                 instances.append(instance)
             return instances, count
 
@@ -520,7 +520,7 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         Returns:
             The list of instances, after filtering applied.
         """
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
         statement = kwargs.pop("statement", self.statement)
         statement = self._apply_filters(*filters, statement=statement)
         statement = self._filter_select_by_kwargs(statement, **kwargs)
@@ -529,7 +529,7 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
             result = self._execute(statement)
             instances = list(result.scalars())
             for instance in instances:
-                self._expunge(instance, auto_expunge=_auto_expunge)
+                self._expunge(instance, auto_expunge=auto_expunge)
             return instances
 
     def upsert(
@@ -558,16 +558,16 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         Raises:
             NotFoundError: If no instance found with same identifier as `data`.
         """
-        _auto_commit = kwargs.pop("auto_commit", self.auto_commit)
-        _auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
-        _auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
+        auto_commit = kwargs.pop("auto_commit", self.auto_commit)
+        auto_expunge = kwargs.pop("auto_expunge", self.auto_expunge)
+        auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
         with wrap_sqlalchemy_exception():
             instance = self._attach_to_session(data, strategy="merge")
-            self._flush_or_commit(auto_commit=_auto_commit)
+            self._flush_or_commit(auto_commit=auto_commit)
             self._refresh(
-                instance, attribute_names=attribute_names, with_for_update=with_for_update, auto_refresh=_auto_refresh
+                instance, attribute_names=attribute_names, with_for_update=with_for_update, auto_refresh=auto_refresh
             )
-            self._expunge(instance, auto_expunge=_auto_expunge)
+            self._expunge(instance, auto_expunge=auto_expunge)
             return instance
 
     def filter_collection_by_kwargs(  # type:ignore[override]

--- a/litestar/contrib/sqlalchemy/repository/_sync.py
+++ b/litestar/contrib/sqlalchemy/repository/_sync.py
@@ -442,9 +442,11 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         attribute_names: Iterable[str] | None = None,
         with_for_update: bool | None = None,
     ) -> None:
-        if auto_refresh:
-            return self.session.refresh(instance, attribute_names=attribute_names, with_for_update=with_for_update)
-        return None
+        return (
+            self.session.refresh(instance, attribute_names=attribute_names, with_for_update=with_for_update)
+            if auto_refresh
+            else None
+        )
 
     def _list_and_count_window(
         self,

--- a/litestar/contrib/sqlalchemy/repository/_sync.py
+++ b/litestar/contrib/sqlalchemy/repository/_sync.py
@@ -2,7 +2,7 @@
 # litestar/contrib/sqlalchemy/repository/_async.py
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generic, Literal, cast
+from typing import TYPE_CHECKING, Any, Generic, Iterable, Literal, cast
 
 from sqlalchemy import Result, Select, delete, over, select, text, update
 from sqlalchemy import func as sql_func
@@ -38,7 +38,8 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         *,
         statement: Select[tuple[ModelT]] | None = None,
         session: Session,
-        expunge: bool = False,
+        auto_expunge: bool = False,
+        auto_refresh: bool = False,
         **kwargs: Any,
     ) -> None:
         """Repository pattern for SQLAlchemy models.
@@ -46,12 +47,14 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         Args:
             statement: To facilitate customization of the underlying select query.
             session: Session managing the unit-of-work for the operation.
-            expunge: Remove object from session before returning.
+            auto_expunge: Remove object from session before returning.
+            auto_refresh: Refresh object from session before returning.
             **kwargs: Additional arguments.
 
         """
         super().__init__(**kwargs)
-        self.expunge = expunge
+        self.auto_expunge = auto_expunge
+        self.auto_refresh = auto_refresh
         self.session = session
         self.statement = statement if statement is not None else select(self.model_type)
         if not self.session.bind:
@@ -59,10 +62,6 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
             # narrow down the types
             raise ValueError("Session improperly configure")
         self._dialect = self.session.bind.dialect
-
-    def _expunge(self, instance: ModelT) -> None:
-        if self.expunge:
-            self.session.expunge(instance)
 
     def add(self, data: ModelT) -> ModelT:
         """Add `data` to the collection.
@@ -76,7 +75,7 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         with wrap_sqlalchemy_exception():
             instance = self._attach_to_session(data)
             self.session.flush()
-            self.session.refresh(instance)
+            self._refresh(instance)
             self._expunge(instance)
             return instance
 
@@ -225,13 +224,20 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
             return instance  # type: ignore
 
     def get_or_create(
-        self, match_fields: list[str] | str | None = None, upsert: bool = True, **kwargs: Any
+        self,
+        match_fields: list[str] | str | None = None,
+        upsert: bool = True,
+        attribute_names: Iterable[str] | None = None,
+        with_for_update: bool | None = None,
+        **kwargs: Any,
     ) -> tuple[ModelT, bool]:
         """Get instance identified by ``kwargs`` or create if it doesn't exist.
 
         Args:
             match_fields: a list of keys to use to match the existing model.  When empty, all fields are matched.
             upsert: When using match_fields and actual model values differ from `kwargs`, perform an update operation on the model.
+            attribute_names: an iterable of attribute names to pass into the ``update`` method.
+            with_for_update: indicating FOR UPDATE should be used, or may be a dictionary containing flags to indicate a more specific set of FOR UPDATE flags for the SELECT
             **kwargs: Identifier of the instance to be retrieved.
 
         Returns:
@@ -258,7 +264,7 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
                     setattr(existing, field_name, new_field_value)
             existing = self._attach_to_session(existing, strategy="merge")
             self.session.flush()
-            self.session.refresh(existing)
+            self._refresh(existing, attribute_names=attribute_names, with_for_update=with_for_update)
             self._expunge(existing)
         return existing, False
 
@@ -282,19 +288,26 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         results = self._execute(statement)
         return results.scalar_one()  # type: ignore
 
-    def update(self, data: ModelT) -> ModelT:
+    def update(
+        self,
+        data: ModelT,
+        attribute_names: Iterable[str] | None = None,
+        with_for_update: bool | None = None,
+    ) -> ModelT:
         """Update instance with the attribute values present on `data`.
 
         Args:
             data: An instance that should have a value for `self.id_attribute` that exists in the
                 collection.
-
+            attribute_names: an iterable of attribute names to pass into the ``update`` method.
+            with_for_update: indicating FOR UPDATE should be used, or may be a dictionary containing flags to indicate a more specific set of FOR UPDATE flags for the SELECT
         Returns:
             The updated instance.
 
         Raises:
             NotFoundError: If no instance found with same identifier as `data`.
         """
+
         with wrap_sqlalchemy_exception():
             item_id = self.get_id_attribute_value(data)
             # this will raise for not found, and will put the item in the session
@@ -302,7 +315,7 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
             # this will merge the inbound data to the instance we just put in the session
             instance = self._attach_to_session(data, strategy="merge")
             self.session.flush()
-            self.session.refresh(instance)
+            self._refresh(instance, attribute_names=attribute_names, with_for_update=with_for_update)
             self._expunge(instance)
             return instance
 
@@ -362,6 +375,19 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         if self._dialect.name in {"spanner", "spanner+spanner"}:
             return self._list_and_count_basic(*filters, **kwargs)
         return self._list_and_count_window(*filters, **kwargs)
+
+    def _expunge(self, instance: ModelT) -> None:
+        if self.auto_expunge:
+            self.session.expunge(instance)
+
+    def _refresh(
+        self,
+        instance: ModelT,
+        attribute_names: Iterable[str] | None = None,
+        with_for_update: bool | None = None,
+    ) -> None:
+        if self.auto_refresh:
+            self.session.refresh(instance, attribute_names=attribute_names, with_for_update=with_for_update)
 
     def _list_and_count_window(
         self,
@@ -444,7 +470,12 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
                 self._expunge(instance)
             return instances
 
-    def upsert(self, data: ModelT) -> ModelT:
+    def upsert(
+        self,
+        data: ModelT,
+        attribute_names: Iterable[str] | None = None,
+        with_for_update: bool | None = None,
+    ) -> ModelT:
         """Update or create instance.
 
         Updates instance with the attribute values present on `data`, or creates a new instance if
@@ -454,7 +485,8 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
             data: Instance to update existing, or be created. Identifier used to determine if an
                 existing instance exists is the value of an attribute on `data` named as value of
                 `self.id_attribute`.
-
+            attribute_names: an iterable of attribute names to pass into the ``update`` method.
+            with_for_update: indicating FOR UPDATE should be used, or may be a dictionary containing flags to indicate a more specific set of FOR UPDATE flags for the SELECT
         Returns:
             The updated or created instance.
 
@@ -464,7 +496,7 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         with wrap_sqlalchemy_exception():
             instance = self._attach_to_session(data, strategy="merge")
             self.session.flush()
-            self.session.refresh(instance)
+            self._refresh(instance, attribute_names=attribute_names, with_for_update=with_for_update)
             self._expunge(instance)
             return instance
 

--- a/litestar/contrib/sqlalchemy/repository/_sync.py
+++ b/litestar/contrib/sqlalchemy/repository/_sync.py
@@ -38,7 +38,7 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         *,
         statement: Select[tuple[ModelT]] | None = None,
         session: Session,
-        auto_expunge: bool = True,
+        auto_expunge: bool = False,
         auto_refresh: bool = True,
         auto_commit: bool = False,
         **kwargs: Any,

--- a/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
@@ -60,7 +60,7 @@ bigint_item_tag = Table(
 
 
 class BigIntItem(BigIntBase):
-    name: Mapped[str] = mapped_column(String(length=50), unique=True)  # pyright: ignore
+    name: Mapped[str] = mapped_column(String(length=50))  # pyright: ignore
     description: Mapped[str] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
     tags: Mapped[List[BigIntTag]] = relationship(  # pyright: ignore  # noqa: UP
         secondary=lambda: bigint_item_tag, back_populates="items"
@@ -70,7 +70,7 @@ class BigIntItem(BigIntBase):
 class BigIntTag(BigIntBase):
     """The event log domain object."""
 
-    name: Mapped[str] = mapped_column(String(length=50), unique=True)  # pyright: ignore
+    name: Mapped[str] = mapped_column(String(length=50))  # pyright: ignore
     items: Mapped[List[BigIntItem]] = relationship(  # pyright: ignore  # noqa: UP
         secondary=lambda: bigint_item_tag, back_populates="tags"
     )

--- a/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
@@ -62,14 +62,18 @@ bigint_item_tag = Table(
 class BigIntItem(BigIntBase):
     name: Mapped[str] = mapped_column(String(), unique=True)
     description: Mapped[str | None]
-    tags: Mapped[list[BigIntTag]] = relationship(secondary=lambda: bigint_item_tag, back_populates="items")
+    tags: Mapped[List[BigIntTag]] = relationship(  # noqa: UP006
+        secondary=lambda: bigint_item_tag, back_populates="items"
+    )
 
 
 class BigIntTag(BigIntBase):
     """The event log domain object."""
 
     name: Mapped[str] = mapped_column(String(50), unique=True)
-    items: Mapped[list[BigIntItem]] = relationship(secondary=lambda: bigint_item_tag, back_populates="tags")
+    items: Mapped[List[BigIntItem]] = relationship(  # noqa: UP006
+        secondary=lambda: bigint_item_tag, back_populates="tags"
+    )
 
 
 class BigIntRule(BigIntAuditBase):

--- a/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
@@ -54,8 +54,8 @@ class BigIntModelWithFetchedValue(BigIntBase):
 bigint_item_tag = Table(
     "bigint_item_tag",
     BigIntBase.metadata,
-    Column("item_id", ForeignKey("bigint_item.id"), primary_key=True),
-    Column("tag_id", ForeignKey("bigint_tag.id"), primary_key=True),
+    Column("item_id", ForeignKey("big_int_item.id"), primary_key=True),
+    Column("tag_id", ForeignKey("big_int_tag.id"), primary_key=True),
 )
 
 

--- a/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
@@ -62,18 +62,14 @@ bigint_item_tag = Table(
 class BigIntItem(BigIntBase):
     name: Mapped[str] = mapped_column(String(), unique=True)
     description: Mapped[str | None]
-    tags: Mapped[list[BigIntTag]] = relationship(
-        secondary=lambda: bigint_item_tag, back_populates="items", lazy="noload"  # <-- here be problems
-    )
+    tags: Mapped[list[BigIntTag]] = relationship(secondary=lambda: bigint_item_tag, back_populates="items")
 
 
 class BigIntTag(BigIntBase):
     """The event log domain object."""
 
     name: Mapped[str] = mapped_column(String(50), unique=True)
-    items: Mapped[list[BigIntItem]] = relationship(
-        secondary=lambda: bigint_item_tag, back_populates="tags", lazy="noload"
-    )
+    items: Mapped[list[BigIntItem]] = relationship(secondary=lambda: bigint_item_tag, back_populates="tags")
 
 
 class BigIntRule(BigIntAuditBase):

--- a/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
@@ -43,8 +43,8 @@ class BigIntEventLog(BigIntAuditBase):
 class BigIntModelWithFetchedValue(BigIntBase):
     """The ModelWithFetchedValue BigIntBase."""
 
-    val: Mapped[int]
-    updated: Mapped[datetime] = mapped_column(
+    val: Mapped[int]  # pyright: ignore
+    updated: Mapped[datetime] = mapped_column(  # pyright: ignore
         server_default=func.current_timestamp(),
         onupdate=func.current_timestamp(),
         server_onupdate=FetchedValue(),
@@ -60,9 +60,9 @@ bigint_item_tag = Table(
 
 
 class BigIntItem(BigIntBase):
-    name: Mapped[str] = mapped_column(String(), unique=True)
-    description: Mapped[str | None]
-    tags: Mapped[List[BigIntTag]] = relationship(  # noqa: UP006
+    name: Mapped[str] = mapped_column(String(), unique=True)  # pyright: ignore
+    description: Mapped[str | None]  # pyright: ignore
+    tags: Mapped[List[BigIntTag]] = relationship(  # pyright: ignore  # noqa: UP
         secondary=lambda: bigint_item_tag, back_populates="items"
     )
 
@@ -70,8 +70,8 @@ class BigIntItem(BigIntBase):
 class BigIntTag(BigIntBase):
     """The event log domain object."""
 
-    name: Mapped[str] = mapped_column(String(50), unique=True)
-    items: Mapped[List[BigIntItem]] = relationship(  # noqa: UP006
+    name: Mapped[str] = mapped_column(String(50), unique=True)  # pyright: ignore
+    items: Mapped[List[BigIntItem]] = relationship(  # pyright: ignore  # noqa: UP
         secondary=lambda: bigint_item_tag, back_populates="tags"
     )
 

--- a/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
@@ -60,8 +60,8 @@ bigint_item_tag = Table(
 
 
 class BigIntItem(BigIntBase):
-    name: Mapped[str] = mapped_column(String(), unique=True)  # pyright: ignore
-    description: Mapped[str | None]  # pyright: ignore
+    name: Mapped[str] = mapped_column(String(50), unique=True)  # pyright: ignore
+    description: Mapped[str] = mapped_column(String(100), optional=True)  # pyright: ignore
     tags: Mapped[List[BigIntTag]] = relationship(  # pyright: ignore  # noqa: UP
         secondary=lambda: bigint_item_tag, back_populates="items"
     )

--- a/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
@@ -60,8 +60,8 @@ bigint_item_tag = Table(
 
 
 class BigIntItem(BigIntBase):
-    name: Mapped[str] = mapped_column(String(50), unique=True)  # pyright: ignore
-    description: Mapped[str] = mapped_column(String(100), nullable=True)  # pyright: ignore
+    name: Mapped[str] = mapped_column(String(length=50), unique=True)  # pyright: ignore
+    description: Mapped[str] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
     tags: Mapped[List[BigIntTag]] = relationship(  # pyright: ignore  # noqa: UP
         secondary=lambda: bigint_item_tag, back_populates="items"
     )
@@ -70,7 +70,7 @@ class BigIntItem(BigIntBase):
 class BigIntTag(BigIntBase):
     """The event log domain object."""
 
-    name: Mapped[str] = mapped_column(String(50), unique=True)  # pyright: ignore
+    name: Mapped[str] = mapped_column(String(length=50), unique=True)  # pyright: ignore
     items: Mapped[List[BigIntItem]] = relationship(  # pyright: ignore  # noqa: UP
         secondary=lambda: bigint_item_tag, back_populates="tags"
     )

--- a/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
@@ -61,7 +61,7 @@ bigint_item_tag = Table(
 
 class BigIntItem(BigIntBase):
     name: Mapped[str] = mapped_column(String(50), unique=True)  # pyright: ignore
-    description: Mapped[str] = mapped_column(String(100), optional=True)  # pyright: ignore
+    description: Mapped[str] = mapped_column(String(100), nullable=True)  # pyright: ignore
     tags: Mapped[List[BigIntTag]] = relationship(  # pyright: ignore  # noqa: UP
         secondary=lambda: bigint_item_tag, back_populates="items"
     )

--- a/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
@@ -52,7 +52,7 @@ class BigIntModelWithFetchedValue(BigIntBase):
 
 
 bigint_item_tag = Table(
-    "uuid_item_tag",
+    "bigint_item_tag",
     BigIntBase.metadata,
     Column("item_id", ForeignKey("item.id"), primary_key=True),
     Column("tag_id", ForeignKey("tag.id"), primary_key=True),

--- a/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import List
 
-from sqlalchemy import FetchedValue, ForeignKey, String, func
+from sqlalchemy import Column, FetchedValue, ForeignKey, String, Table, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from litestar.contrib.sqlalchemy.base import BigIntAuditBase, BigIntBase
@@ -51,6 +51,29 @@ class BigIntModelWithFetchedValue(BigIntBase):
     )
 
 
+bigint_item_tag = Table(
+    "uuid_item_tag",
+    BigIntBase.metadata,
+    Column("item_id", ForeignKey("item.id"), primary_key=True),
+    Column("tag_id", ForeignKey("tag.id"), primary_key=True),
+)
+
+
+class BigIntItem(BigIntBase):
+    name: Mapped[str] = mapped_column(String(), unique=True)
+    description: Mapped[str | None]
+    tags: Mapped[list[BigIntTag]] = relationship(
+        secondary=bigint_item_tag, back_populates="items", lazy="noload"  # <-- here be problems
+    )
+
+
+class BigIntTag(BigIntBase):
+    """The event log domain object."""
+
+    name: Mapped[str] = mapped_column(String(50), unique=True)
+    items: Mapped[list[BigIntItem]] = relationship(secondary=bigint_item_tag, back_populates="tags", lazy="noload")
+
+
 class BigIntRule(BigIntAuditBase):
     """The rule domain object."""
 
@@ -88,6 +111,18 @@ class ModelWithFetchedValueAsyncRepository(SQLAlchemyAsyncRepository[BigIntModel
     model_type = BigIntModelWithFetchedValue
 
 
+class TagAsyncRepository(SQLAlchemyAsyncRepository[BigIntTag]):
+    """Tag repository."""
+
+    model_type = BigIntTag
+
+
+class ItemAsyncRepository(SQLAlchemyAsyncRepository[BigIntItem]):
+    """Item repository."""
+
+    model_type = BigIntItem
+
+
 class AuthorSyncRepository(SQLAlchemySyncRepository[BigIntAuthor]):
     """Author repository."""
 
@@ -116,3 +151,15 @@ class ModelWithFetchedValueSyncRepository(SQLAlchemySyncRepository[BigIntModelWi
     """ModelWithFetchedValue repository."""
 
     model_type = BigIntModelWithFetchedValue
+
+
+class TagSyncRepository(SQLAlchemySyncRepository[BigIntTag]):
+    """Tag repository."""
+
+    model_type = BigIntTag
+
+
+class ItemSyncRepository(SQLAlchemySyncRepository[BigIntItem]):
+    """Item repository."""
+
+    model_type = BigIntItem

--- a/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
@@ -54,8 +54,8 @@ class BigIntModelWithFetchedValue(BigIntBase):
 bigint_item_tag = Table(
     "bigint_item_tag",
     BigIntBase.metadata,
-    Column("item_id", ForeignKey("item.id"), primary_key=True),
-    Column("tag_id", ForeignKey("tag.id"), primary_key=True),
+    Column("item_id", ForeignKey("bigint_item.id"), primary_key=True),
+    Column("tag_id", ForeignKey("bigint_tag.id"), primary_key=True),
 )
 
 

--- a/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py
@@ -63,7 +63,7 @@ class BigIntItem(BigIntBase):
     name: Mapped[str] = mapped_column(String(), unique=True)
     description: Mapped[str | None]
     tags: Mapped[list[BigIntTag]] = relationship(
-        secondary=bigint_item_tag, back_populates="items", lazy="noload"  # <-- here be problems
+        secondary=lambda: bigint_item_tag, back_populates="items", lazy="noload"  # <-- here be problems
     )
 
 
@@ -71,7 +71,9 @@ class BigIntTag(BigIntBase):
     """The event log domain object."""
 
     name: Mapped[str] = mapped_column(String(50), unique=True)
-    items: Mapped[list[BigIntItem]] = relationship(secondary=bigint_item_tag, back_populates="tags", lazy="noload")
+    items: Mapped[list[BigIntItem]] = relationship(
+        secondary=lambda: bigint_item_tag, back_populates="tags", lazy="noload"
+    )
 
 
 class BigIntRule(BigIntAuditBase):

--- a/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
@@ -61,7 +61,7 @@ uuid_item_tag = Table(
 
 
 class UUIDItem(UUIDBase):
-    name: Mapped[str] = mapped_column(String(length=50), unique=True)  # pyright: ignore
+    name: Mapped[str] = mapped_column(String(length=50))  # pyright: ignore
     description: Mapped[str] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
     tags: Mapped[List[UUIDTag]] = relationship(  # pyright: ignore  # noqa: UP
         secondary=lambda: uuid_item_tag, back_populates="items"
@@ -71,7 +71,7 @@ class UUIDItem(UUIDBase):
 class UUIDTag(UUIDAuditBase):
     """The event log domain object."""
 
-    name: Mapped[str] = mapped_column(String(length=50), unique=True)  # pyright: ignore
+    name: Mapped[str] = mapped_column(String(length=50))  # pyright: ignore
     items: Mapped[List[UUIDItem]] = relationship(  # pyright: ignore  # noqa: UP
         secondary=lambda: uuid_item_tag, back_populates="tags"
     )

--- a/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
@@ -54,8 +54,8 @@ class UUIDModelWithFetchedValue(UUIDBase):
 uuid_item_tag = Table(
     "uuid_item_tag",
     UUIDBase.metadata,
-    Column("item_id", ForeignKey("item.id"), primary_key=True),
-    Column("tag_id", ForeignKey("tag.id"), primary_key=True),
+    Column("item_id", ForeignKey("uuid_item.id"), primary_key=True),
+    Column("tag_id", ForeignKey("uuid_tag.id"), primary_key=True),
 )
 
 

--- a/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
@@ -63,14 +63,14 @@ uuid_item_tag = Table(
 class UUIDItem(UUIDBase):
     name: Mapped[str] = mapped_column(String(), unique=True)
     description: Mapped[str | None]
-    tags: Mapped[list[UUIDTag]] = relationship(secondary=lambda: uuid_item_tag, back_populates="items", lazy="noload")
+    tags: Mapped[list[UUIDTag]] = relationship(secondary=lambda: uuid_item_tag, back_populates="items")
 
 
 class UUIDTag(UUIDAuditBase):
     """The event log domain object."""
 
     name: Mapped[str] = mapped_column(String(50), unique=True)
-    items: Mapped[list[UUIDItem]] = relationship(secondary=lambda: uuid_item_tag, back_populates="tags", lazy="noload")
+    items: Mapped[list[UUIDItem]] = relationship(secondary=lambda: uuid_item_tag, back_populates="tags")
 
 
 class UUIDRule(UUIDAuditBase):

--- a/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
@@ -62,7 +62,7 @@ uuid_item_tag = Table(
 
 class UUIDItem(UUIDBase):
     name: Mapped[str] = mapped_column(String(), unique=True)  # pyright: ignore
-    description: Mapped[str] = mapped_column(String(100), optional=True)  # pyright: ignore
+    description: Mapped[str] = mapped_column(String(100), nullable=True)  # pyright: ignore
     tags: Mapped[List[UUIDTag]] = relationship(  # pyright: ignore  # noqa: UP
         secondary=lambda: uuid_item_tag, back_populates="items"
     )

--- a/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
@@ -44,8 +44,8 @@ class UUIDEventLog(UUIDAuditBase):
 class UUIDModelWithFetchedValue(UUIDBase):
     """The ModelWithFetchedValue UUIDBase."""
 
-    val: Mapped[int]
-    updated: Mapped[datetime] = mapped_column(
+    val: Mapped[int]  # pyright: ignore
+    updated: Mapped[datetime] = mapped_column(  # pyright: ignore
         server_default=func.current_timestamp(),
         onupdate=func.current_timestamp(),
         server_onupdate=FetchedValue(),
@@ -61,16 +61,20 @@ uuid_item_tag = Table(
 
 
 class UUIDItem(UUIDBase):
-    name: Mapped[str] = mapped_column(String(), unique=True)
-    description: Mapped[str | None]
-    tags: Mapped[List[UUIDTag]] = relationship(secondary=lambda: uuid_item_tag, back_populates="items")  # noqa: UP006
+    name: Mapped[str] = mapped_column(String(), unique=True)  # pyright: ignore
+    description: Mapped[str | None]  # pyright: ignore
+    tags: Mapped[List[UUIDTag]] = relationship(  # pyright: ignore  # noqa: UP
+        secondary=lambda: uuid_item_tag, back_populates="items"
+    )
 
 
 class UUIDTag(UUIDAuditBase):
     """The event log domain object."""
 
-    name: Mapped[str] = mapped_column(String(50), unique=True)
-    items: Mapped[List[UUIDItem]] = relationship(secondary=lambda: uuid_item_tag, back_populates="tags")  # noqa: UP006
+    name: Mapped[str] = mapped_column(String(50), unique=True)  # pyright: ignore
+    items: Mapped[List[UUIDItem]] = relationship(  # pyright: ignore  # noqa: UP
+        secondary=lambda: uuid_item_tag, back_populates="tags"
+    )
 
 
 class UUIDRule(UUIDAuditBase):

--- a/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
@@ -63,16 +63,14 @@ uuid_item_tag = Table(
 class UUIDItem(UUIDBase):
     name: Mapped[str] = mapped_column(String(), unique=True)
     description: Mapped[str | None]
-    tags: Mapped[list[UUIDTag]] = relationship(
-        secondary=lambda: uuid_item_tag, back_populates="items", lazy="noload"  # <-- here be problems
-    )
+    tags: Mapped[list[UUIDTag]] = relationship(secondary=lambda: uuid_item_tag, back_populates="items")
 
 
 class UUIDTag(UUIDAuditBase):
     """The event log domain object."""
 
     name: Mapped[str] = mapped_column(String(50), unique=True)
-    items: Mapped[list[UUIDItem]] = relationship(secondary=lambda: uuid_item_tag, back_populates="tags", lazy="noload")
+    items: Mapped[list[UUIDItem]] = relationship(secondary=lambda: uuid_item_tag, back_populates="tags")
 
 
 class UUIDRule(UUIDAuditBase):

--- a/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
@@ -61,8 +61,8 @@ uuid_item_tag = Table(
 
 
 class UUIDItem(UUIDBase):
-    name: Mapped[str] = mapped_column(String(), unique=True)  # pyright: ignore
-    description: Mapped[str] = mapped_column(String(100), nullable=True)  # pyright: ignore
+    name: Mapped[str] = mapped_column(String(length=50), unique=True)  # pyright: ignore
+    description: Mapped[str] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
     tags: Mapped[List[UUIDTag]] = relationship(  # pyright: ignore  # noqa: UP
         secondary=lambda: uuid_item_tag, back_populates="items"
     )
@@ -71,7 +71,7 @@ class UUIDItem(UUIDBase):
 class UUIDTag(UUIDAuditBase):
     """The event log domain object."""
 
-    name: Mapped[str] = mapped_column(String(50), unique=True)  # pyright: ignore
+    name: Mapped[str] = mapped_column(String(length=50), unique=True)  # pyright: ignore
     items: Mapped[List[UUIDItem]] = relationship(  # pyright: ignore  # noqa: UP
         secondary=lambda: uuid_item_tag, back_populates="tags"
     )

--- a/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
@@ -63,14 +63,14 @@ uuid_item_tag = Table(
 class UUIDItem(UUIDBase):
     name: Mapped[str] = mapped_column(String(), unique=True)
     description: Mapped[str | None]
-    tags: Mapped[list[UUIDTag]] = relationship(secondary=lambda: uuid_item_tag, back_populates="items")
+    tags: Mapped[list[UUIDTag]] = relationship(secondary=lambda: uuid_item_tag, back_populates="items", lazy="noload")
 
 
 class UUIDTag(UUIDAuditBase):
     """The event log domain object."""
 
     name: Mapped[str] = mapped_column(String(50), unique=True)
-    items: Mapped[list[UUIDItem]] = relationship(secondary=lambda: uuid_item_tag, back_populates="tags")
+    items: Mapped[list[UUIDItem]] = relationship(secondary=lambda: uuid_item_tag, back_populates="tags", lazy="noload")
 
 
 class UUIDRule(UUIDAuditBase):

--- a/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
@@ -63,14 +63,14 @@ uuid_item_tag = Table(
 class UUIDItem(UUIDBase):
     name: Mapped[str] = mapped_column(String(), unique=True)
     description: Mapped[str | None]
-    tags: Mapped[list[UUIDTag]] = relationship(secondary=lambda: uuid_item_tag, back_populates="items")
+    tags: Mapped[List[UUIDTag]] = relationship(secondary=lambda: uuid_item_tag, back_populates="items")  # noqa: UP006
 
 
 class UUIDTag(UUIDAuditBase):
     """The event log domain object."""
 
     name: Mapped[str] = mapped_column(String(50), unique=True)
-    items: Mapped[list[UUIDItem]] = relationship(secondary=lambda: uuid_item_tag, back_populates="tags")
+    items: Mapped[List[UUIDItem]] = relationship(secondary=lambda: uuid_item_tag, back_populates="tags")  # noqa: UP006
 
 
 class UUIDRule(UUIDAuditBase):

--- a/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
@@ -9,6 +9,7 @@ from uuid import UUID
 from sqlalchemy import Column, FetchedValue, ForeignKey, String, Table, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from litestar.contrib.sqlalchemy import base
 from litestar.contrib.sqlalchemy.base import UUIDAuditBase, UUIDBase
 from litestar.contrib.sqlalchemy.repository import SQLAlchemyAsyncRepository, SQLAlchemySyncRepository
 
@@ -53,7 +54,7 @@ class UUIDModelWithFetchedValue(UUIDBase):
 
 uuid_item_tag = Table(
     "uuid_item_tag",
-    UUIDBase.metadata,
+    base.orm_registry.metadata,
     Column("item_id", ForeignKey("uuid_item.id"), primary_key=True),
     Column("tag_id", ForeignKey("uuid_tag.id"), primary_key=True),
 )
@@ -63,7 +64,7 @@ class UUIDItem(UUIDBase):
     name: Mapped[str] = mapped_column(String(), unique=True)
     description: Mapped[str | None]
     tags: Mapped[list[UUIDTag]] = relationship(
-        secondary=uuid_item_tag, back_populates="items", lazy="noload"  # <-- here be problems
+        secondary=lambda: uuid_item_tag, back_populates="items", lazy="noload"  # <-- here be problems
     )
 
 
@@ -71,7 +72,7 @@ class UUIDTag(UUIDAuditBase):
     """The event log domain object."""
 
     name: Mapped[str] = mapped_column(String(50), unique=True)
-    items: Mapped[list[UUIDItem]] = relationship(secondary=uuid_item_tag, back_populates="tags", lazy="noload")
+    items: Mapped[list[UUIDItem]] = relationship(secondary=lambda: uuid_item_tag, back_populates="tags", lazy="noload")
 
 
 class UUIDRule(UUIDAuditBase):

--- a/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py
@@ -62,7 +62,7 @@ uuid_item_tag = Table(
 
 class UUIDItem(UUIDBase):
     name: Mapped[str] = mapped_column(String(), unique=True)  # pyright: ignore
-    description: Mapped[str | None]  # pyright: ignore
+    description: Mapped[str] = mapped_column(String(100), optional=True)  # pyright: ignore
     tags: Mapped[List[UUIDTag]] = relationship(  # pyright: ignore  # noqa: UP
         secondary=lambda: uuid_item_tag, back_populates="items"
     )

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/conftest.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/conftest.py
@@ -292,7 +292,7 @@ def engine(request: FixtureRequest) -> Engine:
 
 @pytest.fixture()
 def session(engine: Engine) -> Generator[Session, None, None]:
-    session = sessionmaker(bind=engine)()
+    session = sessionmaker(bind=engine, expire_on_commit=False)()
     try:
         yield session
     finally:
@@ -402,7 +402,7 @@ def async_engine(request: FixtureRequest) -> AsyncEngine:
 
 @pytest.fixture()
 async def async_session(async_engine: AsyncEngine) -> AsyncGenerator[AsyncSession, None]:
-    session = async_sessionmaker(bind=async_engine)()
+    session = async_sessionmaker(bind=async_engine, expire_on_commit=False)()
     try:
         yield session
     finally:

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_bigint.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_bigint.py
@@ -546,12 +546,15 @@ async def test_lazy_load(item_repo: ItemAsyncRepository, tag_repo: TagAsyncRepos
     assert len(new_items) > 0
     first_item_id = new_items[0].id
     new_items[1].id
-    update_data = {"name": "A modified Name", "tag_names": ["A new tag"]}
-    update_data.update({"id": first_item_id})  # type: ignore
+    update_data = {
+        "name": "A modified Name",
+        "tag_names": ["A new tag"],
+        "id": first_item_id,
+    }
     tags_to_add = await maybe_async(tag_repo.list(CollectionFilter("name", update_data.pop("tag_names", []))))
     assert len(tags_to_add) > 0
     assert tags_to_add[0].id is not None
-    update_data.update({"tags": tags_to_add})  # type: ignore
+    update_data["tags"] = tags_to_add
     updated_obj = await maybe_async(item_repo.update(BigIntItem(**update_data)))
     await maybe_async(item_repo.session.commit())
     assert len(updated_obj.tags) > 0

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_bigint.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_bigint.py
@@ -555,7 +555,7 @@ async def test_lazy_load(item_repo: ItemAsyncRepository, tag_repo: TagAsyncRepos
     assert len(tags_to_add) > 0
     assert tags_to_add[0].id is not None
     update_data["tags"] = tags_to_add
-    updated_obj = await maybe_async(item_repo.update(BigIntItem(**update_data)))
+    updated_obj = await maybe_async(item_repo.update(BigIntItem(**update_data), auto_refresh=False))
     await maybe_async(item_repo.session.commit())
     assert len(updated_obj.tags) > 0
     assert updated_obj.tags[0].name == "A new tag"

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_bigint.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_bigint.py
@@ -551,7 +551,7 @@ async def test_lazy_load(item_repo: ItemAsyncRepository, tag_repo: TagAsyncRepos
         "tag_names": ["A new tag"],
         "id": first_item_id,
     }
-    tags_to_add = await maybe_async(tag_repo.list(CollectionFilter("name", update_data.pop("tag_names", []))))
+    tags_to_add = await maybe_async(tag_repo.list(CollectionFilter("name", update_data.pop("tag_names", []))))  # type: ignore
     assert len(tags_to_add) > 0
     assert tags_to_add[0].id is not None
     update_data["tags"] = tags_to_add

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_bigint.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_bigint.py
@@ -541,6 +541,8 @@ async def test_lazy_load(item_repo: ItemAsyncRepository, tag_repo: TagAsyncRepos
     new_items = await maybe_async(
         item_repo.add_many([BigIntItem(name="The first item"), BigIntItem(name="The second item")])
     )
+    await maybe_async(item_repo.session.commit())
+    await maybe_async(tag_repo.session.commit())
     assert len(new_items) > 0
     first_item_id = new_items[0].id
     new_items[1].id
@@ -548,6 +550,9 @@ async def test_lazy_load(item_repo: ItemAsyncRepository, tag_repo: TagAsyncRepos
     update_data.update({"id": first_item_id})  # type: ignore
     tags_to_add = await maybe_async(tag_repo.list(CollectionFilter("name", update_data.pop("tag_names", []))))
     assert len(tags_to_add) > 0
+    assert tags_to_add[0].id is not None
     update_data.update({"tags": tags_to_add})  # type: ignore
     updated_obj = await maybe_async(item_repo.update(BigIntItem(**update_data)))
+    await maybe_async(item_repo.session.commit())
     assert len(updated_obj.tags) > 0
+    assert updated_obj.tags[0].name == "A new tag"

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_uuid.py
@@ -647,6 +647,8 @@ async def test_lazy_load(item_repo: ItemAsyncRepository, tag_repo: TagAsyncRepos
     new_items = await maybe_async(
         item_repo.add_many([UUIDItem(name="The first item"), UUIDItem(name="The second item")])
     )
+    await maybe_async(item_repo.session.commit())
+    await maybe_async(tag_repo.session.commit())
     assert len(new_items) > 0
     first_item_id = new_items[0].id
     new_items[1].id
@@ -654,6 +656,9 @@ async def test_lazy_load(item_repo: ItemAsyncRepository, tag_repo: TagAsyncRepos
     update_data.update({"id": first_item_id})  # type: ignore
     tags_to_add = await maybe_async(tag_repo.list(CollectionFilter("name", update_data.pop("tag_names", []))))
     assert len(tags_to_add) > 0
+    assert tags_to_add[0].id is not None
     update_data.update({"tags": tags_to_add})  # type: ignore
     updated_obj = await maybe_async(item_repo.update(UUIDItem(**update_data)))
+    await maybe_async(item_repo.session.commit())
     assert len(updated_obj.tags) > 0
+    assert updated_obj.tags[0].name == "A new tag"

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_uuid.py
@@ -657,7 +657,7 @@ async def test_lazy_load(item_repo: ItemAsyncRepository, tag_repo: TagAsyncRepos
         "tag_names": ["A new tag"],
         "id": first_item_id,
     }
-    tags_to_add = await maybe_async(tag_repo.list(CollectionFilter("name", update_data.pop("tag_names", []))))
+    tags_to_add = await maybe_async(tag_repo.list(CollectionFilter("name", update_data.pop("tag_names", []))))  # type: ignore
     assert len(tags_to_add) > 0
     assert tags_to_add[0].id is not None
     update_data["tags"] = tags_to_add

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_uuid.py
@@ -20,13 +20,13 @@ from sqlalchemy.orm import Session, sessionmaker
 from litestar.contrib.repository.exceptions import RepositoryError
 from litestar.contrib.repository.filters import BeforeAfter, CollectionFilter, OrderBy, SearchFilter
 from litestar.contrib.sqlalchemy import base
-from tests.unit.test_contrib.test_sqlalchemy.models_bigint import ItemSyncRepository
 from tests.unit.test_contrib.test_sqlalchemy.models_uuid import (
     AuthorAsyncRepository,
     AuthorSyncRepository,
     BookAsyncRepository,
     BookSyncRepository,
     ItemAsyncRepository,
+    ItemSyncRepository,
     ModelWithFetchedValueAsyncRepository,
     ModelWithFetchedValueSyncRepository,
     RuleAsyncRepository,

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_uuid.py
@@ -661,7 +661,7 @@ async def test_lazy_load(item_repo: ItemAsyncRepository, tag_repo: TagAsyncRepos
     assert len(tags_to_add) > 0
     assert tags_to_add[0].id is not None
     update_data["tags"] = tags_to_add
-    updated_obj = await maybe_async(item_repo.update(UUIDItem(**update_data)))
+    updated_obj = await maybe_async(item_repo.update(UUIDItem(**update_data), auto_refresh=False))
     await maybe_async(item_repo.session.commit())
     assert len(updated_obj.tags) > 0
     assert updated_obj.tags[0].name == "A new tag"

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_uuid.py
@@ -652,12 +652,15 @@ async def test_lazy_load(item_repo: ItemAsyncRepository, tag_repo: TagAsyncRepos
     assert len(new_items) > 0
     first_item_id = new_items[0].id
     new_items[1].id
-    update_data = {"name": "A modified Name", "tag_names": ["A new tag"]}
-    update_data.update({"id": first_item_id})  # type: ignore
+    update_data = {
+        "name": "A modified Name",
+        "tag_names": ["A new tag"],
+        "id": first_item_id,
+    }
     tags_to_add = await maybe_async(tag_repo.list(CollectionFilter("name", update_data.pop("tag_names", []))))
     assert len(tags_to_add) > 0
     assert tags_to_add[0].id is not None
-    update_data.update({"tags": tags_to_add})  # type: ignore
+    update_data["tags"] = tags_to_add
     updated_obj = await maybe_async(item_repo.update(UUIDItem(**update_data)))
     await maybe_async(item_repo.session.commit())
     assert len(updated_obj.tags) > 0

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_uuid.py
@@ -20,19 +20,25 @@ from sqlalchemy.orm import Session, sessionmaker
 from litestar.contrib.repository.exceptions import RepositoryError
 from litestar.contrib.repository.filters import BeforeAfter, CollectionFilter, OrderBy, SearchFilter
 from litestar.contrib.sqlalchemy import base
+from tests.unit.test_contrib.test_sqlalchemy.models_bigint import ItemSyncRepository
 from tests.unit.test_contrib.test_sqlalchemy.models_uuid import (
     AuthorAsyncRepository,
     AuthorSyncRepository,
     BookAsyncRepository,
     BookSyncRepository,
+    ItemAsyncRepository,
     ModelWithFetchedValueAsyncRepository,
     ModelWithFetchedValueSyncRepository,
     RuleAsyncRepository,
     RuleSyncRepository,
+    TagAsyncRepository,
+    TagSyncRepository,
     UUIDAuthor,
     UUIDBook,
+    UUIDItem,
     UUIDModelWithFetchedValue,
     UUIDRule,
+    UUIDTag,
 )
 
 from .helpers import maybe_async, update_raw_records
@@ -187,6 +193,20 @@ def book_repo(any_session: AsyncSession | Session) -> BookAsyncRepository | Book
     if isinstance(any_session, AsyncSession):
         return BookAsyncRepository(session=any_session)
     return BookSyncRepository(session=any_session)
+
+
+@pytest.fixture()
+def tag_repo(any_session: AsyncSession | Session) -> TagAsyncRepository | TagSyncRepository:
+    if isinstance(any_session, AsyncSession):
+        return TagAsyncRepository(session=any_session)
+    return TagSyncRepository(session=any_session)
+
+
+@pytest.fixture()
+def item_repo(any_session: AsyncSession | Session) -> ItemAsyncRepository | ItemSyncRepository:
+    if isinstance(any_session, AsyncSession):
+        return ItemAsyncRepository(session=any_session)
+    return ItemSyncRepository(session=any_session)
 
 
 @pytest.fixture()
@@ -612,3 +632,28 @@ async def test_repo_fetched_value(model_with_fetched_value_repo: ModelWithFetche
     assert obj.updated is not None
     assert obj.val == 2
     assert obj.updated != first_time
+
+
+async def test_lazy_load(item_repo: ItemAsyncRepository, tag_repo: TagAsyncRepository) -> None:
+    """Test SQLALchemy fetched value in various places.
+
+    Args:
+        item_repo (ItemAsyncRepository): The item mock repository
+        tag_repo (TagAsyncRepository): The tag mock repository
+    """
+
+    tag_obj = await maybe_async(tag_repo.add(UUIDTag(name="A new tag")))
+    assert tag_obj
+    new_items = await maybe_async(
+        item_repo.add_many([UUIDItem(name="The first item"), UUIDItem(name="The second item")])
+    )
+    assert len(new_items) > 0
+    first_item_id = new_items[0].id
+    new_items[1].id
+    update_data = {"name": "A modified Name", "tag_names": ["A new tag"]}
+    update_data.update({"id": first_item_id})  # type: ignore
+    tags_to_add = await maybe_async(tag_repo.list(CollectionFilter("name", update_data.pop("tag_names", []))))
+    assert len(tags_to_add) > 0
+    update_data.update({"tags": tags_to_add})  # type: ignore
+    updated_obj = await maybe_async(item_repo.update(UUIDItem(**update_data)))
+    assert len(updated_obj.tags) > 0

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_sqlalchemy_async.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_sqlalchemy_async.py
@@ -123,7 +123,7 @@ async def test_sqlalchemy_repo_add(mock_repo: SQLAlchemyAsyncRepository) -> None
     mock_repo.session.add.assert_called_once_with(mock_instance)
     mock_repo.session.flush.assert_called_once()
     mock_repo.session.refresh.assert_called_once_with(mock_instance, attribute_names=None, with_for_update=None)
-    mock_repo.session.expunge.assert_called_once_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
 
 
@@ -151,7 +151,7 @@ async def test_sqlalchemy_repo_add_many(mock_repo: SQLAlchemyAsyncRepository, mo
     assert len(instances) == 3
     for row in instances:
         assert row.id is not None
-    mock_repo.session.expunge.assert_called()
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
 
 
@@ -194,7 +194,7 @@ async def test_sqlalchemy_repo_delete(mock_repo: SQLAlchemyAsyncRepository, monk
     assert instance is mock_instance
     mock_repo.session.delete.assert_called_once_with(mock_instance)
     mock_repo.session.flush.assert_called_once()
-    mock_repo.session.expunge.assert_called_once_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
 
 
@@ -236,7 +236,7 @@ async def test_sqlalchemy_repo_get_member(mock_repo: SQLAlchemyAsyncRepository, 
     monkeypatch.setattr(mock_repo, "_execute", execute_mock)
     instance = await mock_repo.get("instance-id")
     assert instance is mock_instance
-    mock_repo.session.expunge.assert_called_once_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
 
 
@@ -249,7 +249,7 @@ async def test_sqlalchemy_repo_get_one_member(mock_repo: SQLAlchemyAsyncReposito
     monkeypatch.setattr(mock_repo, "_execute", execute_mock)
     instance = await mock_repo.get_one(id="instance-id")
     assert instance is mock_instance
-    mock_repo.session.expunge.assert_called_once_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
 
 
@@ -267,7 +267,7 @@ async def test_sqlalchemy_repo_get_or_create_member_existing(
     instance, created = await mock_repo.get_or_create(id="instance-id", upsert=False)
     assert instance is mock_instance
     assert created is False
-    mock_repo.session.expunge.assert_called_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.merge.assert_not_called()
     mock_repo.session.refresh.assert_not_called()
 
@@ -286,7 +286,7 @@ async def test_sqlalchemy_repo_get_or_create_member_existing_upsert(
     instance, created = await mock_repo.get_or_create(id="instance-id", upsert=True, an_extra_attribute="yep")
     assert instance is mock_instance
     assert created is False
-    mock_repo.session.expunge.assert_called_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo._attach_to_session.assert_called_once()
     mock_repo.session.flush.assert_called_once()
     mock_repo.session.refresh.assert_called_once_with(mock_instance, attribute_names=None, with_for_update=None)
@@ -304,7 +304,7 @@ async def test_sqlalchemy_repo_get_or_create_member_existing_no_upsert(
     instance, created = await mock_repo.get_or_create(id="instance-id", upsert=False, an_extra_attribute="yep")
     assert instance is mock_instance
     assert created is False
-    mock_repo.session.expunge.assert_called_once_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.add.assert_not_called()
     mock_repo.session.refresh.assert_not_called()
 
@@ -320,7 +320,7 @@ async def test_sqlalchemy_repo_get_or_create_member_created(
     instance, created = await mock_repo.get_or_create(id="new-id")
     assert instance is not None
     assert created is True
-    mock_repo.session.expunge.assert_called_once_with(instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.add.assert_called_once_with(instance)
     mock_repo.session.refresh.assert_called_once_with(instance, attribute_names=None, with_for_update=None)
 
@@ -336,7 +336,7 @@ async def test_sqlalchemy_repo_get_one_or_none_member(
     monkeypatch.setattr(mock_repo, "_execute", execute_mock)
     instance = await mock_repo.get_one_or_none(id="instance-id")
     assert instance is mock_instance
-    mock_repo.session.expunge.assert_called_once_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
 
 
@@ -364,7 +364,7 @@ async def test_sqlalchemy_repo_list(mock_repo: SQLAlchemyAsyncRepository, monkey
     monkeypatch.setattr(mock_repo, "_execute", execute_mock)
     instances = await mock_repo.list()
     assert instances == mock_instances
-    mock_repo.session.expunge.assert_has_calls(*mock_instances)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
 
 
@@ -378,7 +378,7 @@ async def test_sqlalchemy_repo_list_and_count(mock_repo: SQLAlchemyAsyncReposito
     instances, instance_count = await mock_repo.list_and_count()
     assert instances == mock_instances
     assert instance_count == mock_count
-    mock_repo.session.expunge.assert_has_calls(*mock_instances)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
 
 
@@ -475,7 +475,7 @@ async def test_sqlalchemy_repo_update(mock_repo: SQLAlchemyAsyncRepository, monk
     assert instance is mock_instance
     mock_repo.session.merge.assert_called_once_with(mock_instance)
     mock_repo.session.flush.assert_called_once()
-    mock_repo.session.expunge.assert_called_once_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
     mock_repo.session.refresh.assert_called_once_with(mock_instance, attribute_names=None, with_for_update=None)
 
@@ -488,7 +488,7 @@ async def test_sqlalchemy_repo_upsert(mock_repo: SQLAlchemyAsyncRepository) -> N
     assert instance is mock_instance
     mock_repo.session.merge.assert_called_once_with(mock_instance)
     mock_repo.session.flush.assert_called_once()
-    mock_repo.session.expunge.assert_called_once_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
     mock_repo.session.refresh.assert_called_once_with(mock_instance, attribute_names=None, with_for_update=None)
 

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_sqlalchemy_async.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_sqlalchemy_async.py
@@ -122,7 +122,7 @@ async def test_sqlalchemy_repo_add(mock_repo: SQLAlchemyAsyncRepository) -> None
     assert instance is mock_instance
     mock_repo.session.add.assert_called_once_with(mock_instance)
     mock_repo.session.flush.assert_called_once()
-    mock_repo.session.refresh.assert_called_once_with(mock_instance)
+    mock_repo.session.refresh.assert_called_once_with(mock_instance, attribute_names=None, with_for_update=None)
     mock_repo.session.expunge.assert_called_once_with(mock_instance)
     mock_repo.session.commit.assert_not_called()
 
@@ -289,7 +289,7 @@ async def test_sqlalchemy_repo_get_or_create_member_existing_upsert(
     mock_repo.session.expunge.assert_called_with(mock_instance)
     mock_repo._attach_to_session.assert_called_once()
     mock_repo.session.flush.assert_called_once()
-    mock_repo.session.refresh.assert_called_once_with(mock_instance)
+    mock_repo.session.refresh.assert_called_once_with(mock_instance, attribute_names=None, with_for_update=None)
 
 
 async def test_sqlalchemy_repo_get_or_create_member_existing_no_upsert(
@@ -322,7 +322,7 @@ async def test_sqlalchemy_repo_get_or_create_member_created(
     assert created is True
     mock_repo.session.expunge.assert_called_once_with(instance)
     mock_repo.session.add.assert_called_once_with(instance)
-    mock_repo.session.refresh.assert_called_once_with(instance)
+    mock_repo.session.refresh.assert_called_once_with(instance, attribute_names=None, with_for_update=None)
 
 
 async def test_sqlalchemy_repo_get_one_or_none_member(
@@ -477,7 +477,7 @@ async def test_sqlalchemy_repo_update(mock_repo: SQLAlchemyAsyncRepository, monk
     mock_repo.session.flush.assert_called_once()
     mock_repo.session.expunge.assert_called_once_with(mock_instance)
     mock_repo.session.commit.assert_not_called()
-    mock_repo.session.refresh.assert_called_once_with(mock_instance)
+    mock_repo.session.refresh.assert_called_once_with(mock_instance, attribute_names=None, with_for_update=None)
 
 
 async def test_sqlalchemy_repo_upsert(mock_repo: SQLAlchemyAsyncRepository) -> None:
@@ -490,7 +490,7 @@ async def test_sqlalchemy_repo_upsert(mock_repo: SQLAlchemyAsyncRepository) -> N
     mock_repo.session.flush.assert_called_once()
     mock_repo.session.expunge.assert_called_once_with(mock_instance)
     mock_repo.session.commit.assert_not_called()
-    mock_repo.session.refresh.assert_called_once_with(mock_instance)
+    mock_repo.session.refresh.assert_called_once_with(mock_instance, attribute_names=None, with_for_update=None)
 
 
 async def test_attach_to_session_unexpected_strategy_raises_valueerror(

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_sqlalchemy_sync.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_sqlalchemy_sync.py
@@ -322,7 +322,7 @@ def test_sqlalchemy_repo_get_or_create_member_created(
     assert created is True
     mock_repo.session.expunge.assert_called_with(instance)
     mock_repo.session.add.assert_called_once_with(instance)
-    mock_repo.session.refresh.assert_called_once_with(instance)
+    mock_repo.session.refresh.assert_called_once_with(instance, attribute_names=None, with_for_update=None)
 
 
 def test_sqlalchemy_repo_get_one_or_none_member(mock_repo: SQLAlchemySyncRepository, monkeypatch: MonkeyPatch) -> None:

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_sqlalchemy_sync.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_sqlalchemy_sync.py
@@ -122,7 +122,7 @@ def test_sqlalchemy_repo_add(mock_repo: SQLAlchemySyncRepository) -> None:
     mock_repo.session.add.assert_called_once_with(mock_instance)
     mock_repo.session.flush.assert_called_once()
     mock_repo.session.refresh.assert_called_once_with(mock_instance, attribute_names=None, with_for_update=None)
-    mock_repo.session.expunge.assert_called_once_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
 
 
@@ -150,7 +150,7 @@ def test_sqlalchemy_repo_add_many(mock_repo: SQLAlchemySyncRepository, monkeypat
     assert len(instances) == 3
     for row in instances:
         assert row.id is not None
-    mock_repo.session.expunge.assert_called()
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
 
 
@@ -193,7 +193,7 @@ def test_sqlalchemy_repo_delete(mock_repo: SQLAlchemySyncRepository, monkeypatch
     assert instance is mock_instance
     mock_repo.session.delete.assert_called_once_with(mock_instance)
     mock_repo.session.flush.assert_called_once()
-    mock_repo.session.expunge.assert_called_once_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
 
 
@@ -235,7 +235,7 @@ def test_sqlalchemy_repo_get_member(mock_repo: SQLAlchemySyncRepository, monkeyp
     monkeypatch.setattr(mock_repo, "_execute", execute_mock)
     instance = mock_repo.get("instance-id")
     assert instance is mock_instance
-    mock_repo.session.expunge.assert_called_once_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
 
 
@@ -248,7 +248,7 @@ def test_sqlalchemy_repo_get_one_member(mock_repo: SQLAlchemySyncRepository, mon
     monkeypatch.setattr(mock_repo, "_execute", execute_mock)
     instance = mock_repo.get_one(id="instance-id")
     assert instance is mock_instance
-    mock_repo.session.expunge.assert_called_once_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
 
 
@@ -267,7 +267,7 @@ def test_sqlalchemy_repo_get_or_create_member_existing(
     instance, created = mock_repo.get_or_create(id="instance-id", upsert=False)
     assert instance is mock_instance
     assert created is False
-    mock_repo.session.expunge.assert_called_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.merge.assert_not_called()
     mock_repo.session.refresh.assert_not_called()
 
@@ -286,7 +286,7 @@ def test_sqlalchemy_repo_get_or_create_member_existing_upsert(
     instance, created = mock_repo.get_or_create(id="instance-id", upsert=True, an_extra_attribute="yep")
     assert instance is mock_instance
     assert created is False
-    mock_repo.session.expunge.assert_called_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo._attach_to_session.assert_called_once()
     mock_repo.session.flush.assert_called_once()
     mock_repo.session.refresh.assert_called_once_with(mock_instance, attribute_names=None, with_for_update=None)
@@ -304,7 +304,7 @@ def test_sqlalchemy_repo_get_or_create_member_existing_no_upsert(
     instance, created = mock_repo.get_or_create(id="instance-id", upsert=False, an_extra_attribute="yep")
     assert instance is mock_instance
     assert created is False
-    mock_repo.session.expunge.assert_called_once_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.add.assert_not_called()
     mock_repo.session.refresh.assert_not_called()
 
@@ -320,7 +320,7 @@ def test_sqlalchemy_repo_get_or_create_member_created(
     instance, created = mock_repo.get_or_create(id="new-id")
     assert instance is not None
     assert created is True
-    mock_repo.session.expunge.assert_called_with(instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.add.assert_called_once_with(instance)
     mock_repo.session.refresh.assert_called_once_with(instance, attribute_names=None, with_for_update=None)
 
@@ -334,7 +334,7 @@ def test_sqlalchemy_repo_get_one_or_none_member(mock_repo: SQLAlchemySyncReposit
     monkeypatch.setattr(mock_repo, "_execute", execute_mock)
     instance = mock_repo.get_one_or_none(id="instance-id")
     assert instance is mock_instance
-    mock_repo.session.expunge.assert_called_once_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
 
 
@@ -362,7 +362,7 @@ def test_sqlalchemy_repo_list(mock_repo: SQLAlchemySyncRepository, monkeypatch: 
     monkeypatch.setattr(mock_repo, "_execute", execute_mock)
     instances = mock_repo.list()
     assert instances == mock_instances
-    mock_repo.session.expunge.assert_has_calls(*mock_instances)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
 
 
@@ -376,7 +376,7 @@ def test_sqlalchemy_repo_list_and_count(mock_repo: SQLAlchemySyncRepository, mon
     instances, instance_count = mock_repo.list_and_count()
     assert instances == mock_instances
     assert instance_count == mock_count
-    mock_repo.session.expunge.assert_has_calls(*mock_instances)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
 
 
@@ -471,7 +471,7 @@ def test_sqlalchemy_repo_update(mock_repo: SQLAlchemySyncRepository, monkeypatch
     assert instance is mock_instance
     mock_repo.session.merge.assert_called_once_with(mock_instance)
     mock_repo.session.flush.assert_called_once()
-    mock_repo.session.expunge.assert_called_once_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
     mock_repo.session.refresh.assert_called_once_with(mock_instance, attribute_names=None, with_for_update=None)
 
@@ -484,7 +484,7 @@ def test_sqlalchemy_repo_upsert(mock_repo: SQLAlchemySyncRepository) -> None:
     assert instance is mock_instance
     mock_repo.session.merge.assert_called_once_with(mock_instance)
     mock_repo.session.flush.assert_called_once()
-    mock_repo.session.expunge.assert_called_once_with(mock_instance)
+    mock_repo.session.expunge.assert_not_called()
     mock_repo.session.commit.assert_not_called()
     mock_repo.session.refresh.assert_called_once_with(mock_instance, attribute_names=None, with_for_update=None)
 

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_sqlalchemy_sync.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_sqlalchemy_sync.py
@@ -121,7 +121,7 @@ def test_sqlalchemy_repo_add(mock_repo: SQLAlchemySyncRepository) -> None:
     assert instance is mock_instance
     mock_repo.session.add.assert_called_once_with(mock_instance)
     mock_repo.session.flush.assert_called_once()
-    mock_repo.session.refresh.assert_called_once_with(mock_instance)
+    mock_repo.session.refresh.assert_called_once_with(mock_instance, attribute_names=None, with_for_update=None)
     mock_repo.session.expunge.assert_called_once_with(mock_instance)
     mock_repo.session.commit.assert_not_called()
 
@@ -289,7 +289,7 @@ def test_sqlalchemy_repo_get_or_create_member_existing_upsert(
     mock_repo.session.expunge.assert_called_with(mock_instance)
     mock_repo._attach_to_session.assert_called_once()
     mock_repo.session.flush.assert_called_once()
-    mock_repo.session.refresh.assert_called_once_with(mock_instance)
+    mock_repo.session.refresh.assert_called_once_with(mock_instance, attribute_names=None, with_for_update=None)
 
 
 def test_sqlalchemy_repo_get_or_create_member_existing_no_upsert(
@@ -473,7 +473,7 @@ def test_sqlalchemy_repo_update(mock_repo: SQLAlchemySyncRepository, monkeypatch
     mock_repo.session.flush.assert_called_once()
     mock_repo.session.expunge.assert_called_once_with(mock_instance)
     mock_repo.session.commit.assert_not_called()
-    mock_repo.session.refresh.assert_called_once_with(mock_instance)
+    mock_repo.session.refresh.assert_called_once_with(mock_instance, attribute_names=None, with_for_update=None)
 
 
 def test_sqlalchemy_repo_upsert(mock_repo: SQLAlchemySyncRepository) -> None:
@@ -486,7 +486,7 @@ def test_sqlalchemy_repo_upsert(mock_repo: SQLAlchemySyncRepository) -> None:
     mock_repo.session.flush.assert_called_once()
     mock_repo.session.expunge.assert_called_once_with(mock_instance)
     mock_repo.session.commit.assert_not_called()
-    mock_repo.session.refresh.assert_called_once_with(mock_instance)
+    mock_repo.session.refresh.assert_called_once_with(mock_instance, attribute_names=None, with_for_update=None)
 
 
 def test_attach_to_session_unexpected_strategy_raises_valueerror(


### PR DESCRIPTION
Fixes #1895

This PR does the following:

- exposes the `attribute_names` and `with_for_update` parameters on functions that execute `session.refresh`
- Adds `auto_commit` parameter.  When this is true, the session will `commit` instead of `flush` before returning (default=False).
- Adds `auto_refresh` parameters.  When this is true, the session will execute `refresh` objects  before returning (default=True).
- Adds `auto_expunge` parameters.  When this is true, the session will execute `expunge` on all objects before returning (default=True).(default=True).



### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
