### PR TITLE
fix(v1.51): #1948 passing wrapper class to struct logging config causes pydantic exception

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Code owner settings for `litestar`
+# @maintainers should be assigned to all reviews.
+# Most specific assignment takes precedence though, so if you add a more specific thing than the `*` glob, you must also add @maintainers
+# For more info about code owners see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-example
+
+# Global Assignment
+*      @litestar-org/maintainers @litestar-org/members
+
+# Documentation
+docs/* @litestar-org/maintainers @JacobCoffee @provinzkraut

--- a/starlite/config/logging.py
+++ b/starlite/config/logging.py
@@ -259,7 +259,7 @@ class StructLoggingConfig(BaseLoggingConfig, BaseModel):
 
     processors: Optional[List[Processor]] = Field(default_factory=default_structlog_processors)  # pyright: ignore
     """Iterable of structlog logging processors."""
-    wrapper_class: Optional[Type[BindableLogger]] = Field(default_factory=default_wrapper_class)  # pyright: ignore
+    wrapper_class: Any = Field(default_factory=default_wrapper_class)  # pyright: ignore
     """Structlog bindable logger."""
     context_class: Optional[Dict[str, Any]] = None
     """Context class (a 'contextvar' context) for the logger."""


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

- This PR is to fix #1948, but the only way I have been able to resolve it is through changing the type hint to `Any`. I do not think this is the right resolution, i have tried do a couple of other things but nothing has worked... would like input so I can learn.
 
### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

- Closes #1948
