### PR TITLE
chore: remove poetry lock from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,6 @@ repos:
     rev: "1.6.1"
     hooks:
       - id: poetry-check
-      - id: poetry-lock
-        args: ["--no-update"]
   - repo: https://github.com/provinzkraut/unasyncd
     rev: "v0.6.0"
     hooks:


### PR DESCRIPTION
This isn't feasible as it requires everyone updating the `poetry.lock` to have the exact same version of poetry.