### PR TITLE
docs: remove references to `SQLAlchemyAsyncConfig.create_engine`

### DIFF
--- a/docs/examples/contrib/sqlalchemy/sqlalchemy_async_repository.py
+++ b/docs/examples/contrib/sqlalchemy/sqlalchemy_async_repository.py
@@ -204,7 +204,7 @@ sqlalchemy_plugin = SQLAlchemyInitPlugin(config=sqlalchemy_config)
 
 async def on_startup() -> None:
     """Initializes the database."""
-    async with sqlalchemy_config.create_engine().begin() as conn:
+    async with sqlalchemy_config.get_engine().begin() as conn:
         await conn.run_sync(UUIDBase.metadata.create_all)
 
 

--- a/docs/examples/contrib/sqlalchemy/sqlalchemy_declarative_models.py
+++ b/docs/examples/contrib/sqlalchemy/sqlalchemy_declarative_models.py
@@ -39,7 +39,7 @@ sqlalchemy_plugin = SQLAlchemyInitPlugin(config=sqlalchemy_config)
 
 async def on_startup() -> None:
     """Initializes the database."""
-    async with sqlalchemy_config.create_engine().begin() as conn:
+    async with sqlalchemy_config.get_engine().begin() as conn:
         await conn.run_sync(UUIDBase.metadata.create_all)
 
 

--- a/docs/examples/contrib/sqlalchemy/sqlalchemy_repository_extension.py
+++ b/docs/examples/contrib/sqlalchemy/sqlalchemy_repository_extension.py
@@ -141,7 +141,7 @@ sqlalchemy_plugin = SQLAlchemyInitPlugin(config=sqlalchemy_config)
 
 async def on_startup() -> None:
     """Initializes the database."""
-    async with sqlalchemy_config.create_engine().begin() as conn:
+    async with sqlalchemy_config.get_engine().begin() as conn:
         await conn.run_sync(UUIDAuditBase.metadata.create_all)
 
 

--- a/docs/examples/contrib/sqlalchemy/sqlalchemy_sync_repository.py
+++ b/docs/examples/contrib/sqlalchemy/sqlalchemy_sync_repository.py
@@ -205,7 +205,7 @@ sqlalchemy_plugin = SQLAlchemyInitPlugin(config=sqlalchemy_config)
 
 def on_startup() -> None:
     """Initializes the database."""
-    with sqlalchemy_config.create_engine().begin() as conn:
+    with sqlalchemy_config.get_engine().begin() as conn:
         UUIDBase.metadata.create_all(conn)
 
 

--- a/docs/examples/pagination/using_offset_pagination_with_sqlalchemy.py
+++ b/docs/examples/pagination/using_offset_pagination_with_sqlalchemy.py
@@ -45,7 +45,7 @@ sqlalchemy_plugin = SQLAlchemyInitPlugin(config=sqlalchemy_config)
 
 async def on_startup() -> None:
     """Initializes the database."""
-    async with sqlalchemy_config.create_engine().begin() as conn:
+    async with sqlalchemy_config.get_engine().begin() as conn:
         await conn.run_sync(UUIDBase.metadata.create_all)
 
 


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
[//]: # "Please describe your pull request for new release changelog purposes"
[//]: # "Example: 'This pr adds the capability to use server-sent events, and documents it in the usage docs'"

- Remove references to `SQLAlchemyAsyncConfig.create_engine` from docs; use `SQLAlchemyAsyncConfig.get_engine` in examples instead.

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

- Closes #2374
