### PR TITLE
fix: don't implicitly parse URL encoded form data as JSON

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1104,7 +1104,7 @@ typing-extensions = {version = ">=3.10.0.1", markers = "python_version <= \"3.8\
 name = "fast-query-parsers"
 version = "1.0.3"
 description = "Ultra-fast query string and url-encoded form-data parsers"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "fast_query_parsers-1.0.3-cp38-abi3-macosx_10_7_x86_64.whl", hash = "sha256:afbf71c1b4398dacfb9d84755eb026f8e759f68a066f1f3cc19e471fc342e74f"},
@@ -4293,7 +4293,7 @@ attrs = ["attrs"]
 brotli = ["brotli"]
 cli = ["jsbeautifier", "uvicorn"]
 cryptography = ["cryptography"]
-full = ["advanced-alchemy", "annotated-types", "attrs", "brotli", "cryptography", "jinja2", "jsbeautifier", "mako", "minijinja", "opentelemetry-instrumentation-asgi", "piccolo", "picologging", "prometheus-client", "pydantic", "pydantic-extra-types", "python-jose", "redis", "structlog", "uvicorn"]
+full = ["advanced-alchemy", "annotated-types", "attrs", "brotli", "cryptography", "fast-query-parsers", "jinja2", "jsbeautifier", "mako", "minijinja", "opentelemetry-instrumentation-asgi", "piccolo", "picologging", "prometheus-client", "pydantic", "pydantic-extra-types", "python-jose", "redis", "structlog", "uvicorn"]
 jinja = ["jinja2"]
 jsbeautifier = ["jsbeautifier"]
 jwt = ["cryptography", "python-jose"]
@@ -4306,10 +4306,10 @@ prometheus = ["prometheus-client"]
 pydantic = ["pydantic", "pydantic-extra-types"]
 redis = ["redis"]
 sqlalchemy = ["advanced-alchemy"]
-standard = ["jinja2", "jsbeautifier", "uvicorn"]
+standard = ["fast-query-parsers", "jinja2", "jsbeautifier", "uvicorn"]
 structlog = ["structlog"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "ea7b1c0ac6f00e05451ed86ad33c3d47bb46418d728beb69780f42c61f850f3f"
+content-hash = "162ff5be14a8e045a386af07cecc80464c936d38bd59f04d98f4bdb2d45338bd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ attrs = { version = "*", optional = true }
 brotli = { version = "*", optional = true }
 click = "*"
 cryptography = { version = "*", optional = true }
-fast-query-parsers = ">=1.0.2"
+fast-query-parsers = {version = ">=1.0.2", optional = true }
 httpx = ">=0.22"
 importlib-metadata = { version = "*", python = "<3.10" }
 importlib-resources = { version = ">=5.12.0", python = "<3.9" }
@@ -180,7 +180,7 @@ prometheus = ["prometheus-client"]
 pydantic = ["pydantic", "pydantic-extra-types"]
 redis = ["redis"]
 sqlalchemy = ["advanced-alchemy"]
-standard = ["jinja2", "jsbeautifier", "uvicorn"]
+standard = ["jinja2", "jsbeautifier", "uvicorn", "fast-query-parsers"]
 structlog = ["structlog"]
 
 full = [
@@ -202,7 +202,8 @@ full = [
     "redis",
     "structlog",
     "uvicorn",
-    "advanced-alchemy"
+    "advanced-alchemy",
+    "fast-query-parsers",
 ]
 
 [tool.poetry.scripts]

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -31,11 +31,11 @@ def test_parse_form_data() -> None:
     )
     assert result == {
         "value": ["10", "12"],
-        "veggies": ["tomato", "potato", "aubergine"],
-        "nested": {"some_key": "some_value"},
+        "veggies": '["tomato", "potato", "aubergine"]',
+        "nested": '{"some_key": "some_value"}',
         "calories": "122.53",
-        "healthy": True,
-        "polluting": False,
+        "healthy": "true",
+        "polluting": "false",
     }
 
 


### PR DESCRIPTION
We currently parse URL encoded form data as JSON. This is arguably not the correct behaviour and can lead to serious bugs if something looks like JSON but isn't meant to be. It is also unexpected and there's no way for a user to control this.

This PR fixes the behaviour and adjusts the tests accordingly.

As an aside, it allows us to make `fast-query-parsers` optional as a speedup, which has now been moved to the `standard` and `full` extra.