### PR TITLE
chore: use `Final` instead of `Literal` for constants

### DIFF
--- a/litestar/status_codes.py
+++ b/litestar/status_codes.py
@@ -1,241 +1,241 @@
-from typing import Literal
+from typing import Final
 
 # HTTP Status Codes
 
-HTTP_100_CONTINUE: Literal[100] = 100
+HTTP_100_CONTINUE: Final = 100
 """HTTP status code 'Continue'"""
 
-HTTP_101_SWITCHING_PROTOCOLS: Literal[101] = 101
+HTTP_101_SWITCHING_PROTOCOLS: Final = 101
 """HTTP status code 'Switching Protocols'"""
 
-HTTP_102_PROCESSING: Literal[102] = 102
+HTTP_102_PROCESSING: Final = 102
 """HTTP status code 'Processing'"""
 
-HTTP_103_EARLY_HINTS: Literal[103] = 103
+HTTP_103_EARLY_HINTS: Final = 103
 """HTTP status code 'Early Hints'"""
 
-HTTP_200_OK: Literal[200] = 200
+HTTP_200_OK: Final = 200
 """HTTP status code 'OK'"""
 
-HTTP_201_CREATED: Literal[201] = 201
+HTTP_201_CREATED: Final = 201
 """HTTP status code 'Created'"""
 
-HTTP_202_ACCEPTED: Literal[202] = 202
+HTTP_202_ACCEPTED: Final = 202
 """HTTP status code 'Accepted'"""
 
-HTTP_203_NON_AUTHORITATIVE_INFORMATION: Literal[203] = 203
+HTTP_203_NON_AUTHORITATIVE_INFORMATION: Final = 203
 """HTTP status code 'Non Authoritative Information'"""
 
-HTTP_204_NO_CONTENT: Literal[204] = 204
+HTTP_204_NO_CONTENT: Final = 204
 """HTTP status code 'No Content'"""
 
-HTTP_205_RESET_CONTENT: Literal[205] = 205
+HTTP_205_RESET_CONTENT: Final = 205
 """HTTP status code 'Reset Content'"""
 
-HTTP_206_PARTIAL_CONTENT: Literal[206] = 206
+HTTP_206_PARTIAL_CONTENT: Final = 206
 """HTTP status code 'Partial Content'"""
 
-HTTP_207_MULTI_STATUS: Literal[207] = 207
+HTTP_207_MULTI_STATUS: Final = 207
 """HTTP status code 'Multi Status'"""
 
-HTTP_208_ALREADY_REPORTED: Literal[208] = 208
+HTTP_208_ALREADY_REPORTED: Final = 208
 """HTTP status code 'Already Reported'"""
 
-HTTP_226_IM_USED: Literal[226] = 226
+HTTP_226_IM_USED: Final = 226
 """HTTP status code 'I'm Used'"""
 
-HTTP_300_MULTIPLE_CHOICES: Literal[300] = 300
+HTTP_300_MULTIPLE_CHOICES: Final = 300
 """HTTP status code 'Multiple Choices'"""
 
-HTTP_301_MOVED_PERMANENTLY: Literal[301] = 301
+HTTP_301_MOVED_PERMANENTLY: Final = 301
 """HTTP status code 'Moved Permanently'"""
 
-HTTP_302_FOUND: Literal[302] = 302
+HTTP_302_FOUND: Final = 302
 """HTTP status code 'Found'"""
 
-HTTP_303_SEE_OTHER: Literal[303] = 303
+HTTP_303_SEE_OTHER: Final = 303
 """HTTP status code 'See Other'"""
 
-HTTP_304_NOT_MODIFIED: Literal[304] = 304
+HTTP_304_NOT_MODIFIED: Final = 304
 """HTTP status code 'Not Modified'"""
 
-HTTP_305_USE_PROXY: Literal[305] = 305
+HTTP_305_USE_PROXY: Final = 305
 """HTTP status code 'Use Proxy'"""
 
-HTTP_306_RESERVED: Literal[306] = 306
+HTTP_306_RESERVED: Final = 306
 """HTTP status code 'Reserved'"""
 
-HTTP_307_TEMPORARY_REDIRECT: Literal[307] = 307
+HTTP_307_TEMPORARY_REDIRECT: Final = 307
 """HTTP status code 'Temporary Redirect'"""
 
-HTTP_308_PERMANENT_REDIRECT: Literal[308] = 308
+HTTP_308_PERMANENT_REDIRECT: Final = 308
 """HTTP status code 'Permanent Redirect'"""
 
-HTTP_400_BAD_REQUEST: Literal[400] = 400
+HTTP_400_BAD_REQUEST: Final = 400
 """HTTP status code 'Bad Request'"""
 
-HTTP_401_UNAUTHORIZED: Literal[401] = 401
+HTTP_401_UNAUTHORIZED: Final = 401
 """HTTP status code 'Unauthorized'"""
 
-HTTP_402_PAYMENT_REQUIRED: Literal[402] = 402
+HTTP_402_PAYMENT_REQUIRED: Final = 402
 """HTTP status code 'Payment Required'"""
 
-HTTP_403_FORBIDDEN: Literal[403] = 403
+HTTP_403_FORBIDDEN: Final = 403
 """HTTP status code 'Forbidden'"""
 
-HTTP_404_NOT_FOUND: Literal[404] = 404
+HTTP_404_NOT_FOUND: Final = 404
 """HTTP status code 'Not Found'"""
 
-HTTP_405_METHOD_NOT_ALLOWED: Literal[405] = 405
+HTTP_405_METHOD_NOT_ALLOWED: Final = 405
 """HTTP status code 'Method Not Allowed'"""
 
-HTTP_406_NOT_ACCEPTABLE: Literal[406] = 406
+HTTP_406_NOT_ACCEPTABLE: Final = 406
 """HTTP status code 'Not Acceptable'"""
 
-HTTP_407_PROXY_AUTHENTICATION_REQUIRED: Literal[407] = 407
+HTTP_407_PROXY_AUTHENTICATION_REQUIRED: Final = 407
 """HTTP status code 'Proxy Authentication Required'"""
 
-HTTP_408_REQUEST_TIMEOUT: Literal[408] = 408
+HTTP_408_REQUEST_TIMEOUT: Final = 408
 """HTTP status code 'Request Timeout'"""
 
-HTTP_409_CONFLICT: Literal[409] = 409
+HTTP_409_CONFLICT: Final = 409
 """HTTP status code 'Conflict'"""
 
-HTTP_410_GONE: Literal[410] = 410
+HTTP_410_GONE: Final = 410
 """HTTP status code 'Gone'"""
 
-HTTP_411_LENGTH_REQUIRED: Literal[411] = 411
+HTTP_411_LENGTH_REQUIRED: Final = 411
 """HTTP status code 'Length Required'"""
 
-HTTP_412_PRECONDITION_FAILED: Literal[412] = 412
+HTTP_412_PRECONDITION_FAILED: Final = 412
 """HTTP status code 'Precondition Failed'"""
 
-HTTP_413_REQUEST_ENTITY_TOO_LARGE: Literal[413] = 413
+HTTP_413_REQUEST_ENTITY_TOO_LARGE: Final = 413
 """HTTP status code 'Request Entity Too Large'"""
 
-HTTP_414_REQUEST_URI_TOO_LONG: Literal[414] = 414
+HTTP_414_REQUEST_URI_TOO_LONG: Final = 414
 """HTTP status code 'Request URI Too Long'"""
 
-HTTP_415_UNSUPPORTED_MEDIA_TYPE: Literal[415] = 415
+HTTP_415_UNSUPPORTED_MEDIA_TYPE: Final = 415
 """HTTP status code 'Unsupported Media Type'"""
 
-HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE: Literal[416] = 416
+HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE: Final = 416
 """HTTP status code 'Requested Range Not Satisfiable'"""
 
-HTTP_417_EXPECTATION_FAILED: Literal[417] = 417
+HTTP_417_EXPECTATION_FAILED: Final = 417
 """HTTP status code 'Expectation Failed'"""
 
-HTTP_418_IM_A_TEAPOT: Literal[418] = 418
+HTTP_418_IM_A_TEAPOT: Final = 418
 """HTTP status code 'I'm A Teapot'"""
 
-HTTP_421_MISDIRECTED_REQUEST: Literal[421] = 421
+HTTP_421_MISDIRECTED_REQUEST: Final = 421
 """HTTP status code 'Misdirected Request'"""
 
-HTTP_422_UNPROCESSABLE_ENTITY: Literal[422] = 422
+HTTP_422_UNPROCESSABLE_ENTITY: Final = 422
 """HTTP status code 'Unprocessable Entity'"""
 
-HTTP_423_LOCKED: Literal[423] = 423
+HTTP_423_LOCKED: Final = 423
 """HTTP status code 'Locked'"""
 
-HTTP_424_FAILED_DEPENDENCY: Literal[424] = 424
+HTTP_424_FAILED_DEPENDENCY: Final = 424
 """HTTP status code 'Failed Dependency'"""
 
-HTTP_425_TOO_EARLY: Literal[425] = 425
+HTTP_425_TOO_EARLY: Final = 425
 """HTTP status code 'Too Early'"""
 
-HTTP_426_UPGRADE_REQUIRED: Literal[426] = 426
+HTTP_426_UPGRADE_REQUIRED: Final = 426
 """HTTP status code 'Upgrade Required'"""
 
-HTTP_428_PRECONDITION_REQUIRED: Literal[428] = 428
+HTTP_428_PRECONDITION_REQUIRED: Final = 428
 """HTTP status code 'Precondition Required'"""
 
-HTTP_429_TOO_MANY_REQUESTS: Literal[429] = 429
+HTTP_429_TOO_MANY_REQUESTS: Final = 429
 """HTTP status code 'Too Many Requests'"""
 
-HTTP_431_REQUEST_HEADER_FIELDS_TOO_LARGE: Literal[431] = 431
+HTTP_431_REQUEST_HEADER_FIELDS_TOO_LARGE: Final = 431
 """HTTP status code 'Request Header Fields Too Large'"""
 
-HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS: Literal[451] = 451
+HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS: Final = 451
 """HTTP status code 'Unavailable For Legal Reasons'"""
 
-HTTP_500_INTERNAL_SERVER_ERROR: Literal[500] = 500
+HTTP_500_INTERNAL_SERVER_ERROR: Final = 500
 """HTTP status code 'Internal Server Error'"""
 
-HTTP_501_NOT_IMPLEMENTED: Literal[501] = 501
+HTTP_501_NOT_IMPLEMENTED: Final = 501
 """HTTP status code 'Not Implemented'"""
 
-HTTP_502_BAD_GATEWAY: Literal[502] = 502
+HTTP_502_BAD_GATEWAY: Final = 502
 """HTTP status code 'Bad Gateway'"""
 
-HTTP_503_SERVICE_UNAVAILABLE: Literal[503] = 503
+HTTP_503_SERVICE_UNAVAILABLE: Final = 503
 """HTTP status code 'Service Unavailable'"""
 
-HTTP_504_GATEWAY_TIMEOUT: Literal[504] = 504
+HTTP_504_GATEWAY_TIMEOUT: Final = 504
 """HTTP status code 'Gateway Timeout'"""
 
-HTTP_505_HTTP_VERSION_NOT_SUPPORTED: Literal[505] = 505
+HTTP_505_HTTP_VERSION_NOT_SUPPORTED: Final = 505
 """HTTP status code 'Http Version Not Supported'"""
 
-HTTP_506_VARIANT_ALSO_NEGOTIATES: Literal[506] = 506
+HTTP_506_VARIANT_ALSO_NEGOTIATES: Final = 506
 """HTTP status code 'Variant Also Negotiates'"""
 
-HTTP_507_INSUFFICIENT_STORAGE: Literal[507] = 507
+HTTP_507_INSUFFICIENT_STORAGE: Final = 507
 """HTTP status code 'Insufficient Storage'"""
 
-HTTP_508_LOOP_DETECTED: Literal[508] = 508
+HTTP_508_LOOP_DETECTED: Final = 508
 """HTTP status code 'Loop Detected'"""
 
-HTTP_510_NOT_EXTENDED: Literal[510] = 510
+HTTP_510_NOT_EXTENDED: Final = 510
 """HTTP status code 'Not Extended'"""
 
-HTTP_511_NETWORK_AUTHENTICATION_REQUIRED: Literal[511] = 511
+HTTP_511_NETWORK_AUTHENTICATION_REQUIRED: Final = 511
 """HTTP status code 'Network Authentication Required'"""
 
 
 # Websocket Codes
-WS_1000_NORMAL_CLOSURE: Literal[1000] = 1000
+WS_1000_NORMAL_CLOSURE: Final = 1000
 """WebSocket status code 'Normal Closure'"""
 
-WS_1001_GOING_AWAY: Literal[1001] = 1001
+WS_1001_GOING_AWAY: Final = 1001
 """WebSocket status code 'Going Away'"""
 
-WS_1002_PROTOCOL_ERROR: Literal[1002] = 1002
+WS_1002_PROTOCOL_ERROR: Final = 1002
 """WebSocket status code 'Protocol Error'"""
 
-WS_1003_UNSUPPORTED_DATA: Literal[1003] = 1003
+WS_1003_UNSUPPORTED_DATA: Final = 1003
 """WebSocket status code 'Unsupported Data'"""
 
-WS_1005_NO_STATUS_RECEIVED: Literal[1005] = 1005
+WS_1005_NO_STATUS_RECEIVED: Final = 1005
 """WebSocket status code 'No Status Received'"""
 
-WS_1006_ABNORMAL_CLOSURE: Literal[1006] = 1006
+WS_1006_ABNORMAL_CLOSURE: Final = 1006
 """WebSocket status code 'Abnormal Closure'"""
 
-WS_1007_INVALID_FRAME_PAYLOAD_DATA: Literal[1007] = 1007
+WS_1007_INVALID_FRAME_PAYLOAD_DATA: Final = 1007
 """WebSocket status code 'Invalid Frame Payload Data'"""
 
-WS_1008_POLICY_VIOLATION: Literal[1008] = 1008
+WS_1008_POLICY_VIOLATION: Final = 1008
 """WebSocket status code 'Policy Violation'"""
 
-WS_1009_MESSAGE_TOO_BIG: Literal[1009] = 1009
+WS_1009_MESSAGE_TOO_BIG: Final = 1009
 """WebSocket status code 'Message Too Big'"""
 
-WS_1010_MANDATORY_EXT: Literal[1010] = 1010
+WS_1010_MANDATORY_EXT: Final = 1010
 """WebSocket status code 'Mandatory Ext.'"""
 
-WS_1011_INTERNAL_ERROR: Literal[1011] = 1011
+WS_1011_INTERNAL_ERROR: Final = 1011
 """WebSocket status code 'Internal Error'"""
 
-WS_1012_SERVICE_RESTART: Literal[1012] = 1012
+WS_1012_SERVICE_RESTART: Final = 1012
 """WebSocket status code 'Service Restart'"""
 
-WS_1013_TRY_AGAIN_LATER: Literal[1013] = 1013
+WS_1013_TRY_AGAIN_LATER: Final = 1013
 """WebSocket status code 'Try Again Later'"""
 
-WS_1014_BAD_GATEWAY: Literal[1014] = 1014
+WS_1014_BAD_GATEWAY: Final = 1014
 """WebSocket status code 'Bad Gateway'"""
 
-WS_1015_TLS_HANDSHAKE: Literal[1015] = 1015
+WS_1015_TLS_HANDSHAKE: Final = 1015
 """WebSocket status code 'TLS Handshake'"""
 
 


### PR DESCRIPTION
There are several differences:
- `Final` does not need value duplication, it is inferenced by type-checkers to be `Literal[value]` automagically
- `Final` does not allow value re-assigning (`x: Literal[1] = 1; x = 1` is allowed)