### PR TITLE
fix: handle dialects that don't support json

### DIFF
--- a/litestar/contrib/sqlalchemy/plugins/init/config/common.py
+++ b/litestar/contrib/sqlalchemy/plugins/init/config/common.py
@@ -186,7 +186,7 @@ class GenericSQLAlchemyConfig(Generic[EngineT, SessionT, SessionMakerT]):
         engine_config = self.engine_config_dict
         try:
             self.engine_instance = self.create_engine_callable(self.connection_string, **engine_config)
-        except ValueError:
+        except TypeError:
             # likely due to a dialect that doesn't support json type
             del engine_config["json_deserializer"]
             del engine_config["json_serializer"]

--- a/tests/unit/test_contrib/test_sqlalchemy/test_init_plugin/test_common.py
+++ b/tests/unit/test_contrib/test_sqlalchemy/test_init_plugin/test_common.py
@@ -66,7 +66,7 @@ def test_create_engine_if_no_engine_instance_or_connection_string_provided(
         config.create_engine()
 
 
-def test_call_create_engine_callable_value_error_handling(
+def test_call_create_engine_callable_type_error_handling(
     config_cls: type[SQLAlchemySyncConfig | SQLAlchemySyncConfig], monkeypatch: MonkeyPatch
 ) -> None:
     """If the dialect doesn't support JSON types, we get a ValueError.
@@ -78,7 +78,7 @@ def test_call_create_engine_callable_value_error_handling(
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            raise ValueError()
+            raise TypeError()
 
     config = config_cls(connection_string="sqlite://")
     create_engine_callable_mock = MagicMock(side_effect=side_effect)


### PR DESCRIPTION
### Pull Request Checklist

- [x] New code has 100% test coverage
- [x] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [x] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
This pr adds proper handling for SQLAlchemy dialects that do not support JSON types

### Close Issue(s)
Fixes #2137 