### PR TITLE
fix: avoid conversion to bool in debug response

### DIFF
--- a/litestar/middleware/exceptions/_debug_response.py
+++ b/litestar/middleware/exceptions/_debug_response.py
@@ -48,8 +48,13 @@ def get_symbol_name(frame: FrameInfo) -> str:
     locals_dict = frame.frame.f_locals
     # this piece assumes that the code uses standard names "self" and "cls"
     # in instance and class methods
-    instance_or_cls = locals_dict.get("self") or locals_dict.get("cls")
-    classname = f"{get_name(instance_or_cls)}." if instance_or_cls else ""
+    instance_or_cls = None
+    if "self" in locals_dict:
+        instance_or_cls = locals_dict["self"]
+    elif "cls" in locals_dict:
+        instance_or_cls = locals_dict["cls"]
+
+    classname = f"{get_name(instance_or_cls)}." if instance_or_cls is not None else ""
 
     return f"{classname}{frame.function}"
 

--- a/litestar/middleware/exceptions/_debug_response.py
+++ b/litestar/middleware/exceptions/_debug_response.py
@@ -48,11 +48,7 @@ def get_symbol_name(frame: FrameInfo) -> str:
     locals_dict = frame.frame.f_locals
     # this piece assumes that the code uses standard names "self" and "cls"
     # in instance and class methods
-    instance_or_cls = None
-    if "self" in locals_dict:
-        instance_or_cls = locals_dict["self"]
-    elif "cls" in locals_dict:
-        instance_or_cls = locals_dict["cls"]
+    instance_or_cls = inst if (inst := locals_dict.get("self")) is not None else locals_dict.get("cls")
 
     classname = f"{get_name(instance_or_cls)}." if instance_or_cls is not None else ""
 


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "By submitting this issue, you agree to:"
[//]: # "- follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow Litestar's [Contribution Guidelines](https://litestar.dev/community/contribution-guide)"

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description
Avoid implicit conversion to `bool` in `_debug_response.py` as this causes problems with some sqlalchemy classes, where instead of the original DB error being propagated, a `TypeError` is raised. See #2381 



### Close Issue(s)
Closes #2381 
