### PR TITLE
test: fix failing tests

### DIFF
--- a/docs/examples/parameters/path_parameters_2.py
+++ b/docs/examples/parameters/path_parameters_2.py
@@ -19,8 +19,9 @@ ORDERS_BY_DATETIME = {
 }
 
 
-@get(path="/orders/{from_date:int}", sync_to_thread=False)
-def get_orders(from_date: datetime) -> List[Order]:
+@get(path="/orders/{from_timestamp:int}", sync_to_thread=False)
+def get_orders(from_timestamp: int) -> List[Order]:
+    from_date = datetime.fromtimestamp(from_timestamp, tz=timezone.utc)
     return ORDERS_BY_DATETIME[from_date]
 
 

--- a/docs/examples/request_data/request_data_4.py
+++ b/docs/examples/request_data/request_data_4.py
@@ -14,9 +14,7 @@ class User:
 
 
 @post(path="/")
-async def create_user(
-    data: Annotated[User, Body(media_type=RequestEncodingType.URL_ENCODED)],
-) -> User:
+async def create_user(data: Annotated[User, Body(media_type=RequestEncodingType.URL_ENCODED)]) -> User:
     return data
 
 

--- a/litestar/_parsers.py
+++ b/litestar/_parsers.py
@@ -21,7 +21,7 @@ def parse_url_encoded_form_data(encoded_data: bytes) -> dict[str, Any]:
     Returns:
         A parsed dict.
     """
-    return parse_url_encoded_dict(qs=encoded_data, parse_numbers=False)
+    return parse_url_encoded_dict(qs=encoded_data)
 
 
 @lru_cache(1024)

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -30,10 +30,10 @@ def test_parse_form_data() -> None:
         ).encode(),
     )
     assert result == {
-        "value": ["10", "12"],
+        "value": [10, 12],
         "veggies": ["tomato", "potato", "aubergine"],
         "nested": {"some_key": "some_value"},
-        "calories": "122.53",
+        "calories": 122.53,
         "healthy": True,
         "polluting": False,
     }


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"
- Many tests are failing from various changes, this aims to fix most 

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

### Notes

I have not been able to fix the following tests:

Due to validation on datetime issues:
- `tests.unit.test_kwargs.test_path_params.test_path_param_type_resolution`
- `tests.unit.test_kwargs.test_query_params.test_query_params`
- `tests.unit.test_openapi.test_schema.test_annotated_types` The date is always one day off?
- `tests.unit.test_openapi.test_constrained_fields.test_create_date_constrained_field_schema_pydantic_v1` date off by one here also... but pydantic v1 so im not sure if it will test correctly?