### PR TITLE
fix: moved application/octet-stream from contentEncoding to contentMediaType

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,7 +1,5 @@
 {
-  "files": [
-    "README.md"
-  ],
+  "files": ["README.md"],
   "imageSize": 100,
   "commit": false,
   "contributors": [
@@ -40,193 +38,147 @@
       "name": "Ashwin Vinod",
       "avatar_url": "https://avatars.githubusercontent.com/u/38067089?v=4",
       "profile": "https://ashwinvin.github.io",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "dkress59",
       "name": "Damian",
       "avatar_url": "https://avatars.githubusercontent.com/u/28515387?v=4",
       "profile": "http://www.damiankress.de",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "vincentsarago",
       "name": "Vincent Sarago",
       "avatar_url": "https://avatars.githubusercontent.com/u/10407788?v=4",
       "profile": "https://remotepixel.ca",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "JonasKs",
       "name": "Jonas Krüger Svensson",
       "avatar_url": "https://avatars.githubusercontent.com/u/5310116?v=4",
       "profile": "https://hotfix.guru",
-      "contributions": [
-        "platform"
-      ]
+      "contributions": ["platform"]
     },
     {
       "login": "sondrelg",
       "name": "Sondre Lillebø Gundersen",
       "avatar_url": "https://avatars.githubusercontent.com/u/25310870?v=4",
       "profile": "https://github.com/sondrelg",
-      "contributions": [
-        "platform"
-      ]
+      "contributions": ["platform"]
     },
     {
       "login": "vrslev",
       "name": "Lev",
       "avatar_url": "https://avatars.githubusercontent.com/u/75225148?v=4",
       "profile": "https://github.com/vrslev",
-      "contributions": [
-        "code",
-        "ideas"
-      ]
+      "contributions": ["code", "ideas"]
     },
     {
       "login": "timwedde",
       "name": "Tim Wedde",
       "avatar_url": "https://avatars.githubusercontent.com/u/20231751?v=4",
       "profile": "https://github.com/timwedde",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "tclasen",
       "name": "Tory Clasen",
       "avatar_url": "https://avatars.githubusercontent.com/u/11999013?v=4",
       "profile": "https://github.com/tclasen",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "Bobronium",
       "name": "Arseny Boykov",
       "avatar_url": "https://avatars.githubusercontent.com/u/36469655?v=4",
       "profile": "http://t.me/Bobronium",
-      "contributions": [
-        "code",
-        "ideas"
-      ]
+      "contributions": ["code", "ideas"]
     },
     {
       "login": "yudjinn",
       "name": "Jacob Rodgers",
       "avatar_url": "https://avatars.githubusercontent.com/u/7493084?v=4",
       "profile": "https://github.com/yudjinn",
-      "contributions": [
-        "example"
-      ]
+      "contributions": ["example"]
     },
     {
       "login": "danesolberg",
       "name": "Dane Solberg",
       "avatar_url": "https://avatars.githubusercontent.com/u/25882507?v=4",
       "profile": "https://github.com/danesolberg",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "madlad33",
       "name": "madlad33",
       "avatar_url": "https://avatars.githubusercontent.com/u/54079440?v=4",
       "profile": "https://github.com/madlad33",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "Butch78",
       "name": "Matthew Aylward ",
       "avatar_url": "https://avatars.githubusercontent.com/u/19205392?v=4",
       "profile": "http://matthewtyleraylward.com",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "Joko013",
       "name": "Jan Klima",
       "avatar_url": "https://avatars.githubusercontent.com/u/30841710?v=4",
       "profile": "https://github.com/Joko013",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "i404788",
       "name": "C2D",
       "avatar_url": "https://avatars.githubusercontent.com/u/50617709?v=4",
       "profile": "https://github.com/i404788",
-      "contributions": [
-        "test"
-      ]
+      "contributions": ["test"]
     },
     {
       "login": "to-ph",
       "name": "to-ph",
       "avatar_url": "https://avatars.githubusercontent.com/u/84818322?v=4",
       "profile": "https://github.com/to-ph",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "imbev",
       "name": "imbev",
       "avatar_url": "https://avatars.githubusercontent.com/u/105524473?v=4",
       "profile": "https://imbev.gitlab.io/site",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "185504a9",
       "name": "cătălin",
       "avatar_url": "https://avatars.githubusercontent.com/u/45485069?v=4",
       "profile": "https://git.roboces.dev/catalin",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "Seon82",
       "name": "Seon82",
       "avatar_url": "https://avatars.githubusercontent.com/u/46298009?v=4",
       "profile": "https://github.com/Seon82",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "slavugan",
       "name": "Slava",
       "avatar_url": "https://avatars.githubusercontent.com/u/8457612?v=4",
       "profile": "https://github.com/slavugan",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "Harry-Lees",
       "name": "Harry",
       "avatar_url": "https://avatars.githubusercontent.com/u/52263746?v=4",
       "profile": "https://github.com/Harry-Lees",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "cofin",
@@ -248,193 +200,147 @@
       "name": "Christian Clauss",
       "avatar_url": "https://avatars.githubusercontent.com/u/3709715?v=4",
       "profile": "https://www.patreon.com/cclauss",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "josepdaniel",
       "name": "josepdaniel",
       "avatar_url": "https://avatars.githubusercontent.com/u/36941460?v=4",
       "profile": "https://github.com/josepdaniel",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "devtud",
       "name": "devtud",
       "avatar_url": "https://avatars.githubusercontent.com/u/6808024?v=4",
       "profile": "https://github.com/devtud",
-      "contributions": [
-        "bug"
-      ]
+      "contributions": ["bug"]
     },
     {
       "login": "nramos0",
       "name": "Nicholas Ramos",
       "avatar_url": "https://avatars.githubusercontent.com/u/35410160?v=4",
       "profile": "https://github.com/nramos0",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "seladb",
       "name": "seladb",
       "avatar_url": "https://avatars.githubusercontent.com/u/9059541?v=4",
       "profile": "https://twitter.com/seladb",
-      "contributions": [
-        "doc",
-        "code"
-      ]
+      "contributions": ["doc", "code"]
     },
     {
       "login": "aedify-swi",
       "name": "Simon Wienhöfer",
       "avatar_url": "https://avatars.githubusercontent.com/u/66629131?v=4",
       "profile": "https://github.com/aedify-swi",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "mobiusxs",
       "name": "MobiusXS",
       "avatar_url": "https://avatars.githubusercontent.com/u/57055149?v=4",
       "profile": "https://github.com/mobiusxs",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "Aidan-Simard",
       "name": "Aidan Simard",
       "avatar_url": "https://avatars.githubusercontent.com/u/73361895?v=4",
       "profile": "http://aidansimard.dev",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "waweber",
       "name": "wweber",
       "avatar_url": "https://avatars.githubusercontent.com/u/714224?v=4",
       "profile": "https://github.com/waweber",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "samuelcolvin",
       "name": "Samuel Colvin",
       "avatar_url": "https://avatars.githubusercontent.com/u/4039449?v=4",
       "profile": "http://scolvin.com",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "toudi",
       "name": "Mateusz Mikołajczyk",
       "avatar_url": "https://avatars.githubusercontent.com/u/81148?v=4",
       "profile": "https://github.com/toudi",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "Alex-CodeLab",
       "name": "Alex ",
       "avatar_url": "https://avatars.githubusercontent.com/u/1678423?v=4",
       "profile": "https://github.com/Alex-CodeLab",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "odiseo0",
       "name": "Odiseo",
       "avatar_url": "https://avatars.githubusercontent.com/u/87550035?v=4",
       "profile": "https://github.com/odiseo0",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "ingjavierpinilla",
       "name": "Javier  Pinilla",
       "avatar_url": "https://avatars.githubusercontent.com/u/36714646?v=4",
       "profile": "https://github.com/ingjavierpinilla",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "Chaoyingz",
       "name": "Chaoying",
       "avatar_url": "https://avatars.githubusercontent.com/u/32626585?v=4",
       "profile": "https://github.com/Chaoyingz",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "infohash",
       "name": "infohash",
       "avatar_url": "https://avatars.githubusercontent.com/u/46137868?v=4",
       "profile": "https://github.com/infohash",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "john-ingles",
       "name": "John Ingles",
       "avatar_url": "https://avatars.githubusercontent.com/u/35442886?v=4",
       "profile": "https://www.linkedin.com/in/john-ingles/",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "h0rn3t",
       "name": "Eugene",
       "avatar_url": "https://avatars.githubusercontent.com/u/1213719?v=4",
       "profile": "https://github.com/h0rn3t",
-      "contributions": [
-        "test",
-        "code"
-      ]
+      "contributions": ["test", "code"]
     },
     {
       "login": "jonadaly",
       "name": "Jon Daly",
       "avatar_url": "https://avatars.githubusercontent.com/u/26462826?v=4",
       "profile": "https://github.com/jonadaly",
-      "contributions": [
-        "doc",
-        "code"
-      ]
+      "contributions": ["doc", "code"]
     },
     {
       "login": "Harshal6927",
       "name": "Harshal Laheri",
       "avatar_url": "https://avatars.githubusercontent.com/u/73422191?v=4",
       "profile": "https://harshallaheri.me/",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "sorasful",
       "name": "Téva KRIEF",
       "avatar_url": "https://avatars.githubusercontent.com/u/32820423?v=4",
       "profile": "https://github.com/sorasful",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "jtraub",
@@ -456,27 +362,21 @@
       "name": "Mitchell Henry",
       "avatar_url": "https://avatars.githubusercontent.com/u/17354727?v=4",
       "profile": "http://linkedin.com/in/mitchell-henry334/",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "chbndrhnns",
       "name": "chbndrhnns",
       "avatar_url": "https://avatars.githubusercontent.com/u/7534547?v=4",
       "profile": "https://github.com/chbndrhnns",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "nielsvanhooy",
       "name": "nielsvanhooy",
       "avatar_url": "https://avatars.githubusercontent.com/u/40770348?v=4",
       "profile": "https://github.com/nielsvanhooy",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "provinzkraut",
@@ -499,225 +399,168 @@
       "name": "Joshua Bronson",
       "avatar_url": "https://avatars.githubusercontent.com/u/64992?v=4",
       "profile": "https://github.com/jab",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "ReznikovRoman",
       "name": "Roman Reznikov",
       "avatar_url": "https://avatars.githubusercontent.com/u/44291988?v=4",
       "profile": "http://linkedin.com/in/roman-reznikov",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "mookrs",
       "name": "mookrs",
       "avatar_url": "https://avatars.githubusercontent.com/u/985439?v=4",
       "profile": "http://mookrs.com",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "mivade",
       "name": "Mike DePalatis",
       "avatar_url": "https://avatars.githubusercontent.com/u/2805515?v=4",
       "profile": "http://mike.depalatis.net",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "pemocarlo",
       "name": "Carlos Alberto Pérez-Molano",
       "avatar_url": "https://avatars.githubusercontent.com/u/7297323?v=4",
       "profile": "https://github.com/pemocarlo",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "ThinksFast",
       "name": "ThinksFast",
       "avatar_url": "https://avatars.githubusercontent.com/u/114229148?v=4",
       "profile": "https://www.bestcryptocodes.com",
-      "contributions": [
-        "test",
-        "doc"
-      ]
+      "contributions": ["test", "doc"]
     },
     {
       "login": "ottermata",
       "name": "Christopher Krause",
       "avatar_url": "https://avatars.githubusercontent.com/u/9451844?v=4",
       "profile": "https://github.com/ottermata",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "smithk86",
       "name": "Kyle Smith",
       "avatar_url": "https://avatars.githubusercontent.com/u/1161424?v=4",
       "profile": "http://www.kylesmith.me",
-      "contributions": [
-        "code",
-        "doc",
-        "bug"
-      ]
+      "contributions": ["code", "doc", "bug"]
     },
     {
       "login": "scott2b",
       "name": "Scott Bradley",
       "avatar_url": "https://avatars.githubusercontent.com/u/307713?v=4",
       "profile": "https://github.com/scott2b",
-      "contributions": [
-        "bug"
-      ]
+      "contributions": ["bug"]
     },
     {
       "login": "srikanthccv",
       "name": "Srikanth Chekuri",
       "avatar_url": "https://avatars.githubusercontent.com/u/22846633?v=4",
       "profile": "https://www.linkedin.com/in/srikanthccv/",
-      "contributions": [
-        "test",
-        "doc"
-      ]
+      "contributions": ["test", "doc"]
     },
     {
       "login": "LonelyVikingMichael",
       "name": "Michael Bosch",
       "avatar_url": "https://avatars.githubusercontent.com/u/78952809?v=4",
       "profile": "https://lonelyviking.com",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "sssssss340",
       "name": "sssssss340",
       "avatar_url": "https://avatars.githubusercontent.com/u/8406195?v=4",
       "profile": "https://github.com/sssssss340",
-      "contributions": [
-        "bug"
-      ]
+      "contributions": ["bug"]
     },
     {
       "login": "ste-pool",
       "name": "ste-pool",
       "avatar_url": "https://avatars.githubusercontent.com/u/17198460?v=4",
       "profile": "https://github.com/ste-pool",
-      "contributions": [
-        "code",
-        "infra"
-      ]
+      "contributions": ["code", "infra"]
     },
     {
       "login": "Alc-Alc",
       "name": "Alc-Alc",
       "avatar_url": "https://avatars.githubusercontent.com/u/45509143?v=4",
       "profile": "https://github.com/Alc-Alc",
-      "contributions": [
-        "doc",
-        "code",
-        "test"
-      ]
+      "contributions": ["doc", "code", "test"]
     },
     {
       "login": "asomethings",
       "name": "asomethings",
       "avatar_url": "https://avatars.githubusercontent.com/u/16171942?v=4",
       "profile": "http://asomethings.com",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "garburator",
       "name": "Garry Bullock",
       "avatar_url": "https://avatars.githubusercontent.com/u/14207857?v=4",
       "profile": "https://github.com/garburator",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "NiclasHaderer",
       "name": "Niclas Haderer",
       "avatar_url": "https://avatars.githubusercontent.com/u/109728711?v=4",
       "profile": "https://github.com/NiclasHaderer",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "dialvarezs",
       "name": "Diego Alvarez",
       "avatar_url": "https://avatars.githubusercontent.com/u/13831919?v=4",
       "profile": "https://github.com/dialvarezs",
-      "contributions": [
-        "doc",
-        "code"
-      ]
+      "contributions": ["doc", "code"]
     },
     {
       "login": "rgajason",
       "name": "Jason Nance",
       "avatar_url": "https://avatars.githubusercontent.com/u/51208317?v=4",
       "profile": "https://www.rgare.com",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "spikenn",
       "name": "Igor Kapadze",
       "avatar_url": "https://avatars.githubusercontent.com/u/32995595?v=4",
       "profile": "https://github.com/spikenn",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "Jarmos-san",
       "name": "Somraj Saha",
       "avatar_url": "https://avatars.githubusercontent.com/u/31373860?v=4",
       "profile": "https://jarmos.vercel.app",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "maggias",
       "name": "Magnús Ágúst Skúlason",
       "avatar_url": "https://avatars.githubusercontent.com/u/11139514?v=4",
       "profile": "http://skulason.me",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "pomma89",
       "name": "Alessio Parma",
       "avatar_url": "https://avatars.githubusercontent.com/u/4697032?v=4",
       "profile": "https://alessioparma.xyz/",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "Lugoues",
       "name": "Peter Brunner",
       "avatar_url": "https://avatars.githubusercontent.com/u/372610?v=4",
       "profile": "https://github.com/Lugoues",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "JacobCoffee",
@@ -740,454 +583,343 @@
       "name": "Gamazic",
       "avatar_url": "https://avatars.githubusercontent.com/u/33692402?v=4",
       "profile": "https://github.com/Gamazic",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "kareemmahlees",
       "name": "Kareem Mahlees",
       "avatar_url": "https://avatars.githubusercontent.com/u/89863279?v=4",
       "profile": "https://github.com/kareemmahlees",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "abdulhaq-e",
       "name": "Abdulhaq Emhemmed",
       "avatar_url": "https://avatars.githubusercontent.com/u/2532125?v=4",
       "profile": "https://github.com/abdulhaq-e",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "jenish2014",
       "name": "Jenish",
       "avatar_url": "https://avatars.githubusercontent.com/u/9599888?v=4",
       "profile": "https://github.com/jenish2014",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "chris-telemetry",
       "name": "chris-telemetry",
       "avatar_url": "https://avatars.githubusercontent.com/u/78052999?v=4",
       "profile": "https://github.com/chris-telemetry",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "WardPearce",
       "name": "Ward",
       "avatar_url": "https://avatars.githubusercontent.com/u/27844174?v=4",
       "profile": "http://wardpearce.com",
-      "contributions": [
-        "bug"
-      ]
+      "contributions": ["bug"]
     },
     {
       "login": "knowsuchagency",
       "name": "Stephan Fitzpatrick",
       "avatar_url": "https://avatars.githubusercontent.com/u/11974795?v=4",
       "profile": "https://knowsuchagency.com",
-      "contributions": [
-        "bug"
-      ]
+      "contributions": ["bug"]
     },
     {
       "login": "ekeric13",
       "name": "Eric Kennedy",
       "avatar_url": "https://avatars.githubusercontent.com/u/6489651?v=4",
       "profile": "https://codepen.io/ekeric13/",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "wassafshahzad",
       "name": "wassaf shahzad",
       "avatar_url": "https://avatars.githubusercontent.com/u/25094157?v=4",
       "profile": "https://github.com/wassafshahzad",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "nilsso",
       "name": "Nils Olsson",
       "avatar_url": "https://avatars.githubusercontent.com/u/567181?v=4",
       "profile": "http://nilsso.github.io",
-      "contributions": [
-        "code",
-        "bug"
-      ]
+      "contributions": ["code", "bug"]
     },
     {
       "login": "Nadock",
       "name": "Riley Chase",
       "avatar_url": "https://avatars.githubusercontent.com/u/1491530?v=4",
       "profile": "http://rileychase.net",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "onerandomusername",
       "name": "arl",
       "avatar_url": "https://avatars.githubusercontent.com/u/71233171?v=4",
       "profile": "https://gh.arielle.codes",
-      "contributions": [
-        "maintenance"
-      ]
+      "contributions": ["maintenance"]
     },
     {
       "login": "Galdanwing",
       "name": "Antoine van der Horst",
       "avatar_url": "https://avatars.githubusercontent.com/u/29492757?v=4",
       "profile": "https://github.com/Galdanwing",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "zoni",
       "name": "Nick Groenen",
       "avatar_url": "https://avatars.githubusercontent.com/u/145285?v=4",
       "profile": "https://nick.groenen.me",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "giorgiovilardo",
       "name": "Giorgio Vilardo",
       "avatar_url": "https://avatars.githubusercontent.com/u/56472600?v=4",
       "profile": "https://github.com/giorgiovilardo",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "bollwyvl",
       "name": "Nicholas Bollweg",
       "avatar_url": "https://avatars.githubusercontent.com/u/45380?v=4",
       "profile": "https://github.com/bollwyvl",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "tompin82",
       "name": "Tomas Jonsson",
       "avatar_url": "https://avatars.githubusercontent.com/u/47041409?v=4",
       "profile": "https://github.com/tompin82",
-      "contributions": [
-        "test",
-        "code"
-      ]
+      "contributions": ["test", "code"]
     },
     {
       "login": "khiemdoan",
       "name": "Khiem Doan",
       "avatar_url": "https://avatars.githubusercontent.com/u/15646249?v=4",
       "profile": "https://www.linkedin.com/in/khiem-doan/",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "kedod",
       "name": "kedod",
       "avatar_url": "https://avatars.githubusercontent.com/u/35638715?v=4",
       "profile": "https://github.com/kedod",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "sonpro1296",
       "name": "sonpro1296",
       "avatar_url": "https://avatars.githubusercontent.com/u/17319142?v=4",
       "profile": "https://github.com/sonpro1296",
-      "contributions": [
-        "code",
-        "test",
-        "infra",
-        "doc"
-      ]
+      "contributions": ["code", "test", "infra", "doc"]
     },
     {
       "login": "patrickarmengol",
       "name": "Patrick Armengol",
       "avatar_url": "https://avatars.githubusercontent.com/u/42473149?v=4",
       "profile": "https://patrickarmengol.com",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "SanderWegter",
       "name": "Sander",
       "avatar_url": "https://avatars.githubusercontent.com/u/7465799?v=4",
       "profile": "https://sanderwegter.nl",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "erhuabushuo",
       "name": "疯人院主任",
       "avatar_url": "https://avatars.githubusercontent.com/u/1642364?v=4",
       "profile": "https://github.com/erhuabushuo",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "aviral-nayya",
       "name": "aviral-nayya",
       "avatar_url": "https://avatars.githubusercontent.com/u/121891493?v=4",
       "profile": "https://github.com/aviral-nayya",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "whiskeyriver",
       "name": "whiskeyriver",
       "avatar_url": "https://avatars.githubusercontent.com/u/162092?v=4",
       "profile": "https://github.com/whiskeyriver",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "v3ss0n",
       "name": "Phyo Arkar Lwin",
       "avatar_url": "https://avatars.githubusercontent.com/u/419606?v=4",
       "profile": "https://hexcode.tech",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "MatthewNewland",
       "name": "MatthewNewland",
       "avatar_url": "https://avatars.githubusercontent.com/u/9618670?v=4",
       "profile": "https://github.com/MatthewNewland",
-      "contributions": [
-        "bug",
-        "code",
-        "test"
-      ]
+      "contributions": ["bug", "code", "test"]
     },
     {
       "login": "vtarchon",
       "name": "Tom Kuo",
       "avatar_url": "https://avatars.githubusercontent.com/u/1598170?v=4",
       "profile": "https://github.com/vtarchon",
-      "contributions": [
-        "bug"
-      ]
+      "contributions": ["bug"]
     },
     {
       "login": "LeckerenSirupwaffeln",
       "name": "LeckerenSirupwaffeln",
       "avatar_url": "https://avatars.githubusercontent.com/u/83568015?v=4",
       "profile": "https://github.com/LeckerenSirupwaffeln",
-      "contributions": [
-        "bug"
-      ]
+      "contributions": ["bug"]
     },
     {
       "login": "eldano1995",
       "name": "Daniel González Fernández",
       "avatar_url": "https://avatars.githubusercontent.com/u/24553679?v=4",
       "profile": "https://github.com/eldano1995",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "01EK98",
       "name": "01EK98",
       "avatar_url": "https://avatars.githubusercontent.com/u/101988390?v=4",
       "profile": "https://github.com/01EK98",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "sarbor",
       "name": "Sarbo Roy",
       "avatar_url": "https://avatars.githubusercontent.com/u/15257226?v=4",
       "profile": "https://github.com/sarbor",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "rseeley",
       "name": "Ryan Seeley",
       "avatar_url": "https://avatars.githubusercontent.com/u/5397221?v=4",
       "profile": "https://github.com/rseeley",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "ctrl-Felix",
       "name": "Felix",
       "avatar_url": "https://avatars.githubusercontent.com/u/62290842?v=4",
       "profile": "https://github.com/ctrl-Felix",
-      "contributions": [
-        "doc",
-        "bug"
-      ]
+      "contributions": ["doc", "bug"]
     },
     {
       "login": "gsakkis",
       "name": "George Sakkis",
       "avatar_url": "https://avatars.githubusercontent.com/u/291289?v=4",
       "profile": "https://www.linkedin.com/in/gsakkis",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "floxay",
       "name": "Huba Tuba",
       "avatar_url": "https://avatars.githubusercontent.com/u/57007485?v=4",
       "profile": "https://github.com/floxay",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "sfermigier",
       "name": "Stefane Fermigier",
       "avatar_url": "https://avatars.githubusercontent.com/u/271079?v=4",
       "profile": "http://fermigier.com/",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "r4gesingh47",
       "name": "r4ge",
       "avatar_url": "https://avatars.githubusercontent.com/u/71139938?v=4",
       "profile": "https://github.com/r4gesingh47",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "jaykv",
       "name": "Jay",
       "avatar_url": "https://avatars.githubusercontent.com/u/18240054?v=4",
       "profile": "https://github.com/jaykv",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "sinisaos",
       "name": "sinisaos",
       "avatar_url": "https://avatars.githubusercontent.com/u/30960668?v=4",
       "profile": "https://github.com/sinisaos",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "Tsdevendra1",
       "name": "Tharuka Devendra",
       "avatar_url": "https://avatars.githubusercontent.com/u/38055748?v=4",
       "profile": "https://github.com/Tsdevendra1",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "euri10",
       "name": "euri10",
       "avatar_url": "https://avatars.githubusercontent.com/u/1104190?v=4",
       "profile": "https://github.com/euri10",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "su-shubham",
       "name": "Shubham",
       "avatar_url": "https://avatars.githubusercontent.com/u/75021117?v=4",
       "profile": "https://github.com/su-shubham",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "erik-hasse",
       "name": "Erik Hasse",
       "avatar_url": "https://avatars.githubusercontent.com/u/37126755?v=4",
       "profile": "https://www.linkedin.com/in/erik-hasse",
-      "contributions": [
-        "bug",
-        "code"
-      ]
+      "contributions": ["bug", "code"]
     },
     {
       "login": "sobolevn",
       "name": "Nikita Sobolev",
       "avatar_url": "https://avatars.githubusercontent.com/u/4660275?v=4",
       "profile": "https://sobolevn.me",
-      "contributions": [
-        "infra",
-        "code"
-      ]
+      "contributions": ["infra", "code"]
     },
     {
       "login": "lazyc97",
       "name": "Nguyễn Hoàng Đức",
       "avatar_url": "https://avatars.githubusercontent.com/u/8538104?v=4",
       "profile": "https://github.com/lazyc97",
-      "contributions": [
-        "bug"
-      ]
+      "contributions": ["bug"]
     },
     {
       "login": "RavanaBhrama",
       "name": "RavanaBhrama",
       "avatar_url": "https://avatars.githubusercontent.com/u/131459969?v=4",
       "profile": "https://github.com/RavanaBhrama",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "mj0nez",
       "name": "Marcel Johannesmann",
       "avatar_url": "https://avatars.githubusercontent.com/u/20128340?v=4",
       "profile": "https://github.com/mj0nez",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "therealzanfar",
       "name": "Matthew",
       "avatar_url": "https://avatars.githubusercontent.com/u/10294685?v=4",
       "profile": "http://zanfar.com/",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     }
   ],
   "contributorsPerLine": 7,

--- a/litestar/_openapi/responses.py
+++ b/litestar/_openapi/responses.py
@@ -130,8 +130,8 @@ def create_success_response(  # noqa: C901
                 route_handler.media_type: OpenAPIMediaType(
                     schema=Schema(
                         type=OpenAPIType.STRING,
-                        content_encoding=route_handler.content_encoding or "application/octet-stream",
-                        content_media_type=route_handler.content_media_type,
+                        content_encoding=route_handler.content_encoding,
+                        content_media_type=route_handler.content_media_type or "application/octet-stream",
                     ),
                 )
             },

--- a/poetry.lock
+++ b/poetry.lock
@@ -1641,13 +1641,13 @@ files = [
 
 [[package]]
 name = "hypothesis"
-version = "6.82.0"
+version = "6.82.1"
 description = "A library for property-based testing"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "hypothesis-6.82.0-py3-none-any.whl", hash = "sha256:fa8eee429b99f7d3c953fb2b57de415fd39b472b09328b86c1978f12669ef395"},
-    {file = "hypothesis-6.82.0.tar.gz", hash = "sha256:ffece8e40a34329e7112f7408f2c45fe587761978fdbc6f4f91bf0d683a7d4d9"},
+    {file = "hypothesis-6.82.1-py3-none-any.whl", hash = "sha256:a643ee61dd1bebced7609c93195ff2dce444f7e28b8799b3a960d4632fbd9625"},
+    {file = "hypothesis-6.82.1.tar.gz", hash = "sha256:eea19d6c4cd578837239cfe7604a09059029e84d5d3318710d82260b363f1809"},
 ]
 
 [package.dependencies]
@@ -2747,13 +2747,13 @@ test = ["codecov", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
 name = "pygments"
-version = "2.15.1"
+version = "2.16.1"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Pygments-2.15.1-py3-none-any.whl", hash = "sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"},
-    {file = "Pygments-2.15.1.tar.gz", hash = "sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c"},
+    {file = "Pygments-2.16.1-py3-none-any.whl", hash = "sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692"},
+    {file = "Pygments-2.16.1.tar.gz", hash = "sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"},
 ]
 
 [package.extras]

--- a/tests/unit/test_openapi/test_responses.py
+++ b/tests/unit/test_openapi/test_responses.py
@@ -443,3 +443,15 @@ def test_response_generation_with_dto() -> None:
     mock_dto.create_openapi_schema.assert_called_once_with(
         field_definition=field_definition, handler_id=handler.handler_id, schema_creator=schema_creator
     )
+
+
+@pytest.mark.parametrize(
+    "content_media_type, expected", ((MediaType.TEXT, MediaType.TEXT), (None, "application/octet-stream"))
+)
+def test_file_response_media_type(content_media_type: Any, expected: Any) -> None:
+    @get("/", content_media_type=content_media_type)
+    def handler() -> File:
+        return File("test.txt")
+
+    openapi_response = create_success_response(handler, SchemaCreator())
+    assert next(iter(openapi_response.content.values())).schema.content_media_type == expected  # type: ignore


### PR DESCRIPTION
This PR fixes a bug in the response schema where `contentEncoding` had a default of `application/octet-stream`, which actually should be the default of `contentMediaType`.