### PR TITLE
test: use stricter pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,7 +240,7 @@ exclude_lines = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--dist=loadgroup"
+addopts = "--strict-markers --strict-config --dist=loadgroup"
 asyncio_mode = "auto"
 filterwarnings = [
     "ignore::trio.TrioDeprecationWarning:anyio._backends._trio*:",


### PR DESCRIPTION
Looking at https://github.com/litestar-org/litestar/pull/2325 I've noticed that `noww` is not a registered marker. Later, I've noticed that `pytest` does not check any existing markers or any existing configuration options. I propose to fix that.

See:

```
Unregistered marks applied with the @pytest.mark.name_of_the_mark decorator will always emit a warning in order to avoid silently doing something surprising due to mistyped names. As described in the previous section, you can disable the warning for custom marks by registering them in your pytest.ini file or using a custom pytest_configure hook.

When the --strict-markers command-line flag is passed, any unknown marks applied with the @pytest.mark.name_of_the_mark decorator will trigger an error. You can enforce this validation in your project by adding --strict-markers to addopts:
```

Here: https://docs.pytest.org/en/latest/how-to/mark.html#raising-errors-on-unknown-marks

```
--strict-config       any warnings encountered while parsing the `pytest`
                        section of the configuration file raise errors.
```

Here: https://docs.pytest.org/en/7.1.x/reference/reference.html