### PR TITLE
chore: Make Async Docs Note More Clear

### DIFF
--- a/docs/topics/sync-vs-async.rst
+++ b/docs/topics/sync-vs-async.rst
@@ -39,9 +39,9 @@ time*.
     Since "blocking" is about the flow of execution, one might think of ``await`` as
     blocking as well; the execution will not proceed past it until the awaitable has
     been resolved, which fits the definition of the term. However, since at the same
-    time *other parts of the program* (more precisely, other parts currently waiting at
-    an ``await``) are allowed to proceed, this is not considered blocking and usually
-    referred to as "waiting".
+    time *other parts of the program* (more precisely, other coroutines which had
+    given up control at an ``await`` that has since completed) are allowed to
+    proceed, this is not considered blocking and usually referred to as "waiting".
 
 
 I/O bound vs. CPU bound


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [x] New code has 100% test coverage
- [x] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [x] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

- Hopefully make the note more clear/accurate

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

- #2275
