### PR TITLE
fix(infra): mypy should ignore untyped decorators in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -306,6 +306,10 @@ module = "tests.unit.test_contrib.test_sqlalchemy.test_dto"
 disable_error_code = ["arg-type", "misc", "valid-type", "var-annotated"]
 
 [[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_decorators = false
+
+[[tool.mypy.overrides]]
 module = ["mako.*", "pytimeparse.*", "brotli.*", "jsbeautifier.*"]
 ignore_missing_imports = true
 


### PR DESCRIPTION
Follow up to https://github.com/litestar-org/litestar/pull/1976

I forgot this section from `mypy.ini`: https://github.com/litestar-org/litestar/commit/11f0235ce1c0eec31b92a367d976e4903cef659a#diff-6f2d4ba9ca9a357d31014946667b7bed1bfdbc6d2530afc77778fa0a36bee457L21-L23

Please, see this comment to see the failure results: https://github.com/litestar-org/litestar/pull/1976#issuecomment-1637067589