### PR TITLE
fix: Ensure app-dir is appended to path during autodiscovery.

### DIFF
--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -91,7 +91,7 @@ class LitestarEnv:
     is_app_factory: bool = False
 
     @classmethod
-    def from_env(cls, app_path: str | None) -> LitestarEnv:
+    def from_env(cls, app_path: str | None, app_dir: Path | None = None) -> LitestarEnv:
         """Load environment variables.
 
         If ``python-dotenv`` is installed, use it to populate environment first
@@ -100,6 +100,9 @@ class LitestarEnv:
         cwd_str_path = str(cwd)
         if cwd_str_path not in sys.path:
             sys.path.append(cwd_str_path)
+
+        if app_dir is not None:
+            sys.path.append(str(app_dir))
 
         with contextlib.suppress(ImportError):
             import dotenv
@@ -212,7 +215,7 @@ class LitestarExtensionGroup(LitestarGroup):
             env: LitestarEnv | None = ctx.obj
         else:
             try:
-                env = ctx.obj = LitestarEnv.from_env(ctx.params.get("app_path"))
+                env = ctx.obj = LitestarEnv.from_env(ctx.params.get("app_path"), ctx.params.get("app_dir"))
             except LitestarCLIException:
                 env = None
 

--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -96,13 +96,10 @@ class LitestarEnv:
 
         If ``python-dotenv`` is installed, use it to populate environment first
         """
-        cwd = Path().cwd()
+        cwd = Path().cwd() if app_dir is None else app_dir
         cwd_str_path = str(cwd)
         if cwd_str_path not in sys.path:
             sys.path.append(cwd_str_path)
-
-        if app_dir is not None:
-            sys.path.append(str(app_dir))
 
         with contextlib.suppress(ImportError):
             import dotenv

--- a/litestar/cli/main.py
+++ b/litestar/cli/main.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -47,8 +46,6 @@ __all__ = ("litestar_group",)
 @pass_context
 def litestar_group(ctx: Context, app_path: str | None, app_dir: Path | None = None) -> None:
     """Litestar CLI."""
-    sys.path.append(str(app_dir))
-
     if ctx.obj is None:  # env has not been loaded yet, so we can lazy load it
         ctx.obj = lambda: LitestarEnv.from_env(app_path, app_dir=app_dir)
 

--- a/litestar/cli/main.py
+++ b/litestar/cli/main.py
@@ -50,7 +50,7 @@ def litestar_group(ctx: Context, app_path: str | None, app_dir: Path | None = No
     sys.path.append(str(app_dir))
 
     if ctx.obj is None:  # env has not been loaded yet, so we can lazy load it
-        ctx.obj = lambda: LitestarEnv.from_env(app_path)
+        ctx.obj = lambda: LitestarEnv.from_env(app_path, app_dir=app_dir)
 
 
 # add sub commands here

--- a/tests/unit/test_cli/test_cli.py
+++ b/tests/unit/test_cli/test_cli.py
@@ -3,6 +3,9 @@ import sys
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
+from tests.unit.test_cli import CREATE_APP_FILE_CONTENT
+from tests.unit.test_cli.conftest import CreateAppFileFixture
+
 try:
     from rich_click import group
 except ImportError:
@@ -33,6 +36,25 @@ def test_format_is_enabled() -> None:
 def test_info_command(mocker: "MockerFixture", runner: "CliRunner", app_file: "Path") -> None:
     mock = mocker.patch("litestar.cli.commands.core.show_app_info")
     result = runner.invoke(cli_command, ["info"])
+
+    assert result.exception is None
+    mock.assert_called_once()
+
+
+def test_info_command_with_app_dir(
+    mocker: "MockerFixture", runner: "CliRunner", create_app_file: CreateAppFileFixture
+) -> None:
+    app_file = "main.py"
+    app_file_without_extension = app_file.split(".")[0]
+    create_app_file(
+        file=app_file,
+        directory="src",
+        content=CREATE_APP_FILE_CONTENT,
+        subdir="info_with_app_dir",
+        init_content=f"from .{app_file_without_extension} import create_app",
+    )
+    mock = mocker.patch("litestar.cli.commands.core.show_app_info")
+    result = runner.invoke(cli_command, ["--app", "info_with_app_dir:create_app", "--app-dir", "src", "info"])
 
     assert result.exception is None
     mock.assert_called_once()

--- a/tests/unit/test_cli/test_core_commands.py
+++ b/tests/unit/test_cli/test_core_commands.py
@@ -127,7 +127,7 @@ def test_run_command(
         else:
             args.extend([f"--reload-dir={s}" for s in reload_dir])
 
-    path = create_app_file(custom_app_file or "app.py", subdir=app_dir)
+    path = create_app_file(custom_app_file or "app.py", directory=app_dir)
 
     result = runner.invoke(cli_command, args)
 

--- a/tests/unit/test_cli/test_env_resolution.py
+++ b/tests/unit/test_cli/test_env_resolution.py
@@ -114,3 +114,32 @@ def test_env_from_env_autodiscover_from_files_ignore_paths(
 
     with pytest.raises(ClickException):
         LitestarEnv.from_env(None)
+
+
+@pytest.mark.parametrize("use_file_in_app_path", [True, False])
+def test_env_usin_app_dir(
+    app_file_content: str, app_file_app_name: str, create_app_file: CreateAppFileFixture, use_file_in_app_path: bool
+) -> None:
+    app_file = "main.py"
+    app_file_without_extension = app_file.split(".")[0]
+    tmp_file_path = create_app_file(
+        file=app_file,
+        directory="src",
+        content=app_file_content,
+        subdir=f"litestar_test_{app_file_app_name}",
+        init_content=f"from .{app_file_without_extension} import {app_file_app_name}",
+    )
+    app_path_components = [f"litestar_test_{app_file_app_name}"]
+    if use_file_in_app_path:
+        app_path_components.append(app_file_without_extension)
+
+    app_path = f"{'.'.join(app_path_components)}:{app_file_app_name}"
+    env = LitestarEnv.from_env(app_path, app_dir=Path().cwd() / "src")
+
+    dotted_path = _path_to_dotted_path(tmp_file_path.relative_to(Path.cwd()))
+
+    assert isinstance(env.app, Litestar)
+    dotted_path = dotted_path.replace("src.", "")
+    if not use_file_in_app_path:
+        dotted_path = dotted_path.replace(".main", "")
+    assert env.app_path == f"{dotted_path}:{app_file_app_name}"

--- a/tests/unit/test_cli/test_env_resolution.py
+++ b/tests/unit/test_cli/test_env_resolution.py
@@ -117,7 +117,7 @@ def test_env_from_env_autodiscover_from_files_ignore_paths(
 
 
 @pytest.mark.parametrize("use_file_in_app_path", [True, False])
-def test_env_usin_app_dir(
+def test_env_using_app_dir(
     app_file_content: str, app_file_app_name: str, create_app_file: CreateAppFileFixture, use_file_in_app_path: bool
 ) -> None:
     app_file = "main.py"


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

- This PR fixes a bug which caused the `--app-dir` option to the `litestar` CLI to not be propagated during autodiscovery.

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

- Fixes #2266 

### Notes

I am unclear what kind of tests should be written for this, since the existing test should capture it, yet I'm not sure why it doesn't.