### PR TITLE
test: Fix pydantic warning in `tests/unit/test_openapi/test_integration.py`

### DIFF
--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -187,7 +187,7 @@ def test_pydantic_schema_generation(create_examples: bool) -> None:
                 ),
             ]
         else:
-            id: Annotated[
+            id: Annotated[  # type: ignore[no-redef]
                 str,
                 Field(
                     min_length=12,

--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 import msgspec
+import pydantic
 import pytest
 import yaml
 from pydantic import BaseModel, Field
@@ -175,15 +176,26 @@ def test_msgspec_schema_generation(create_examples: bool) -> None:
 @pytest.mark.parametrize("create_examples", CREATE_EXAMPLES_VALUES)
 def test_pydantic_schema_generation(create_examples: bool) -> None:
     class Lookup(BaseModel):
-        id: Annotated[
-            str,
-            Field(
-                min_length=12,
-                max_length=16,
-                description="A unique identifier",
-                example="e4eaaaf2-d142-11e1-b3e4-080027620cdd",
-            ),
-        ]
+        if pydantic.VERSION.startswith("1"):
+            id: Annotated[
+                str,
+                Field(
+                    min_length=12,
+                    max_length=16,
+                    description="A unique identifier",
+                    example="e4eaaaf2-d142-11e1-b3e4-080027620cdd",
+                ),
+            ]
+        else:
+            id: Annotated[
+                str,
+                Field(
+                    min_length=12,
+                    max_length=16,
+                    description="A unique identifier",
+                    json_schema_extra={"example": "e4eaaaf2-d142-11e1-b3e4-080027620cdd"},
+                ),
+            ]
 
     @post("/example")
     async def example_route() -> Lookup:


### PR DESCRIPTION
Before:

```
 tests/unit/test_openapi/test_integration.py::test_pydantic_schema_generation[True]
tests/unit/test_openapi/test_integration.py::test_pydantic_schema_generation[True]
tests/unit/test_openapi/test_integration.py::test_pydantic_schema_generation[False]
tests/unit/test_openapi/test_integration.py::test_pydantic_schema_generation[False]
  /home/runner/work/litestar/litestar/.venv/lib/python3.10/site-packages/pydantic/fields.py:792: PydanticDeprecatedSince20: Using extra keyword arguments on `Field` is deprecated and will be removed. Use `json_schema_extra` instead. (Extra keys: 'example'). Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.3/migration/
    warn(
```
