### PR TITLE
fix: SQL Alchemy repository `updated` vs `updated_at` column reference.

### DIFF
--- a/litestar/contrib/sqlalchemy/base.py
+++ b/litestar/contrib/sqlalchemy/base.py
@@ -66,7 +66,7 @@ def touch_updated_timestamp(session: Session, *_: Any) -> None:
     """
     for instance in session.dirty:
         if hasattr(instance, "updated_at"):
-            instance.updated = (datetime.now(timezone.utc),)
+            instance.updated_at = datetime.now(timezone.utc)
 
 
 @runtime_checkable

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_bigint.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_bigint.py
@@ -164,7 +164,7 @@ async def test_repo_created_updated(author_repo: AuthorAsyncRepository) -> None:
 
     author.books.append(BigIntBook(title="Testing"))
     author = await maybe_async(author_repo.update(author))
-    assert author.updated_at == original_update_dt
+    assert author.updated_at > original_update_dt
 
 
 async def test_repo_list_method(raw_authors_bigint: list[dict[str, Any]], author_repo: AuthorAsyncRepository) -> None:

--- a/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_uuid.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_repository/test_repo_uuid.py
@@ -260,7 +260,7 @@ async def test_repo_created_updated(author_repo: AuthorAsyncRepository) -> None:
 
     author.books.append(UUIDBook(title="Testing"))
     author = await maybe_async(author_repo.update(author))
-    assert author.updated_at == original_update_dt
+    assert author.updated_at > original_update_dt
 
 
 async def test_repo_list_method(


### PR DESCRIPTION
Fixes #1905

Updates the column name attribute from `updated` to `updated_at`.

The existing test case to verify this was incorrect, so we didn't catch this earlier.

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
