### PR TITLE
test: fix `AsyncRedis.close()` deprecation warning

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -313,6 +313,6 @@ async def redis_client(docker_ip: str, redis_service: None) -> AsyncGenerator[As
     client: AsyncRedis = AsyncRedis(host=docker_ip, port=6397)
     yield client
     try:
-        await client.close()
+        await client.aclose()
     except RuntimeError:
         pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -313,6 +313,6 @@ async def redis_client(docker_ip: str, redis_service: None) -> AsyncGenerator[As
     client: AsyncRedis = AsyncRedis(host=docker_ip, port=6397)
     yield client
     try:
-        await client.aclose()
+        await client.aclose()  # type: ignore[attr-defined]
     except RuntimeError:
         pass

--- a/tests/docker_service_fixtures.py
+++ b/tests/docker_service_fixtures.py
@@ -124,7 +124,7 @@ async def redis_responsive(host: str) -> bool:
     except (ConnectionError, RedisConnectionError):
         return False
     finally:
-        await client.close()
+        await client.aclose()
 
 
 @pytest.fixture()


### PR DESCRIPTION
Before:

```
  /home/runner/work/litestar/litestar/tests/conftest.py:316: DeprecationWarning: Call to deprecated close. (Use aclose() instead) -- Deprecated since version 5.0.0.
    await client.close()
```

Source: https://github.com/redis/redis-py/blob/cc4bc1a544d1030aec1696baef2861064fa8dd1c/redis/asyncio/client.py#L568-L573