### PR TITLE
fix(sessions): Fix #2033 - Server-side session middleware overrides CSRF cookies

### DIFF
--- a/litestar/middleware/session/server_side.py
+++ b/litestar/middleware/session/server_side.py
@@ -119,7 +119,9 @@ class ServerSideSessionBackend(BaseSessionBackend["ServerSideSessionConfig"]):
         else:
             serialised_data = self.serialize_data(scope_session, scope)
             await self.set(session_id=session_id, data=serialised_data, store=store)
-            headers["Set-Cookie"] = Cookie(value=session_id, key=self.config.key, **cookie_params).to_header(header="")
+            headers.add(
+                "Set-Cookie", Cookie(value=session_id, key=self.config.key, **cookie_params).to_header(header="")
+            )
 
     async def load_from_connection(self, connection: ASGIConnection) -> dict[str, Any]:
         """Load session data from a connection and return it as a dictionary to be used in the current application


### PR DESCRIPTION
Fix a bug that would cause the `ServerSideSessionBackend` to override existing cookies.

Closes #2033