### PR TITLE
style: Mark `Empty` and `CACHE_FOREVER` as `@typing.final`

### DIFF
--- a/litestar/config/response_cache.py
+++ b/litestar/config/response_cache.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, final
 from urllib.parse import urlencode
 
 __all__ = ("ResponseCacheConfig", "default_cache_key_builder", "CACHE_FOREVER")
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from litestar.types import CacheKeyBuilder
 
 
+@final
 class CACHE_FOREVER:  # noqa: N801
     """Sentinel value indicating that a cached response should be stored without an expiration, explicitly skipping the
     default expiration

--- a/litestar/types/empty.py
+++ b/litestar/types/empty.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 __all__ = ("Empty", "EmptyType")
 
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING, Type, final
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
 
+@final
 class Empty:
     """A sentinel class used as placeholder."""
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description

mypy soon will have special narrowing for `@final` singleton types: https://github.com/python/mypy/pull/15646

So, it is a good idea to use `@final` for such types.
