### PR TITLE
docs(templates): Add missing sync_to_thread for examples

### DIFF
--- a/docs/examples/templating/returning_templates_jinja.py
+++ b/docs/examples/templating/returning_templates_jinja.py
@@ -6,7 +6,7 @@ from litestar.response import Template
 from litestar.template.config import TemplateConfig
 
 
-@get(path="/")
+@get(path="/", sync_to_thread=False)
 def index(name: str) -> Template:
     return Template(template_name="hello.html.jinja2", context={"name": name})
 

--- a/docs/examples/templating/returning_templates_mako.py
+++ b/docs/examples/templating/returning_templates_mako.py
@@ -6,7 +6,7 @@ from litestar.response import Template
 from litestar.template.config import TemplateConfig
 
 
-@get(path="/")
+@get(path="/", sync_to_thread=False)
 def index(name: str) -> Template:
     return Template(template_name="hello.html.mako", context={"name": name})
 

--- a/docs/examples/templating/template_functions_jinja.py
+++ b/docs/examples/templating/template_functions_jinja.py
@@ -25,7 +25,7 @@ template_config = TemplateConfig(
 )
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def index() -> Template:
     return Template(template_name="index.html.jinja2")
 

--- a/docs/examples/templating/template_functions_mako.py
+++ b/docs/examples/templating/template_functions_mako.py
@@ -25,7 +25,7 @@ template_config = TemplateConfig(
 )
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def index() -> Template:
     return Template(template_name="index.html.mako")
 

--- a/docs/examples/templating/template_functions_minijinja.py
+++ b/docs/examples/templating/template_functions_minijinja.py
@@ -26,7 +26,7 @@ template_config = TemplateConfig(
 )
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def index() -> Template:
     return Template(template_name="index.html.minijinja")
 


### PR DESCRIPTION
Adds a missing `sync_to_thread=False` for the template docs examples