### PR TITLE
docs(signature-namespace): Fix code block to render without removing the imports

### DIFF
--- a/docs/usage/routing/handlers.rst
+++ b/docs/usage/routing/handlers.rst
@@ -560,6 +560,7 @@ In this example, Litestar will be unable to generate the signature model because
 the module scope at runtime. We can address this on a case-by-case basis by silencing our linters, for example:
 
 .. code-block:: python
+    :no-upgrade:
 
     from __future__ import annotations
 
@@ -567,7 +568,8 @@ the module scope at runtime. We can address this on a case-by-case basis by sile
 
     from litestar import Controller, post
 
-    from domain import Model  # noqa: TC002
+    # Choose the appropriate noqa directive according to your linter
+    from domain import Model  # noqa: TCH002
 
 However, this approach can get tedious, so as an alternative, Litestar accepts a ``signature_namespace`` mapping at
 every :ref:`layer <layered-architecture>` of the application. The following is a demonstration of how to use this


### PR DESCRIPTION

### Pull Request Checklist

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

- Renders the code block without removing the imports so that the necessity of the feature is better conveyed.

Before 
<img width="393" alt="image" src="https://github.com/litestar-org/litestar/assets/45509143/977e4ce3-ecae-4743-b82c-958e925d64f5">

After
<img width="608" alt="image" src="https://github.com/litestar-org/litestar/assets/45509143/43e292e0-06a4-4ec9-8b17-77cc9626aefc">



### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

- Closes #2320 
