### PR TITLE
fix: openapi schema generation when creating examples with Pydantic models

### DIFF
--- a/litestar/_openapi/schema_generation/examples.py
+++ b/litestar/_openapi/schema_generation/examples.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import typing
 from dataclasses import replace
 from decimal import Decimal
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
+import msgspec
 from polyfactory.exceptions import ParameterException
 from polyfactory.factories import DataclassFactory
 from polyfactory.field_meta import FieldMeta, Null
 from polyfactory.utils.helpers import unwrap_annotation
+from polyfactory.utils.predicates import is_union
+from typing_extensions import get_args
 
 from litestar.openapi.spec import Example
 from litestar.types import Empty
@@ -25,6 +29,18 @@ class ExampleFactory(DataclassFactory[Example]):
 
 def _normalize_example_value(value: Any) -> Any:
     """Normalize the example value to make it look a bit prettier."""
+    # if UnsetType is part of the union, then it might get chosen as the value
+    # but that will not be properly serialized by msgspec unless it is for a field
+    # in a msgspec Struct
+    if is_union(value):
+        args = list(get_args(value))
+        try:
+            args.remove(msgspec.UnsetType)
+            value = typing.Union[tuple(args)]  # pyright: ignore
+        except ValueError:
+            # UnsetType not part of the Union
+            pass
+
     value = unwrap_annotation(annotation=value, random=ExampleFactory.__random__)
     if isinstance(value, (Decimal, float)):
         value = round(float(value), 2)

--- a/litestar/openapi/controller.py
+++ b/litestar/openapi/controller.py
@@ -64,7 +64,7 @@ class OpenAPIController(Controller):
     """Download url for the Stoplight Elements JS bundle."""
 
     # internal
-    _dumped_schema: str = ""
+    _dumped_json_schema: str = ""
     # until swagger-ui supports v3.1.* of OpenAPI officially, we need to modify the schema for it and keep it
     # separate from the redoc version of the schema, which is unmodified.
     dto = None
@@ -162,7 +162,7 @@ class OpenAPIController(Controller):
         """
         if self.should_serve_endpoint(request):
             return ASGIResponse(
-                body=encode_json(self.get_schema_from_request(request).to_schema()),
+                body=self._get_schema_as_json(request),
                 media_type=OpenAPIMediaType.OPENAPI_JSON,
             )
         return ASGIResponse(body=b"", status_code=HTTP_404_NOT_FOUND, media_type=MediaType.HTML)
@@ -272,7 +272,7 @@ class OpenAPIController(Controller):
             <div id='swagger-container'/>
             <script type="text/javascript">
             const ui = SwaggerUIBundle({{
-                spec: {encode_json(schema.to_schema()).decode("utf-8")},
+                spec: {self._get_schema_as_json(request)},
                 dom_id: '#swagger-container',
                 deepLinking: true,
                 showExtensions: true,
@@ -353,9 +353,6 @@ class OpenAPIController(Controller):
         """
         schema = self.get_schema_from_request(request)
 
-        if not self._dumped_schema:
-            self._dumped_schema = encode_json(schema.to_schema()).decode("utf-8")
-
         head = f"""
           <head>
             <title>{schema.info.title}</title>
@@ -382,7 +379,7 @@ class OpenAPIController(Controller):
             <div id='redoc-container'/>
             <script type="text/javascript">
                 Redoc.init(
-                    {self._dumped_schema},
+                    {self._get_schema_as_json(request)},
                     undefined,
                     document.getElementById('redoc-container')
                 )
@@ -422,3 +419,13 @@ class OpenAPIController(Controller):
             </body>
         </html>
         """.encode()
+
+    def _get_schema_as_json(self, request: Request) -> str:
+        """Get the schema encoded as a JSON string."""
+
+        if not self._dumped_json_schema:
+            schema = self.get_schema_from_request(request).to_schema()
+            json_encoded_schema = encode_json(schema, request.route_handler.default_serializer)
+            self._dumped_json_schema = json_encoded_schema.decode("utf-8")
+
+        return self._dumped_json_schema

--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -1,6 +1,7 @@
 from typing import Type
 
 import msgspec
+import pytest
 import yaml
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated
@@ -9,12 +10,19 @@ from litestar import Controller, post
 from litestar.app import DEFAULT_OPENAPI_CONFIG
 from litestar.enums import OpenAPIMediaType
 from litestar.openapi import OpenAPIConfig, OpenAPIController
+from litestar.serialization.msgspec_hooks import decode_json, encode_json, get_serializer
 from litestar.status_codes import HTTP_200_OK, HTTP_404_NOT_FOUND
 from litestar.testing import create_test_client
 
+CREATE_EXAMPLES_VALUES = (True, False)
 
-def test_openapi_yaml(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
-    with create_test_client([person_controller, pet_controller], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+
+@pytest.mark.parametrize("create_examples", CREATE_EXAMPLES_VALUES)
+def test_openapi_yaml(
+    person_controller: Type[Controller], pet_controller: Type[Controller], create_examples: bool
+) -> None:
+    openapi_config = OpenAPIConfig("Example API", "1.0.0", create_examples=create_examples)
+    with create_test_client([person_controller, pet_controller], openapi_config=openapi_config) as client:
         assert client.app.openapi_schema
         openapi_schema = client.app.openapi_schema
         assert openapi_schema.paths
@@ -22,11 +30,17 @@ def test_openapi_yaml(person_controller: Type[Controller], pet_controller: Type[
         assert response.status_code == HTTP_200_OK
         assert response.headers["content-type"] == OpenAPIMediaType.OPENAPI_YAML.value
         assert client.app.openapi_schema
-        assert yaml.unsafe_load(response.content) == client.app.openapi_schema.to_schema()
+        serializer = get_serializer(client.app.type_encoders)
+        schema_json = decode_json(encode_json(openapi_schema.to_schema(), serializer))
+        assert response.content.decode("utf-8") == yaml.dump(schema_json)
 
 
-def test_openapi_json(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
-    with create_test_client([person_controller, pet_controller], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+@pytest.mark.parametrize("create_examples", CREATE_EXAMPLES_VALUES)
+def test_openapi_json(
+    person_controller: Type[Controller], pet_controller: Type[Controller], create_examples: bool
+) -> None:
+    openapi_config = OpenAPIConfig("Example API", "1.0.0", create_examples=create_examples)
+    with create_test_client([person_controller, pet_controller], openapi_config=openapi_config) as client:
         assert client.app.openapi_schema
         openapi_schema = client.app.openapi_schema
         assert openapi_schema.paths
@@ -34,7 +48,8 @@ def test_openapi_json(person_controller: Type[Controller], pet_controller: Type[
         assert response.status_code == HTTP_200_OK
         assert response.headers["content-type"] == OpenAPIMediaType.OPENAPI_JSON.value
         assert client.app.openapi_schema
-        assert response.json() == client.app.openapi_schema.to_schema()
+        serializer = get_serializer(client.app.type_encoders)
+        assert response.content == encode_json(openapi_schema.to_schema(), serializer)
 
 
 def test_openapi_yaml_not_allowed(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
@@ -118,7 +133,8 @@ def test_openapi_custom_path_overrides_custom_controller_path() -> None:
         assert response.status_code == HTTP_200_OK
 
 
-def test_msgspec_schema_generation() -> None:
+@pytest.mark.parametrize("create_examples", CREATE_EXAMPLES_VALUES)
+def test_msgspec_schema_generation(create_examples: bool) -> None:
     class Lookup(msgspec.Struct):
         id: Annotated[
             str,
@@ -139,6 +155,7 @@ def test_msgspec_schema_generation() -> None:
         openapi_config=OpenAPIConfig(
             title="Example API",
             version="1.0.0",
+            create_examples=create_examples,
         ),
     ) as client:
         response = client.get("/schema/openapi.json")
@@ -152,7 +169,8 @@ def test_msgspec_schema_generation() -> None:
         }
 
 
-def test_pydantic_schema_generation() -> None:
+@pytest.mark.parametrize("create_examples", CREATE_EXAMPLES_VALUES)
+def test_pydantic_schema_generation(create_examples: bool) -> None:
     class Lookup(BaseModel):
         id: Annotated[
             str,
@@ -173,6 +191,7 @@ def test_pydantic_schema_generation() -> None:
         openapi_config=OpenAPIConfig(
             title="Example API",
             version="1.0.0",
+            create_examples=create_examples,
         ),
     ) as client:
         response = client.get("/schema/openapi.json")

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -5,6 +5,7 @@ import pytest
 from litestar import Controller, Litestar, Router, get
 from litestar._openapi.parameters import create_parameter_for_handler
 from litestar._openapi.schema_generation import SchemaCreator
+from litestar._openapi.schema_generation.examples import ExampleFactory
 from litestar._openapi.typescript_converter.schema_parsing import is_schema_value
 from litestar._signature import SignatureModel
 from litestar.di import Provide
@@ -41,6 +42,8 @@ def _create_parameters(app: Litestar, path: str) -> List["OpenAPIParameter"]:
 
 
 def test_create_parameters(person_controller: Type[Controller]) -> None:
+    ExampleFactory.seed_random(10)
+
     parameters = _create_parameters(app=Litestar(route_handlers=[person_controller]), path="/{service_id}/person")
     assert len(parameters) == 9
     page, name, page_size, service_id, from_date, to_date, gender, secret_header, cookie_value = tuple(parameters)


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

- This PR corrects the encoding of the OpenAPI schema into JSON and YAML when the `create_examples` flag is set to `True` in the `OpenAPIConfig`

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

- Fixes #2133 