### PR TITLE
fix(exception-handling): Fix #2147 - setting app debug does not propagate to exception handling middleware

### DIFF
--- a/litestar/cli/commands/core.py
+++ b/litestar/cli/commands/core.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 import uvicorn
 from rich.tree import Tree
 
-from litestar.cli._utils import RICH_CLICK_INSTALLED, console, show_app_info
+from litestar.cli._utils import RICH_CLICK_INSTALLED, LitestarEnv, console, show_app_info
 from litestar.routes import HTTPRoute, WebSocketRoute
 from litestar.utils.helpers import unwrap_partial
 
@@ -118,7 +118,7 @@ def run_command(
         if pdb:
             ctx.obj.app.pdb_on_exception = True
 
-    env = ctx.obj
+    env: LitestarEnv = ctx.obj
     app = env.app
 
     reload_dirs = env.reload_dirs or reload_dir

--- a/litestar/middleware/exceptions/middleware.py
+++ b/litestar/middleware/exceptions/middleware.py
@@ -153,15 +153,18 @@ class ExceptionHandlerMiddleware:
 
         Args:
             app: The ``next`` ASGI app to call.
-            debug: Whether ``debug`` mode is enabled. Deprecated. Debug mode will eb inferred from the request scope
+            debug: Whether ``debug`` mode is enabled. Deprecated. Debug mode will be inferred from the request scope
             exception_handlers: A dictionary mapping status codes and/or exception types to handler functions.
+
+        .. deprecated:: 2.0.0
+            The ``debug`` parameter is deprecated. It will be inferred from the request scope
         """
         self.app = app
         self.exception_handlers = exception_handlers
         self.debug = debug
         if debug is not None:
             warn_deprecation(
-                "2.0.0rc2",
+                "2.0.0",
                 deprecated_name="debug",
                 kind="parameter",
                 info="Debug mode will be inferred from the request scope",

--- a/tests/unit/test_middleware/test_exception_handler_middleware.py
+++ b/tests/unit/test_middleware/test_exception_handler_middleware.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import pytest
 from _pytest.capture import CaptureFixture
@@ -7,17 +7,14 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from structlog.testing import capture_logs
 
 from litestar import Litestar, Request, Response, get
-from litestar.exceptions import (
-    HTTPException,
-    InternalServerException,
-    ValidationException,
-)
+from litestar.exceptions import HTTPException, InternalServerException, ValidationException
 from litestar.logging.config import LoggingConfig, StructLoggingConfig
 from litestar.middleware.exceptions import ExceptionHandlerMiddleware
 from litestar.middleware.exceptions.middleware import get_exception_handler
 from litestar.status_codes import HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
 from litestar.testing import TestClient, create_test_client
 from litestar.types import ExceptionHandlersMap
+from litestar.types.asgi_types import HTTPScope
 
 if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
@@ -30,13 +27,26 @@ async def dummy_app(scope: Any, receive: Any, send: Any) -> None:
     return None
 
 
-middleware = ExceptionHandlerMiddleware(dummy_app, False, {})
+@pytest.fixture()
+def app() -> Litestar:
+    return Litestar()
 
 
-def test_default_handle_http_exception_handling_extra_object() -> None:
+@pytest.fixture()
+def middleware() -> ExceptionHandlerMiddleware:
+    return ExceptionHandlerMiddleware(dummy_app, False, {})
+
+
+@pytest.fixture()
+def scope(create_scope: Callable[..., HTTPScope], app: Litestar) -> HTTPScope:
+    return create_scope(app=app)
+
+
+def test_default_handle_http_exception_handling_extra_object(
+    scope: HTTPScope, middleware: ExceptionHandlerMiddleware
+) -> None:
     response = middleware.default_http_exception_handler(
-        Request(scope={"type": "http", "method": "GET"}),  # type: ignore
-        HTTPException(detail="litestar_exception", extra={"key": "value"}),
+        Request(scope=scope), HTTPException(detail="litestar_exception", extra={"key": "value"})
     )
     assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
     assert response.content == {
@@ -46,28 +56,31 @@ def test_default_handle_http_exception_handling_extra_object() -> None:
     }
 
 
-def test_default_handle_http_exception_handling_extra_none() -> None:
+def test_default_handle_http_exception_handling_extra_none(
+    scope: HTTPScope, middleware: ExceptionHandlerMiddleware
+) -> None:
     response = middleware.default_http_exception_handler(
-        Request(scope={"type": "http", "method": "GET"}),  # type: ignore
-        HTTPException(detail="litestar_exception"),
+        Request(scope=scope), HTTPException(detail="litestar_exception")
     )
     assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
     assert response.content == {"detail": "Internal Server Error", "status_code": 500}
 
 
-def test_default_handle_litestar_http_exception_handling() -> None:
+def test_default_handle_litestar_http_exception_handling(
+    scope: HTTPScope, middleware: ExceptionHandlerMiddleware
+) -> None:
     response = middleware.default_http_exception_handler(
-        Request(scope={"type": "http", "method": "GET"}),  # type: ignore
-        HTTPException(detail="litestar_exception"),
+        Request(scope=scope), HTTPException(detail="litestar_exception")
     )
     assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
     assert response.content == {"detail": "Internal Server Error", "status_code": 500}
 
 
-def test_default_handle_litestar_http_exception_extra_list() -> None:
+def test_default_handle_litestar_http_exception_extra_list(
+    scope: HTTPScope, middleware: ExceptionHandlerMiddleware
+) -> None:
     response = middleware.default_http_exception_handler(
-        Request(scope={"type": "http", "method": "GET"}),  # type: ignore
-        HTTPException(detail="litestar_exception", extra=["extra-1", "extra-2"]),
+        Request(scope=scope), HTTPException(detail="litestar_exception", extra=["extra-1", "extra-2"])
     )
     assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
     assert response.content == {
@@ -77,22 +90,21 @@ def test_default_handle_litestar_http_exception_extra_list() -> None:
     }
 
 
-def test_default_handle_starlette_http_exception_handling() -> None:
+def test_default_handle_starlette_http_exception_handling(
+    scope: HTTPScope, middleware: ExceptionHandlerMiddleware
+) -> None:
     response = middleware.default_http_exception_handler(
-        Request(scope={"type": "http", "method": "GET"}),  # type: ignore
+        Request(scope=scope),
         StarletteHTTPException(detail="litestar_exception", status_code=HTTP_500_INTERNAL_SERVER_ERROR),
     )
     assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
-    assert response.content == {
-        "detail": "Internal Server Error",
-        "status_code": 500,
-    }
+    assert response.content == {"detail": "Internal Server Error", "status_code": 500}
 
 
-def test_default_handle_python_http_exception_handling() -> None:
-    response = middleware.default_http_exception_handler(
-        Request(scope={"type": "http", "method": "GET"}), AttributeError("oops")  # type: ignore
-    )
+def test_default_handle_python_http_exception_handling(
+    scope: HTTPScope, middleware: ExceptionHandlerMiddleware
+) -> None:
+    response = middleware.default_http_exception_handler(Request(scope=scope), AttributeError("oops"))
     assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
     assert response.content == {
         "detail": "Internal Server Error",
@@ -307,3 +319,24 @@ def test_pdb_on_exception(mocker: MockerFixture) -> None:
 
     assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
     mock_post_mortem.assert_called_once()
+
+
+def test_get_debug_from_scope(get_logger: "GetLogger", caplog: "LogCaptureFixture") -> None:
+    @get("/test")
+    def handler() -> None:
+        raise ValueError("Test debug exception")
+
+    app = Litestar([handler], debug=False)
+    app.debug = True
+
+    with caplog.at_level("ERROR", "litestar"), TestClient(app=app) as client:
+        client.app.logger = get_logger("litestar")
+        response = client.get("/test")
+
+        assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
+        assert "Test debug exception" in response.text
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == "ERROR"
+        assert caplog.records[0].message.startswith(
+            "exception raised on http connection to route /test\n\nTraceback (most recent call last):\n"
+        )


### PR DESCRIPTION
Change `ExceptionHandlerMiddleware` to use the current application's debug value rather than assigning it statically at creation / startup time.

### Pull Request Checklist

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

-

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

- #2147 
