### PR TITLE
fix: #1301 - Apply compression before caching

### DIFF
--- a/litestar/_asgi/routing_trie/mapping.py
+++ b/litestar/_asgi/routing_trie/mapping.py
@@ -186,6 +186,8 @@ def build_route_middleware_stack(
     from litestar.middleware.allowed_hosts import AllowedHostsMiddleware
     from litestar.middleware.compression import CompressionMiddleware
     from litestar.middleware.csrf import CSRFMiddleware
+    from litestar.middleware.response_cache import ResponseCacheMiddleware
+    from litestar.routes import HTTPRoute
 
     # we wrap the route.handle method in the ExceptionHandlerMiddleware
     asgi_handler = wrap_in_exception_handler(
@@ -197,6 +199,10 @@ def build_route_middleware_stack(
 
     if app.compression_config:
         asgi_handler = CompressionMiddleware(app=asgi_handler, config=app.compression_config)
+
+    if isinstance(route, HTTPRoute) and any(r.cache for r in route.route_handlers):
+        asgi_handler = ResponseCacheMiddleware(app=asgi_handler, config=app.response_cache_config)
+
     if app.allowed_hosts:
         asgi_handler = AllowedHostsMiddleware(app=asgi_handler, config=app.allowed_hosts)
 

--- a/litestar/constants.py
+++ b/litestar/constants.py
@@ -20,6 +20,7 @@ RESERVED_KWARGS: Final = {"state", "headers", "cookies", "request", "socket", "d
 SCOPE_STATE_DEPENDENCY_CACHE: Final = "dependency_cache"
 SCOPE_STATE_NAMESPACE: Final = "__litestar__"
 SCOPE_STATE_RESPONSE_COMPRESSED: Final = "response_compressed"
+SCOPE_STATE_IS_CACHED: Final = "is_cached"
 SKIP_VALIDATION_NAMES: Final = {"request", "socket", "scope", "receive", "send"}
 UNDEFINED_SENTINELS: Final = {Signature.empty, Empty, Ellipsis, MISSING, UnsetType}
 WEBSOCKET_CLOSE: Final = "websocket.close"

--- a/litestar/middleware/response_cache.py
+++ b/litestar/middleware/response_cache.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from msgspec.msgpack import encode as encode_msgpack
+
+from litestar.enums import ScopeType
+from litestar.utils import get_litestar_scope_state
+
+from .base import AbstractMiddleware
+
+__all__ = ["ResponseCacheMiddleware"]
+
+from typing import TYPE_CHECKING, cast
+
+from litestar import Request
+from litestar.constants import SCOPE_STATE_IS_CACHED
+
+if TYPE_CHECKING:
+    from litestar.config.response_cache import ResponseCacheConfig
+    from litestar.handlers import HTTPRouteHandler
+    from litestar.types import ASGIApp, Message, Receive, Scope, Send
+
+
+class ResponseCacheMiddleware(AbstractMiddleware):
+    def __init__(self, app: ASGIApp, config: ResponseCacheConfig) -> None:
+        self.config = config
+        super().__init__(app=app, scopes={ScopeType.HTTP})
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        route_handler = cast("HTTPRouteHandler", scope["route_handler"])
+        store = self.config.get_store_from_app(scope["app"])
+
+        expires_in: int | None = None
+        if route_handler.cache is True:
+            expires_in = self.config.default_expiration
+        elif route_handler.cache is not False and isinstance(route_handler.cache, int):
+            expires_in = route_handler.cache
+
+        messages = []
+
+        async def wrapped_send(message: Message) -> None:
+            if not get_litestar_scope_state(scope, SCOPE_STATE_IS_CACHED):
+                messages.append(message)
+                if message["type"] == "http.response.body" and not message["more_body"]:
+                    key = (route_handler.cache_key_builder or self.config.key_builder)(Request(scope))
+                    await store.set(key, encode_msgpack(messages), expires_in=expires_in)
+            await send(message)
+
+        await self.app(scope, receive, wrapped_send)

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from itertools import chain
 from typing import TYPE_CHECKING, Any, cast
 
+from msgspec.msgpack import decode as _decode_msgpack_plain
+
 from litestar.constants import DEFAULT_ALLOWED_CORS_HEADERS, SCOPE_STATE_IS_CACHED
 from litestar.datastructures.headers import Headers
 from litestar.datastructures.upload_file import UploadFile
@@ -13,7 +15,6 @@ from litestar.response import Response
 from litestar.routes.base import BaseRoute
 from litestar.status_codes import HTTP_204_NO_CONTENT, HTTP_400_BAD_REQUEST
 from litestar.utils import set_litestar_scope_state
-from msgspec.msgpack import decode as _decode_msgpack_plain
 
 if TYPE_CHECKING:
     from litestar._kwargs import KwargsModel

--- a/tests/e2e/test_response_caching.py
+++ b/tests/e2e/test_response_caching.py
@@ -1,7 +1,7 @@
 import gzip
 import random
 from datetime import timedelta
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Type, Union
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -211,7 +211,7 @@ def test_does_not_apply_to_non_cached_routes(mock: MagicMock) -> None:
     ],
 )
 def test_middleware_not_applied_to_non_cached_routes(
-    cache: bool | int | type[CACHE_FOREVER], expect_applied: bool
+    cache: Union[bool, int, Type[CACHE_FOREVER]], expect_applied: bool
 ) -> None:
     @get(path="/", cache=cache)
     def handler() -> None:


### PR DESCRIPTION
Fix #1301 by introducing a moving caching to a hybrid approach that records outgoing ASGI messages within a middleware and hydrates them within the route when responding to a request.

There are some additional benefits to this approach:

- Improved performance and reduced size of the stored responses by switching from pickle to MessagePack and storing already compressed responses and only compressing them once
- Reduced overhead because the middleware can be applied ahead of time to only those routes that have caching enabled instead of checking each request
- Every response can now be cached without issues; Previously only those that could be pickled could be cached