### PR TITLE
fix(dto): Fix #2125 - excluded attributes being accessed during transfer

### DIFF
--- a/litestar/dto/_backend.py
+++ b/litestar/dto/_backend.py
@@ -583,13 +583,14 @@ def _transfer_instance_data(
         should_use_serialization_name = is_data_field and not is_dto_data_type
         source_name = field_definition.serialization_name if should_use_serialization_name else field_definition.name
 
-        source_has_value = (
+        if not is_data_field:
+            if field_definition.is_excluded:
+                continue
+        elif not (
             source_name in source_instance
             if isinstance(source_instance, Mapping)
             else hasattr(source_instance, source_name)
-        )
-
-        if (is_data_field and not source_has_value) or (not is_data_field and field_definition.is_excluded):
+        ):
             continue
 
         transfer_type = field_definition.transfer_type


### PR DESCRIPTION
The attributes were accessed prematurely during the transfer process. This has been fixed by moving the check to after it has already been determined that the attribute is included.

### Pull Request Checklist

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR


### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

- #2125
