### PR TITLE
refactor(tests): use in-memory SQLite databases for testing where possible

### DIFF
--- a/tests/examples/test_contrib/test_piccolo/test_piccolo_crud.py
+++ b/tests/examples/test_contrib/test_piccolo/test_piccolo_crud.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from unittest import TestCase
 
 import pytest
@@ -24,6 +25,9 @@ class TestCrud(TestCase):
 
     def tearDown(self):
         Task.alter().drop_table().run_sync()
+        from docs.examples.contrib.piccolo.piccolo_conf import DB
+
+        Path(DB.path).unlink()
 
     def test_get_tasks(self):
         with TestClient(app=app) as client:

--- a/tests/examples/test_contrib/test_sqlalchemy/plugins/test_example_apps.py
+++ b/tests/examples/test_contrib/test_sqlalchemy/plugins/test_example_apps.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from sqlalchemy import Engine, StaticPool, create_engine
 
 from litestar.testing import TestClient
-
-pytestmark = pytest.mark.xdist_group("sqla-plugin-examples")
 
 
 @pytest.fixture
@@ -14,45 +14,64 @@ def data() -> list[dict[str, Any]]:
     return [{"title": "test", "done": False}]
 
 
-def test_sqlalchemy_async_plugin_example(data: dict[str, Any]) -> None:
-    from docs.examples.contrib.sqlalchemy.plugins.sqlalchemy_async_plugin_example import app
+@pytest.fixture()
+def sqlite_engine() -> Engine:
+    return create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
 
-    with TestClient(app) as client:
+
+def test_sqlalchemy_async_plugin_example(data: dict[str, Any], monkeypatch: MonkeyPatch) -> None:
+    from docs.examples.contrib.sqlalchemy.plugins import sqlalchemy_async_plugin_example
+
+    monkeypatch.setattr(sqlalchemy_async_plugin_example.config, "connection_string", "sqlite+aiosqlite://")
+
+    with TestClient(sqlalchemy_async_plugin_example.app) as client:
         assert client.post("/", json=data[0]).json() == data
 
 
-def test_sqlalchemy_sync_plugin_example(data: dict[str, Any]) -> None:
-    from docs.examples.contrib.sqlalchemy.plugins.sqlalchemy_sync_plugin_example import app
+def test_sqlalchemy_sync_plugin_example(data: dict[str, Any], monkeypatch: MonkeyPatch, sqlite_engine: Engine) -> None:
+    from docs.examples.contrib.sqlalchemy.plugins import sqlalchemy_sync_plugin_example
 
-    with TestClient(app) as client:
+    monkeypatch.setattr(sqlalchemy_sync_plugin_example.config, "engine_instance", sqlite_engine)
+
+    with TestClient(sqlalchemy_sync_plugin_example.app) as client:
         assert client.post("/", json=data[0]).json() == data
 
 
-def test_sqlalchemy_async_init_plugin_example(data: dict[str, Any]) -> None:
-    from docs.examples.contrib.sqlalchemy.plugins.sqlalchemy_async_init_plugin_example import app
+def test_sqlalchemy_async_init_plugin_example(data: dict[str, Any], monkeypatch: MonkeyPatch) -> None:
+    from docs.examples.contrib.sqlalchemy.plugins import sqlalchemy_async_init_plugin_example
 
-    with TestClient(app) as client:
+    monkeypatch.setattr(sqlalchemy_async_init_plugin_example.config, "connection_string", "sqlite+aiosqlite://")
+
+    with TestClient(sqlalchemy_async_init_plugin_example.app) as client:
         assert client.post("/", json=data[0]).json() == data
 
 
-def test_sqlalchemy_sync_init_plugin_example(data: dict[str, Any]) -> None:
-    from docs.examples.contrib.sqlalchemy.plugins.sqlalchemy_sync_init_plugin_example import app
+def test_sqlalchemy_sync_init_plugin_example(
+    data: dict[str, Any], monkeypatch: MonkeyPatch, sqlite_engine: Engine
+) -> None:
+    from docs.examples.contrib.sqlalchemy.plugins import sqlalchemy_sync_init_plugin_example
 
-    with TestClient(app) as client:
+    monkeypatch.setattr(sqlalchemy_sync_init_plugin_example.config, "engine_instance", sqlite_engine)
+
+    with TestClient(sqlalchemy_sync_init_plugin_example.app) as client:
         assert client.post("/", json=data[0]).json() == data
 
 
-def test_sqlalchemy_async_init_plugin_dependencies() -> None:
-    from docs.examples.contrib.sqlalchemy.plugins.sqlalchemy_async_dependencies import app
+def test_sqlalchemy_async_init_plugin_dependencies(monkeypatch: MonkeyPatch) -> None:
+    from docs.examples.contrib.sqlalchemy.plugins import sqlalchemy_async_dependencies
 
-    with TestClient(app) as client:
+    monkeypatch.setattr(sqlalchemy_async_dependencies.config, "connection_string", "sqlite+aiosqlite://")
+
+    with TestClient(sqlalchemy_async_dependencies.app) as client:
         assert client.post("/").json() == [1, 2]
 
 
-def test_sqlalchemy_sync_init_plugin_dependencies() -> None:
-    from docs.examples.contrib.sqlalchemy.plugins.sqlalchemy_sync_dependencies import app
+def test_sqlalchemy_sync_init_plugin_dependencies(monkeypatch: MonkeyPatch) -> None:
+    from docs.examples.contrib.sqlalchemy.plugins import sqlalchemy_sync_dependencies
 
-    with TestClient(app) as client:
+    monkeypatch.setattr(sqlalchemy_sync_dependencies.config, "connection_string", "sqlite://")
+
+    with TestClient(sqlalchemy_sync_dependencies.app) as client:
         assert client.post("/").json() == [1, 2]
 
 

--- a/tests/examples/test_plugins/test_sqlalchemy_init_plugin.py
+++ b/tests/examples/test_plugins/test_sqlalchemy_init_plugin.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from _pytest.monkeypatch import MonkeyPatch
 
 from litestar.testing import TestClient

--- a/tests/examples/test_plugins/test_sqlalchemy_init_plugin.py
+++ b/tests/examples/test_plugins/test_sqlalchemy_init_plugin.py
@@ -2,19 +2,30 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-from docs.examples.plugins.sqlalchemy_init_plugin.sqlalchemy_async import app as async_sqla_app
-from docs.examples.plugins.sqlalchemy_init_plugin.sqlalchemy_sync import app as sync_sqla_app
+from _pytest.monkeypatch import MonkeyPatch
 
 from litestar.testing import TestClient
 
 if TYPE_CHECKING:
-    from litestar import Litestar
+    pass
 
 
-@pytest.mark.parametrize("app", [async_sqla_app, sync_sqla_app])
-def test_app(app: Litestar) -> None:
-    with TestClient(app=app) as client:
+def test_sync_app(monkeypatch: MonkeyPatch) -> None:
+    from docs.examples.plugins.sqlalchemy_init_plugin import sqlalchemy_sync
+
+    monkeypatch.setattr(sqlalchemy_sync.sqlalchemy_config, "connection_string", "sqlite://")
+    with TestClient(app=sqlalchemy_sync.app) as client:
+        res = client.get("/sqlalchemy-app")
+        assert res.status_code == 200
+        assert res.text == "1 2"
+
+
+def test_async_app(monkeypatch: MonkeyPatch) -> None:
+    from docs.examples.plugins.sqlalchemy_init_plugin import sqlalchemy_async
+
+    monkeypatch.setattr(sqlalchemy_async.sqlalchemy_config, "connection_string", "sqlite+aiosqlite://")
+
+    with TestClient(app=sqlalchemy_async.app) as client:
         res = client.get("/sqlalchemy-app")
         assert res.status_code == 200
         assert res.text == "1 2"

--- a/tests/examples/test_plugins/test_sqlalchemy_init_plugin.py
+++ b/tests/examples/test_plugins/test_sqlalchemy_init_plugin.py
@@ -6,9 +6,6 @@ from _pytest.monkeypatch import MonkeyPatch
 
 from litestar.testing import TestClient
 
-if TYPE_CHECKING:
-    pass
-
 
 def test_sync_app(monkeypatch: MonkeyPatch) -> None:
     from docs.examples.plugins.sqlalchemy_init_plugin import sqlalchemy_sync


### PR DESCRIPTION
Refactor test that use SQLite (SQLAlchemy / piccolo) to use an in-memory SQLite database instead of a file