### PR TITLE
fix(testing): Remove `AssertionErrors` in LifeSpanHandler wait_startup and wait_shutdown methods

### DIFF
--- a/litestar/testing/life_span_handler.py
+++ b/litestar/testing/life_span_handler.py
@@ -46,7 +46,10 @@ class LifeSpanHandler(Generic[T]):
             "lifespan.startup.complete",
             "lifespan.startup.failed",
         ):
-            raise AssertionError
+            raise RuntimeError(
+                "Received unexpected ASGI message type. Expected 'lifespan.startup.complete' or "
+                f"'lifespan.startup.failed'. Got {message['type']!r}",
+            )
         if message["type"] == "lifespan.startup.failed":
             await self.receive()
 
@@ -60,7 +63,10 @@ class LifeSpanHandler(Generic[T]):
                 "lifespan.shutdown.complete",
                 "lifespan.shutdown.failed",
             ):
-                raise AssertionError
+                raise RuntimeError(
+                    "Received unexpected ASGI message type. Expected 'lifespan.shutdown.complete' or "
+                    f"'lifespan.shutdown.failed'. Got {message['type']!r}",
+                )
             if message["type"] == "lifespan.shutdown.failed":
                 await self.receive()
 

--- a/tests/unit/test_testing/test_lifespan_handler.py
+++ b/tests/unit/test_testing/test_lifespan_handler.py
@@ -1,0 +1,24 @@
+import pytest
+
+from litestar.testing import TestClient
+from litestar.testing.life_span_handler import LifeSpanHandler
+from litestar.types import Receive, Scope, Send
+
+
+async def test_wait_startup_invalid_event() -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "lifespan.startup.something_unexpected"})  # type: ignore[typeddict-item]
+
+    with pytest.raises(RuntimeError, match="Received unexpected ASGI message type"):
+        LifeSpanHandler(TestClient(app))
+
+
+async def test_wait_shutdown_invalid_event() -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "lifespan.startup.complete"})  # type: ignore[typeddict-item]
+        await send({"type": "lifespan.shutdown.something_unexpected"})  # type: ignore[typeddict-item]
+
+    handler = LifeSpanHandler(TestClient(app))
+
+    with pytest.raises(RuntimeError, match="Received unexpected ASGI message type"):
+        await handler.wait_shutdown()


### PR DESCRIPTION
- Replace the `AssertionError` in `LifeSpanHandler.wait_startup` and `LifeSpanHandler.wait_shutdown` with a `RuntimeError`, providing a useful error message
- Add tests for `wait_startup` and `wait_shutdown`