### PR TITLE
refactor(tests): Move tutorial example tests to tests directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,7 @@ ignore-words-list = "selectin"
 skip = 'poetry.lock,docs/examples/contrib/sqlalchemy/us_state_lookup.json'
 
 [tool.coverage.run]
-omit = ["*/tests/*", "litestar/contrib/sqlalchemy_1/*"]
+omit = ["*/tests/*"]
 
 [tool.coverage.report]
 exclude_lines = [
@@ -236,7 +236,7 @@ exclude_lines = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--ignore=examples -m='not sqlalchemy_integration' --dist=loadgroup"
+addopts = "-m='not sqlalchemy_integration' --dist=loadgroup"
 asyncio_mode = "auto"
 filterwarnings = [
     "ignore::trio.TrioDeprecationWarning:anyio._backends._trio*:",

--- a/tests/examples/test_todo_app.py
+++ b/tests/examples/test_todo_app.py
@@ -1,17 +1,21 @@
 from typing import Any
 
 import pytest
+from docs.examples.todo_app import full_app
+from docs.examples.todo_app import update as update_app
+from docs.examples.todo_app.create import dataclass as dataclass_create_app
+from docs.examples.todo_app.create import dict as dict_create_app
+from docs.examples.todo_app.get_list import dataclass as get_dataclass_app
+from docs.examples.todo_app.get_list import dict as get_dict_app
+from docs.examples.todo_app.get_list import (
+    query_param,
+    query_param_default,
+    query_param_validate,
+    query_param_validate_manually,
+)
 from msgspec import to_builtins
 
 from litestar.testing import TestClient
-
-from .todo_app import full_app
-from .todo_app import update as update_app
-from .todo_app.create import dataclass as dataclass_create_app
-from .todo_app.create import dict as dict_create_app
-from .todo_app.get_list import dataclass as get_dataclass_app
-from .todo_app.get_list import dict as get_dict_app
-from .todo_app.get_list import query_param, query_param_default, query_param_validate, query_param_validate_manually
 
 
 @pytest.mark.parametrize("module", [update_app, full_app])


### PR DESCRIPTION
- Move tests located in `docs/examples` to `tests/examples` that were overlooked when refactoring the tests in #1850.
- Remove some unused pytest configuration from `pyproject.toml`