### PR TITLE
feat: allow customization of Pydantic integration

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ By submitting this pull request, you agree to:
 Please describe your pull request for new release changelog purposes
 -->
 
-- 
+-
 
 ### Close Issue(s)
 <!--
@@ -26,4 +26,4 @@ Please add in issue numbers this pull request will close, if applicable
 Examples: Fixes #4321 or Closes #1234
 -->
 
-- 
+-

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -341,9 +341,7 @@ class Litestar(Router):
             opt=dict(opt or {}),
             parameters=parameters or {},
             pdb_on_exception=pdb_on_exception,
-            plugins=[
-                *self._get_default_plugins(list(plugins or [])),
-            ],
+            plugins=self._get_default_plugins(list(plugins or [])),
             request_class=request_class,
             response_cache_config=response_cache_config or ResponseCacheConfig(),
             response_class=response_class,

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -341,7 +341,9 @@ class Litestar(Router):
             opt=dict(opt or {}),
             parameters=parameters or {},
             pdb_on_exception=pdb_on_exception,
-            plugins=[*(plugins or []), *self._get_default_plugins()],
+            plugins=[
+                *self._get_default_plugins(list(plugins or [])),
+            ],
             request_class=request_class,
             response_cache_config=response_cache_config or ResponseCacheConfig(),
             response_class=response_class,
@@ -466,18 +468,24 @@ class Litestar(Router):
         return list(self.plugins.serialization)
 
     @staticmethod
-    def _get_default_plugins() -> list[PluginProtocol]:
-        default_plugins: list[PluginProtocol] = []
+    def _get_default_plugins(plugins: list[PluginProtocol] | None = None) -> list[PluginProtocol]:
+        if plugins is None:
+            plugins = []
         with suppress(MissingDependencyException):
-            from litestar.contrib.pydantic import PydanticInitPlugin, PydanticSchemaPlugin
+            from litestar.contrib.pydantic import PydanticInitPlugin, PydanticPlugin, PydanticSchemaPlugin
 
-            default_plugins.extend((PydanticInitPlugin(), PydanticSchemaPlugin()))
-
+            pre_configured = any(
+                isinstance(plugin, (PydanticPlugin, PydanticInitPlugin, PydanticSchemaPlugin)) for plugin in plugins
+            )
+            if not pre_configured:
+                plugins.append(PydanticPlugin())
         with suppress(MissingDependencyException):
             from litestar.contrib.attrs import AttrsSchemaPlugin
 
-            default_plugins.append(AttrsSchemaPlugin())
-        return default_plugins
+            pre_configured = any(isinstance(plugin, AttrsSchemaPlugin) for plugin in plugins)
+            if not pre_configured:
+                plugins.append(AttrsSchemaPlugin())
+        return plugins
 
     @property
     def debug(self) -> bool:

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -472,11 +472,15 @@ class Litestar(Router):
         with suppress(MissingDependencyException):
             from litestar.contrib.pydantic import PydanticInitPlugin, PydanticPlugin, PydanticSchemaPlugin
 
-            pre_configured = any(
-                isinstance(plugin, (PydanticPlugin, PydanticInitPlugin, PydanticSchemaPlugin)) for plugin in plugins
-            )
-            if not pre_configured:
+            pydantic_plugin_found = any(isinstance(plugin, PydanticPlugin) for plugin in plugins)
+            pydantic_init_plugin_found = any(isinstance(plugin, PydanticInitPlugin) for plugin in plugins)
+            pydantic_schema_plugin_found = any(isinstance(plugin, PydanticSchemaPlugin) for plugin in plugins)
+            if not pydantic_plugin_found and not pydantic_init_plugin_found and not pydantic_schema_plugin_found:
                 plugins.append(PydanticPlugin())
+            elif not pydantic_plugin_found and pydantic_init_plugin_found and not pydantic_schema_plugin_found:
+                plugins.append(PydanticSchemaPlugin())
+            elif not pydantic_plugin_found and not pydantic_init_plugin_found and pydantic_schema_plugin_found:
+                plugins.append(PydanticInitPlugin())
         with suppress(MissingDependencyException):
             from litestar.contrib.attrs import AttrsSchemaPlugin
 

--- a/litestar/contrib/pydantic/__init__.py
+++ b/litestar/contrib/pydantic/__init__.py
@@ -39,7 +39,7 @@ class PydanticPlugin(InitPluginProtocol):
         """Initialize ``PydanticPlugin``.
 
         Args:
-            prefer_alias: OpenAPI and type_encoders will export by alias
+            prefer_alias: OpenAPI and ``type_encoders`` will export by alias
         """
         self.prefer_alias = prefer_alias
 

--- a/litestar/contrib/pydantic/__init__.py
+++ b/litestar/contrib/pydantic/__init__.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from litestar.plugins import InitPluginProtocol
+
 from .pydantic_dto_factory import PydanticDTO
 from .pydantic_init_plugin import PydanticInitPlugin
 from .pydantic_schema_plugin import PydanticSchemaPlugin
@@ -9,7 +11,9 @@ from .pydantic_schema_plugin import PydanticSchemaPlugin
 if TYPE_CHECKING:
     import pydantic
 
-__all__ = ("PydanticDTO", "PydanticInitPlugin", "PydanticSchemaPlugin")
+    from litestar.config.app import AppConfig
+
+__all__ = ("PydanticDTO", "PydanticInitPlugin", "PydanticSchemaPlugin", "PydanticPlugin")
 
 
 def _model_dump(model: pydantic.BaseModel, *, by_alias: bool = False) -> dict[str, Any]:
@@ -20,5 +24,32 @@ def _model_dump(model: pydantic.BaseModel, *, by_alias: bool = False) -> dict[st
     )
 
 
-def _model_dump_json(model: pydantic.BaseModel) -> str:
-    return model.model_dump_json() if hasattr(model, "model_dump_json") else model.json()
+def _model_dump_json(model: pydantic.BaseModel, by_alias: bool = False) -> str:
+    return (
+        model.model_dump_json(by_alias=by_alias) if hasattr(model, "model_dump_json") else model.json(by_alias=by_alias)
+    )
+
+
+class PydanticPlugin(InitPluginProtocol):
+    """A plugin that provides Pydantic integration."""
+
+    __slots__ = ("prefer_alias",)
+
+    def __init__(self, prefer_alias: bool = False) -> None:
+        """Initialize ``PydanticPlugin``.
+
+        Args:
+            prefer_alias: OpenAPI and type_encoders will export by alias
+        """
+        self.prefer_alias = prefer_alias
+
+    def on_app_init(self, app_config: AppConfig) -> AppConfig:
+        """Configure application for use with Pydantic.
+
+        Args:
+            app_config: The :class:`AppConfig <.config.app.AppConfig>` instance.
+        """
+        app_config.plugins.extend(
+            [PydanticInitPlugin(prefer_alias=self.prefer_alias), PydanticSchemaPlugin(prefer_alias=self.prefer_alias)]
+        )
+        return app_config

--- a/litestar/contrib/pydantic/pydantic_schema_plugin.py
+++ b/litestar/contrib/pydantic/pydantic_schema_plugin.py
@@ -132,6 +132,11 @@ _supported_types = (pydantic.BaseModel, *list(PYDANTIC_TYPE_MAP.keys()))
 
 
 class PydanticSchemaPlugin(OpenAPISchemaPluginProtocol):
+    __slots__ = ("prefer_alias",)
+
+    def __init__(self, prefer_alias: bool = False) -> None:
+        self.prefer_alias = prefer_alias
+
     @staticmethod
     def is_plugin_supported_type(value: Any) -> bool:
         return isinstance(value, _supported_types) or is_class_and_subclass(value, _supported_types)  # type: ignore
@@ -146,6 +151,8 @@ class PydanticSchemaPlugin(OpenAPISchemaPluginProtocol):
         Returns:
             An :class:`OpenAPI <litestar.openapi.spec.schema.Schema>` instance.
         """
+        if schema_creator.prefer_alias != self.prefer_alias:
+            schema_creator.prefer_alias = True
         if is_pydantic_model_class(field_definition.annotation):
             return self.for_pydantic_model(annotation=field_definition.annotation, schema_creator=schema_creator)
         return PYDANTIC_TYPE_MAP[field_definition.annotation]  # pragma: no cover

--- a/tests/unit/test_contrib/test_pydantic/test_plugin_serialization.py
+++ b/tests/unit/test_contrib/test_pydantic/test_plugin_serialization.py
@@ -175,25 +175,13 @@ def test_serialization_of_model_instance(model: BaseModel) -> None:
     assert serializer(model) == _model_dump(model)
 
 
-def test_pydantic_json_compatibility(model: BaseModel) -> None:
-    raw = _model_dump_json(model)
-    encoded_json = encode_json(model, serializer=get_serializer(PydanticInitPlugin.encoders()))
-
-    raw_result = json.loads(raw)
-    encoded_result = json.loads(encoded_json)
-
-    if VERSION.startswith("1"):
-        # pydantic v1 dumps decimals into floats as json, we therefore regard this as an error
-        assert raw_result.get("condecimal") == float(encoded_result.get("condecimal"))
-        del raw_result["condecimal"]
-        del encoded_result["condecimal"]
-
-    assert raw_result == encoded_result
-
-
-def test_pydantic_json_by_alias_compatibility(model: BaseModel) -> None:
-    raw = _model_dump_json(model, by_alias=True)
-    encoded_json = encode_json(model, serializer=get_serializer(PydanticInitPlugin.encoders(prefer_alias=True)))
+@pytest.mark.parametrize(
+    "prefer_alias",
+    [(False), (True)],
+)
+def test_pydantic_json_compatibility(model: BaseModel, prefer_alias: bool) -> None:
+    raw = _model_dump_json(model, by_alias=prefer_alias)
+    encoded_json = encode_json(model, serializer=get_serializer(PydanticInitPlugin.encoders(prefer_alias=prefer_alias)))
 
     raw_result = json.loads(raw)
     encoded_result = json.loads(encoded_json)
@@ -219,29 +207,25 @@ def test_decode_json_raises_serialization_exception(model: BaseModel, decoder: A
         decoder(b"str")
 
 
-def test_decode_json_typed(model: BaseModel) -> None:
-    dumped_model = _model_dump_json(model)
+@pytest.mark.parametrize(
+    "prefer_alias",
+    [(False), (True)],
+)
+def test_decode_json_typed(model: BaseModel, prefer_alias: bool) -> None:
+    dumped_model = _model_dump_json(model, by_alias=prefer_alias)
     decoded_model = decode_json(value=dumped_model, target_type=Model, type_decoders=PydanticInitPlugin.decoders())
-    assert _model_dump_json(decoded_model) == dumped_model
+    assert _model_dump_json(decoded_model, by_alias=prefer_alias) == dumped_model
 
 
-def test_decode_msgpack_typed(model: BaseModel) -> None:
-    model_json = _model_dump_json(model)
+@pytest.mark.parametrize(
+    "prefer_alias",
+    [(False), (True)],
+)
+def test_decode_msgpack_typed(model: BaseModel, prefer_alias: bool) -> None:
+    model_json = _model_dump_json(model, by_alias=prefer_alias)
     assert (
         decode_msgpack(
-            encode_msgpack(model, serializer=get_serializer(PydanticInitPlugin.encoders())),
-            Model,
-            type_decoders=PydanticInitPlugin.decoders(),
-        ).json()
-        == model_json
-    )
-
-
-def test_decode_msgpack_typed_aliased(model: BaseModel) -> None:
-    model_json = _model_dump_json(model, by_alias=True)
-    assert (
-        decode_msgpack(
-            encode_msgpack(model, serializer=get_serializer(PydanticInitPlugin.encoders(prefer_alias=True))),
+            encode_msgpack(model, serializer=get_serializer(PydanticInitPlugin.encoders(prefer_alias=prefer_alias))),
             Model,
             type_decoders=PydanticInitPlugin.decoders(),
         ).json()

--- a/tests/unit/test_openapi/test_config.py
+++ b/tests/unit/test_openapi/test_config.py
@@ -5,6 +5,7 @@ import pytest
 from pydantic import BaseModel, Field
 
 from litestar import Litestar, get, post
+from litestar.contrib.pydantic import PydanticPlugin
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.openapi.config import OpenAPIConfig
 from litestar.openapi.spec import Components, Example, OpenAPIHeader, OpenAPIType, Schema
@@ -71,6 +72,45 @@ def test_by_alias() -> None:
         "title": "RequestWithAlias",
     }
     response_key = "first"
+    assert schemas["ResponseWithAlias"] == {
+        "properties": {response_key: {"type": "string"}},
+        "type": "object",
+        "required": [response_key],
+        "title": "ResponseWithAlias",
+    }
+
+    with TestClient(app) as client:
+        response = client.post("/", json={request_key: "foo"})
+        assert response.json() == {response_key: "foo"}
+
+
+def test_pydantic_plugin_override_by_alias() -> None:
+    class RequestWithAlias(BaseModel):
+        first: str = Field(alias="second")
+
+    class ResponseWithAlias(BaseModel):
+        first: str = Field(alias="second")
+
+    @post("/")
+    def handler(data: RequestWithAlias) -> ResponseWithAlias:
+        return ResponseWithAlias(second=data.first)
+
+    app = Litestar(
+        route_handlers=[handler],
+        openapi_config=OpenAPIConfig(title="my title", version="1.0.0"),
+        plugins=[PydanticPlugin(prefer_alias=True)],
+    )
+
+    assert app.openapi_schema
+    schemas = app.openapi_schema.to_schema()["components"]["schemas"]
+    request_key = "second"
+    assert schemas["RequestWithAlias"] == {
+        "properties": {request_key: {"type": "string"}},
+        "type": "object",
+        "required": [request_key],
+        "title": "RequestWithAlias",
+    }
+    response_key = "second"
     assert schemas["ResponseWithAlias"] == {
         "properties": {response_key: {"type": "string"}},
         "type": "object",


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- This PR adds a new `PydanticPlugin` that allows for customization of the Pydantic integration.  Currently, the only feature is to let a user export a model by alias.  When setting this, it applies to OpenAPI and responses.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- Closes #2373
