### PR TITLE
chore: Add proper `.PHONY` markers to all targets in `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,50 +1,64 @@
-.PHONY: docs
-
+.PHONY: sourcery
 sourcery:
 	poetry run sourcery review --fix .
 
+.PHONY: docs-clean
 docs-clean:
 	rm -rf docs/_build
 
+.PHONY: docs-serve
 docs-serve:
 	sphinx-autobuild docs docs/_build/ -j auto --watch litestar,examples
 
+.PHONY: docs
 docs: docs-clean
 	sphinx-build -M html docs docs/_build/ -a -j auto -W --keep-going
 
+.PHONY: test-examples
 test-examples:
 	pytest tests/examples
 
+.PHONY: test-sqlalchemy-asyncpg
 test-sqlalchemy-asyncpg:
 	pytest tests -m='sqlalchemy_asyncpg'
 
+.PHONY: test-sqlalchemy-psycopg-async
 test-sqlalchemy-psycopg-async:
 	pytest tests -m='sqlalchemy_psycopg_async'
 
+.PHONY: test-sqlalchemy-psycopg-sync
 test-sqlalchemy-psycopg-sync:
 	pytest tests -m='sqlalchemy_psycopg_sync'
 
+.PHONY: test-sqlalchemy-asyncmy
 test-sqlalchemy-asyncmy:
 	pytest tests -m='sqlalchemy_asyncmy'
 
+.PHONY: test-sqlalchemy-oracledb
 test-sqlalchemy-oracledb:
 	pytest tests -m='sqlalchemy_oracledb'
 
+.PHONY: test-sqlalchemy-duckdb
 test-sqlalchemy-duckdb:
 	pytest tests -m='sqlalchemy_duckdb'
 
+.PHONY: test-sqlalchemy-spanner
 test-sqlalchemy-spanner:
 	pytest tests -m='sqlalchemy_spanner'
 
+.PHONY: test-sqlalchemy-integration
 test-sqlalchemy-integration:
 	pytest tests -m='sqlalchemy_integration'
 
+.PHONY: tests
 test:
 	pytest tests
 
+.PHONY: test-all
 test-all:
 	pytest -m=""
 
+.PHONY: coverage
 coverage:
 	pytest tests --cov=litestar
 	coverage html


### PR DESCRIPTION
### Pull Request Checklist

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

I agree to:
- [x] follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)

### Description

See docs about `.PHONY` targets and why it is important: https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html

- [ ] Please describe your pull request for new release changelog purposes
  Usually changes like this do not need a changelog entry

### Close Issue(s)

- [ ] Please add in issue numbers this pull request will close, if applicable
  No issue exists, I can open one if needed.

