### PR TITLE
fix: DTOData bug with renamed fields

### DIFF
--- a/litestar/dto/data_structures.py
+++ b/litestar/dto/data_structures.py
@@ -32,7 +32,9 @@ class DTOData(Generic[T]):
         data = dict(self._data_as_builtins)
         for k, v in kwargs.items():
             _set_nested_dict_value(data, k.split("__"), v)
-        return self._backend.transfer_data_from_builtins(data)  # type:ignore[no-any-return]
+        return self._backend.transfer_data_from_builtins(  # type:ignore[no-any-return]
+            data, override_serialization_name=True
+        )
 
     def update_instance(self, instance: T, **kwargs: Any) -> T:
         """Update an instance with the DTO validated data.

--- a/tests/unit/test_dto/test_factory/test_backends/test_utils.py
+++ b/tests/unit/test_dto/test_factory/test_backends/test_utils.py
@@ -57,7 +57,7 @@ def test_transfer_nested_union_type_data_raises_runtime_error_for_complex_union(
             transfer_type=transfer_type,
             is_data_field=True,
             source_value=1,
-            is_dto_data_type=True,
+            override_serialization_name=True,
         )
 
 

--- a/tests/unit/test_dto/test_factory/test_integration.py
+++ b/tests/unit/test_dto/test_factory/test_integration.py
@@ -214,10 +214,24 @@ def test_dto_data_with_url_encoded_form_data() -> None:
         assert response.json() == {"name": "John", "age": 42, "read_only": "read-only"}
 
 
+RenamedBarT = TypeVar("RenamedBarT")
+
+
 @dataclass
-class RenamedBar:
+class GenericRenamedBar(Generic[RenamedBarT]):
     bar: str
+    spam_bar: RenamedBarT
     foo_foo: str
+
+
+@dataclass
+class InnerBar:
+    best_greeting: str
+
+
+@dataclass
+class RenamedBar(GenericRenamedBar[InnerBar]):
+    pass
 
 
 def test_dto_data_create_instance_renamed_fields() -> None:
@@ -229,14 +243,15 @@ def test_dto_data_create_instance_renamed_fields() -> None:
         assert isinstance(data, DTOData)
         result = data.create_instance(foo_foo="world")
         assert result.foo_foo == "world"
+        assert result.spam_bar.best_greeting == "hello world"
         return result
 
     with create_test_client(
         route_handlers=[handler], signature_namespace={"NestedFoo": NestedFoo, "NestingBar": NestingBar}
     ) as client:
-        response = client.post("/", json={"bar": "hello"})
+        response = client.post("/", json={"bar": "hello", "spamBar": {"bestGreeting": "hello world"}})
         assert response.status_code == 201
-        assert response.json() == {"bar": "hello", "fooFoo": "world"}
+        assert response.json() == {"bar": "hello", "fooFoo": "world", "spamBar": {"bestGreeting": "hello world"}}
 
 
 def test_dto_data_with_patch_request() -> None:


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [X] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"


Implementing a fix for `DTOData` #2065  introduced a new bug. Originally, fields passed to `DTOData.create_instance` were handled using their serialized names. For example, when using camel case for an excluded field `entity_id`, `data.create_instance(entityId="1")` would work  but `data.create_instance(entity_id="A")` wouldn't. That was not ideal so the erroneous fix was to ignore serialized field names altogether when dealing with `DTOData`. Here is an example of why this would fail:

```python
@dataclass
class User):
    entityId: str
    firstName: str

@post(
    dto=DataclassDTO[Annotated[User, DTOConfig(exclude={"entity_id"}, rename_strategy="camel")]],
)
def handler(data: DTOData[User]) -> User:
    result = data.create_instance(entity_id="123")
    return result
``` 

Since. #2065  ignored serialized names, the above example will fail to deserialize `b'{firstName: "J"}'`. The fix: only override serialization names when using `data.create_instance`, otherwise, when dealing with `DTOData` we *should* use the serialization name (to successfully deserialize)


### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

-
