### PR TITLE
fix(schema): handling of optional path parameters

### DIFF
--- a/litestar/_openapi/parameters.py
+++ b/litestar/_openapi/parameters.py
@@ -54,8 +54,9 @@ class ParameterCollection:
             # path parameter. e.g. get(path=["/", "/{param:str}"]). When parsing the parameter for path, the route handler
             # would still have a kwarg called param:
             # def handler(param: str | None) -> ...
-            if parameter.param_in != ParamType.QUERY or not any(
-                "{" + parameter.name + ":" in path for path in self.route_handler.paths
+            if parameter.param_in != ParamType.QUERY or all(
+                "{" + parameter.name + ":" not in path
+                for path in self.route_handler.paths
             ):
                 self._parameters[parameter.name] = parameter
             return

--- a/litestar/_openapi/parameters.py
+++ b/litestar/_openapi/parameters.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from litestar.constants import RESERVED_KWARGS
@@ -49,8 +48,16 @@ class ParameterCollection:
         If an existing parameter with the same name but different type exists, raises
         ``ImproperlyConfiguredException``.
         """
+
         if parameter.name not in self._parameters:
-            self._parameters[parameter.name] = parameter
+            # because we are defining routes as unique per path, we have to handle here a situation when there is an optional
+            # path parameter. e.g. get(path=["/", "/{param:str}"]). When parsing the parameter for path, the route handler
+            # would still have a kwarg called param:
+            # def handler(param: str | None) -> ...
+            if parameter.param_in != ParamType.QUERY or not any(
+                "{" + parameter.name + ":" in path for path in self.route_handler.paths
+            ):
+                self._parameters[parameter.name] = parameter
             return
 
         pre_existing = self._parameters[parameter.name]
@@ -83,8 +90,7 @@ def create_parameter(
     if any(path_param.name == parameter_name for path_param in path_parameters):
         param_in = ParamType.PATH
         is_required = True
-        path_parameter = next(p for p in path_parameters if parameter_name in p.name)
-        result = schema_creator.for_field_definition(replace(field_definition, annotation=path_parameter.type))
+        result = schema_creator.for_field_definition(field_definition)
     elif kwarg_definition and kwarg_definition.header:
         parameter_name = kwarg_definition.header
         param_in = ParamType.HEADER
@@ -193,7 +199,6 @@ def create_parameter_for_handler(
     """Create a list of path/query/header Parameter models for the given PathHandler."""
     parameters = ParameterCollection(route_handler=route_handler)
     dependency_providers = route_handler.resolve_dependencies()
-
     layered_parameters = route_handler.resolve_layered_parameters()
 
     unique_handler_fields = tuple(

--- a/tests/unit/test_kwargs/test_path_params.py
+++ b/tests/unit/test_kwargs/test_path_params.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 from unittest.mock import MagicMock
 from uuid import UUID, uuid1, uuid4
 
@@ -172,3 +172,19 @@ def test_differently_named_path_params_on_same_level() -> None:
         response = client.post("/Moishe")
         assert response.status_code == HTTP_201_CREATED
         assert response.text == "Hello, Moishe!"
+
+
+def test_optional_path_parameter() -> None:
+    @get(path=["/", "/{message:str}"], media_type=MediaType.TEXT, sync_to_thread=False)
+    def handler(message: Optional[str]) -> str:
+        if message:
+            return message
+        return "no message"
+
+    with create_test_client(route_handlers=[handler]) as client:
+        response = client.get("/")
+        assert response.status_code == HTTP_200_OK
+        assert response.text == "no message"
+        response = client.get("/hello")
+        assert response.status_code == HTTP_200_OK
+        assert response.text == "hello"

--- a/tests/unit/test_kwargs/test_path_params.py
+++ b/tests/unit/test_kwargs/test_path_params.py
@@ -177,9 +177,7 @@ def test_differently_named_path_params_on_same_level() -> None:
 def test_optional_path_parameter() -> None:
     @get(path=["/", "/{message:str}"], media_type=MediaType.TEXT, sync_to_thread=False)
     def handler(message: Optional[str]) -> str:
-        if message:
-            return message
-        return "no message"
+        return message if message else "no message"
 
     with create_test_client(route_handlers=[handler]) as client:
         response = client.get("/")

--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -1,4 +1,4 @@
-from typing import Type
+from __future__ import annotations
 
 import msgspec
 import pytest
@@ -6,9 +6,9 @@ import yaml
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated
 
-from litestar import Controller, post
+from litestar import Controller, get, post
 from litestar.app import DEFAULT_OPENAPI_CONFIG
-from litestar.enums import OpenAPIMediaType
+from litestar.enums import MediaType, OpenAPIMediaType, ParamType
 from litestar.openapi import OpenAPIConfig, OpenAPIController
 from litestar.serialization.msgspec_hooks import decode_json, encode_json, get_serializer
 from litestar.status_codes import HTTP_200_OK, HTTP_404_NOT_FOUND
@@ -19,7 +19,7 @@ CREATE_EXAMPLES_VALUES = (True, False)
 
 @pytest.mark.parametrize("create_examples", CREATE_EXAMPLES_VALUES)
 def test_openapi_yaml(
-    person_controller: Type[Controller], pet_controller: Type[Controller], create_examples: bool
+    person_controller: type[Controller], pet_controller: type[Controller], create_examples: bool
 ) -> None:
     openapi_config = OpenAPIConfig("Example API", "1.0.0", create_examples=create_examples)
     with create_test_client([person_controller, pet_controller], openapi_config=openapi_config) as client:
@@ -37,7 +37,7 @@ def test_openapi_yaml(
 
 @pytest.mark.parametrize("create_examples", CREATE_EXAMPLES_VALUES)
 def test_openapi_json(
-    person_controller: Type[Controller], pet_controller: Type[Controller], create_examples: bool
+    person_controller: type[Controller], pet_controller: type[Controller], create_examples: bool
 ) -> None:
     openapi_config = OpenAPIConfig("Example API", "1.0.0", create_examples=create_examples)
     with create_test_client([person_controller, pet_controller], openapi_config=openapi_config) as client:
@@ -52,7 +52,7 @@ def test_openapi_json(
         assert response.content == encode_json(openapi_schema.to_schema(), serializer)
 
 
-def test_openapi_yaml_not_allowed(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
+def test_openapi_yaml_not_allowed(person_controller: type[Controller], pet_controller: type[Controller]) -> None:
     openapi_config = DEFAULT_OPENAPI_CONFIG
     openapi_config.enabled_endpoints.discard("openapi.yaml")
 
@@ -64,7 +64,7 @@ def test_openapi_yaml_not_allowed(person_controller: Type[Controller], pet_contr
         assert response.status_code == HTTP_404_NOT_FOUND
 
 
-def test_openapi_json_not_allowed(person_controller: Type[Controller], pet_controller: Type[Controller]) -> None:
+def test_openapi_json_not_allowed(person_controller: type[Controller], pet_controller: type[Controller]) -> None:
     openapi_config = DEFAULT_OPENAPI_CONFIG
     openapi_config.enabled_endpoints.discard("openapi.json")
 
@@ -157,6 +157,7 @@ def test_msgspec_schema_generation(create_examples: bool) -> None:
             version="1.0.0",
             create_examples=create_examples,
         ),
+        signature_namespace={"Lookup": Lookup},
     ) as client:
         response = client.get("/schema/openapi.json")
         assert response.status_code == HTTP_200_OK
@@ -193,6 +194,7 @@ def test_pydantic_schema_generation(create_examples: bool) -> None:
             version="1.0.0",
             create_examples=create_examples,
         ),
+        signature_namespace={"Lookup": Lookup},
     ) as client:
         response = client.get("/schema/openapi.json")
         assert response.status_code == HTTP_200_OK
@@ -203,3 +205,27 @@ def test_pydantic_schema_generation(create_examples: bool) -> None:
             "minLength": 12,
             "type": "string",
         }
+
+
+def test_schema_for_optional_path_parameter() -> None:
+    @get(path=["/", "/{test_message:str}"], media_type=MediaType.TEXT, sync_to_thread=False)
+    def handler(test_message: str | None) -> str:
+        if test_message:
+            return test_message
+        return "no message"
+
+    with create_test_client(
+        route_handlers=[handler],
+        openapi_config=OpenAPIConfig(
+            title="Example API",
+            version="1.0.0",
+            create_examples=True,
+        ),
+    ) as client:
+        response = client.get("/schema/openapi.json")
+        assert response.status_code == HTTP_200_OK
+        assert "parameters" not in response.json()["paths"]["/"]["get"]  # type[ignore]
+        parameter = response.json()["paths"]["/{test_message}"]["get"]["parameters"][0]  # type[ignore]
+        assert parameter
+        assert parameter["in"] == ParamType.PATH
+        assert parameter["name"] == "test_message"

--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -210,9 +210,7 @@ def test_pydantic_schema_generation(create_examples: bool) -> None:
 def test_schema_for_optional_path_parameter() -> None:
     @get(path=["/", "/{test_message:str}"], media_type=MediaType.TEXT, sync_to_thread=False)
     def handler(test_message: str | None) -> str:
-        if test_message:
-            return test_message
-        return "no message"
+        return test_message if test_message else "no message"
 
     with create_test_client(
         route_handlers=[handler],


### PR DESCRIPTION
This PR does the following:

1. fix #2222 - where optional path parameters caused a 500 error to be raised.
2. fix another bug where a query parameter was created for an optional path parameter. 