### PR TITLE
chore(ci): drop timeout to 10 minutes, remove integration setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,6 @@ jobs:
     uses: ./.github/workflows/test.yaml
     with:
       coverage: ${{ matrix.python-version == '3.11' && matrix.pydantic-version == '2' }}
-      integration: ${{ matrix.python-version == '3.11' && matrix.pydantic-version == '2' }}
       pydantic-version: ${{ matrix.pydantic-version }}
       python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,15 +17,11 @@ on:
         required: false
         type: string
         default: "ubuntu-latest"
-      integration:
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   test:
     runs-on: ${{ inputs.os }}
-    timeout-minutes: ${{ inputs.integrations && 15 || 30 }}
+    timeout-minutes: 10
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Since we're no longer running integration tests for databases, we don't need long timeouts of 15/30 minutes anymore. This PR drops those.