### PR TITLE
fix: use os.replace instead of shutil.move for renaming file

### DIFF
--- a/litestar/stores/file.py
+++ b/litestar/stores/file.py
@@ -64,7 +64,7 @@ class FileStore(NamespacedStore):
                 finally:
                     os.close(tmp_file_fd)
 
-                shutil.move(tmp_file_name, target_file)
+                os.replace(tmp_file_name, target_file)  # noqa: PTH105
                 renamed = True
             finally:
                 if not renamed:

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -344,7 +344,7 @@ def test_registry_register_exist_override(memory_store: MemoryStore) -> None:
 
 
 async def test_file_store_handle_rename_fail(file_store: FileStore, mocker: MockerFixture) -> None:
-    mocker.patch("litestar.stores.file.shutil.move", side_effect=OSError)
+    mocker.patch("litestar.stores.file.os.replace", side_effect=OSError)
     mock_unlink = mocker.patch("litestar.stores.file.os.unlink")
 
     await file_store.set("foo", "bar")


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

- This PR uses `os.replace` instead of `shutil.move` for renaming files to ensure atomicity.

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"