### PR TITLE
fix: set proper default for `exclude_http_methods` in auth middleware

### DIFF
--- a/litestar/middleware/authentication.py
+++ b/litestar/middleware/authentication.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Sequence
 
 from litestar.connection import ASGIConnection
-from litestar.enums import ScopeType
+from litestar.enums import HttpMethod, ScopeType
 from litestar.middleware._utils import (
     build_exclude_path_pattern,
     should_bypass_middleware,
@@ -62,7 +62,7 @@ class AbstractAuthenticationMiddleware(ABC):
         """
         self.app = app
         self.exclude = build_exclude_path_pattern(exclude=exclude)
-        self.exclude_http_methods = exclude_http_methods
+        self.exclude_http_methods = (HttpMethod.OPTIONS,) if exclude_http_methods is None else exclude_http_methods
         self.exclude_opt_key = exclude_from_auth_key
         self.scopes = scopes or {ScopeType.HTTP, ScopeType.WEBSOCKET}
 

--- a/litestar/types/asgi_types.py
+++ b/litestar/types/asgi_types.py
@@ -44,6 +44,8 @@ from typing import (
     Union,
 )
 
+from litestar.enums import HttpMethod
+
 __all__ = (
     "ASGIApp",
     "ASGIVersion",
@@ -101,7 +103,7 @@ if TYPE_CHECKING:
     from .internal_types import LitestarType, RouteHandlerType
     from .serialization import DataContainerType
 
-Method: TypeAlias = Literal["GET", "POST", "DELETE", "PATCH", "PUT", "HEAD", "TRACE", "OPTIONS"]
+Method: TypeAlias = Literal["GET", "POST", "DELETE", "PATCH", "PUT", "HEAD", "TRACE", "OPTIONS"] | HttpMethod
 ScopeSession: TypeAlias = "EmptyType | Dict[str, Any] | DataContainerType | None"
 
 

--- a/litestar/types/asgi_types.py
+++ b/litestar/types/asgi_types.py
@@ -103,7 +103,7 @@ if TYPE_CHECKING:
     from .internal_types import LitestarType, RouteHandlerType
     from .serialization import DataContainerType
 
-Method: TypeAlias = Literal["GET", "POST", "DELETE", "PATCH", "PUT", "HEAD", "TRACE", "OPTIONS"] | HttpMethod
+Method: TypeAlias = Union[Literal["GET", "POST", "DELETE", "PATCH", "PUT", "HEAD", "TRACE", "OPTIONS"], HttpMethod]
 ScopeSession: TypeAlias = "EmptyType | Dict[str, Any] | DataContainerType | None"
 
 

--- a/tests/unit/test_middleware/test_base_authentication_middleware.py
+++ b/tests/unit/test_middleware/test_base_authentication_middleware.py
@@ -228,7 +228,6 @@ def test_authentication_middleware_exclude_from_auth_custom_key() -> None:
         assert response.status_code == HTTP_403_FORBIDDEN
 
 
-@pytest.mark.noww
 def test_authentication_exclude_http_methods() -> None:
     auth_mw = DefineMiddleware(AuthMiddleware, exclude_http_methods=[HttpMethod.GET])
 
@@ -244,7 +243,6 @@ def test_authentication_exclude_http_methods() -> None:
         assert response.status_code == HTTP_403_FORBIDDEN
 
 
-@pytest.mark.noww
 def test_authentication_exclude_http_methods_default() -> None:
     auth_mw = DefineMiddleware(AuthMiddleware)
 

--- a/tests/unit/test_middleware/test_base_authentication_middleware.py
+++ b/tests/unit/test_middleware/test_base_authentication_middleware.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from litestar import Litestar, get, websocket
 from litestar.connection import Request, WebSocket
+from litestar.enums import HttpMethod
 from litestar.exceptions import PermissionDeniedException, WebSocketDisconnect
 from litestar.middleware.authentication import (
     AbstractAuthenticationMiddleware,
@@ -225,3 +226,36 @@ def test_authentication_middleware_exclude_from_auth_custom_key() -> None:
 
         response = client.get("/west")
         assert response.status_code == HTTP_403_FORBIDDEN
+
+
+@pytest.mark.noww
+def test_authentication_exclude_http_methods() -> None:
+    auth_mw = DefineMiddleware(AuthMiddleware, exclude_http_methods=[HttpMethod.GET])
+
+    @get("/")
+    def exclude_get_handler() -> None:
+        return None
+
+    with create_test_client(route_handlers=[exclude_get_handler], middleware=[auth_mw]) as client:
+        response = client.get("/")
+        assert response.status_code == HTTP_200_OK
+
+        response = client.options("/")
+        assert response.status_code == HTTP_403_FORBIDDEN
+
+
+@pytest.mark.noww
+def test_authentication_exclude_http_methods_default() -> None:
+    auth_mw = DefineMiddleware(AuthMiddleware)
+
+    @get("/")
+    def exclude_get_handler() -> None:
+        return None
+
+    with create_test_client(route_handlers=[exclude_get_handler], middleware=[auth_mw]) as client:
+        response = client.get("/")
+        assert response.status_code == HTTP_403_FORBIDDEN
+
+        # OPTIONS should be excluded by default
+        response = client.options("/")
+        assert response.is_success


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

- This PR sets `OPTIONS` as the default value for `exclude_http_methods` in the base authentication middleware class.

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

- Fixes #2205 