### PR TITLE
docs: remove references to removed `partial` module

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -27,7 +27,6 @@ API reference
     openapi/index
     pagination
     params
-    partial
     plugins
     response/index
     router

--- a/docs/reference/partial.rst
+++ b/docs/reference/partial.rst
@@ -1,6 +1,0 @@
-partial
-=======
-
-
-.. automodule:: litestar.partial
-    :members:


### PR DESCRIPTION
Remove references in the docs to the removed `partial.py` module