### PR TITLE
test: silence `ResourceWarning` in `test_file_response`

### DIFF
--- a/tests/unit/test_response/test_file_response.py
+++ b/tests/unit/test_response/test_file_response.py
@@ -2,7 +2,7 @@ import os
 from email.utils import formatdate
 from os import stat, urandom
 from pathlib import Path
-from typing import Any
+from typing import Any, Coroutine
 
 import pytest
 from fsspec.implementations.local import LocalFileSystem
@@ -315,7 +315,8 @@ def test_does_not_override_existing_last_modified_header(header_name: str, tmpdi
 
 def test_asgi_response_encoded_headers(file: Path) -> None:
     response = ASGIFileResponse(encoded_headers=[(b"foo", b"bar")], file_path=file)
-    response.file_info.close()  # silence the ResourceWarning
+    if isinstance(response.file_info, Coroutine):
+        response.file_info.close()  # silence the ResourceWarning
     assert response.encode_headers() == [
         (b"foo", b"bar"),
         (b"content-type", b"application/octet-stream"),

--- a/tests/unit/test_response/test_file_response.py
+++ b/tests/unit/test_response/test_file_response.py
@@ -315,6 +315,7 @@ def test_does_not_override_existing_last_modified_header(header_name: str, tmpdi
 
 def test_asgi_response_encoded_headers(file: Path) -> None:
     response = ASGIFileResponse(encoded_headers=[(b"foo", b"bar")], file_path=file)
+    response.file_info.close()  # silence the ResourceWarning
     assert response.encode_headers() == [
         (b"foo", b"bar"),
         (b"content-type", b"application/octet-stream"),


### PR DESCRIPTION
Before:

```
» pytest -k test_asgi_response_encoded_headers
=================================== test session starts ===================================
platform darwin -- Python 3.11.5, pytest-7.4.2, pluggy-1.3.0
rootdir: /Users/sobolev/Desktop/litestar
configfile: pyproject.toml
plugins: anyio-4.0.0, rerunfailures-12.0, hypothesis-6.86.2, timeout-2.1.0, cov-4.1.0, asyncio-0.21.1, mock-3.11.1, xdist-3.3.1, time-machine-2.12.0, Faker-19.6.1, lazy-fixture-0.6.3
asyncio: mode=Mode.AUTO
collected 3268 items / 3265 deselected / 3 selected                                       

tests/unit/test_response/test_base_response.py .                                    [ 33%]
tests/unit/test_response/test_file_response.py .                                    [ 66%]
tests/unit/test_response/test_streaming_response.py .                               [100%]

==================================== warnings summary =====================================
tests/unit/test_response/test_file_response.py::test_asgi_response_encoded_headers
  /Users/sobolev/Desktop/litestar/.venv/lib/python3.11/site-packages/_pytest/python.py:194: RuntimeWarning: coroutine 'FileSystemAdapter.info' was never awaited
    result = testfunction(**testargs)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================== 3 passed, 3265 deselected, 1 warning in 1.57s ======================                        
```

After:

```
» pytest -k test_asgi_response_encoded_headers 
=================================== test session starts ===================================
platform darwin -- Python 3.11.5, pytest-7.4.2, pluggy-1.3.0
rootdir: /Users/sobolev/Desktop/litestar
configfile: pyproject.toml
plugins: anyio-4.0.0, rerunfailures-12.0, hypothesis-6.86.2, timeout-2.1.0, cov-4.1.0, asyncio-0.21.1, mock-3.11.1, xdist-3.3.1, time-machine-2.12.0, Faker-19.6.1, lazy-fixture-0.6.3
asyncio: mode=Mode.AUTO
collected 3268 items / 3265 deselected / 3 selected                                       

tests/unit/test_response/test_base_response.py .                                    [ 33%]
tests/unit/test_response/test_file_response.py .                                    [ 66%]
tests/unit/test_response/test_streaming_response.py .                               [100%]

=========================== 3 passed, 3265 deselected in 6.33s ============================
                                       
```