### PR TITLE
test: use `xfail_strict` for pytest config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,6 @@ jobs:
       python-version: ${{ matrix.python-version }}
 
   test-platform-compat:
-    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,7 @@ jobs:
       python-version: ${{ matrix.python-version }}
 
   test-platform-compat:
+    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,6 +242,7 @@ exclude_lines = [
 [tool.pytest.ini_options]
 addopts = "--strict-markers --strict-config --dist=loadgroup"
 asyncio_mode = "auto"
+xfail_strict = true
 filterwarnings = [
     "ignore::trio.TrioDeprecationWarning:anyio._backends._trio*:",
     "ignore::DeprecationWarning:pkg_resources.*",

--- a/tests/unit/test_file_system.py
+++ b/tests/unit/test_file_system.py
@@ -50,7 +50,7 @@ async def test_file_adapter_open_handles_file_not_found_exception(file_system: "
 
 
 @pytest.mark.parametrize("file_system", (BaseLocalFileSystem(), LocalFileSystem()))
-@pytest.mark.xfail(sys.platform == "win32", reason="Suspected fsspec issue")
+@pytest.mark.xfail(sys.platform == "win32", reason="Suspected fsspec issue", strict=False)
 async def test_file_adapter_info(tmpdir: Path, file_system: "FileSystemProtocol") -> None:
     file = Path(tmpdir / "test.txt")
     file.write_bytes(b"test")

--- a/tests/unit/test_template/test_builtin_functions.py
+++ b/tests/unit/test_template/test_builtin_functions.py
@@ -15,7 +15,7 @@ from litestar.template.config import TemplateConfig
 from litestar.testing import create_test_client
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="For some reason this is flaky on windows")
+@pytest.mark.xfail(sys.platform == "win32", reason="For some reason this is flaky on windows", strict=False)
 def test_jinja_url_for(tmp_path: Path) -> None:
     template_config = TemplateConfig(engine=JinjaTemplateEngine, directory=tmp_path)
 
@@ -75,7 +75,8 @@ def test_jinja_url_for(tmp_path: Path) -> None:
         assert response.status_code == 500
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="For some reason this is flaky on windows")
+# TODO: use some other flaky test technique, probably re-running flaky tests?
+@pytest.mark.xfail(sys.platform == "win32", reason="For some reason this is flaky on windows", strict=False)
 def test_jinja_url_for_static_asset(tmp_path: Path) -> None:
     template_config = TemplateConfig(engine=JinjaTemplateEngine, directory=tmp_path)
 
@@ -180,7 +181,7 @@ def test_mako_url_for(tmp_path: Path, builtin: str, expected_status: int, expect
             assert response.text == expected_text
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="For some reason this is flaky on windows")
+@pytest.mark.xfail(sys.platform == "win32", reason="For some reason this is flaky on windows", strict=False)
 def test_minijinja_url_for(tmp_path: Path) -> None:
     template_config = TemplateConfig(engine=MiniJinjaTemplateEngine, directory=tmp_path)
 
@@ -244,7 +245,7 @@ def test_minijinja_url_for(tmp_path: Path) -> None:
         assert response.status_code == 500
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="For some reason this is flaky on windows")
+@pytest.mark.xfail(sys.platform == "win32", reason="For some reason this is flaky on windows", strict=False)
 def test_minijinja_url_for_static_asset(tmp_path: Path) -> None:
     template_config = TemplateConfig(engine=MiniJinjaTemplateEngine, directory=tmp_path)
 


### PR DESCRIPTION
One more check that I forgot in https://github.com/litestar-org/litestar/pull/2327

Looks like we have several `xfail` tests: 

```
» ag xfail
tests/unit/test_file_system.py
27:@pytest.mark.xfail(sys.platform == "win32", reason="permissions equivalent missing on windows")
53:@pytest.mark.xfail(sys.platform == "win32", reason="Suspected fsspec issue")
85:@pytest.mark.xfail(sys.platform == "win32", reason="permissions equivalent missing on windows")

tests/unit/test_template/test_builtin_functions.py
18:@pytest.mark.xfail(sys.platform == "win32", reason="For some reason this is flaky on windows")
78:@pytest.mark.xfail(sys.platform == "win32", reason="For some reason this is flaky on windows")
183:@pytest.mark.xfail(sys.platform == "win32", reason="For some reason this is flaky on windows")
247:@pytest.mark.xfail(sys.platform == "win32", reason="For some reason this is flaky on windows")

tests/unit/test_stores.py
140:        pytest.xfail("bug in FileStore and MemoryStore")
```

Without `xfail_strict` test can pass and pytest won't report unexpected pass as an xfail error. With this setting it will.

Docs: https://docs.pytest.org/en/7.1.x/how-to/skipping.html#strict-parameter