### PR TITLE
feat(schema): support configuring operation_id_creator on the route h…

### DIFF
--- a/docs/usage/openapi.rst
+++ b/docs/usage/openapi.rst
@@ -89,8 +89,7 @@ You can also modify the generated schema for the route handler using the followi
     customize the `operation object <https://spec.openapis.org/oas/v3.1.0#operation-object>`_ for the handler.
 
 ``operation_id``
-    An identifier used for the route's schema *operationId*. Defaults to the ``__name__`` attribute of the
-    wrapped function.
+    A string or callable that returns a string, which servers as an identifier used for the route's schema *operationId*.
 
 ``deprecated``
     A boolean dictating whether this route should be marked as deprecated in the OpenAPI schema. Defaults

--- a/litestar/_openapi/path_item.py
+++ b/litestar/_openapi/path_item.py
@@ -13,7 +13,6 @@ from litestar.utils.helpers import unwrap_partial
 
 __all__ = ("create_path_item", "extract_layered_values", "get_description_for_handler")
 
-
 if TYPE_CHECKING:
     from litestar.handlers.http_handlers import HTTPRouteHandler
     from litestar.openapi.spec import Schema, SecurityRequirement
@@ -110,9 +109,14 @@ def create_path_item(
                 request_body = create_request_body(
                     route_handler=route_handler, field=handler_fields["data"], schema_creator=request_schema_creator
                 )
-            operation_id = route_handler.operation_id or operation_id_creator(
-                route_handler, http_method, route.path_components
-            )
+
+            if isinstance(route_handler.operation_id, str):
+                operation_id = route_handler.operation_id
+            elif callable(route_handler.operation_id):
+                operation_id = route_handler.operation_id(route_handler, http_method, route.path_components)
+            else:
+                operation_id = operation_id_creator(route_handler, http_method, route.path_components)
+
             tags, security = extract_layered_values(route_handler)
             operation = route_handler.operation_class(
                 operation_id=operation_id,

--- a/litestar/_openapi/utils.py
+++ b/litestar/_openapi/utils.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from litestar.types import Method
 
 
-__all__ = ("default_operation_id_creator",)
+__all__ = ("default_operation_id_creator", "SEPARATORS_CLEANUP_PATTERN")
 
 SEPARATORS_CLEANUP_PATTERN = re.compile(r"[!#$%&'*+\-.^_`|~:]+")
 

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
     from litestar.dto.interface import DTOInterface
     from litestar.openapi.datastructures import ResponseSpec
     from litestar.openapi.spec import SecurityRequirement
+    from litestar.types.callable_types import OperationIDCreator
 
 __all__ = ("HTTPRouteHandler", "route")
 
@@ -145,7 +146,7 @@ class HTTPRouteHandler(BaseRouteHandler):
         description: str | None = None,
         include_in_schema: bool = True,
         operation_class: type[Operation] = Operation,
-        operation_id: str | None = None,
+        operation_id: str | OperationIDCreator | None = None,
         raises: Sequence[type[HTTPException]] | None = None,
         response_description: str | None = None,
         responses: Mapping[int, ResponseSpec] | None = None,
@@ -214,7 +215,7 @@ class HTTPRouteHandler(BaseRouteHandler):
             description: Text used for the route's schema description section.
             include_in_schema: A boolean flag dictating whether  the route handler should be documented in the OpenAPI schema.
             operation_class: :class:`Operation <.openapi.spec.operation.Operation>` to be used with the route's OpenAPI schema.
-            operation_id: An identifier used for the route's schema operationId. Defaults to the ``__name__`` of the wrapped function.
+            operation_id: Either a string or a callable returning a string. An identifier used for the route's schema operationId.
             raises:  A list of exception classes extending from litestar.HttpException that is used for the OpenAPI documentation.
                 This list should describe all exceptions raised within the route handler's function/method. The Litestar
                 ValidationException will be added automatically for the schema if any validation is involved.

--- a/litestar/handlers/http_handlers/decorators.py
+++ b/litestar/handlers/http_handlers/decorators.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
         ResponseType,
         TypeEncodersMap,
     )
+    from litestar.types.callable_types import OperationIDCreator
 
 
 __all__ = ("get", "head", "post", "put", "patch", "delete")
@@ -83,7 +84,7 @@ class delete(HTTPRouteHandler):
         description: str | None = None,
         include_in_schema: bool = True,
         operation_class: type[Operation] = Operation,
-        operation_id: str | None = None,
+        operation_id: str | OperationIDCreator | None = None,
         raises: list[type[HTTPException]] | None = None,
         response_description: str | None = None,
         responses: dict[int, ResponseSpec] | None = None,
@@ -150,7 +151,7 @@ class delete(HTTPRouteHandler):
             description: Text used for the route's schema description section.
             include_in_schema: A boolean flag dictating whether  the route handler should be documented in the OpenAPI schema.
             operation_class: :class:`Operation <.openapi.spec.operation.Operation>` to be used with the route's OpenAPI schema.
-            operation_id: An identifier used for the route's schema operationId. Defaults to the ``__name__`` of the wrapped function.
+            operation_id: Either a string or a callable returning a string. An identifier used for the route's schema operationId.
             raises:  A list of exception classes extending from litestar.HttpException that is used for the OpenAPI documentation.
                 This list should describe all exceptions raised within the route handler's function/method. The Litestar
                 ValidationException will be added automatically for the schema if any validation is involved.
@@ -247,7 +248,7 @@ class get(HTTPRouteHandler):
         description: str | None = None,
         include_in_schema: bool = True,
         operation_class: type[Operation] = Operation,
-        operation_id: str | None = None,
+        operation_id: str | OperationIDCreator | None = None,
         raises: list[type[HTTPException]] | None = None,
         response_description: str | None = None,
         responses: dict[int, ResponseSpec] | None = None,
@@ -314,7 +315,7 @@ class get(HTTPRouteHandler):
             description: Text used for the route's schema description section.
             include_in_schema: A boolean flag dictating whether  the route handler should be documented in the OpenAPI schema.
             operation_class: :class:`Operation <.openapi.spec.operation.Operation>` to be used with the route's OpenAPI schema.
-            operation_id: An identifier used for the route's schema operationId. Defaults to the ``__name__`` of the wrapped function.
+            operation_id: Either a string or a callable returning a string. An identifier used for the route's schema operationId.
             raises:  A list of exception classes extending from litestar.HttpException that is used for the OpenAPI documentation.
                 This list should describe all exceptions raised within the route handler's function/method. The Litestar
                 ValidationException will be added automatically for the schema if any validation is involved.
@@ -411,7 +412,7 @@ class head(HTTPRouteHandler):
         description: str | None = None,
         include_in_schema: bool = True,
         operation_class: type[Operation] = Operation,
-        operation_id: str | None = None,
+        operation_id: str | OperationIDCreator | None = None,
         raises: list[type[HTTPException]] | None = None,
         response_description: str | None = None,
         responses: dict[int, ResponseSpec] | None = None,
@@ -483,7 +484,7 @@ class head(HTTPRouteHandler):
             description: Text used for the route's schema description section.
             include_in_schema: A boolean flag dictating whether  the route handler should be documented in the OpenAPI schema.
             operation_class: :class:`Operation <.openapi.spec.operation.Operation>` to be used with the route's OpenAPI schema.
-            operation_id: An identifier used for the route's schema operationId. Defaults to the ``__name__`` of the wrapped function.
+            operation_id: Either a string or a callable returning a string. An identifier used for the route's schema operationId.
             raises:  A list of exception classes extending from litestar.HttpException that is used for the OpenAPI documentation.
                 This list should describe all exceptions raised within the route handler's function/method. The Litestar
                 ValidationException will be added automatically for the schema if any validation is involved.
@@ -594,7 +595,7 @@ class patch(HTTPRouteHandler):
         description: str | None = None,
         include_in_schema: bool = True,
         operation_class: type[Operation] = Operation,
-        operation_id: str | None = None,
+        operation_id: str | OperationIDCreator | None = None,
         raises: list[type[HTTPException]] | None = None,
         response_description: str | None = None,
         responses: dict[int, ResponseSpec] | None = None,
@@ -661,7 +662,7 @@ class patch(HTTPRouteHandler):
             description: Text used for the route's schema description section.
             include_in_schema: A boolean flag dictating whether  the route handler should be documented in the OpenAPI schema.
             operation_class: :class:`Operation <.openapi.spec.operation.Operation>` to be used with the route's OpenAPI schema.
-            operation_id: An identifier used for the route's schema operationId. Defaults to the ``__name__`` of the wrapped function.
+            operation_id: Either a string or a callable returning a string. An identifier used for the route's schema operationId.
             raises:  A list of exception classes extending from litestar.HttpException that is used for the OpenAPI documentation.
                 This list should describe all exceptions raised within the route handler's function/method. The Litestar
                 ValidationException will be added automatically for the schema if any validation is involved.
@@ -758,7 +759,7 @@ class post(HTTPRouteHandler):
         description: str | None = None,
         include_in_schema: bool = True,
         operation_class: type[Operation] = Operation,
-        operation_id: str | None = None,
+        operation_id: str | OperationIDCreator | None = None,
         raises: list[type[HTTPException]] | None = None,
         response_description: str | None = None,
         responses: dict[int, ResponseSpec] | None = None,
@@ -825,7 +826,7 @@ class post(HTTPRouteHandler):
             description: Text used for the route's schema description section.
             include_in_schema: A boolean flag dictating whether  the route handler should be documented in the OpenAPI schema.
             operation_class: :class:`Operation <.openapi.spec.operation.Operation>` to be used with the route's OpenAPI schema.
-            operation_id: An identifier used for the route's schema operationId. Defaults to the ``__name__`` of the wrapped function.
+            operation_id: Either a string or a callable returning a string. An identifier used for the route's schema operationId.
             raises:  A list of exception classes extending from litestar.HttpException that is used for the OpenAPI documentation.
                 This list should describe all exceptions raised within the route handler's function/method. The Litestar
                 ValidationException will be added automatically for the schema if any validation is involved.
@@ -922,7 +923,7 @@ class put(HTTPRouteHandler):
         description: str | None = None,
         include_in_schema: bool = True,
         operation_class: type[Operation] = Operation,
-        operation_id: str | None = None,
+        operation_id: str | OperationIDCreator | None = None,
         raises: list[type[HTTPException]] | None = None,
         response_description: str | None = None,
         responses: dict[int, ResponseSpec] | None = None,
@@ -989,7 +990,7 @@ class put(HTTPRouteHandler):
             description: Text used for the route's schema description section.
             include_in_schema: A boolean flag dictating whether  the route handler should be documented in the OpenAPI schema.
             operation_class: :class:`Operation <.openapi.spec.operation.Operation>` to be used with the route's OpenAPI schema.
-            operation_id: An identifier used for the route's schema operationId. Defaults to the ``__name__`` of the wrapped function.
+            operation_id: Either a string or a callable returning a string. An identifier used for the route's schema operationId.
             raises:  A list of exception classes extending from litestar.HttpException that is used for the OpenAPI documentation.
                 This list should describe all exceptions raised within the route handler's function/method. The Litestar
                 ValidationException will be added automatically for the schema if any validation is involved.

--- a/litestar/types/composite_types.py
+++ b/litestar/types/composite_types.py
@@ -27,6 +27,7 @@ __all__ = (
     "TypeEncodersMap",
 )
 
+
 if TYPE_CHECKING:
     from os import PathLike
     from pathlib import Path


### PR DESCRIPTION
This PR allows `operation_id` on route handlers to be a callable. Previously we supported this only on the global open api configuration, but it also makes sense to allow this to be locally overriden. 