### PR TITLE
fix: updates import to `decimal` from `_decimal`

### DIFF
--- a/litestar/_openapi/schema_generation/constrained_fields.py
+++ b/litestar/_openapi/schema_generation/constrained_fields.py
@@ -8,7 +8,7 @@ from litestar.openapi.spec.enums import OpenAPIFormat, OpenAPIType
 from litestar.openapi.spec.schema import Schema
 
 if TYPE_CHECKING:
-    from _decimal import Decimal
+    from decimal import Decimal
 
     from litestar.params import KwargDefinition
 

--- a/litestar/_openapi/schema_generation/examples.py
+++ b/litestar/_openapi/schema_generation/examples.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from decimal import Decimal
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from _decimal import Decimal
 from polyfactory.exceptions import ParameterException
 from polyfactory.field_meta import FieldMeta, Null
 from polyfactory.utils.helpers import unwrap_annotation

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -4,6 +4,7 @@ from collections import deque
 from copy import copy
 from dataclasses import MISSING, fields
 from datetime import date, datetime, time, timedelta
+from decimal import Decimal
 from enum import EnumMeta
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path
@@ -32,7 +33,6 @@ from typing import (
 )
 from uuid import UUID
 
-from _decimal import Decimal
 from msgspec.structs import FieldInfo
 from msgspec.structs import fields as msgspec_struct_fields
 from typing_extensions import NotRequired, Required, get_args, get_type_hints

--- a/litestar/contrib/piccolo.py
+++ b/litestar/contrib/piccolo.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from decimal import Decimal
 from typing import Any, Generator, Generic, Optional, TypeVar
 
-from _decimal import Decimal
 from msgspec import Meta
 from typing_extensions import Annotated
 

--- a/tests/unit/test_contrib/test_piccolo_orm/test_piccolo_orm_dto.py
+++ b/tests/unit/test_contrib/test_piccolo_orm/test_piccolo_orm_dto.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import AsyncGenerator, Callable
 
 import pytest
-from _decimal import Decimal
 from polyfactory.utils.predicates import is_annotated
 from typing_extensions import get_args
 

--- a/tests/unit/test_contrib/test_pydantic/test_plugin_serialization.py
+++ b/tests/unit/test_contrib/test_pydantic/test_plugin_serialization.py
@@ -1,12 +1,12 @@
 import datetime
 import json
+from decimal import Decimal
 from functools import partial
 from pathlib import Path
 from typing import Any
 
 import pydantic
 import pytest
-from _decimal import Decimal
 from pydantic import (
     VERSION,
     BaseModel,


### PR DESCRIPTION
### Pull Request Checklist

This PR updates the import for decimal to `decimal` from `_decimal`.  This was incorrectly causing import errors in certain installation.


[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

-

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

-
