### PR TITLE
chore(utils): remove unused and undocumented `compact` function

### DIFF
--- a/litestar/utils/__init__.py
+++ b/litestar/utils/__init__.py
@@ -31,7 +31,7 @@ from .scope import (
     get_serializer_from_scope,
     set_litestar_scope_state,
 )
-from .sequence import compact, find_index, unique
+from .sequence import find_index, unique
 from .sync import AsyncCallable, AsyncIteratorWrapper, async_partial
 from .typing import annotation_is_iterable_of_type, get_origin_or_inner_type, make_non_optional_union
 
@@ -41,7 +41,6 @@ __all__ = (
     "Ref",
     "annotation_is_iterable_of_type",
     "async_partial",
-    "compact",
     "delete_litestar_scope_state",
     "deprecated",
     "encode_headers",

--- a/litestar/utils/sequence.py
+++ b/litestar/utils/sequence.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Sequence, TypeVar
+from typing import Callable, Sequence, TypeVar
 
-__all__ = ("find_index", "unique", "compact")
+__all__ = ("find_index", "unique")
 
 
 T = TypeVar("T")
@@ -26,16 +26,3 @@ def unique(value: Sequence[T]) -> list[T]:
             if element not in output:
                 output.append(element)
         return output
-
-
-def compact(value: Sequence[Any]) -> Sequence[Any]:
-    """Remove all 'falsy' values from a sequence.
-
-    Args:
-        value: A sequence.
-
-
-    Returns:
-        A tuple.
-    """
-    return tuple(v for v in value if v)


### PR DESCRIPTION
Remove the unused and undocumented `utils.sequence.compact` function