### PR TITLE
fix: remove runtime assignment of type aliases to `Any`.

### DIFF
--- a/litestar/types/callable_types.py
+++ b/litestar/types/callable_types.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Generator
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
-    from typing import Any
-
     from typing_extensions import TypeAlias
 
     from litestar.config.app import AppConfig
@@ -25,8 +22,8 @@ AfterRequestHookHandler: TypeAlias = (
     "Callable[[ASGIApp], SyncOrAsyncUnion[ASGIApp]] | Callable[[Response], SyncOrAsyncUnion[Response]]"
 )
 AfterResponseHookHandler: TypeAlias = "Callable[[Request], SyncOrAsyncUnion[None]]"
-AsyncAnyCallable: TypeAlias = "Callable[..., Awaitable[Any]]"
-AnyCallable: TypeAlias = "Callable[..., Any]"
+AsyncAnyCallable: TypeAlias = Callable[..., Awaitable[Any]]
+AnyCallable: TypeAlias = Callable[..., Any]
 AnyGenerator: TypeAlias = "Generator[Any, Any, Any] | AsyncGenerator[Any, Any]"
 BeforeMessageSendHookHandler: TypeAlias = "Callable[[Message, Scope], SyncOrAsyncUnion[None]]"
 BeforeRequestHookHandler: TypeAlias = "Callable[[Request], Any | Awaitable[Any]]"
@@ -38,4 +35,4 @@ Guard: TypeAlias = "Callable[[ASGIConnection, BaseRouteHandler], SyncOrAsyncUnio
 LifespanHook: TypeAlias = "Callable[[LitestarType], SyncOrAsyncUnion[Any]] | Callable[[], SyncOrAsyncUnion[Any]]"
 OnAppInitHandler: TypeAlias = "Callable[[AppConfig], AppConfig]"
 OperationIDCreator: TypeAlias = "Callable[[HTTPRouteHandler, Method, list[str | PathParameterDefinition]], str]"
-Serializer: TypeAlias = "Callable[[Any], Any]"
+Serializer: TypeAlias = Callable[[Any], Any]

--- a/litestar/types/callable_types.py
+++ b/litestar/types/callable_types.py
@@ -1,17 +1,10 @@
 from __future__ import annotations
 
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    AsyncGenerator,
-    Awaitable,
-    Callable,
-    Generator,
-    List,
-    Union,
-)
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Any, AsyncGenerator, Awaitable, Callable, Generator, List, Union
+
     from typing_extensions import TypeAlias
 
     from litestar.config.app import AppConfig
@@ -25,43 +18,23 @@ if TYPE_CHECKING:
     from litestar.types.internal_types import LitestarType, PathParameterDefinition
     from litestar.types.protocols import Logger
 
-    AfterExceptionHookHandler: TypeAlias = Callable[[Exception, Scope], SyncOrAsyncUnion[None]]
-    AfterRequestHookHandler: TypeAlias = Union[
-        Callable[[ASGIApp], SyncOrAsyncUnion[ASGIApp]], Callable[[Response], SyncOrAsyncUnion[Response]]
-    ]
-    AfterResponseHookHandler: TypeAlias = Callable[[Request], SyncOrAsyncUnion[None]]
-    AsyncAnyCallable: TypeAlias = Callable[..., Awaitable[Any]]
-    AnyCallable: TypeAlias = Callable[..., Any]
-    AnyGenerator: TypeAlias = Union[Generator[Any, Any, Any], AsyncGenerator[Any, Any]]
-    BeforeMessageSendHookHandler: TypeAlias = Callable[[Message, Scope], SyncOrAsyncUnion[None]]
-    BeforeRequestHookHandler: TypeAlias = Callable[[Request], Union[Any, Awaitable[Any]]]
-    CacheKeyBuilder: TypeAlias = Callable[[Request], str]
-    ExceptionHandler: TypeAlias = Callable[[Request, Exception], Response]
-    ExceptionLoggingHandler: TypeAlias = Callable[[Logger, Scope, List[str]], None]
-    GetLogger: TypeAlias = Callable[..., Logger]
-    Guard: TypeAlias = Callable[[ASGIConnection, BaseRouteHandler], SyncOrAsyncUnion[None]]
-    LifespanHook: TypeAlias = Union[
-        Callable[[LitestarType], SyncOrAsyncUnion[Any]],
-        Callable[[], SyncOrAsyncUnion[Any]],
-    ]
-    OnAppInitHandler: TypeAlias = Callable[[AppConfig], AppConfig]
-    OperationIDCreator: TypeAlias = Callable[[HTTPRouteHandler, Method, List[Union[str, PathParameterDefinition]]], str]
-    Serializer: TypeAlias = Callable[[Any], Any]
-else:
-    AfterExceptionHookHandler: TypeAlias = Any
-    AfterRequestHookHandler: TypeAlias = Any
-    AfterResponseHookHandler: TypeAlias = Any
-    AsyncAnyCallable: TypeAlias = Any
-    AnyCallable: TypeAlias = Any
-    AnyGenerator: TypeAlias = Any
-    BeforeMessageSendHookHandler: TypeAlias = Any
-    BeforeRequestHookHandler: TypeAlias = Any
-    CacheKeyBuilder: TypeAlias = Any
-    ExceptionHandler: TypeAlias = Any
-    ExceptionLoggingHandler: TypeAlias = Any
-    GetLogger: TypeAlias = Any
-    Guard: TypeAlias = Any
-    LifespanHook: TypeAlias = Any
-    OnAppInitHandler: TypeAlias = Any
-    OperationIDCreator: TypeAlias = Any
-    Serializer: TypeAlias = Any
+
+AfterExceptionHookHandler: TypeAlias = "Callable[[Exception, Scope], SyncOrAsyncUnion[None]]"
+AfterRequestHookHandler: TypeAlias = (
+    "Union[Callable[[ASGIApp], SyncOrAsyncUnion[ASGIApp]], Callable[[Response], SyncOrAsyncUnion[Response]]]"
+)
+AfterResponseHookHandler: TypeAlias = "Callable[[Request], SyncOrAsyncUnion[None]]"
+AsyncAnyCallable: TypeAlias = "Callable[..., Awaitable[Any]]"
+AnyCallable: TypeAlias = "Callable[..., Any]"
+AnyGenerator: TypeAlias = "Union[Generator[Any, Any, Any], AsyncGenerator[Any, Any]]"
+BeforeMessageSendHookHandler: TypeAlias = "Callable[[Message, Scope], SyncOrAsyncUnion[None]]"
+BeforeRequestHookHandler: TypeAlias = "Callable[[Request], Union[Any, Awaitable[Any]]]"
+CacheKeyBuilder: TypeAlias = "Callable[[Request], str]"
+ExceptionHandler: TypeAlias = "Callable[[Request, Exception], Response]"
+ExceptionLoggingHandler: TypeAlias = "Callable[[Logger, Scope, List[str]], None]"
+GetLogger: TypeAlias = "Callable[..., Logger]"
+Guard: TypeAlias = "Callable[[ASGIConnection, BaseRouteHandler], SyncOrAsyncUnion[None]]"
+LifespanHook: TypeAlias = "Union[Callable[[LitestarType], SyncOrAsyncUnion[Any]], Callable[[], SyncOrAsyncUnion[Any]]]"
+OnAppInitHandler: TypeAlias = "Callable[[AppConfig], AppConfig]"
+OperationIDCreator: TypeAlias = "Callable[[HTTPRouteHandler, Method, List[Union[str, PathParameterDefinition]]], str]"
+Serializer: TypeAlias = "Callable[[Any], Any]"

--- a/litestar/types/callable_types.py
+++ b/litestar/types/callable_types.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, AsyncGenerator, Awaitable, Callable, Generator, List, Union
+    from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
+    from typing import Any
 
     from typing_extensions import TypeAlias
 
@@ -21,20 +22,20 @@ if TYPE_CHECKING:
 
 AfterExceptionHookHandler: TypeAlias = "Callable[[Exception, Scope], SyncOrAsyncUnion[None]]"
 AfterRequestHookHandler: TypeAlias = (
-    "Union[Callable[[ASGIApp], SyncOrAsyncUnion[ASGIApp]], Callable[[Response], SyncOrAsyncUnion[Response]]]"
+    "Callable[[ASGIApp], SyncOrAsyncUnion[ASGIApp]] | Callable[[Response], SyncOrAsyncUnion[Response]]"
 )
 AfterResponseHookHandler: TypeAlias = "Callable[[Request], SyncOrAsyncUnion[None]]"
 AsyncAnyCallable: TypeAlias = "Callable[..., Awaitable[Any]]"
 AnyCallable: TypeAlias = "Callable[..., Any]"
-AnyGenerator: TypeAlias = "Union[Generator[Any, Any, Any], AsyncGenerator[Any, Any]]"
+AnyGenerator: TypeAlias = "Generator[Any, Any, Any] | AsyncGenerator[Any, Any]"
 BeforeMessageSendHookHandler: TypeAlias = "Callable[[Message, Scope], SyncOrAsyncUnion[None]]"
-BeforeRequestHookHandler: TypeAlias = "Callable[[Request], Union[Any, Awaitable[Any]]]"
+BeforeRequestHookHandler: TypeAlias = "Callable[[Request], Any | Awaitable[Any]]"
 CacheKeyBuilder: TypeAlias = "Callable[[Request], str]"
 ExceptionHandler: TypeAlias = "Callable[[Request, Exception], Response]"
-ExceptionLoggingHandler: TypeAlias = "Callable[[Logger, Scope, List[str]], None]"
+ExceptionLoggingHandler: TypeAlias = "Callable[[Logger, Scope, list[str]], None]"
 GetLogger: TypeAlias = "Callable[..., Logger]"
 Guard: TypeAlias = "Callable[[ASGIConnection, BaseRouteHandler], SyncOrAsyncUnion[None]]"
-LifespanHook: TypeAlias = "Union[Callable[[LitestarType], SyncOrAsyncUnion[Any]], Callable[[], SyncOrAsyncUnion[Any]]]"
+LifespanHook: TypeAlias = "Callable[[LitestarType], SyncOrAsyncUnion[Any]] | Callable[[], SyncOrAsyncUnion[Any]]"
 OnAppInitHandler: TypeAlias = "Callable[[AppConfig], AppConfig]"
-OperationIDCreator: TypeAlias = "Callable[[HTTPRouteHandler, Method, List[Union[str, PathParameterDefinition]]], str]"
+OperationIDCreator: TypeAlias = "Callable[[HTTPRouteHandler, Method, list[str | PathParameterDefinition]], str]"
 Serializer: TypeAlias = "Callable[[Any], Any]"

--- a/litestar/types/internal_types.py
+++ b/litestar/types/internal_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, Callable, Literal, NamedTuple
 
 __all__ = (
     "ControllerRouterHandler",
@@ -15,9 +15,6 @@ __all__ = (
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Any, Literal
-
     from typing_extensions import TypeAlias
 
     from litestar.app import Litestar
@@ -29,7 +26,7 @@ if TYPE_CHECKING:
     from litestar.router import Router
     from litestar.types import Method
 
-ReservedKwargs: TypeAlias = 'Literal["request", "socket", "headers", "query", "cookies", "state", "data"]'
+ReservedKwargs: TypeAlias = Literal["request", "socket", "headers", "query", "cookies", "state", "data"]
 LitestarType: TypeAlias = "Litestar"
 RouteHandlerType: TypeAlias = "HTTPRouteHandler | WebsocketRouteHandler | ASGIRouteHandler"
 ResponseType: TypeAlias = "type[Response]"

--- a/litestar/types/internal_types.py
+++ b/litestar/types/internal_types.py
@@ -1,14 +1,6 @@
 from __future__ import annotations
 
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Literal,
-    NamedTuple,
-    Union,
-)
+from typing import TYPE_CHECKING, NamedTuple
 
 __all__ = (
     "ControllerRouterHandler",
@@ -23,6 +15,9 @@ __all__ = (
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any, Literal
+
     from typing_extensions import TypeAlias
 
     from litestar.app import Litestar
@@ -34,19 +29,12 @@ if TYPE_CHECKING:
     from litestar.router import Router
     from litestar.types import Method
 
-    ReservedKwargs: TypeAlias = Literal["request", "socket", "headers", "query", "cookies", "state", "data"]
-    LitestarType: TypeAlias = Litestar
-    RouteHandlerType: TypeAlias = Union[HTTPRouteHandler, WebsocketRouteHandler, ASGIRouteHandler]
-    ResponseType: TypeAlias = type[Response]
-    ControllerRouterHandler: TypeAlias = Union[type[Controller], RouteHandlerType, Router, Callable[..., Any]]
-    RouteHandlerMapItem: TypeAlias = Dict[Union[Method, Literal["websocket", "asgi"]], RouteHandlerType]
-else:
-    ReservedKwargs: TypeAlias = Any
-    LitestarType: TypeAlias = Any
-    RouteHandlerType: TypeAlias = Any
-    ResponseType: TypeAlias = Any
-    ControllerRouterHandler: TypeAlias = Any
-    RouteHandlerMapItem: TypeAlias = Any
+ReservedKwargs: TypeAlias = 'Literal["request", "socket", "headers", "query", "cookies", "state", "data"]'
+LitestarType: TypeAlias = "Litestar"
+RouteHandlerType: TypeAlias = "HTTPRouteHandler | WebsocketRouteHandler | ASGIRouteHandler"
+ResponseType: TypeAlias = "type[Response]"
+ControllerRouterHandler: TypeAlias = "type[Controller] | RouteHandlerType | Router | Callable[..., Any]"
+RouteHandlerMapItem: TypeAlias = 'dict[Method | Literal["websocket", "asgi"], RouteHandlerType]'
 
 
 class PathParameterDefinition(NamedTuple):


### PR DESCRIPTION
This PR replaces this pattern:

```py
from typing import TYPE_CHECKING, Any

if TYPE_CHECKING:
    from typing_extensions import TypeAlias

    from litestar import Thing

    ThingAlias: TypeAlias = Thing
else:
    ThingAlias: TypeAlias = Any
```

My best guess is that this pattern was some workaround for circular dependencies before we introduced `__future__.annotations`.

I believe these changes will be beneficial as:
- the current pattern is non-standard (at least in my experience)
- the current pattern causes the types to be documented as `Any` in the API docs.

Example of current API docs for alias types:

![image](https://github.com/litestar-org/litestar/assets/20659309/b713b93d-27ba-41b5-bd61-d1ab4a188ef2)


### Pull Request Checklist

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

-

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

-
