### PR TITLE
Pin Redis version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3279,17 +3279,17 @@ files = [
 
 [[package]]
 name = "redis"
-version = "4.6.0"
+version = "4.4.4"
 description = "Python client for Redis database and key-value store"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "redis-4.6.0-py3-none-any.whl", hash = "sha256:e2b03db868160ee4591de3cb90d40ebb50a90dd302138775937f6a42b7ed183c"},
-    {file = "redis-4.6.0.tar.gz", hash = "sha256:585dc516b9eb042a619ef0a39c3d7d55fe81bdb4df09a52c9cdde0d07bf1aa7d"},
+    {file = "redis-4.4.4-py3-none-any.whl", hash = "sha256:da92a39fec86438d3f1e2a1db33c312985806954fe860120b582a8430e231d8f"},
+    {file = "redis-4.4.4.tar.gz", hash = "sha256:68226f7ede928db8302f29ab088a157f41061fa946b7ae865452b6d7838bbffb"},
 ]
 
 [package.dependencies]
-async-timeout = {version = ">=4.0.2", markers = "python_full_version <= \"3.11.2\""}
+async-timeout = ">=4.0.2"
 hiredis = {version = ">=1.0.0", optional = true, markers = "extra == \"hiredis\""}
 
 [package.extras]
@@ -4409,4 +4409,4 @@ tortoise-orm = ["tortoise-orm"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "a7a33ee9e32b2a05db0c0ed52b208b45bbba48ba12f372bea8206d02572bc522"
+content-hash = "d504b895e3da91fa145af40a00d08e01eb843cd045bb9ff8a6a218d34a0fb1b7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ python-dateutil = { version = "*", optional = true }
 python-jose = { version = "*", optional = true }
 pytimeparse = { version = "*", optional = true }
 pyyaml = "*"
-redis = { version = ">=4.6.0", optional = true, extras = ["hiredis"] }
+redis = { version = ">=4.4.4, <4.5.0", optional = true, extras = ["hiredis"] }
 rich = { version = ">=13.0.0", optional = true }
 rich-click = { version = "*", optional = true }
 sqlalchemy = { version = ">=2.0.12", optional = true }
@@ -151,7 +151,7 @@ python-dateutil = "*"
 python-dotenv = "*"
 python-jose = "*"
 pytimeparse = "*"
-redis = "*"
+redis = ">=4.4.4, <4.5.0"
 rich = "*"
 rich-click = "*"
 sqlalchemy = ">=2.0"

--- a/tests/unit/test_channels/test_plugin.py
+++ b/tests/unit/test_channels/test_plugin.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from secrets import token_hex
-from typing import Generator, cast
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -18,16 +18,6 @@ from litestar.testing import TestClient, create_test_client
 from litestar.types.asgi_types import WebSocketMode
 
 from .util import get_from_stream
-
-
-@pytest.fixture(scope="session")
-def event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
 
 
 @pytest.fixture(


### PR DESCRIPTION
This PR pins the redis version to the 4.4.4+ range, because the tests fail on redis 4.5.* and above.

Note- py-redis is about to release v5.0.0 in the near future, and we will need to tackle this. 