### PR TITLE
docs: Add instruction to downgrade pydantic to example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -103,7 +103,7 @@ Then, run the following command:
 .. attention::
 
     If it fails with ``pydantic.errors.PydanticUserError: `const` is removed, use `Literal` instead`` error,
-    please downgrade Pydantic by ``pip install "pydantic==1.10.10"``
+    please downgrade Pydantic using ``pip install "pydantic==1.10.10"``
 
 You can now visit ``http://localhost:8000/`` and ``http://localhost:8000/books/1`` in your browser and
 you should see the JSON responses of your two endpoints:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,6 +100,11 @@ Then, run the following command:
     # Or you can run Uvicorn directly:
     uvicorn app:app --reload
 
+.. attention::
+
+    If it fails with ``pydantic.errors.PydanticUserError: `const` is removed, use `Literal` instead`` error,
+    please downgrade Pydantic by ``pip install "pydantic==1.10.10"``
+
 You can now visit ``http://localhost:8000/`` and ``http://localhost:8000/books/1`` in your browser and
 you should see the JSON responses of your two endpoints:
 


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

 `pip install starlite` currently install Pydantic V2 as dependency instead of V1. The stable version doesn't support Pydantic V2 yet. This pull request add instruction to downgrade Pydantic in the example in the docs while we wait for new version release.

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
