### PR TITLE
feat(infra): add conventional commit pre-commit and semantic pull request workflow

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,20 @@
+name: "Lint PR Title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
 default_language_version:
   python: "3.11"
 repos:
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v2.3.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
@@ -12,12 +17,12 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
-  - repo: https://github.com/python-poetry/poetry
-    rev: "1.5.1"
-    hooks:
-      - id: poetry-check
-      - id: poetry-lock
-        args: ["--no-update"]
+  #  - repo: https://github.com/python-poetry/poetry
+  #    rev: "1.5.0"
+  #    hooks:
+  #      - id: poetry-check
+  #      - id: poetry-lock
+  #        args: ["--no-update"]
   - repo: https://github.com/provinzkraut/unasyncd
     rev: "v0.4.0"
     hooks:
@@ -46,7 +51,7 @@ repos:
     rev: "v3.0.0"
     hooks:
       - id: prettier
-        exclude: "_templates"
+        exclude: "_templates|.git"
   - repo: https://github.com/python-formate/flake8-dunder-all
     rev: v0.3.0
     hooks:
@@ -65,7 +70,7 @@ repos:
         exclude: "test_apps|tools|docs|tests/examples|tests/docker_service_fixtures"
         additional_dependencies:
           [
-            "polyfactory>=2.3.2",
+            polyfactory,
             aiosqlite,
             annotated_types,
             async_timeout,
@@ -119,13 +124,13 @@ repos:
             prometheus_client,
           ]
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.316
+    rev: v1.1.317
     hooks:
       - id: pyright
         exclude: "test_apps|tools|docs|_openapi|tests/examples|tests/docker_service_fixtures"
         additional_dependencies:
           [
-            "polyfactory>=2.3.2",
+            polyfactory,
             aiosqlite,
             annotated_types,
             async_timeout,

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -9,7 +9,7 @@ Setting up the environment
    the dependencies
 3. If you're working on the documentation and need to build it locally, install the extra dependencies with ``poetry install --with docs``
 4. Install `pre-commit <https://pre-commit.com/>`_
-5. Run ``pre-commit install`` to install pre-commit hooks
+5. Run ``pre-commit install && pre-commit install --hook-type commit-msg`` to install pre-commit hooks
 
 .. tip::
   Many modern IDEs like PyCharm or VS Code will enable the poetry-managed virtualenv that is created in step 2 for you automatically.
@@ -31,14 +31,13 @@ Workflow
 4. Make your changes
 5. (Optional) Run ``pre-commit run --all-files`` to run linters and formatters. This step is optional and will be executed
    automatically by git before you make a commit, but you may want to run it manually in order to apply fixes
-6. Commit your changes to git
+6. Commit your changes to git. Note - we follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/),
+   which are enforced using a `pre-commit` hook.
 7. Push the changes to your fork
 8. Open a `pull request <https://docs.github.com/en/pull-requests>`_. Give the pull request a descriptive title
-   indicating what it changes. If it has a corresponding open issue, the issue number should be included in the title as
-   well. For example a pull request that fixes issue ``Bug: Increased stack size making it impossible to find needle #100``
-   could be titled ``Fix #100 - Make needles easier to find by applying fire to haystack``
+   indicating what it changes. The style of the PR title should also follow
+   [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), and this is enforced using a GitHub action.
 9. Add yourself as a contributor using the `all-contributors bot <https://allcontributors.org/docs/en/bot/usage>`_
-
 
 Guidelines for writing code
 ----------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,6 +87,7 @@ nitpick_ignore = [
     (PY_METH, "_types.TypeDecorator.process_bind_param"),
     (PY_METH, "_types.TypeDecorator.process_result_value"),
     (PY_METH, "type_engine"),
+    (PY_METH, "litestar.typing.ParsedType.is_subclass_of"),
     # type vars and aliases / intentionally undocumented
     (PY_CLASS, "RouteHandlerType"),
     (PY_OBJ, "litestar.security.base.AuthType"),

--- a/poetry.lock
+++ b/poetry.lock
@@ -3025,13 +3025,13 @@ files = [
 
 [[package]]
 name = "pyright"
-version = "1.1.316"
+version = "1.1.317"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyright-1.1.316-py3-none-any.whl", hash = "sha256:7259d73287c882f933d8cd88c238ef02336e172171ae95117a963a962a1fed4a"},
-    {file = "pyright-1.1.316.tar.gz", hash = "sha256:bac1baf8567b90f2082ec95b61fc1cb50a68917119212c5608a72210870c6a9a"},
+    {file = "pyright-1.1.317-py3-none-any.whl", hash = "sha256:9cf24f83fe8f2cf00773068e06ce771f03331590c7d5e771546f81d7f60efaba"},
+    {file = "pyright-1.1.317.tar.gz", hash = "sha256:74da4d3e2dcfe66a2d1d1001e16431ec17aac0ad35b03c0410f7379c2cb5c7f0"},
 ]
 
 [package.dependencies]
@@ -3065,13 +3065,13 @@ testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "no
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.21.0"
+version = "0.21.1"
 description = "Pytest support for asyncio"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-asyncio-0.21.0.tar.gz", hash = "sha256:2b38a496aef56f56b0e87557ec313e11e1ab9276fc3863f6a7be0f1d0e415e1b"},
-    {file = "pytest_asyncio-0.21.0-py3-none-any.whl", hash = "sha256:f2b3366b7cd501a4056858bd39349d5af19742aed2d81660b7998b6341c7eb9c"},
+    {file = "pytest-asyncio-0.21.1.tar.gz", hash = "sha256:40a7eae6dded22c7b604986855ea48400ab15b069ae38116e8c01238e9eeb64d"},
+    {file = "pytest_asyncio-0.21.1-py3-none-any.whl", hash = "sha256:8666c1c8ac02631d7c51ba282e0c69a8a452b211ffedf2599099845da5c5c37b"},
 ]
 
 [package.dependencies]
@@ -4368,4 +4368,4 @@ tortoise-orm = ["tortoise-orm"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "169eb10699b24bf6f44a0e72f012a8bc08850c56f1edc78b77b8e2fcce82bfe7"
+content-hash = "70f5c93f8dda8cc11bf8c1939968fe289983304abe84a221d88d3316e57f7104"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4368,4 +4368,4 @@ tortoise-orm = ["tortoise-orm"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "70f5c93f8dda8cc11bf8c1939968fe289983304abe84a221d88d3316e57f7104"
+content-hash = "169eb10699b24bf6f44a0e72f012a8bc08850c56f1edc78b77b8e2fcce82bfe7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,8 @@ structlog = "*"
 tortoise-orm = "*"
 trio = "*"
 uvicorn = "*"
+mypy = "^1.4.1"
+pyright = "^1.1.316"
 
 [tool.poetry.group.docs]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,8 +160,6 @@ structlog = "*"
 tortoise-orm = "*"
 trio = "*"
 uvicorn = "*"
-mypy = "^1.4.1"
-pyright = "^1.1.316"
 
 [tool.poetry.group.docs]
 optional = true


### PR DESCRIPTION
This PR does the following:

1. it adds conventional-commit pre-commit hook. This follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. it add s the semantic-PR github action, which enforces conventional PR titles following the same style guide.
3. it updates the readme and contribution guidelines to explain this.
4. it comments our the poetry action, since it currently bugs out. 