### PR TITLE
feat: jinja async support

### DIFF
--- a/litestar/contrib/jinja.py
+++ b/litestar/contrib/jinja.py
@@ -93,3 +93,7 @@ class JinjaTemplateEngine(TemplateEngineProtocol["JinjaTemplate"]):
             JinjaTemplateEngine instance
         """
         return cls(directory=None, engine_instance=jinja_environment)
+
+    @property
+    def is_async(self) -> bool:
+        return self.engine.is_async

--- a/litestar/contrib/mako.py
+++ b/litestar/contrib/mako.py
@@ -61,6 +61,9 @@ class MakoTemplate(TemplateProtocol):
 
         return str(self.template.render(*args, **kwargs))
 
+    async def render_async(self, *args: Any, **kwargs: Any) -> str:
+        raise NotImplementedError("Mako engine doesn't support async rendering")
+
 
 class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate]):
     """Mako based TemplateEngine."""
@@ -131,3 +134,7 @@ class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate]):
             MakoTemplateEngine instance
         """
         return cls(directory=None, engine_instance=template_lookup)
+
+    @property
+    def is_async(self) -> bool:
+        return False

--- a/litestar/contrib/minijnja.py
+++ b/litestar/contrib/minijnja.py
@@ -59,6 +59,9 @@ class MiniJinjaTemplate(TemplateProtocol):
         """
         return str(self.engine.render_template(self.template_name, *args, **kwargs))
 
+    async def render_async(self, *args: Any, **kwargs: Any) -> str:
+        raise NotImplementedError("MiniJinja engine doesn't support async rendering")
+
 
 class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate"]):
     """The engine instance."""
@@ -153,3 +156,7 @@ class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate"]):
             MiniJinjaTemplateEngine instance
         """
         return cls(directory=None, engine_instance=minijinja_environment)
+
+    @property
+    def is_async(self) -> bool:
+        return False

--- a/litestar/response/template.py
+++ b/litestar/response/template.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from litestar.datastructures import Cookie
     from litestar.template.base import TemplateProtocol
     from litestar.types import (
-        HTTPResponseStartEvent,
         ResponseCookies,
         Send,
         TypeEncodersMap,
@@ -133,12 +132,7 @@ class ASGITemplateResponse(ASGIResponse):
             None
         """
         await self.prepare_content()
-        event: HTTPResponseStartEvent = {
-            "type": "http.response.start",
-            "status": self.status_code,
-            "headers": self.encode_headers(),
-        }
-        await send(event)
+        await super().start_response(send)
 
 
 class Template(Response[bytes]):

--- a/litestar/template/base.py
+++ b/litestar/template/base.py
@@ -93,6 +93,18 @@ class TemplateProtocol(Protocol):  # pragma: no cover
         """
         ...
 
+    async def render_async(self, *args: Any, **kwargs: Any) -> str:
+        """Eeturns a coroutine that when awaited returns the entire rendered template string.
+
+        Args:
+            *args: Positional arguments passed to the TemplateEngine
+            **kwargs: A string keyed mapping of values passed to the TemplateEngine
+
+        Returns:
+            The rendered template string wrapped in a coroutine
+        """
+        ...
+
 
 T_co = TypeVar("T_co", bound=TemplateProtocol, covariant=True)
 
@@ -134,3 +146,13 @@ class TemplateEngineProtocol(Protocol[T_co]):  # pragma: no cover
         Returns:
             None
         """
+
+    @property
+    def is_async(self) -> bool:
+        """Whether the templating engine supports async rendering.
+
+        Returns:
+            bool
+
+        """
+        ...

--- a/test_apps/jinja_async_test_app/main.py
+++ b/test_apps/jinja_async_test_app/main.py
@@ -1,0 +1,23 @@
+from jinja2.environment import Environment
+from jinja2.loaders import DictLoader
+
+from litestar import Litestar, get
+from litestar.contrib.jinja import JinjaTemplateEngine
+from litestar.response import Template
+from litestar.template import TemplateConfig
+
+jinja_env = Environment(enable_async=True, loader=DictLoader({"index.html": "Hello {{name}}!"}))
+template_config = TemplateConfig(instance=JinjaTemplateEngine.from_environment(jinja_env))
+
+
+@get("/")
+async def index() -> Template:
+    return Template("index.html", context={"name": "Litestar"})
+
+
+app = Litestar(route_handlers=[index], template_config=template_config)
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app)


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
After #2195 , it is now possible to initiate Jinja env with `enable_async=True`. Litestar needs a way to recognize this and call `render_async` instead of the standard async. In this PR:
- `TemplateProtocol` was extended with a `render_async` method
- `TemplateEngineProtocol` was extended with `is_async` property
- For other existing engines (mako, minijinja) that do not support async, the former raises `NotImplementedError` and the latter always returns `False`

Somewhere in an async context, we need to `await` rendering of the template. The first possible place is `start_response` in `ASGIResponse`. However this class already counts on having the body and content length available. To solve this:

- New class `ASGITemplateResponse` was created with modified slots and constructor
- The template, context and `is_async` information is passed into it
- Most of the logic from `ASGIResponse` constructor was moved to an async function, where the template will be rendered sync or async and the `content_length` will be assigned along with more validation
- This is then awaited from within `start_response`

I tested it in the included test app and it seems to work. Just setting the engine to `enable_async` true lead to an exception (see #651 )


### Close Issue(s)
Implements #651
