### PR TITLE
fix: set model response to NOT prefer alias

### DIFF
--- a/litestar/_openapi/path_item.py
+++ b/litestar/_openapi/path_item.py
@@ -87,7 +87,7 @@ def create_path_item(
     operation_ids: list[str] = []
 
     request_schema_creator = SchemaCreator(create_examples, plugins, schemas, prefer_alias=True)
-    response_schema_creator = SchemaCreator(create_examples, plugins, schemas, prefer_alias=True)
+    response_schema_creator = SchemaCreator(create_examples, plugins, schemas, prefer_alias=False)
     for http_method, handler_tuple in route.route_handler_map.items():
         route_handler, _ = handler_tuple
 

--- a/tests/unit/test_openapi/test_config.py
+++ b/tests/unit/test_openapi/test_config.py
@@ -8,6 +8,7 @@ from litestar import Litestar, get, post
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.openapi.config import OpenAPIConfig
 from litestar.openapi.spec import Components, Example, OpenAPIHeader, OpenAPIType, Schema
+from litestar.testing import TestClient
 
 if TYPE_CHECKING:
     from litestar.handlers.http_handlers import HTTPRouteHandler
@@ -62,18 +63,24 @@ def test_by_alias() -> None:
 
     assert app.openapi_schema
     schemas = app.openapi_schema.to_schema()["components"]["schemas"]
+    request_key = "second"
     assert schemas["RequestWithAlias"] == {
-        "properties": {"second": {"type": "string"}},
+        "properties": {request_key: {"type": "string"}},
         "type": "object",
-        "required": ["second"],
+        "required": [request_key],
         "title": "RequestWithAlias",
     }
+    response_key = "first"
     assert schemas["ResponseWithAlias"] == {
-        "properties": {"second": {"type": "string"}},
+        "properties": {response_key: {"type": "string"}},
         "type": "object",
-        "required": ["second"],
+        "required": [response_key],
         "title": "ResponseWithAlias",
     }
+
+    with TestClient(app) as client:
+        response = client.post("/", json={request_key: "foo"})
+        assert response.json() == {response_key: "foo"}
 
 
 def test_allows_customization_of_operation_id_creator() -> None:


### PR DESCRIPTION
### Pull Request Checklist

- [x] New code has 100% test coverage

### Description

As brought up on Discord few weeks ago, the generated OpenAPI schema should agree with the actual response for aliased Pydantic fields but it doesn't since [this change](https://github.com/litestar-org/litestar/commit/702037026719c2c7af65735f04c70fd845db403a#diff-271e0f4f9a138cb2276b567323c4695a6e8ef6eff01395cd799b50ae9bcf6420L91).
