### PR TITLE
test(docker-service-fixture): Remove usage of `shell=True`

### DIFF
--- a/tests/docker_service_fixtures.py
+++ b/tests/docker_service_fixtures.py
@@ -67,10 +67,8 @@ class DockerServiceRegistry:
         raise ValueError(f'Invalid value for DOCKER_HOST: "{docker_host}".')
 
     def run_command(self, *args: str) -> None:
-        if sys.platform == "darwin":
-            subprocess.call([*self._base_command, *args], shell=True)
-        else:
-            subprocess.run([*self._base_command, *args], check=True, capture_output=True)
+        command = [*self._base_command, *args]
+        subprocess.run(command, check=True, capture_output=True)
 
     async def start(
         self,


### PR DESCRIPTION
### Pull Request Checklist

Removes the usage of `shell=True` for docker related subprocess calls on macOS. Implementation is same as the one here https://github.com/cofin/litestar-fullstack/pull/40

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

-

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

-
