### PR TITLE
fix: #2196 - incorrect handling of mutable headers in ASGIResponse

### DIFF
--- a/litestar/handlers/http_handlers/_utils.py
+++ b/litestar/handlers/http_handlers/_utils.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Sequence, cast
 from litestar.enums import HttpMethod
 from litestar.exceptions import ValidationException
 from litestar.status_codes import HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT
-from litestar.utils import encode_headers
 
 if TYPE_CHECKING:
     from litestar.app import Litestar
@@ -60,7 +59,6 @@ def create_data_handler(
         A handler function.
 
     """
-    raw_headers = encode_headers(normalize_headers(headers).items(), cookies, [])
 
     async def handler(
         data: Any,
@@ -82,7 +80,7 @@ def create_data_handler(
         if after_request:
             response = await after_request(response)  # type: ignore[arg-type,misc]
 
-        return response.to_asgi_response(app=None, request=request, encoded_headers=raw_headers)
+        return response.to_asgi_response(app=None, request=request, headers=normalize_headers(headers), cookies=cookies)
 
     return handler
 

--- a/litestar/response/base.py
+++ b/litestar/response/base.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, Literal, Mapping, TypeVar, overload
+import itertools
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Iterable, Literal, Mapping, TypeVar, overload
 
 from litestar.datastructures.cookie import Cookie
-from litestar.datastructures.headers import ETag
+from litestar.datastructures.headers import ETag, MutableScopeHeaders
 from litestar.enums import MediaType, OpenAPIMediaType
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.serialization import default_serializer, encode_json, encode_msgpack, get_serializer
 from litestar.status_codes import HTTP_200_OK, HTTP_204_NO_CONTENT, HTTP_304_NOT_MODIFIED
-from litestar.utils.deprecation import warn_deprecation
-from litestar.utils.helpers import encode_headers, filter_cookies, get_enum_string_value
+from litestar.utils.deprecation import deprecated, warn_deprecation
+from litestar.utils.helpers import get_enum_string_value
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -41,10 +42,11 @@ class ASGIResponse:
         "background",
         "body",
         "content_length",
-        "encoded_headers",
         "encoding",
         "is_head_response",
         "status_code",
+        "_encoded_cookies",
+        "headers",
     )
 
     _should_set_content_length: ClassVar[bool] = True
@@ -56,10 +58,10 @@ class ASGIResponse:
         background: BackgroundTask | BackgroundTasks | None = None,
         body: bytes | str = b"",
         content_length: int | None = None,
-        cookies: list[Cookie] | None = None,
-        encoded_headers: list[tuple[bytes, bytes]] | None = None,
+        cookies: Iterable[Cookie] | None = None,
+        encoded_headers: Iterable[tuple[bytes, bytes]] | None = None,
         encoding: str = "utf-8",
-        headers: dict[str, Any] | None = None,
+        headers: dict[str, Any] | Iterable[tuple[str, str]] | None = None,
         is_head_response: bool = False,
         media_type: MediaType | str | None = None,
         status_code: int | None = None,
@@ -80,8 +82,17 @@ class ASGIResponse:
         """
         body = body.encode() if isinstance(body, str) else body
         status_code = status_code or HTTP_200_OK
-        encoded_headers = encoded_headers or []
-        headers = headers or {}
+        self.headers = MutableScopeHeaders()
+
+        if encoded_headers is not None:
+            warn_deprecation("3.0", kind="parameter", deprecated_name="encoded_headers", alternative="headers")
+            for header_name, header_value in encoded_headers:
+                self.headers.add(header_name.decode("latin-1"), header_value.decode("latin-1"))
+
+        if headers is not None:
+            for k, v in headers.items() if isinstance(headers, dict) else headers:
+                self.headers.add(k, v)  # pyright: ignore
+
         media_type = get_enum_string_value(media_type or MediaType.JSON)
 
         status_allows_body = (
@@ -99,26 +110,30 @@ class ASGIResponse:
                 )
             body = b""
         else:
-            encoded_headers.append(
-                (
-                    b"content-type",
-                    (f"{media_type}; charset={encoding}" if media_type.startswith("text/") else media_type).encode(
-                        "latin-1"
-                    ),
-                ),
+            self.headers.setdefault(
+                "content-type", (f"{media_type}; charset={encoding}" if media_type.startswith("text/") else media_type)
             )
 
-            if self._should_set_content_length and "content-length" not in headers:
-                encoded_headers.append((b"content-length", str(content_length).encode("latin-1")))
+            if self._should_set_content_length:
+                self.headers.setdefault("content-length", str(content_length))
 
         self.background = background
         self.body = body
         self.content_length = content_length
-        cookies = cookies or []
-        self.encoded_headers = encode_headers(headers.items(), cookies, encoded_headers)
+        self._encoded_cookies = tuple(
+            cookie.to_encoded_header() for cookie in (cookies or ()) if not cookie.documentation_only
+        )
         self.encoding = encoding
         self.is_head_response = is_head_response
         self.status_code = status_code
+
+    @property
+    @deprecated("3.0", kind="property", alternative="encode_headers()")
+    def encoded_headers(self) -> tuple[tuple[bytes, bytes], ...]:
+        return self.encode_headers()
+
+    def encode_headers(self) -> tuple[tuple[bytes, bytes], ...]:
+        return *self.headers.headers, *self._encoded_cookies
 
     async def after_response(self) -> None:
         """Execute after the response is sent.
@@ -141,7 +156,7 @@ class ASGIResponse:
         event: HTTPResponseStartEvent = {
             "type": "http.response.start",
             "status": self.status_code,
-            "headers": self.encoded_headers,
+            "headers": self.encode_headers(),
         }
         await send(event)
 
@@ -379,8 +394,8 @@ class Response(Generic[T]):
         request: Request,
         *,
         background: BackgroundTask | BackgroundTasks | None = None,
-        cookies: list[Cookie] | None = None,
-        encoded_headers: list[tuple[bytes, bytes]] | None = None,
+        cookies: Iterable[Cookie] | None = None,
+        encoded_headers: Iterable[tuple[bytes, bytes]] | None = None,
         headers: dict[str, str] | None = None,
         is_head_response: bool = False,
         media_type: MediaType | str | None = None,
@@ -415,7 +430,7 @@ class Response(Generic[T]):
             )
 
         headers = {**headers, **self.headers} if headers is not None else self.headers
-        cookies = self.cookies if cookies is None else filter_cookies(self.cookies, cookies)
+        cookies = self.cookies if cookies is None else itertools.chain(self.cookies, cookies)
 
         if type_encoders:
             type_encoders = {**type_encoders, **(self.response_type_encoders or {})}

--- a/litestar/response/base.py
+++ b/litestar/response/base.py
@@ -129,11 +129,11 @@ class ASGIResponse:
 
     @property
     @deprecated("3.0", kind="property", alternative="encode_headers()")
-    def encoded_headers(self) -> tuple[tuple[bytes, bytes], ...]:
+    def encoded_headers(self) -> list[tuple[bytes, bytes]]:
         return self.encode_headers()
 
-    def encode_headers(self) -> tuple[tuple[bytes, bytes], ...]:
-        return *self.headers.headers, *self._encoded_cookies
+    def encode_headers(self) -> list[tuple[bytes, bytes]]:
+        return [*self.headers.headers, *self._encoded_cookies]
 
     async def after_response(self) -> None:
         """Execute after the response is sent.

--- a/litestar/response/template.py
+++ b/litestar/response/template.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
+import itertools
 from mimetypes import guess_type
 from pathlib import PurePath
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Iterable
 
 from litestar.enums import MediaType
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.response.base import ASGIResponse, Response
 from litestar.status_codes import HTTP_200_OK
 from litestar.utils.deprecation import warn_deprecation
-from litestar.utils.helpers import filter_cookies
 
 if TYPE_CHECKING:
     from litestar.app import Litestar
@@ -92,8 +92,8 @@ class Template(Response[bytes]):
         request: Request,
         *,
         background: BackgroundTask | BackgroundTasks | None = None,
-        cookies: list[Cookie] | None = None,
-        encoded_headers: list[tuple[bytes, bytes]] | None = None,
+        cookies: Iterable[Cookie] | None = None,
+        encoded_headers: Iterable[tuple[bytes, bytes]] | None = None,
         headers: dict[str, str] | None = None,
         is_head_response: bool = False,
         media_type: MediaType | str | None = None,
@@ -113,7 +113,7 @@ class Template(Response[bytes]):
             raise ImproperlyConfiguredException("Template engine is not configured")
 
         headers = {**headers, **self.headers} if headers is not None else self.headers
-        cookies = self.cookies if cookies is None else filter_cookies(self.cookies, cookies)
+        cookies = self.cookies if cookies is None else itertools.chain(self.cookies, cookies)
 
         media_type = self.media_type or media_type
         if not media_type:
@@ -134,7 +134,7 @@ class Template(Response[bytes]):
             body=body,
             content_length=None,
             cookies=cookies,
-            encoded_headers=encoded_headers or [],
+            encoded_headers=encoded_headers,
             encoding=self.encoding,
             headers=headers,
             is_head_response=is_head_response,

--- a/litestar/utils/__init__.py
+++ b/litestar/utils/__init__.py
@@ -1,6 +1,6 @@
 from litestar.utils.deprecation import deprecated, warn_deprecation
 
-from .helpers import Ref, encode_headers, get_enum_string_value, get_name, url_quote
+from .helpers import Ref, get_enum_string_value, get_name, url_quote
 from .path import join_paths, normalize_path
 from .predicates import (
     is_annotated_type,
@@ -43,7 +43,6 @@ __all__ = (
     "async_partial",
     "delete_litestar_scope_state",
     "deprecated",
-    "encode_headers",
     "find_index",
     "get_enum_string_value",
     "get_litestar_scope_state",

--- a/litestar/utils/deprecation.py
+++ b/litestar/utils/deprecation.py
@@ -65,7 +65,7 @@ def warn_deprecation(
     text = ". ".join(parts)
     warning_class = PendingDeprecationWarning if pending else DeprecationWarning
 
-    warn(text, warning_class, stacklevel=1)
+    warn(text, warning_class, stacklevel=2)
 
 
 def deprecated(

--- a/litestar/utils/helpers.py
+++ b/litestar/utils/helpers.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from itertools import chain
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 from urllib.parse import quote
 
@@ -14,7 +13,6 @@ if TYPE_CHECKING:
 
 __all__ = (
     "Ref",
-    "encode_headers",
     "filter_cookies",
     "get_enum_string_value",
     "get_name",
@@ -76,28 +74,6 @@ def unwrap_partial(value: MaybePartial[T]) -> T:
     while hasattr(output, "func"):
         output = output.func
     return cast("T", output)
-
-
-def encode_headers(
-    headers: Iterable[tuple[str, Any]], cookies: Iterable[Cookie], raw_headers: list[tuple[bytes, bytes]]
-) -> list[tuple[bytes, bytes]]:
-    """Encode the response headers as a list of byte tuples.
-
-    Args:
-        headers: Iterable of header name/value pairs.
-        cookies: A list of cookies.
-        raw_headers: A list of raw headers.
-
-    Returns:
-        A list of byte tuples.
-    """
-    return list(
-        chain(
-            ((k.lower().encode("latin-1"), str(v).encode("latin-1")) for k, v in headers),
-            (cookie.to_encoded_header() for cookie in cookies if not cookie.documentation_only),
-            raw_headers,
-        )
-    )
 
 
 def filter_cookies(local_cookies: Iterable[Cookie], layered_cookies: Iterable[Cookie]) -> list[Cookie]:

--- a/tests/unit/test_datastructures/test_headers.py
+++ b/tests/unit/test_datastructures/test_headers.py
@@ -224,6 +224,14 @@ def test_mutable_scope_headers_setitem_delitem(
     assert raw_headers == [(b"bar", b"baz")]
 
 
+def test_mutable_scope_headers_setdefault() -> None:
+    headers = MutableScopeHeaders()
+
+    assert headers.setdefault("foo", "bar") == "bar"
+    assert headers.setdefault("foo", "baz") == "bar"
+    assert headers.getall("foo") == ["bar"]
+
+
 def test_mutable_scope_header_len(mutable_headers: MutableScopeHeaders) -> None:
     assert len(mutable_headers) == 1
     mutable_headers.add("foo", "bar")

--- a/tests/unit/test_response/test_base_response.py
+++ b/tests/unit/test_response/test_base_response.py
@@ -206,3 +206,8 @@ def test_get_serializer() -> None:
 def test_head_response_doesnt_support_content() -> None:
     with pytest.raises(ImproperlyConfiguredException):
         ASGIResponse(body=b"hello world", media_type=MediaType.TEXT, is_head_response=True)
+
+
+def test_asgi_response_encoded_headers() -> None:
+    response = ASGIResponse(encoded_headers=[(b"foo", b"bar")])
+    assert response.encode_headers() == [(b"foo", b"bar")]

--- a/tests/unit/test_response/test_base_response.py
+++ b/tests/unit/test_response/test_base_response.py
@@ -210,4 +210,8 @@ def test_head_response_doesnt_support_content() -> None:
 
 def test_asgi_response_encoded_headers() -> None:
     response = ASGIResponse(encoded_headers=[(b"foo", b"bar")])
-    assert response.encode_headers() == [(b"foo", b"bar")]
+    assert response.encode_headers() == [
+        (b"foo", b"bar"),
+        (b"content-type", b"application/json"),
+        (b"content-length", b"0"),
+    ]

--- a/tests/unit/test_response/test_file_response.py
+++ b/tests/unit/test_response/test_file_response.py
@@ -311,3 +311,12 @@ def test_does_not_override_existing_last_modified_header(header_name: str, tmpdi
         response = client.get("/")
         assert response.status_code == HTTP_200_OK
         assert [h.lower() for h in response.headers.get_list("last-modified")] == ["foo"]
+
+
+def test_asgi_response_encoded_headers(file: Path) -> None:
+    response = ASGIFileResponse(encoded_headers=[(b"foo", b"bar")], file_path=file)
+    assert response.encode_headers() == [
+        (b"foo", b"bar"),
+        (b"content-type", b"application/octet-stream"),
+        (b"content-disposition", b'attachment; filename=""'),
+    ]

--- a/tests/unit/test_response/test_file_response.py
+++ b/tests/unit/test_response/test_file_response.py
@@ -310,7 +310,7 @@ def test_does_not_override_existing_last_modified_header(header_name: str, tmpdi
     with create_test_client(handler) as client:
         response = client.get("/")
         assert response.status_code == HTTP_200_OK
-        assert [h.lower() for h in response.headers.get_list("last-modified")] == ["foo"]
+        assert response.headers.get_list("last-modified") == ["foo"]
 
 
 def test_asgi_response_encoded_headers(file: Path) -> None:

--- a/tests/unit/test_response/test_response_to_asgi_response.py
+++ b/tests/unit/test_response/test_response_to_asgi_response.py
@@ -158,12 +158,14 @@ async def test_to_response_returning_redirect_response(anyio_backend: str) -> No
         response = await route_handler.to_response(
             data=route_handler.fn.value(), app=client.app, request=RequestFactory().get()
         )
+        encoded_headers = response.encode_headers()  # type: ignore[attr-defined]
+
         assert isinstance(response, ASGIResponse)
-        assert (b"location", b"/somewhere-else") in response.encoded_headers
-        assert (b"local-header", b"123") in response.encoded_headers
-        assert (b"response-header", b"abc") in response.encoded_headers
-        assert (b"set-cookie", b"general-cookie=xxx; Path=/; SameSite=lax") in response.encoded_headers
-        assert (b"set-cookie", b"redirect-cookie=xyz; Path=/; SameSite=lax") in response.encoded_headers
+        assert (b"location", b"/somewhere-else") in encoded_headers
+        assert (b"local-header", b"123") in encoded_headers
+        assert (b"response-header", b"abc") in encoded_headers
+        assert (b"set-cookie", b"general-cookie=xxx; Path=/; SameSite=lax") in encoded_headers
+        assert (b"set-cookie", b"redirect-cookie=xyz; Path=/; SameSite=lax") in encoded_headers
         assert response.background == background_task
 
 
@@ -214,11 +216,13 @@ async def test_to_response_returning_file_response(anyio_backend: str) -> None:
         assert response.file_info
         if iscoroutine(response.file_info):
             await response.file_info
-        assert (b"local-header", b"123") in response.encoded_headers
-        assert (b"response-header", b"abc") in response.encoded_headers
-        assert (b"set-cookie", b"file-cookie=xyz; Path=/; SameSite=lax") in response.encoded_headers
-        assert (b"set-cookie", b"general-cookie=xxx; Path=/; SameSite=lax") in response.encoded_headers
-        assert (b"set-cookie", b"redirect-cookie=aaa; Path=/; SameSite=lax") in response.encoded_headers
+
+        encoded_headers = response.encode_headers()
+        assert (b"local-header", b"123") in encoded_headers
+        assert (b"response-header", b"abc") in encoded_headers
+        assert (b"set-cookie", b"file-cookie=xyz; Path=/; SameSite=lax") in encoded_headers
+        assert (b"set-cookie", b"general-cookie=xxx; Path=/; SameSite=lax") in encoded_headers
+        assert (b"set-cookie", b"redirect-cookie=aaa; Path=/; SameSite=lax") in encoded_headers
         assert response.background == background_task
 
 
@@ -271,11 +275,12 @@ async def test_to_response_streaming_response(iterator: Any, should_raise: bool,
                 data=route_handler.fn.value(), app=client.app, request=RequestFactory().get()
             )
             assert isinstance(response, ASGIStreamingResponse)
-            assert (b"local-header", b"123") in response.encoded_headers
-            assert (b"response-header", b"abc") in response.encoded_headers
-            assert (b"set-cookie", b"general-cookie=xxx; Path=/; SameSite=lax") in response.encoded_headers
-            assert (b"set-cookie", b"redirect-cookie=aaa; Path=/; SameSite=lax") in response.encoded_headers
-            assert (b"set-cookie", b"streaming-cookie=xyz; Path=/; SameSite=lax") in response.encoded_headers
+            encoded_headers = response.encode_headers()
+            assert (b"local-header", b"123") in encoded_headers
+            assert (b"response-header", b"abc") in encoded_headers
+            assert (b"set-cookie", b"general-cookie=xxx; Path=/; SameSite=lax") in encoded_headers
+            assert (b"set-cookie", b"redirect-cookie=aaa; Path=/; SameSite=lax") in encoded_headers
+            assert (b"set-cookie", b"streaming-cookie=xyz; Path=/; SameSite=lax") in encoded_headers
             assert response.background == background_task
 
 
@@ -316,10 +321,12 @@ async def test_to_response_template_response(anyio_backend: str, tmp_path: Path)
             data=route_handler.fn.value(), app=client.app, request=RequestFactory(app=app).get()
         )
         assert isinstance(response, ASGIResponse)
-        assert (b"local-header", b"123") in response.encoded_headers
-        assert (b"response-header", b"abc") in response.encoded_headers
-        assert (b"set-cookie", b"general-cookie=xxx; Path=/; SameSite=lax") in response.encoded_headers
-        assert (b"set-cookie", b"template-cookie=xyz; Path=/; SameSite=lax") in response.encoded_headers
+        encoded_headers = response.encode_headers()
+
+        assert (b"local-header", b"123") in encoded_headers
+        assert (b"response-header", b"abc") in encoded_headers
+        assert (b"set-cookie", b"general-cookie=xxx; Path=/; SameSite=lax") in encoded_headers
+        assert (b"set-cookie", b"template-cookie=xyz; Path=/; SameSite=lax") in encoded_headers
         assert response.background == background_task
 
 
@@ -364,13 +371,15 @@ async def test_to_response_sse_events(content: str | bytes | StreamType[str | by
         response = await route_handler.to_response(
             data=route_handler.fn.value(), app=client.app, request=RequestFactory().get()
         )
+        encoded_headers = response.encode_headers()  # type: ignore[attr-defined]
+
         assert isinstance(response, ASGIStreamingResponse)
-        assert ((b"cache-control", b"no-cache")) in response.encoded_headers
-        assert (b"x-accel-buffering", b"no") in response.encoded_headers
-        assert (b"connection", b"keep-alive") in response.encoded_headers
-        assert (b"content-type", b"text/event-stream; charset=utf-8") in response.encoded_headers
-        assert (b"response-header", b"abc") in response.encoded_headers
-        assert (b"set-cookie", b"streaming-cookie=xyz; Path=/; SameSite=lax") in response.encoded_headers
+        assert ((b"cache-control", b"no-cache")) in encoded_headers
+        assert (b"x-accel-buffering", b"no") in encoded_headers
+        assert (b"connection", b"keep-alive") in encoded_headers
+        assert (b"content-type", b"text/event-stream; charset=utf-8") in encoded_headers
+        assert (b"response-header", b"abc") in encoded_headers
+        assert (b"set-cookie", b"streaming-cookie=xyz; Path=/; SameSite=lax") in encoded_headers
         assert response.background == background_task
 
 

--- a/tests/unit/test_response/test_streaming_response.py
+++ b/tests/unit/test_response/test_streaming_response.py
@@ -194,3 +194,8 @@ async def test_sse_steaming_response() -> None:
             assert sse.data == "1\n, \n2\n, \n3\n, \n4\n, \n5"
             assert sse.id == "123"
             assert sse.retry == 1000
+
+
+def test_asgi_response_encoded_headers() -> None:
+    response = ASGIStreamingResponse(encoded_headers=[(b"foo", b"bar")], iterator="")
+    assert response.encode_headers() == [(b"foo", b"bar"), (b"content-type", b"application/json")]


### PR DESCRIPTION
Update `ASGIResponse`, `Response` and friends to address a few issues related to headers:

- If `encoded_headers` were passed in at any point, they were mutated within responses, leading to a growing list of headers with every response
- While mutating `encoded_headers`, the checks performed to assert a value was (not) already present, headers were not treated case-insensitive
- Unnecessary work was performed while converting cookies / headers into an encoded headers list

This was fixed by:

- Removing the use of and deprecate `encoded_headers`
- Handling headers on `ASGIResponse` with `MutableScopeHeaders`, which allows for case-insensitive membership tests, `.setdefault` operations etc

Closes #2196.

<hr>

Please review this one thoroughly as it changes some low level stuff that we don't want to break (=

