### PR TITLE
fix(tests): `RedisStore` test for `time-machine` 2.13.0

### DIFF
--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -94,6 +94,7 @@ async def test_get_and_renew(store: Store, renew_for: int | timedelta, frozen_da
 
 @pytest.mark.flaky(reruns=5)
 @pytest.mark.parametrize("renew_for", [10, timedelta(seconds=10)])
+@pytest.mark.xdist_group("redis")
 async def test_get_and_renew_redis(redis_store: RedisStore, renew_for: int | timedelta) -> None:
     # we can't sleep() in frozen datetime, and frozen datetime doesn't affect the redis
     # instance, so we test this separately

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from _pytest.fixtures import FixtureRequest
 from pytest_mock import MockerFixture
+from time_machine import Coordinates
 
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.stores.file import FileStore
@@ -21,7 +22,6 @@ from litestar.stores.registry import StoreRegistry
 
 if TYPE_CHECKING:
     from redis.asyncio import Redis
-    from time_machine import Coordinates
 
     from litestar.stores.base import NamespacedStore, Store
 
@@ -79,13 +79,28 @@ async def test_expires(store: Store, frozen_datetime: Coordinates) -> None:
 @pytest.mark.flaky(reruns=5)
 @pytest.mark.parametrize("renew_for", [10, timedelta(seconds=10)])
 async def test_get_and_renew(store: Store, renew_for: int | timedelta, frozen_datetime: Coordinates) -> None:
+    if isinstance(store, RedisStore):
+        pytest.skip()
+
     await store.set("foo", b"bar", expires_in=1)
     await store.get("foo", renew_for=renew_for)
 
     frozen_datetime.shift(2)
 
-    if isinstance(store, RedisStore):
-        await asyncio.sleep(1.1)
+    stored_value = await store.get("foo")
+
+    assert stored_value is not None
+
+
+@pytest.mark.flaky(reruns=5)
+@pytest.mark.parametrize("renew_for", [10, timedelta(seconds=10)])
+async def test_get_and_renew_redis(store: RedisStore, renew_for: int | timedelta) -> None:
+    # we can't sleep() in frozen datetime, and frozen datetime doesn't affect the redis
+    # instance, so we test this separately
+    await store.set("foo", b"bar", expires_in=1)
+    await store.get("foo", renew_for=renew_for)
+
+    await asyncio.sleep(1.1)
 
     stored_value = await store.get("foo")
 

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -94,15 +94,15 @@ async def test_get_and_renew(store: Store, renew_for: int | timedelta, frozen_da
 
 @pytest.mark.flaky(reruns=5)
 @pytest.mark.parametrize("renew_for", [10, timedelta(seconds=10)])
-async def test_get_and_renew_redis(store: RedisStore, renew_for: int | timedelta) -> None:
+async def test_get_and_renew_redis(redis_store: RedisStore, renew_for: int | timedelta) -> None:
     # we can't sleep() in frozen datetime, and frozen datetime doesn't affect the redis
     # instance, so we test this separately
-    await store.set("foo", b"bar", expires_in=1)
-    await store.get("foo", renew_for=renew_for)
+    await redis_store.set("foo", b"bar", expires_in=1)
+    await redis_store.get("foo", renew_for=renew_for)
 
     await asyncio.sleep(1.1)
 
-    stored_value = await store.get("foo")
+    stored_value = await redis_store.get("foo")
 
     assert stored_value is not None
 


### PR DESCRIPTION
Fixes a `RedisStore` test that would hang with `time-machine` version 2.13.0, because since this version `time.sleep` and `asyncio.sleep` are affected by its patching as well, causing the tests to sleep indefinitely.

Closes #2338.