### PR TITLE
style: Use explicit `TypeAlias` type in `helper_types`

### DIFF
--- a/litestar/types/helper_types.py
+++ b/litestar/types/helper_types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from functools import partial
 from typing import (
+    TYPE_CHECKING,
     AsyncIterable,
     AsyncIterator,
     Awaitable,
@@ -14,22 +15,25 @@ from typing import (
     Union,
 )
 
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
 T = TypeVar("T")
 
 __all__ = ("OptionalSequence", "SyncOrAsyncUnion", "AnyIOBackend", "StreamType", "MaybePartial")
 
-OptionalSequence = Optional[Sequence[T]]
+OptionalSequence: TypeAlias = Optional[Sequence[T]]
 """Types 'T' as union of Sequence[T] and None."""
 
-SyncOrAsyncUnion = Union[T, Awaitable[T]]
+SyncOrAsyncUnion: TypeAlias = Union[T, Awaitable[T]]
 """Types 'T' as a union of T and awaitable T."""
 
 
-AnyIOBackend = Literal["asyncio", "trio"]
+AnyIOBackend: TypeAlias = Literal["asyncio", "trio"]
 """Anyio backend names."""
 
-StreamType = Union[Iterable[T], Iterator[T], AsyncIterable[T], AsyncIterator[T]]
+StreamType: TypeAlias = Union[Iterable[T], Iterator[T], AsyncIterable[T], AsyncIterator[T]]
 """A stream type."""
 
-MaybePartial = Union[T, partial]
+MaybePartial: TypeAlias = Union[T, partial]
 """A potentially partial callable."""


### PR DESCRIPTION


### Pull Request Checklist

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description

All other files in https://github.com/litestar-org/litestar/tree/main/litestar/types use explicit `TypeAlias` annotations.

The only one that does not is now fixed :)

P.S. I am reading though the code base right now, I really like the project. Thanks for creating it! 👏 

Do you welcome small contributions like this? Or do you value decreasing code churn more?