### PR TITLE
docs: Use `dict[str, int]` instead of `JSONResponse`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,7 +92,7 @@ First, create a file named ``app.py`` with the following contents:
 
 
    @get("/books/{book_id:int}")
-   async def get_book(book_id: int) -> JSONResponse:
+   async def get_book(book_id: int) -> dict[str, int]:
        return {"book_id": book_id}
 
 


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [x] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [x] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
