### PR TITLE
feat(cli): CLI plugins

### DIFF
--- a/docs/usage/cli.rst
+++ b/docs/usage/cli.rst
@@ -252,11 +252,17 @@ This will result in:
 Extending the CLI
 -----------------
 
-Litestar's CLI is built with `click <https://click.palletsprojects.com/>`_ and can be easily extended.
-To add subcommands under the `litestar` command, you need to add an
-`entry point <https://packaging.python.org/en/latest/specifications/entry-points/>`_ that points to a
-:class:`click.Command` or :class:`click.Group` under the
-`litestar.commands` group.
+Litestar's CLI is built with `click <https://click.palletsprojects.com/>`_ and can be
+extended by making use of
+`entry points <https://packaging.python.org/en/latest/specifications/entry-points/>`_,
+or by creating a plugin that conforms to the
+:class:`~litestar.plugins.CLIPluginProtocol`.
+
+Using entry points
+^^^^^^^^^^^^^^^^^^
+
+Entry points for the CLI can be added under the ``litestar.commands`` group. These
+entries should point to a :class:`click.Command` or :class:`click.Group`:
 
 .. tab-set::
 
@@ -281,12 +287,38 @@ To add subcommands under the `litestar` command, you need to add an
            [tool.poetry.plugins."litestar.commands"]
            my_command = "my_litestar_plugin.cli:main"
 
+Using a plugin
+^^^^^^^^^^^^^^
+
+A plugin extending the CLI can be created using the
+:class:`~litestar.plugins.CLIPluginProtocol`. Its
+:meth:`~litestar.plugins.CLIPluginProtocol.on_cli_init` will be called during the
+initialization of the CLI, and receive the root :class:`click.Group` as its first
+argument, which can then be used to add or override commands:
+
+.. code-block:: python
+
+    from litestar import Litestar
+    from litestar.plugins import CLIPluginProtocol
+    from click import Group
+
+
+    class CLIPlugin(CLIPluginProtocol):
+        def on_cli_init(self, cli: Group) -> None:
+            @cli.command()
+            def is_debug_mode(app: Litestar):
+                print(app.debug)
+
+
+    app = Litestar(plugins=[CLIPlugin()])
+
+
 Accessing the app instance
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When extending the Litestar CLI, you will most likely need access to the loaded `Litestar` instance.
-You can achieve this by adding the special `app` parameter to your CLI functions. This will cause the
-`Litestar` instance to be injected into the function whenever it is called from a click-context.
+When extending the Litestar CLI, you will most likely need access to the loaded ``Litestar`` instance.
+You can achieve this by adding the special ``app`` parameter to your CLI functions. This will cause the
+``Litestar`` instance to be injected into the function whenever it is called from a click-context.
 
 .. code-block:: python
 

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -30,6 +30,7 @@ from litestar.middleware.cors import CORSMiddleware
 from litestar.openapi.config import OpenAPIConfig
 from litestar.openapi.spec.components import Components
 from litestar.plugins import (
+    CLIPluginProtocol,
     InitPluginProtocol,
     OpenAPISchemaPluginProtocol,
     SerializationPluginProtocol,
@@ -130,6 +131,7 @@ class Litestar(Router):
         "_lifespan_managers",
         "_debug",
         "_openapi_schema",
+        "cli_plugins",
         "after_exception",
         "allowed_hosts",
         "asgi_handler",
@@ -379,6 +381,7 @@ class Litestar(Router):
         self.allowed_hosts = cast("AllowedHostsConfig | None", config.allowed_hosts)
         self.before_send = [AsyncCallable(h) for h in config.before_send]
         self.compression_config = config.compression_config
+        self.cli_plugins = [p for p in config.plugins if isinstance(p, CLIPluginProtocol)]
         self.cors_config = config.cors_config
         self.csrf_config = config.csrf_config
         self.event_emitter = config.event_emitter_backend(listeners=config.listeners)

--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -197,11 +197,45 @@ class LitestarExtensionGroup(LitestarGroup):
     ) -> None:
         """Init ``LitestarExtensionGroup``"""
         super().__init__(name=name, commands=commands, **attrs)
+        self._prepare_done = False
 
         for entry_point in entry_points(group="litestar.commands"):
             command = entry_point.load()
             _wrap_commands([command])
             self.add_command(command, entry_point.name)
+
+    def _prepare(self, ctx: Context) -> None:
+        if self._prepare_done:
+            return
+
+        if isinstance(ctx.obj, LitestarEnv):
+            env: LitestarEnv | None = ctx.obj
+        else:
+            try:
+                env = ctx.obj = LitestarEnv.from_env(ctx.params.get("app_path"))
+            except LitestarCLIException:
+                env = None
+
+        if env:
+            for plugin in env.app.cli_plugins:
+                plugin.on_cli_init(self)
+
+        self._prepare_done = True
+
+    def make_context(
+        self,
+        info_name: str | None,
+        args: list[str],
+        parent: Context | None = None,
+        **extra: Any,
+    ) -> Context:
+        ctx = super().make_context(info_name, args, parent, **extra)
+        self._prepare(ctx)
+        return ctx
+
+    def list_commands(self, ctx: Context) -> list[str]:
+        self._prepare(ctx)
+        return super().list_commands(ctx)
 
 
 def _inject_args(func: Callable[P, T]) -> Callable[Concatenate[Context, P], T]:

--- a/litestar/cli/commands/core.py
+++ b/litestar/cli/commands/core.py
@@ -5,7 +5,7 @@ import multiprocessing
 import os
 import subprocess
 import sys
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import uvicorn
 from rich.tree import Tree
@@ -110,7 +110,15 @@ def run_command(
     if pdb:
         os.environ["LITESTAR_PDB"] = "1"
 
-    env = cast(LitestarEnv, ctx.obj())
+    if not isinstance(ctx.obj, LitestarEnv):
+        ctx.obj = ctx.obj()
+    else:
+        if debug:
+            ctx.obj.app.debug = True
+        if pdb:
+            ctx.obj.app.pdb_on_exception = True
+
+    env = ctx.obj
     app = env.app
 
     reload_dirs = env.reload_dirs or reload_dir

--- a/litestar/cli/main.py
+++ b/litestar/cli/main.py
@@ -48,7 +48,9 @@ __all__ = ("litestar_group",)
 def litestar_group(ctx: Context, app_path: str | None, app_dir: Path | None = None) -> None:
     """Litestar CLI."""
     sys.path.append(str(app_dir))
-    ctx.obj = lambda: LitestarEnv.from_env(app_path)
+
+    if ctx.obj is None:  # env has not been loaded yet, so we can lazy load it
+        ctx.obj = lambda: LitestarEnv.from_env(app_path)
 
 
 # add sub commands here

--- a/litestar/plugins.py
+++ b/litestar/plugins.py
@@ -4,12 +4,12 @@ from typing import TYPE_CHECKING, Any, Protocol, TypeVar, Union, runtime_checkab
 
 if TYPE_CHECKING:
     from litestar._openapi.schema_generation import SchemaCreator
+    from litestar.cli._utils import LitestarGroup
     from litestar.config.app import AppConfig
     from litestar.dto.interface import DTOInterface
     from litestar.dto.types import ForType
     from litestar.openapi.spec import Schema
     from litestar.typing import FieldDefinition
-
 
 __all__ = ("SerializationPluginProtocol", "InitPluginProtocol", "OpenAPISchemaPluginProtocol", "PluginProtocol")
 
@@ -54,6 +54,12 @@ class InitPluginProtocol(Protocol):
             The app config object.
         """
         return app_config  # pragma: no cover
+
+
+@runtime_checkable
+class CLIPluginProtocol(Protocol):
+    def on_cli_init(self, cli: LitestarGroup) -> None:
+        pass
 
 
 @runtime_checkable
@@ -117,4 +123,9 @@ class OpenAPISchemaPluginProtocol(Protocol):
         raise NotImplementedError()
 
 
-PluginProtocol = Union[SerializationPluginProtocol, InitPluginProtocol, OpenAPISchemaPluginProtocol]
+PluginProtocol = Union[
+    SerializationPluginProtocol,
+    InitPluginProtocol,
+    OpenAPISchemaPluginProtocol,
+    CLIPluginProtocol,
+]

--- a/litestar/plugins.py
+++ b/litestar/plugins.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar, Union, runtime_checkable
 
 if TYPE_CHECKING:
+    from click import Group
+
     from litestar._openapi.schema_generation import SchemaCreator
-    from litestar.cli._utils import LitestarGroup
     from litestar.config.app import AppConfig
     from litestar.dto.interface import DTOInterface
     from litestar.dto.types import ForType
@@ -64,8 +65,33 @@ class InitPluginProtocol(Protocol):
 
 @runtime_checkable
 class CLIPluginProtocol(Protocol):
-    def on_cli_init(self, cli: LitestarGroup) -> None:
-        pass
+    """Plugin protocol to extend the CLI."""
+
+    def on_cli_init(self, cli: Group) -> None:
+        """Called when the CLI is initialized.
+
+        This can be used to extend or override existing commands.
+
+        Args:
+            cli: The root :class:`click.Group` of the Litestar CLI
+
+        Examples:
+            .. code-block:: python
+
+                from litestar import Litestar
+                from litestar.plugins import CLIPluginProtocol
+                from click import Group
+
+
+                class CLIPlugin(CLIPluginProtocol):
+                    def on_cli_init(self, cli: Group) -> None:
+                        @cli.command()
+                        def is_debug_mode(app: Litestar):
+                            print(app.debug)
+
+
+                app = Litestar(plugins=[CLIPlugin()])
+        """
 
 
 @runtime_checkable

--- a/litestar/plugins.py
+++ b/litestar/plugins.py
@@ -11,7 +11,13 @@ if TYPE_CHECKING:
     from litestar.openapi.spec import Schema
     from litestar.typing import FieldDefinition
 
-__all__ = ("SerializationPluginProtocol", "InitPluginProtocol", "OpenAPISchemaPluginProtocol", "PluginProtocol")
+__all__ = (
+    "SerializationPluginProtocol",
+    "InitPluginProtocol",
+    "OpenAPISchemaPluginProtocol",
+    "PluginProtocol",
+    "CLIPluginProtocol",
+)
 
 
 T = TypeVar("T")

--- a/tests/unit/test_cli/conftest.py
+++ b/tests/unit/test_cli/conftest.py
@@ -25,6 +25,15 @@ from . import (
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
 
+    from litestar.cli._utils import LitestarGroup
+
+
+@pytest.fixture()
+def root_command() -> LitestarGroup:
+    import litestar.cli.main
+
+    return cast(LitestarGroup, importlib.reload(litestar.cli.main).litestar_group)
+
 
 @pytest.fixture
 def patch_autodiscovery_paths(request: FixtureRequest) -> Callable[[list[str]], None]:

--- a/tests/unit/test_cli/conftest.py
+++ b/tests/unit/test_cli/conftest.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 def root_command() -> LitestarGroup:
     import litestar.cli.main
 
-    return cast(LitestarGroup, importlib.reload(litestar.cli.main).litestar_group)
+    return cast("LitestarGroup", importlib.reload(litestar.cli.main).litestar_group)
 
 
 @pytest.fixture

--- a/tests/unit/test_cli/test_cli_plugin.py
+++ b/tests/unit/test_cli/test_cli_plugin.py
@@ -2,11 +2,11 @@ import textwrap
 
 from click.testing import CliRunner
 
-from litestar.cli.main import litestar_group
+from litestar.cli._utils import LitestarGroup
 from tests.unit.test_cli.conftest import CreateAppFileFixture
 
 
-def test_basic_command(runner: CliRunner, create_app_file: CreateAppFileFixture) -> None:
+def test_basic_command(runner: CliRunner, create_app_file: CreateAppFileFixture, root_command: LitestarGroup) -> None:
     app_file_content = textwrap.dedent(
         """
     from litestar import Litestar
@@ -22,7 +22,7 @@ def test_basic_command(runner: CliRunner, create_app_file: CreateAppFileFixture)
     """
     )
     app_file = create_app_file("command_test_app.py", content=app_file_content)
-    result = runner.invoke(litestar_group, ["--app", f"{app_file.stem}:app", "foo"])
+    result = runner.invoke(root_command, ["--app", f"{app_file.stem}:app", "foo"])
 
     assert not result.exception
     assert "App is loaded: True" in result.output

--- a/tests/unit/test_cli/test_cli_plugin.py
+++ b/tests/unit/test_cli/test_cli_plugin.py
@@ -1,0 +1,28 @@
+import textwrap
+
+from click.testing import CliRunner
+
+from litestar.cli.main import litestar_group
+from tests.unit.test_cli.conftest import CreateAppFileFixture
+
+
+def test_basic_command(runner: CliRunner, create_app_file: CreateAppFileFixture) -> None:
+    app_file_content = textwrap.dedent(
+        """
+    from litestar import Litestar
+    from litestar.plugins import CLIPluginProtocol
+
+    class CLIPlugin(CLIPluginProtocol):
+        def on_cli_init(self, cli):
+            @cli.command()
+            def foo(app: Litestar):
+                print(f"App is loaded: {app is not None}")
+
+    app = Litestar(plugins=[CLIPlugin()])
+    """
+    )
+    app_file = create_app_file("command_test_app.py", content=app_file_content)
+    result = runner.invoke(litestar_group, ["--app", f"{app_file.stem}:app", "foo"])
+
+    assert not result.exception
+    assert "App is loaded: True" in result.output


### PR DESCRIPTION
Add a new `CLIPluginProtocol` that can be used to create CLI plugins.

These contain a single method `on_cli_init`, which will be called when the CLI is initialised. This allows to dynamically register commands, without having to deal with the optional click dependency.

```python
from litestar import Litestar
from litestar.plugins import CLIPluginProtocol

class CLIPlugin(CLIPluginProtocol):
    def on_cli_init(self, cli):
        @cli.command()
        def is_debug_mode(app: Litestar):
            print(app.debug)

app = Litestar(plugins=[CLIPlugin()])
``` 

```shell
$ litestar is-debug-mode

Using Litestar app from app:app
False
```