### PR TITLE
chore(backport): #2192 - remove usages of deprecated ExceptionHandlerMiddleware `debug` parameter

### DIFF
--- a/litestar/_asgi/routing_trie/mapping.py
+++ b/litestar/_asgi/routing_trie/mapping.py
@@ -189,7 +189,7 @@ def build_route_middleware_stack(
 
     # we wrap the route.handle method in the ExceptionHandlerMiddleware
     asgi_handler = wrap_in_exception_handler(
-        debug=app.debug, app=route.handle, exception_handlers=route_handler.resolve_exception_handlers()  # type: ignore[arg-type]
+        app=route.handle, exception_handlers=route_handler.resolve_exception_handlers()  # type: ignore[arg-type]
     )
 
     if app.csrf_config:
@@ -209,7 +209,6 @@ def build_route_middleware_stack(
 
     # we wrap the entire stack again in ExceptionHandlerMiddleware
     return wrap_in_exception_handler(
-        debug=app.debug,
         app=cast("ASGIApp", asgi_handler),
         exception_handlers=route_handler.resolve_exception_handlers(),
     )  # pyright: ignore

--- a/litestar/_asgi/utils.py
+++ b/litestar/_asgi/utils.py
@@ -11,11 +11,10 @@ if TYPE_CHECKING:
     from litestar.types import ASGIApp, ExceptionHandlersMap, RouteHandlerType
 
 
-def wrap_in_exception_handler(debug: bool, app: ASGIApp, exception_handlers: ExceptionHandlersMap) -> ASGIApp:
+def wrap_in_exception_handler(app: ASGIApp, exception_handlers: ExceptionHandlersMap) -> ASGIApp:
     """Wrap the given ASGIApp in an instance of ExceptionHandlerMiddleware.
 
     Args:
-        debug: Dictates whether exceptions are raised in debug mode.
         app: The ASGI app that is being wrapped.
         exception_handlers: A mapping of exceptions to handler functions.
 
@@ -24,7 +23,7 @@ def wrap_in_exception_handler(debug: bool, app: ASGIApp, exception_handlers: Exc
     """
     from litestar.middleware.exceptions import ExceptionHandlerMiddleware
 
-    return ExceptionHandlerMiddleware(app=app, exception_handlers=exception_handlers, debug=debug)
+    return ExceptionHandlerMiddleware(app=app, exception_handlers=exception_handlers, debug=None)
 
 
 def get_route_handlers(route: BaseRoute) -> list[RouteHandlerType]:

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -767,7 +767,7 @@ class Litestar(Router):
             asgi_handler = CORSMiddleware(app=asgi_handler, config=self.cors_config)
 
         return wrap_in_exception_handler(
-            debug=self.debug, app=asgi_handler, exception_handlers=self.exception_handlers or {}  # pyright: ignore
+            app=asgi_handler, exception_handlers=self.exception_handlers or {}  # pyright: ignore
         )
 
     def _wrap_send(self, send: Send, scope: Scope) -> Send:

--- a/litestar/security/session_auth/middleware.py
+++ b/litestar/security/session_auth/middleware.py
@@ -60,7 +60,7 @@ class MiddlewareWrapper:
             exception_middleware = ExceptionHandlerMiddleware(
                 app=auth_middleware,
                 exception_handlers=litestar_app.exception_handlers or {},  # pyright: ignore
-                debug=litestar_app.debug,
+                debug=None,
             )
             self.app = SessionMiddleware(
                 app=exception_middleware,

--- a/tests/unit/test_middleware/test_exception_handler_middleware.py
+++ b/tests/unit/test_middleware/test_exception_handler_middleware.py
@@ -34,7 +34,7 @@ def app() -> Litestar:
 
 @pytest.fixture()
 def middleware() -> ExceptionHandlerMiddleware:
-    return ExceptionHandlerMiddleware(dummy_app, False, {})
+    return ExceptionHandlerMiddleware(dummy_app, None, {})
 
 
 @pytest.fixture()


### PR DESCRIPTION
Backport #2192