### PR TITLE
feat(repo): allow `id_attribute` to be customized per method

### DIFF
--- a/litestar/contrib/repository/abc/_async.py
+++ b/litestar/contrib/repository/abc/_async.py
@@ -253,27 +253,31 @@ class AbstractAsyncRepository(Generic[T], metaclass=ABCMeta):
         return item_or_none
 
     @classmethod
-    def get_id_attribute_value(cls, item: T | type[T]) -> Any:
+    def get_id_attribute_value(cls, item: T | type[T], id_attribute: Any | None = None) -> Any:
         """Get value of attribute named as :attr:`id_attribute <AbstractAsyncRepository.id_attribute>` on ``item``.
 
         Args:
             item: Anything that should have an attribute named as :attr:`id_attribute <AbstractAsyncRepository.id_attribute>` value.
+            id_attribute: Allows customization of the unique identifier to use for model fetching.
+                Defaults to `None`, but can reference any surrogate or candidate key for the table.
 
         Returns:
             The value of attribute on ``item`` named as :attr:`id_attribute <AbstractAsyncRepository.id_attribute>`.
         """
-        return getattr(item, cls.id_attribute)
+        return getattr(item, id_attribute if id_attribute is not None else cls.id_attribute)
 
     @classmethod
-    def set_id_attribute_value(cls, item_id: Any, item: T) -> T:
+    def set_id_attribute_value(cls, item_id: Any, item: T, id_attribute: Any | None = None) -> T:
         """Return the ``item`` after the ID is set to the appropriate attribute.
 
         Args:
             item_id: Value of ID to be set on instance
             item: Anything that should have an attribute named as :attr:`id_attribute <AbstractAsyncRepository.id_attribute>` value.
+            id_attribute: Allows customization of the unique identifier to use for model fetching.
+                Defaults to `None`, but can reference any surrogate or candidate key for the table.
 
         Returns:
             Item with ``item_id`` set to :attr:`id_attribute <AbstractAsyncRepository.id_attribute>`
         """
-        setattr(item, cls.id_attribute, item_id)
+        setattr(item, id_attribute if id_attribute is not None else cls.id_attribute, item_id)
         return item

--- a/litestar/contrib/repository/abc/_async.py
+++ b/litestar/contrib/repository/abc/_async.py
@@ -253,7 +253,7 @@ class AbstractAsyncRepository(Generic[T], metaclass=ABCMeta):
         return item_or_none
 
     @classmethod
-    def get_id_attribute_value(cls, item: T | type[T], id_attribute: Any | None = None) -> Any:
+    def get_id_attribute_value(cls, item: T | type[T], id_attribute: str | None = None) -> Any:
         """Get value of attribute named as :attr:`id_attribute <AbstractAsyncRepository.id_attribute>` on ``item``.
 
         Args:
@@ -267,7 +267,7 @@ class AbstractAsyncRepository(Generic[T], metaclass=ABCMeta):
         return getattr(item, id_attribute if id_attribute is not None else cls.id_attribute)
 
     @classmethod
-    def set_id_attribute_value(cls, item_id: Any, item: T, id_attribute: Any | None = None) -> T:
+    def set_id_attribute_value(cls, item_id: Any, item: T, id_attribute: str | None = None) -> T:
         """Return the ``item`` after the ID is set to the appropriate attribute.
 
         Args:

--- a/litestar/contrib/repository/abc/_sync.py
+++ b/litestar/contrib/repository/abc/_sync.py
@@ -255,27 +255,31 @@ class AbstractSyncRepository(Generic[T], metaclass=ABCMeta):
         return item_or_none
 
     @classmethod
-    def get_id_attribute_value(cls, item: T | type[T]) -> Any:
+    def get_id_attribute_value(cls, item: T | type[T], id_attribute: Any | None = None) -> Any:
         """Get value of attribute named as :attr:`id_attribute <AbstractAsyncRepository.id_attribute>` on ``item``.
 
         Args:
             item: Anything that should have an attribute named as :attr:`id_attribute <AbstractAsyncRepository.id_attribute>` value.
+            id_attribute: Allows customization of the unique identifier to use for model fetching.
+                Defaults to `None`, but can reference any surrogate or candidate key for the table.
 
         Returns:
             The value of attribute on ``item`` named as :attr:`id_attribute <AbstractAsyncRepository.id_attribute>`.
         """
-        return getattr(item, cls.id_attribute)
+        return getattr(item, id_attribute if id_attribute is not None else cls.id_attribute)
 
     @classmethod
-    def set_id_attribute_value(cls, item_id: Any, item: T) -> T:
+    def set_id_attribute_value(cls, item_id: Any, item: T, id_attribute: Any | None = None) -> T:
         """Return the ``item`` after the ID is set to the appropriate attribute.
 
         Args:
             item_id: Value of ID to be set on instance
             item: Anything that should have an attribute named as :attr:`id_attribute <AbstractAsyncRepository.id_attribute>` value.
+            id_attribute: Allows customization of the unique identifier to use for model fetching.
+                Defaults to `None`, but can reference any surrogate or candidate key for the table.
 
         Returns:
             Item with ``item_id`` set to :attr:`id_attribute <AbstractAsyncRepository.id_attribute>`
         """
-        setattr(item, cls.id_attribute, item_id)
+        setattr(item, id_attribute if id_attribute is not None else cls.id_attribute, item_id)
         return item

--- a/litestar/contrib/repository/abc/_sync.py
+++ b/litestar/contrib/repository/abc/_sync.py
@@ -255,7 +255,7 @@ class AbstractSyncRepository(Generic[T], metaclass=ABCMeta):
         return item_or_none
 
     @classmethod
-    def get_id_attribute_value(cls, item: T | type[T], id_attribute: Any | None = None) -> Any:
+    def get_id_attribute_value(cls, item: T | type[T], id_attribute: str | None = None) -> Any:
         """Get value of attribute named as :attr:`id_attribute <AbstractAsyncRepository.id_attribute>` on ``item``.
 
         Args:
@@ -269,7 +269,7 @@ class AbstractSyncRepository(Generic[T], metaclass=ABCMeta):
         return getattr(item, id_attribute if id_attribute is not None else cls.id_attribute)
 
     @classmethod
-    def set_id_attribute_value(cls, item_id: Any, item: T, id_attribute: Any | None = None) -> T:
+    def set_id_attribute_value(cls, item_id: Any, item: T, id_attribute: str | None = None) -> T:
         """Return the ``item`` after the ID is set to the appropriate attribute.
 
         Args:

--- a/litestar/contrib/sqlalchemy/repository/_sync.py
+++ b/litestar/contrib/sqlalchemy/repository/_sync.py
@@ -124,6 +124,7 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         item_id: Any,
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
+        id_attribute: Any | None = None,
     ) -> ModelT:
         """Delete instance identified by ``item_id``.
 
@@ -133,6 +134,8 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
                 :class:`SQLAlchemyAsyncRepository.auto_expunge <SQLAlchemyAsyncRepository>`.
             auto_commit: Commit objects before returning. Defaults to
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
+            id_attribute: Allows customization of the unique identifier to use for model fetching.
+                Defaults to `id`, but can reference any surrogate or candidate key for the table.
 
         Returns:
             The deleted instance.
@@ -141,7 +144,7 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
             NotFoundError: If no instance found identified by ``item_id``.
         """
         with wrap_sqlalchemy_exception():
-            instance = self.get(item_id)
+            instance = self.get(item_id, id_attribute=id_attribute)
             self.session.delete(instance)
             self._flush_or_commit(auto_commit=auto_commit)
             self._expunge(instance, auto_expunge=auto_expunge)
@@ -152,6 +155,7 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         item_ids: list[Any],
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
+        id_attribute: Any | None = None,
     ) -> list[ModelT]:
         """Delete instance identified by `item_id`.
 
@@ -161,12 +165,16 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
                 :class:`SQLAlchemyAsyncRepository.auto_expunge <SQLAlchemyAsyncRepository>`.
             auto_commit: Commit objects before returning. Defaults to
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
+            id_attribute: Allows customization of the unique identifier to use for model fetching.
+                Defaults to `id`, but can reference any surrogate or candidate key for the table.
 
         Returns:
             The deleted instances.
 
         """
+
         with wrap_sqlalchemy_exception():
+            id_attribute = id_attribute if id_attribute is not None else self.id_attribute
             instances: list[ModelT] = []
             chunk_size = 450
             for idx in range(0, len(item_ids), chunk_size):
@@ -175,18 +183,18 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
                     instances.extend(
                         self.session.scalars(
                             delete(self.model_type)
-                            .where(getattr(self.model_type, self.id_attribute).in_(chunk))
+                            .where(getattr(self.model_type, id_attribute).in_(chunk))
                             .returning(self.model_type)
                         )
                     )
                 else:
                     instances.extend(
                         self.session.scalars(
-                            select(self.model_type).where(getattr(self.model_type, self.id_attribute).in_(chunk))
+                            select(self.model_type).where(getattr(self.model_type, id_attribute).in_(chunk))
                         )
                     )
                     self.session.execute(
-                        delete(self.model_type).where(getattr(self.model_type, self.id_attribute).in_(chunk))
+                        delete(self.model_type).where(getattr(self.model_type, id_attribute).in_(chunk))
                     )
             self._flush_or_commit(auto_commit=auto_commit)
             for instance in instances:
@@ -211,6 +219,7 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         item_id: Any,
         auto_expunge: bool | None = None,
         statement: Select[tuple[ModelT]] | None = None,
+        id_attribute: Any | None = None,
     ) -> ModelT:
         """Get instance identified by `item_id`.
 
@@ -220,6 +229,8 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
                 :class:`SQLAlchemyAsyncRepository.auto_expunge <SQLAlchemyAsyncRepository>`
             statement: To facilitate customization of the underlying select query.
                 Defaults to :class:`SQLAlchemyAsyncRepository.statement <SQLAlchemyAsyncRepository>`
+            id_attribute: Allows customization of the unique identifier to use for model fetching.
+                Defaults to `id`, but can reference any surrogate or candidate key for the table.
 
         Returns:
             The retrieved instance.
@@ -228,8 +239,9 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
             NotFoundError: If no instance found identified by `item_id`.
         """
         with wrap_sqlalchemy_exception():
+            id_attribute = id_attribute if id_attribute is not None else self.id_attribute
             statement = statement if statement is not None else self.statement
-            statement = self._filter_select_by_kwargs(statement=statement, **{self.id_attribute: item_id})
+            statement = self._filter_select_by_kwargs(statement=statement, **{id_attribute: item_id})
             instance = (self._execute(statement)).scalar_one_or_none()
             instance = self.check_not_found(instance)
             self._expunge(instance, auto_expunge=auto_expunge)
@@ -388,6 +400,7 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
         auto_commit: bool | None = None,
         auto_expunge: bool | None = None,
         auto_refresh: bool | None = None,
+        id_attribute: Any | None = None,
         **kwargs: Any,
     ) -> ModelT:
         """Update instance with the attribute values present on `data`.
@@ -406,6 +419,8 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
                 :class:`SQLAlchemyAsyncRepository.auto_refresh <SQLAlchemyAsyncRepository>`
             auto_commit: Commit objects before returning. Defaults to
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
+            id_attribute: Allows customization of the unique identifier to use for model fetching.
+                Defaults to `id`, but can reference any surrogate or candidate key for the table.
             **kwargs: Additional arguments.
 
         Returns:
@@ -415,9 +430,9 @@ class SQLAlchemySyncRepository(AbstractSyncRepository[ModelT], Generic[ModelT]):
             NotFoundError: If no instance found with same identifier as `data`.
         """
         with wrap_sqlalchemy_exception():
-            item_id = self.get_id_attribute_value(data)
+            item_id = self.get_id_attribute_value(data, id_attribute=id_attribute)
             # this will raise for not found, and will put the item in the session
-            self.get(item_id)
+            self.get(item_id, id_attribute=id_attribute)
             # this will merge the inbound data to the instance we just put in the session
             instance = self._attach_to_session(data, strategy="merge")
             self._flush_or_commit(auto_commit=auto_commit)


### PR DESCRIPTION
The PR allows the `id_attribute` setting to be overridden without changing the entire class configuration.

This is useful if you want to quickly use the `get` or `delete` method by another candidate/surrogate key such as `slug`.

### Pull Request Checklist

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

-

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

-
