### PR TITLE
fix: set content length header by default

### DIFF
--- a/litestar/response/streaming.py
+++ b/litestar/response/streaming.py
@@ -30,6 +30,8 @@ class ASGIStreamingResponse(ASGIResponse):
 
     __slots__ = ("iterator",)
 
+    _should_set_content_length = False
+
     def __init__(self, *, iterator: StreamType, **kwargs: Any) -> None:
         """A low-level ASGI streaming response.
 

--- a/tests/unit/test_response/test_base_response.py
+++ b/tests/unit/test_response/test_base_response.py
@@ -105,10 +105,7 @@ def test_empty_response(media_type: MediaType, expected: bytes, should_have_cont
     with create_test_client(handler) as client:
         response = client.get("/")
         assert response.content == expected
-        if should_have_content_length:
-            assert "content-length" in response.headers
-        else:
-            assert "content-length" not in response.headers
+        assert response.headers["content-length"] == str(len(expected))
 
 
 @pytest.mark.parametrize("status_code", (HTTP_204_NO_CONTENT, HTTP_304_NOT_MODIFIED))

--- a/tests/unit/test_response/test_redirect_response.py
+++ b/tests/unit/test_response/test_redirect_response.py
@@ -57,7 +57,7 @@ def test_redirect_response_content_length_header() -> None:
     client: TestClient = TestClient(app)
     response = client.request("GET", "/redirect", follow_redirects=False)
     assert str(response.url) == "http://testserver.local/redirect"
-    assert "content-length" not in response.headers
+    assert "content-length" in response.headers
 
 
 def test_redirect_response_status_validation() -> None:


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

- This PR sets the `content-length` header by default even if the length of the body is 0.
