### PR TITLE
fix: app `listeners` param typed as `Sequence`.

### DIFF
--- a/litestar/app.py
+++ b/litestar/app.py
@@ -212,7 +212,9 @@ class Litestar(Router):
         type_encoders: TypeEncodersMap | None = None,
         type_decoders: TypeDecodersSequence | None = None,
         websocket_class: type[WebSocket] | None = None,
-        lifespan: list[Callable[[Litestar], AbstractAsyncContextManager] | AbstractAsyncContextManager] | None = None,
+        lifespan: OptionalSequence[
+            Callable[[Litestar], AbstractAsyncContextManager] | AbstractAsyncContextManager
+        ] = None,
         pdb_on_exception: bool | None = None,
     ) -> None:
         """Initialize a ``Litestar`` application.
@@ -330,7 +332,7 @@ class Litestar(Router):
             exception_handlers=exception_handlers or {},
             guards=list(guards or []),
             include_in_schema=include_in_schema,
-            lifespan=lifespan or [],
+            lifespan=list(lifespan or []),
             listeners=list(listeners or []),
             logging_config=cast("BaseLoggingConfig | None", logging_config),
             middleware=list(middleware or []),


### PR DESCRIPTION
Invariance of `list` is too restrictive, for example:

```py
from __future__ import annotations

from typing import Any

from litestar import Litestar


class AioCtxMgr:
    """A dummy context manager."""

    async def __aenter__(self) -> None:
        pass

    async def __aexit__(self, *args: Any) -> None:
        pass


ctx_mgrs = [AioCtxMgr()]
Litestar(route_handlers=[], lifespan=ctx_mgrs)
```

Would result in:

```
app.py:20: error: Argument "lifespan" to "Litestar" has incompatible type "list[AioCtxMgr]"; expected "list[Callable[[Litestar], AbstractAsyncContextManager[Any]] | AbstractAsyncContextManager[Any]] | None"  [arg-type]
app.py:20: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
app.py:20: note: Consider using "Sequence" instead, which is covariant
```

Closes #2348

### Pull Request Checklist

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

-

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

-
