### PR TITLE
fix: Exception detail attribute

### DIFF
--- a/litestar/exceptions/base_exceptions.py
+++ b/litestar/exceptions/base_exceptions.py
@@ -17,8 +17,14 @@ class LitestarException(Exception):
             *args: args are converted to :class:`str` before passing to :class:`Exception`
             detail: detail of the exception.
         """
+        args = tuple(str(arg) for arg in args if arg)
+        if not detail:
+            if args:
+                detail, *args = args
+            elif hasattr(self, "detail"):
+                detail = self.detail
         self.detail = detail
-        super().__init__(*(str(arg) for arg in args if arg), detail)
+        super().__init__(*args, detail)
 
     def __repr__(self) -> str:
         if self.detail:

--- a/litestar/exceptions/base_exceptions.py
+++ b/litestar/exceptions/base_exceptions.py
@@ -17,14 +17,14 @@ class LitestarException(Exception):
             *args: args are converted to :class:`str` before passing to :class:`Exception`
             detail: detail of the exception.
         """
-        args = tuple(str(arg) for arg in args if arg)
+        str_args = [str(arg) for arg in args if arg]
         if not detail:
-            if args:
-                detail, *args = args
+            if str_args:
+                detail, *str_args = str_args
             elif hasattr(self, "detail"):
                 detail = self.detail
         self.detail = detail
-        super().__init__(*args)
+        super().__init__(*str_args)
 
     def __repr__(self) -> str:
         if self.detail:

--- a/litestar/exceptions/base_exceptions.py
+++ b/litestar/exceptions/base_exceptions.py
@@ -24,7 +24,7 @@ class LitestarException(Exception):
             elif hasattr(self, "detail"):
                 detail = self.detail
         self.detail = detail
-        super().__init__(*args, detail)
+        super().__init__(*args)
 
     def __repr__(self) -> str:
         if self.detail:
@@ -32,7 +32,7 @@ class LitestarException(Exception):
         return self.__class__.__name__
 
     def __str__(self) -> str:
-        return " ".join(self.args).strip()
+        return " ".join((*self.args, self.detail)).strip()
 
 
 class MissingDependencyException(LitestarException, ImportError):

--- a/litestar/exceptions/http_exceptions.py
+++ b/litestar/exceptions/http_exceptions.py
@@ -66,21 +66,19 @@ class HTTPException(LitestarException):
             headers: Headers to set on the response.
             extra: An extra mapping to attach to the exception.
         """
+        super().__init__(*args, detail=detail)
         self.status_code = status_code or self.status_code
-
-        if not detail:
-            if args:
-                detail, *args = args
-            if not detail:
-                detail = getattr(self, "detail", HTTPStatus(self.status_code).phrase)
-
         self.extra = extra
-        self.detail = detail
         self.headers = headers
-        self.args = (f"{self.status_code}: {self.detail}", *args)
+        if not self.detail:
+            self.detail = HTTPStatus(self.status_code).phrase
+        self.args = (f"{self.status_code}: {self.detail}", *self.args)
 
     def __repr__(self) -> str:
         return f"{self.status_code} - {self.__class__.__name__} - {self.detail}"
+
+    def __str__(self) -> str:
+        return " ".join(self.args).strip()
 
 
 class ImproperlyConfiguredException(HTTPException, ValueError):

--- a/litestar/exceptions/http_exceptions.py
+++ b/litestar/exceptions/http_exceptions.py
@@ -66,12 +66,13 @@ class HTTPException(LitestarException):
             headers: Headers to set on the response.
             extra: An extra mapping to attach to the exception.
         """
-        super().__init__()
         self.status_code = status_code or self.status_code
 
         if not detail:
-            detail = args[0] if args else HTTPStatus(self.status_code).phrase
-            args = args[1:]
+            if args:
+                detail, *args = args
+            if not detail:
+                detail = getattr(self, "detail", HTTPStatus(self.status_code).phrase)
 
         self.extra = extra
         self.detail = detail

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -26,6 +26,18 @@ class CustomHTTPException(HTTPException):
 
 
 @given(detail=st.text())
+def test_litestar_exception_detail(detail: str) -> None:
+    for result in LitestarException(detail=detail), LitestarException(detail):
+        assert result.detail == detail
+
+
+@given(detail=st.text())
+def test_custom_litestar_exception_detail(detail: str) -> None:
+    for result in CustomLitestarException(detail=detail), CustomLitestarException(detail):
+        assert result.detail == (detail or "Custom Exception")
+
+
+@given(detail=st.text())
 @pytest.mark.parametrize("ex_type", [LitestarException, CustomLitestarException])
 def test_litestar_exception_repr(ex_type: type[LitestarException], detail: str) -> None:
     for result in ex_type(detail), ex_type(detail=detail):
@@ -39,7 +51,7 @@ def test_litestar_exception_repr(ex_type: type[LitestarException], detail: str) 
 @pytest.mark.parametrize("ex_type", [LitestarException, CustomLitestarException])
 def test_litestar_exception_str(ex_type: type[LitestarException], detail: str) -> None:
     for result in ex_type(detail), ex_type(detail=detail):
-        assert str(result) == detail.strip()
+        assert str(result) == result.detail.strip()
 
     result = ex_type(200, detail=detail)
     assert str(result) == f"200 {detail}".strip()

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,3 +1,5 @@
+from typing import Type
+
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
@@ -39,7 +41,7 @@ def test_custom_litestar_exception_detail(detail: str) -> None:
 
 @given(detail=st.text())
 @pytest.mark.parametrize("ex_type", [LitestarException, CustomLitestarException])
-def test_litestar_exception_repr(ex_type: type[LitestarException], detail: str) -> None:
+def test_litestar_exception_repr(ex_type: Type[LitestarException], detail: str) -> None:
     for result in ex_type(detail), ex_type(detail=detail):
         if result.detail:
             assert repr(result) == f"{result.__class__.__name__} - {result.detail}"
@@ -49,7 +51,7 @@ def test_litestar_exception_repr(ex_type: type[LitestarException], detail: str) 
 
 @given(detail=st.text())
 @pytest.mark.parametrize("ex_type", [LitestarException, CustomLitestarException])
-def test_litestar_exception_str(ex_type: type[LitestarException], detail: str) -> None:
+def test_litestar_exception_str(ex_type: Type[LitestarException], detail: str) -> None:
     for result in ex_type(detail), ex_type(detail=detail):
         assert str(result) == result.detail.strip()
 
@@ -71,7 +73,7 @@ def test_custom_http_exception_detail(detail: str) -> None:
 
 @given(status_code=st.integers(min_value=400, max_value=404), detail=st.text())
 @pytest.mark.parametrize("ex_type", [HTTPException, CustomHTTPException])
-def test_http_exception(ex_type: type[HTTPException], status_code: int, detail: str) -> None:
+def test_http_exception(ex_type: Type[HTTPException], status_code: int, detail: str) -> None:
     assert ex_type().status_code == HTTP_500_INTERNAL_SERVER_ERROR
     for result in ex_type(detail, status_code=status_code), ex_type(detail=detail, status_code=status_code):
         assert isinstance(result, LitestarException)

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -57,6 +57,18 @@ def test_litestar_exception_str(ex_type: type[LitestarException], detail: str) -
     assert str(result) == f"200 {detail}".strip()
 
 
+@given(detail=st.text())
+def test_http_exception_detail(detail: str) -> None:
+    for result in HTTPException(detail=detail), HTTPException(detail):
+        assert result.detail == (detail or "Internal Server Error")
+
+
+@given(detail=st.text())
+def test_custom_http_exception_detail(detail: str) -> None:
+    for result in CustomHTTPException(detail=detail), CustomHTTPException(detail):
+        assert result.detail == (detail or "Custom HTTP Exception")
+
+
 @given(status_code=st.integers(min_value=400, max_value=404), detail=st.text())
 @pytest.mark.parametrize("ex_type", [HTTPException, CustomHTTPException])
 def test_http_exception(ex_type: type[HTTPException], status_code: int, detail: str) -> None:


### PR DESCRIPTION
### Pull Request Checklist

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description

1. Set correctly the `detail` attribute on `LitestarException` and `HTTPException` regardless of whether it's passed positionally or by name.
    
    Main branch:
    ```py
    
    In [1]: from litestar.exceptions import LitestarException, HTTPException
    
    In [2]: LitestarException(detail="foo").detail
    Out[2]: 'foo'
    
    In [3]: LitestarException("foo").detail
    Out[3]: ''
    
    In [4]: HTTPException(detail="").detail
    Out[4]: 'Internal Server Error'
    
    In [5]: HTTPException("").detail
    Out[5]: ''
    ```
    
    This branch:
    ```py
    
    In [1]: from litestar.exceptions import LitestarException, HTTPException
    
    In [2]: LitestarException(detail="foo").detail
    Out[2]: 'foo'
    
    In [3]: LitestarException("foo").detail
    Out[3]: 'foo'
    
    In [4]: HTTPException(detail="").detail
    Out[4]: 'Internal Server Error'
    
    In [5]: HTTPException("").detail
    Out[5]: 'Internal Server Error'
    ```

2. Honor the `detail` class attribute for custom exception classes.

    Main branch:
    ```py
    
    In [1]: from litestar.exceptions import LitestarException, HTTPException
    
    In [2]: class CustomLitestarException(LitestarException):
       ...:     detail = "xxx"
       ...:
    
    In [3]: class CustomHTTPException(HTTPException):
       ...:     detail = "yyy"
       ...:
    
    In [4]: CustomLitestarException().detail
    Out[4]: ''
    
    In [5]: CustomHTTPException().detail
    Out[5]: 'Internal Server Error'
    ```

    This branch:
      ```py
      
      In [1]: from litestar.exceptions import LitestarException, HTTPException
      
      In [2]: class CustomLitestarException(LitestarException):
         ...:     detail = "xxx"
         ...:
      
      In [3]: class CustomHTTPException(HTTPException):
         ...:     detail = "yyy"
         ...:
      
      In [4]: CustomLitestarException().detail
      Out[4]: 'xxx'
      
      In [5]: CustomHTTPException().detail
      Out[5]: 'yyy'
      ```
