### PR TITLE
chore: additional CI and PDM cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,7 +120,7 @@ jobs:
             ./pdm.lock
 
       - name: Install dependencies
-        run: pdm install -G:docs
+        run: pdm install -G:all
 
       - name: Build docs
         run: pdm run make docs

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,7 +29,7 @@ jobs:
             ./pdm.lock
 
       - name: Install dependencies
-        run: pdm install -G:docs
+        run: pdm install -G:all
 
       - name: Fetch gh pages
         run: git fetch origin gh-pages --depth=1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,7 +44,7 @@ jobs:
             ./pdm.lock
 
       - name: Install dependencies
-        run: pdm install
+        run: pdm install -G:all
 
       - if: ${{ inputs.pydantic-version == '1' }}
         name: Prepare for pydantic v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,25 +17,21 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
-  - repo: https://github.com/pdm-project/pdm
-    rev: 2.9.2
-    hooks:
-      - id: pdm-lock-check
   - repo: https://github.com/provinzkraut/unasyncd
     rev: "v0.6.1"
     hooks:
       - id: unasyncd
         additional_dependencies: ["ruff"]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.290"
+    rev: "v0.0.292"
     hooks:
       - id: ruff
         args: ["--fix"]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.5
+    rev: v2.2.6
     hooks:
       - id: codespell
-        exclude: "tests/openapi/typescript_converter/test_converter"
+        exclude: "tests/openapi/typescript_converter/test_converter|README.md"
   - repo: https://github.com/psf/black
     rev: 23.9.1
     hooks:
@@ -72,69 +68,6 @@ repos:
             annotated_types,
             anyio,
             async_timeout,
-            asyncmy,
-            asyncpg,
-            asyncpg_stubs,
-            attrs,
-            beanie,
-            beautifulsoup4,
-            brotli,
-            click,
-            exceptiongroup,
-            fast-query-parsers>=1.0.2,
-            fsspec,
-            httpx==0.24.1,
-            httpx_sse,
-            hypothesis,
-            jsbeautifier,
-            mako,
-            mongomock_motor,
-            msgspec,
-            multidict,
-            opentelemetry-instrumentation-asgi,
-            opentelemetry-sdk,
-            oracledb,
-            piccolo,
-            picologging,
-            polyfactory,
-            prometheus_client,
-            psycopg,
-            pydantic-extra-types,
-            pydantic>=2,
-            pytest,
-            pytest-lazy-fixture,
-            pytest-mock,
-            pytest-timeout,
-            pytest_docker,
-            python-dotenv,
-            python-jose,
-            pyyaml,
-            redis,
-            rich,
-            rich-click,
-            sqlalchemy>=2.0.12,
-            starlette,
-            structlog,
-            advanced-alchemy==0.2.2,
-            time-machine,
-            types-beautifulsoup4,
-            types-python-jose,
-            types-pyyaml,
-            types-redis,
-            uvicorn,
-          ]
-  - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.328
-    hooks:
-      - id: pyright
-        exclude: "test_apps|tools|docs|_openapi|tests/examples|tests/docker_service_fixtures"
-        additional_dependencies:
-          [
-            aiosqlite,
-            annotated_types,
-            anyio,
-            async_timeout,
-            asyncmy,
             asyncpg,
             asyncpg_stubs,
             attrs,
@@ -156,12 +89,10 @@ repos:
             multidict,
             opentelemetry-instrumentation-asgi,
             opentelemetry-sdk,
-            oracledb,
             piccolo,
             picologging,
             polyfactory,
             prometheus_client,
-            psycopg,
             pydantic-extra-types,
             pydantic>=2,
             pytest,
@@ -185,6 +116,70 @@ repos:
             types-pyyaml,
             types-redis,
             uvicorn,
+            uvloop,
+            httptools,
+          ]
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.328
+    hooks:
+      - id: pyright
+        exclude: "test_apps|tools|docs|_openapi|tests/examples|tests/docker_service_fixtures"
+        additional_dependencies:
+          [
+            aiosqlite,
+            annotated_types,
+            anyio,
+            async_timeout,
+            asyncpg,
+            asyncpg_stubs,
+            attrs,
+            beanie,
+            beautifulsoup4,
+            brotli,
+            click,
+            exceptiongroup,
+            fast-query-parsers>=1.0.2,
+            fsspec,
+            httpx==0.24.1,
+            httpx_sse,
+            hypothesis,
+            jsbeautifier,
+            mako,
+            mongomock_motor,
+            minijinja,
+            msgspec,
+            multidict,
+            opentelemetry-instrumentation-asgi,
+            opentelemetry-sdk,
+            piccolo,
+            picologging,
+            polyfactory,
+            prometheus_client,
+            pydantic-extra-types,
+            pydantic>=2,
+            pytest,
+            pytest-lazy-fixture,
+            pytest-mock,
+            pytest-timeout,
+            pytest_docker,
+            python-dotenv,
+            python-jose,
+            pyyaml,
+            redis,
+            rich,
+            rich-click,
+            sqlalchemy>=2.0.12,
+            advanced-alchemy==0.2.2,
+            starlette,
+            structlog,
+            time-machine,
+            types-beautifulsoup4,
+            types-python-jose,
+            types-pyyaml,
+            types-redis,
+            uvicorn,
+            uvloop,
+            httptools,
           ]
   - repo: https://github.com/sphinx-contrib/sphinx-lint
     rev: "v0.6.8"

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ install:											## Install the project, dependencies, and pre-commit for loca
 	if [ "$(VENV_EXISTS)" ]; then $(MAKE) clean; fi
 	@if [ "$(USING_PDM)" ]; then $(PDM) config venv.in_project true && python3 -m venv --copies .venv && . $(ENV_PREFIX)/activate && $(ENV_PREFIX)/pip install --quiet -U wheel setuptools cython pip; fi
 	@if [ "$(USING_PDM)" ]; then $(PDM) install; fi
-	@echo "=> Installing pre-commit hooks"
-	pre-commit install --install-hooks
+	# @echo "=> Installing pre-commit hooks"
+	# pre-commit install --install-hooks
 	@echo "=> Install complete! Note: If you want to re-install re-run 'make install'"
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,6 @@ install:											## Install the project, dependencies, and pre-commit for loca
 	if [ "$(VENV_EXISTS)" ]; then $(MAKE) clean; fi
 	@if [ "$(USING_PDM)" ]; then $(PDM) config venv.in_project true && python3 -m venv --copies .venv && . $(ENV_PREFIX)/activate && $(ENV_PREFIX)/pip install --quiet -U wheel setuptools cython pip; fi
 	@if [ "$(USING_PDM)" ]; then $(PDM) install; fi
-	# @echo "=> Installing pre-commit hooks"
-	# pre-commit install --install-hooks
 	@echo "=> Install complete! Note: If you want to re-install re-run 'make install'"
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ install:											## Install the project, dependencies, and pre-commit for loca
 	if [ "$(VENV_EXISTS)" ]; then $(MAKE) destroy; fi
 	if [ "$(VENV_EXISTS)" ]; then $(MAKE) clean; fi
 	@if [ "$(USING_PDM)" ]; then $(PDM) config venv.in_project true && python3 -m venv --copies .venv && . $(ENV_PREFIX)/activate && $(ENV_PREFIX)/pip install --quiet -U wheel setuptools cython pip; fi
-	@if [ "$(USING_PDM)" ]; then $(PDM) install; fi
+	@if [ "$(USING_PDM)" ]; then $(PDM) install -G:all; fi
 	@echo "=> Install complete! Note: If you want to re-install re-run 'make install'"
 
 .PHONY: clean

--- a/docs/usage/stores.rst
+++ b/docs/usage/stores.rst
@@ -150,7 +150,7 @@ These come with the additional :meth:`with_namespace <.base.NamespacedStore.with
 new :class:`NamespacedStore <.base.NamespacedStore>` instance. Once a namespaced store is created, operations on it
 will only affect itself and its child namespaces.
 
-When using the :class:`RedisStore <.redis.RedisStore>`, this allows to re-use the same underlying
+When using the :class:`RedisStore <.redis.RedisStore>`, this allows to reuse the same underlying
 :class:`Redis <redis.asyncio.Redis>` instance and connection, while ensuring isolation.
 
 .. note::
@@ -237,7 +237,7 @@ This mechanism also allows to control the stores used by various integrations, s
 
 In this example, the registry is being set up with stores using the ``sessions`` and ``response_cache`` keys. These are
 not magic constants, but instead configuration values that can be changed. Those names just happen to be their default
-values. Adjusting those default values allows to easily re-use stores, without the need for a more complex setup:
+values. Adjusting those default values allows to easily reuse stores, without the need for a more complex setup:
 
 .. literalinclude:: /examples/stores/configure_integrations_set_names.py
     :language: python

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,11 +2,11 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "dev", "dev-contrib", "docs", "linting", "test"]
+groups = ["default", "annotated-types", "attrs", "brotli", "cli", "cryptography", "dev", "dev-contrib", "docs", "jinja", "jwt", "linting", "mako", "minijinja", "opentelemetry", "piccolo", "picologging", "prometheus", "pydantic", "redis", "sqlalchemy", "standard", "structlog", "test"]
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:28d7668a00ed3d9f73b55b5e979eb64c20d7747297a53f6dc8a5d8cdb50d09b6"
+content_hash = "sha256:7433bc120c64c01cab7a42d8b0574b12dafc4edcee1ec02d5013b0e9605647d5"
 
 [[package]]
 name = "accessible-pygments"
@@ -1179,6 +1179,43 @@ dependencies = [
 files = [
     {file = "httpcore-0.18.0-py3-none-any.whl", hash = "sha256:adc5398ee0a476567bf87467063ee63584a8bce86078bf748e48754f60202ced"},
     {file = "httpcore-0.18.0.tar.gz", hash = "sha256:13b5e5cd1dca1a6636a6aaea212b19f4f85cd88c366a2b82304181b769aab3c9"},
+]
+
+[[package]]
+name = "httptools"
+version = "0.6.0"
+requires_python = ">=3.5.0"
+summary = "A collection of framework independent HTTP protocol utils."
+files = [
+    {file = "httptools-0.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:818325afee467d483bfab1647a72054246d29f9053fd17cc4b86cda09cc60339"},
+    {file = "httptools-0.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72205730bf1be875003692ca54a4a7c35fac77b4746008966061d9d41a61b0f5"},
+    {file = "httptools-0.6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:33eb1d4e609c835966e969a31b1dedf5ba16b38cab356c2ce4f3e33ffa94cad3"},
+    {file = "httptools-0.6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bdc6675ec6cb79d27e0575750ac6e2b47032742e24eed011b8db73f2da9ed40"},
+    {file = "httptools-0.6.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:463c3bc5ef64b9cf091be9ac0e0556199503f6e80456b790a917774a616aff6e"},
+    {file = "httptools-0.6.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:82f228b88b0e8c6099a9c4757ce9fdbb8b45548074f8d0b1f0fc071e35655d1c"},
+    {file = "httptools-0.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:0781fedc610293a2716bc7fa142d4c85e6776bc59d617a807ff91246a95dea35"},
+    {file = "httptools-0.6.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:721e503245d591527cddd0f6fd771d156c509e831caa7a57929b55ac91ee2b51"},
+    {file = "httptools-0.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:274bf20eeb41b0956e34f6a81f84d26ed57c84dd9253f13dcb7174b27ccd8aaf"},
+    {file = "httptools-0.6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:259920bbae18740a40236807915def554132ad70af5067e562f4660b62c59b90"},
+    {file = "httptools-0.6.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03bfd2ae8a2d532952ac54445a2fb2504c804135ed28b53fefaf03d3a93eb1fd"},
+    {file = "httptools-0.6.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:f959e4770b3fc8ee4dbc3578fd910fab9003e093f20ac8c621452c4d62e517cb"},
+    {file = "httptools-0.6.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6e22896b42b95b3237eccc42278cd72c0df6f23247d886b7ded3163452481e38"},
+    {file = "httptools-0.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:38f3cafedd6aa20ae05f81f2e616ea6f92116c8a0f8dcb79dc798df3356836e2"},
+    {file = "httptools-0.6.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:cf8169e839a0d740f3d3c9c4fa630ac1a5aaf81641a34575ca6773ed7ce041a1"},
+    {file = "httptools-0.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5dcc14c090ab57b35908d4a4585ec5c0715439df07be2913405991dbb37e049d"},
+    {file = "httptools-0.6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d0b0571806a5168013b8c3d180d9f9d6997365a4212cb18ea20df18b938aa0b"},
+    {file = "httptools-0.6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fb4a608c631f7dcbdf986f40af7a030521a10ba6bc3d36b28c1dc9e9035a3c0"},
+    {file = "httptools-0.6.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:93f89975465133619aea8b1952bc6fa0e6bad22a447c6d982fc338fbb4c89649"},
+    {file = "httptools-0.6.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:73e9d66a5a28b2d5d9fbd9e197a31edd02be310186db423b28e6052472dc8201"},
+    {file = "httptools-0.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:22c01fcd53648162730a71c42842f73b50f989daae36534c818b3f5050b54589"},
+    {file = "httptools-0.6.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3f96d2a351b5625a9fd9133c95744e8ca06f7a4f8f0b8231e4bbaae2c485046a"},
+    {file = "httptools-0.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:72ec7c70bd9f95ef1083d14a755f321d181f046ca685b6358676737a5fecd26a"},
+    {file = "httptools-0.6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b703d15dbe082cc23266bf5d9448e764c7cb3fcfe7cb358d79d3fd8248673ef9"},
+    {file = "httptools-0.6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82c723ed5982f8ead00f8e7605c53e55ffe47c47465d878305ebe0082b6a1755"},
+    {file = "httptools-0.6.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b0a816bb425c116a160fbc6f34cece097fd22ece15059d68932af686520966bd"},
+    {file = "httptools-0.6.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:dea66d94e5a3f68c5e9d86e0894653b87d952e624845e0b0e3ad1c733c6cc75d"},
+    {file = "httptools-0.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:23b09537086a5a611fad5696fc8963d67c7e7f98cb329d38ee114d588b0b74cd"},
+    {file = "httptools-0.6.0.tar.gz", hash = "sha256:9fc6e409ad38cbd68b177cd5158fc4042c796b82ca88d99ec78f07bed6c6b796"},
 ]
 
 [[package]]
@@ -3226,6 +3263,39 @@ dependencies = [
 files = [
     {file = "uvicorn-0.23.2-py3-none-any.whl", hash = "sha256:1f9be6558f01239d4fdf22ef8126c39cb1ad0addf76c40e760549d2c2f43ab53"},
     {file = "uvicorn-0.23.2.tar.gz", hash = "sha256:4d3cc12d7727ba72b64d12d3cc7743124074c0a69f7b201512fc50c3e3f1569a"},
+]
+
+[[package]]
+name = "uvloop"
+version = "0.17.0"
+requires_python = ">=3.7"
+summary = "Fast implementation of asyncio event loop on top of libuv"
+files = [
+    {file = "uvloop-0.17.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ce9f61938d7155f79d3cb2ffa663147d4a76d16e08f65e2c66b77bd41b356718"},
+    {file = "uvloop-0.17.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:68532f4349fd3900b839f588972b3392ee56042e440dd5873dfbbcd2cc67617c"},
+    {file = "uvloop-0.17.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0949caf774b9fcefc7c5756bacbbbd3fc4c05a6b7eebc7c7ad6f825b23998d6d"},
+    {file = "uvloop-0.17.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff3d00b70ce95adce264462c930fbaecb29718ba6563db354608f37e49e09024"},
+    {file = "uvloop-0.17.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:a5abddb3558d3f0a78949c750644a67be31e47936042d4f6c888dd6f3c95f4aa"},
+    {file = "uvloop-0.17.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8efcadc5a0003d3a6e887ccc1fb44dec25594f117a94e3127954c05cf144d811"},
+    {file = "uvloop-0.17.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3378eb62c63bf336ae2070599e49089005771cc651c8769aaad72d1bd9385a7c"},
+    {file = "uvloop-0.17.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6aafa5a78b9e62493539456f8b646f85abc7093dd997f4976bb105537cf2635e"},
+    {file = "uvloop-0.17.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c686a47d57ca910a2572fddfe9912819880b8765e2f01dc0dd12a9bf8573e539"},
+    {file = "uvloop-0.17.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:864e1197139d651a76c81757db5eb199db8866e13acb0dfe96e6fc5d1cf45fc4"},
+    {file = "uvloop-0.17.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:2a6149e1defac0faf505406259561bc14b034cdf1d4711a3ddcdfbaa8d825a05"},
+    {file = "uvloop-0.17.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6708f30db9117f115eadc4f125c2a10c1a50d711461699a0cbfaa45b9a78e376"},
+    {file = "uvloop-0.17.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a4aee22ece20958888eedbad20e4dbb03c37533e010fb824161b4f05e641f738"},
+    {file = "uvloop-0.17.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:307958f9fc5c8bb01fad752d1345168c0abc5d62c1b72a4a8c6c06f042b45b20"},
+    {file = "uvloop-0.17.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ebeeec6a6641d0adb2ea71dcfb76017602ee2bfd8213e3fcc18d8f699c5104f"},
+    {file = "uvloop-0.17.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1436c8673c1563422213ac6907789ecb2b070f5939b9cbff9ef7113f2b531595"},
+    {file = "uvloop-0.17.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8887d675a64cfc59f4ecd34382e5b4f0ef4ae1da37ed665adba0c2badf0d6578"},
+    {file = "uvloop-0.17.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:3db8de10ed684995a7f34a001f15b374c230f7655ae840964d51496e2f8a8474"},
+    {file = "uvloop-0.17.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7d37dccc7ae63e61f7b96ee2e19c40f153ba6ce730d8ba4d3b4e9738c1dccc1b"},
+    {file = "uvloop-0.17.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:cbbe908fda687e39afd6ea2a2f14c2c3e43f2ca88e3a11964b297822358d0e6c"},
+    {file = "uvloop-0.17.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d97672dc709fa4447ab83276f344a165075fd9f366a97b712bdd3fee05efae8"},
+    {file = "uvloop-0.17.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1e507c9ee39c61bfddd79714e4f85900656db1aec4d40c6de55648e85c2799c"},
+    {file = "uvloop-0.17.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:c092a2c1e736086d59ac8e41f9c98f26bbf9b9222a76f21af9dfe949b99b2eb9"},
+    {file = "uvloop-0.17.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:30babd84706115626ea78ea5dbc7dd8d0d01a2e9f9b306d24ca4ed5796c66ded"},
+    {file = "uvloop-0.17.0.tar.gz", hash = "sha256:0ddf6baf9cf11a1a22c71487f39f15b2cf78eb5bde7e5b45fbb99e8a9d91b9e1"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -6,7 +6,7 @@ groups = ["default", "annotated-types", "attrs", "brotli", "cli", "cryptography"
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:7433bc120c64c01cab7a42d8b0574b12dafc4edcee1ec02d5013b0e9605647d5"
+content_hash = "sha256:bf83b030487c4352650e3058daea42fb3942de4be025020e57bdfe93b658fa43"
 
 [[package]]
 name = "accessible-pygments"
@@ -33,6 +33,16 @@ dependencies = [
 files = [
     {file = "advanced_alchemy-0.2.2-py3-none-any.whl", hash = "sha256:5c744e61d67d0c4b25e9084776e8c2ca790aaa3f9370f922b71d216b6bef200b"},
     {file = "advanced_alchemy-0.2.2.tar.gz", hash = "sha256:d6c0557f8762b889aa4ad714001ab18c16797c65b6d3eb88fb97e0de13ba8d69"},
+]
+
+[[package]]
+name = "aiosqlite"
+version = "0.19.0"
+requires_python = ">=3.7"
+summary = "asyncio bridge to the standard sqlite3 module"
+files = [
+    {file = "aiosqlite-0.19.0-py3-none-any.whl", hash = "sha256:edba222e03453e094a3ce605db1b970c4b3376264e56f32e2a4959f948d66a96"},
+    {file = "aiosqlite-0.19.0.tar.gz", hash = "sha256:95ee77b91c8d2808bd08a59fbebf66270e9090c3d92ffbf260dc0db0b979577d"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -6,7 +6,7 @@ groups = ["default", "pydantic", "mako", "jinja", "structlog", "minijinja", "sta
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:917a2c09edd60ba788342e5c786f5fa7afd5a31f830cac4bbf04b7228ec97819"
+content_hash = "sha256:28d7668a00ed3d9f73b55b5e979eb64c20d7747297a53f6dc8a5d8cdb50d09b6"
 
 [[package]]
 name = "accessible-pygments"

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "pydantic", "mako", "jinja", "structlog", "minijinja", "standard", "attrs", "dev", "test", "opentelemetry", "piccolo", "jwt", "docs", "redis", "sqlalchemy", "brotli", "picologging", "dev-contrib", "prometheus", "annotated-types", "linting", "cli", "cryptography"]
+groups = ["default", "dev", "dev-contrib", "docs", "linting", "test"]
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
@@ -64,15 +64,15 @@ files = [
 
 [[package]]
 name = "annotated-types"
-version = "0.5.0"
-requires_python = ">=3.7"
+version = "0.6.0"
+requires_python = ">=3.8"
 summary = "Reusable constraint types to use with typing.Annotated"
 dependencies = [
     "typing-extensions>=4.0.0; python_version < \"3.9\"",
 ]
 files = [
-    {file = "annotated_types-0.5.0-py3-none-any.whl", hash = "sha256:58da39888f92c276ad970249761ebea80ba544b77acddaa1a4d6cf78287d45fd"},
-    {file = "annotated_types-0.5.0.tar.gz", hash = "sha256:47cdc3490d9ac1506ce92c7aaa76c579dc3509ff11e098fc867e5130ab7be802"},
+    {file = "annotated_types-0.6.0-py3-none-any.whl", hash = "sha256:0641064de18ba7a25dee8f96403ebc39113d0cb953a01429249d5c7564666a43"},
+    {file = "annotated_types-0.6.0.tar.gz", hash = "sha256:563339e807e53ffd9c267e99fc6d9ea23eb8443c08f112651963e24e22f84a5d"},
 ]
 
 [[package]]
@@ -1022,7 +1022,7 @@ files = [
     {file = "greenlet-3.0.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0b72b802496cccbd9b31acea72b6f87e7771ccfd7f7927437d592e5c92ed703c"},
     {file = "greenlet-3.0.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:527cd90ba3d8d7ae7dceb06fda619895768a46a1b4e423bdb24c1969823b8362"},
     {file = "greenlet-3.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:37f60b3a42d8b5499be910d1267b24355c495064f271cfe74bf28b17b099133c"},
-    {file = "greenlet-3.0.0-cp311-universal2-macosx_10_9_universal2.whl", hash = "sha256:c3692ecf3fe754c8c0f2c95ff19626584459eab110eaab66413b1e7425cd84e9"},
+    {file = "greenlet-3.0.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:1482fba7fbed96ea7842b5a7fc11d61727e8be75a077e603e8ab49d24e234383"},
     {file = "greenlet-3.0.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:be557119bf467d37a8099d91fbf11b2de5eb1fd5fc5b91598407574848dc910f"},
     {file = "greenlet-3.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:73b2f1922a39d5d59cc0e597987300df3396b148a9bd10b76a058a2f2772fc04"},
     {file = "greenlet-3.0.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d1e22c22f7826096ad503e9bb681b05b8c1f5a8138469b255eb91f26a76634f2"},
@@ -1032,7 +1032,6 @@ files = [
     {file = "greenlet-3.0.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:952256c2bc5b4ee8df8dfc54fc4de330970bf5d79253c863fb5e6761f00dda35"},
     {file = "greenlet-3.0.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:269d06fa0f9624455ce08ae0179430eea61085e3cf6457f05982b37fd2cefe17"},
     {file = "greenlet-3.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:9adbd8ecf097e34ada8efde9b6fec4dd2a903b1e98037adf72d12993a1c80b51"},
-    {file = "greenlet-3.0.0-cp312-universal2-macosx_10_9_universal2.whl", hash = "sha256:553d6fb2324e7f4f0899e5ad2c427a4579ed4873f42124beba763f16032959af"},
     {file = "greenlet-3.0.0-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:63acdc34c9cde42a6534518e32ce55c30f932b473c62c235a466469a710bfbf9"},
     {file = "greenlet-3.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4a1a6244ff96343e9994e37e5b4839f09a0207d35ef6134dce5c20d260d0302c"},
     {file = "greenlet-3.0.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b822fab253ac0f330ee807e7485769e3ac85d5eef827ca224feaaefa462dc0d0"},
@@ -1210,7 +1209,7 @@ files = [
 
 [[package]]
 name = "hypothesis"
-version = "6.87.1"
+version = "6.87.3"
 requires_python = ">=3.8"
 summary = "A library for property-based testing"
 dependencies = [
@@ -1219,8 +1218,8 @@ dependencies = [
     "sortedcontainers<3.0.0,>=2.1.0",
 ]
 files = [
-    {file = "hypothesis-6.87.1-py3-none-any.whl", hash = "sha256:6b03e774d7ddddc29810e58ba4c41b5c9a894427aaf336e6400c560655a7449b"},
-    {file = "hypothesis-6.87.1.tar.gz", hash = "sha256:13615a8f7fa27d102c43ab2f92eaef519988700f3ca8129bc6340d36dec372dd"},
+    {file = "hypothesis-6.87.3-py3-none-any.whl", hash = "sha256:684a7b56a4a2e990cb0efb3124c2d886c5138453550b6f4f4a3b75bfc8ef24d4"},
+    {file = "hypothesis-6.87.3.tar.gz", hash = "sha256:e67391efb9e6f663031f493d04b5edfb2e47bfc5a6ea56190aed3bc7993d5899"},
 ]
 
 [[package]]
@@ -1552,46 +1551,46 @@ files = [
 
 [[package]]
 name = "msgspec"
-version = "0.18.3"
+version = "0.18.4"
 requires_python = ">=3.8"
 summary = "A fast serialization and validation library, with builtin support for JSON, MessagePack, YAML, and TOML."
 files = [
-    {file = "msgspec-0.18.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8b4ec8da22b29c48268a42007f3469a649915355e02852c8060ad46886c16b0e"},
-    {file = "msgspec-0.18.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f1f943c2718bc409a041270cf99b435cfab3fcf07386e86f2a75039dabe7b213"},
-    {file = "msgspec-0.18.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5e19937cba1c27d144638fbb70e3e1ce59828a2bed918154d93b0d01319c570"},
-    {file = "msgspec-0.18.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e346d70ca54ba7c96e5c8aea693a73469faf89ba503a970a2695ae61e5dd9d53"},
-    {file = "msgspec-0.18.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:a64822fc823d400bc2700f5dae378b63d0c585a70cfcf4cd20628a449505424a"},
-    {file = "msgspec-0.18.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7d69e336b150f6d0745c9bf08acd173db4a04d97888cdf6a8e7354824374bff2"},
-    {file = "msgspec-0.18.3-cp310-cp310-win_amd64.whl", hash = "sha256:ea17dfb8caae519aea6cb3962151cde321b05ed062815fc98be841ed974a16d3"},
-    {file = "msgspec-0.18.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:94a16aaee51a9f2c6f1f0c083ef4c8192b5daebc4e6b5f33a94a875ad4c67304"},
-    {file = "msgspec-0.18.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:588c655312e2e3d4d26e2b2708fcfb680e1d2a4cf4c441d8bee8856152966825"},
-    {file = "msgspec-0.18.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:641b1a32e584f0bf8f9b94176e09adadcd3b7ebd6864c44e9edd9f043c050593"},
-    {file = "msgspec-0.18.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb4e50deb015d91d852be37a6f1d68217fc0e2f3ac98005e867c6f306d1de544"},
-    {file = "msgspec-0.18.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:abb49caa334a835f32d3fd74e37d0e8f21e966bee5b79da8a5a21470339d987b"},
-    {file = "msgspec-0.18.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0508947cc544ddce174665f44cdd0da4efdc7d114d8d3644fa194ee141f73a16"},
-    {file = "msgspec-0.18.3-cp311-cp311-win_amd64.whl", hash = "sha256:90901ed52e975618be71accd4f45c9027aa28607066a632bd334088fbeb5da78"},
-    {file = "msgspec-0.18.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:fd0c5b8c85e689bd259ee8555ea3e4add131ac0c6ff4ca31d48629d952ef83ca"},
-    {file = "msgspec-0.18.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f4062d631b1113f3a3077fa525e25ac39f8eae99b962f6f288737f126bae9b3"},
-    {file = "msgspec-0.18.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b9f19df2244c0159275bf6ea53fffd4da8ffcfad9b1c14bff3851c9c3668132"},
-    {file = "msgspec-0.18.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e393a8327c69812da6fd3dd96fc29097723cd41e9494a3729c42004e47dfbe0"},
-    {file = "msgspec-0.18.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e37add9994c127895af0ef6af8873dc04842bf694805c3f2d8de59d6e430b679"},
-    {file = "msgspec-0.18.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fa1ae2adaa8f91cc8d29d5abdcc5f71bafc72dbb9c8ffb767e998d30cc9b6fc"},
-    {file = "msgspec-0.18.3-cp312-cp312-win_amd64.whl", hash = "sha256:8522032407d6182450f9f8d44d483284aea54fe7029ca38dab83894be97cdbe3"},
-    {file = "msgspec-0.18.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:25a7a7e9fd77ecd44b2cca6703df597e96f9ddf015ec198b338218d46e330a8f"},
-    {file = "msgspec-0.18.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ba4912ff716c76a30110b8ffc8f1c7301bc2c7d7e1b1fae27ba6fffa69dfef9a"},
-    {file = "msgspec-0.18.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35eb00e1637e82c2172e1ef84631b9bf79a231ada88c46ec171a5fb3ebca83bd"},
-    {file = "msgspec-0.18.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:505acede80a3cfab62d4235fb212ce42d9d6a6d46fb16545df0c867fc1bff11b"},
-    {file = "msgspec-0.18.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:4377cf414bffe0b7734ff0ac3c09586265ced5aac6a469ce0d704b7b434214b2"},
-    {file = "msgspec-0.18.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:3f8b8ef0e8c560452adf878aff733ff9e92b043dcbd5d052606b95dcdc7d44f7"},
-    {file = "msgspec-0.18.3-cp38-cp38-win_amd64.whl", hash = "sha256:36a74189b308c8bc6a330f712b3438bafc15ee54bf818524fce8cf785198768d"},
-    {file = "msgspec-0.18.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c29517539ded0d54ea9efb81808a5536f25ecc1334876ff16ad44fa8197941b3"},
-    {file = "msgspec-0.18.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8691aa006c9c7b05985716037980c550b98c28f528c0ed4996e9a22eb4000d52"},
-    {file = "msgspec-0.18.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee30d21482fd0efba116f716298fcdbbb788c94b4860cceabc3b606c745299f3"},
-    {file = "msgspec-0.18.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:351edc34b76fd44890131608414a5d298a1f5c5a21943eb4ace3f3f81ea4fed4"},
-    {file = "msgspec-0.18.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0fdea736edf7154d35fee99a87ab8ca0036faed28d8820436fec9a455e8d7b37"},
-    {file = "msgspec-0.18.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0b2983e8b3d8b99eb9c347803baaa42de27a9205826143c6c23eca728d338ac9"},
-    {file = "msgspec-0.18.3-cp39-cp39-win_amd64.whl", hash = "sha256:08537be42672d903877182a626b5619396224cde69abb855a46ff530f01d5b76"},
-    {file = "msgspec-0.18.3.tar.gz", hash = "sha256:86e0228fb0f02a54a11fb86bba28e781283a77a5f1f50e74c48762c71bfcec52"},
+    {file = "msgspec-0.18.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4d24a291a3c94a7f5e26e8f5ef93e72bf26c10dfeed4d6ae8fc87ead02f4e265"},
+    {file = "msgspec-0.18.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9714b78965047638c01c818b4b418133d77e849017de17b0655ee37b714b47a6"},
+    {file = "msgspec-0.18.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:241277eed9fd91037372519fca62aecf823f7229c1d351030d0be5e3302580c1"},
+    {file = "msgspec-0.18.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d08175cbb55c1a87dd258645dce6cd00705d6088bf88e7cf510a9d5c24b0720b"},
+    {file = "msgspec-0.18.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:da13a06e77d683204eee3b134b08ecd5e4759a79014027b1bcd7a12c614b466d"},
+    {file = "msgspec-0.18.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:73e70217ff5e4ac244c8f1b0769215cbc81e1c904e135597a5b71162857e6c27"},
+    {file = "msgspec-0.18.4-cp310-cp310-win_amd64.whl", hash = "sha256:dc25e6100026f5e1ecb5120150f4e78beb909cbeb0eb724b9982361b75c86c6b"},
+    {file = "msgspec-0.18.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e14287c3405093645b3812e3436598edd383b9ed724c686852e65d569f39f953"},
+    {file = "msgspec-0.18.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:acdcef2fccfff02f80ac8673dbeab205c288b680d81e05bfb5ae0be6b1502a7e"},
+    {file = "msgspec-0.18.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b052fd7d25a8aa2ffde10126ee1d97b4c6f3d81f3f3ab1258ff759a2bd794874"},
+    {file = "msgspec-0.18.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:826dcb0dfaac0abbcf3a3ae991749900671796eb688b017a69a82bde1e624662"},
+    {file = "msgspec-0.18.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:86800265f87f192a0daefe668e0a9634c35bf8af94b1f297e1352ac62d2e26da"},
+    {file = "msgspec-0.18.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:227fee75a25080a8b3677cdd95b9c0c3652e27869004a084886c65eb558b3dd6"},
+    {file = "msgspec-0.18.4-cp311-cp311-win_amd64.whl", hash = "sha256:828ef92f6654915c36ef6c7d8fec92404a13be48f9ff85f060e73b30299bafe1"},
+    {file = "msgspec-0.18.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:8476848f4937da8faec53700891694df2e412453cb7445991f0664cdd1e2dd16"},
+    {file = "msgspec-0.18.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f668102958841c5bbd3ba7cf569a65d17aa3bdcf22124f394dfcfcf53cc5a9b9"},
+    {file = "msgspec-0.18.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc2405dba5af6478dedd3512bb92197b6f9d1bc0095655afbe9b54d7a426f19f"},
+    {file = "msgspec-0.18.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d99f3c13569a5add0980b0d8c6e0bd94a656f6363b26107435b3091df979d228"},
+    {file = "msgspec-0.18.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:8a198409f672f93534c9c36bdc9eea9fb536827bd63ea846882365516a961356"},
+    {file = "msgspec-0.18.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:e21bc5aae6b80dfe4eb75dc1bb29af65483f967d5522e9e3812115a0ba285cac"},
+    {file = "msgspec-0.18.4-cp312-cp312-win_amd64.whl", hash = "sha256:44d551aee1ec8aa2d7b64762557c266bcbf7d5109f2246955718d05becc509d6"},
+    {file = "msgspec-0.18.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bbbc08d59f74de5791bda63569f26a35ae1dd6bd20c55c3ceba5567b0e5a8ef1"},
+    {file = "msgspec-0.18.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:87bc01949a35970398f5267df8ed4189c340727bb6feec99efdb9969dd05cf30"},
+    {file = "msgspec-0.18.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96ccaef83adc0ce96d95328a03289cd5aead4fe400aac21fbe2008855a124a01"},
+    {file = "msgspec-0.18.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6229dd49438d81ed7a3470e3cbc9646b1cc1b120d415a1786df880dabb1d1c4"},
+    {file = "msgspec-0.18.4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:55e578fd921c88de0d3a209fe5fd392bb66623924c6525b42cea37c72bf8d558"},
+    {file = "msgspec-0.18.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e95bd0a946b5b7206f27c0f654f490231c9ad5e5a4ff65af8c986f5114dfaf0e"},
+    {file = "msgspec-0.18.4-cp38-cp38-win_amd64.whl", hash = "sha256:7e95817021db96c43fd81244228e185b13b085cca3d5169af4e2dfe3ff412954"},
+    {file = "msgspec-0.18.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:847d79f6f0b698671ff390aa5a66e207108f2c23b077ef9314ca4fe7819fa4ec"},
+    {file = "msgspec-0.18.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e4294158c233884f3b3220f0e96a30d3e916a4781f9502ae6d477bd57bbc80ad"},
+    {file = "msgspec-0.18.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:deb11ba2709019192636042df5c8db8738e45946735627021b7e7934714526e4"},
+    {file = "msgspec-0.18.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b01efbf80a987a99e9079257c893c026dc661d4cd05caa1f7eabf4accc7f1fbc"},
+    {file = "msgspec-0.18.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:991aa3c76d1b1ec84e840d0b3c96692af834e1f8a1e1a3974cbd189eaf0f2276"},
+    {file = "msgspec-0.18.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8064908ddb3d95d3261aaca48fd38abb16ccf59dc3f2d01eb4e04591fc1e9bd4"},
+    {file = "msgspec-0.18.4-cp39-cp39-win_amd64.whl", hash = "sha256:5f446f16ea57d70cceec29b7cb85ec0b3bea032e3dec316806e38575ea3a69b4"},
+    {file = "msgspec-0.18.4.tar.gz", hash = "sha256:cb62030bd6b1a00b01a2fcb09735016011696304e6b1d3321e58022548268d3e"},
 ]
 
 [[package]]
@@ -2501,15 +2500,15 @@ files = [
 
 [[package]]
 name = "ruamel-yaml"
-version = "0.17.34"
+version = "0.17.35"
 requires_python = ">=3"
 summary = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
 dependencies = [
     "ruamel-yaml-clib>=0.2.7; platform_python_implementation == \"CPython\" and python_version < \"3.13\"",
 ]
 files = [
-    {file = "ruamel.yaml-0.17.34-py3-none-any.whl", hash = "sha256:cde36dc1683b4f60f18c27ca94fc60c03e47003bac7910a78e00a639a4f282bd"},
-    {file = "ruamel.yaml-0.17.34.tar.gz", hash = "sha256:6ffd0a1906ddeac4a46b7b53d288a5a26bfab8f1986ddab3d8e406beda7e6e72"},
+    {file = "ruamel.yaml-0.17.35-py3-none-any.whl", hash = "sha256:b105e3e6fc15b41fdb201ba1b95162ae566a4ef792b9f884c46b4ccc5513a87a"},
+    {file = "ruamel.yaml-0.17.35.tar.gz", hash = "sha256:801046a9caacb1b43acc118969b49b96b65e8847f29029563b29ac61d02db61b"},
 ]
 
 [[package]]
@@ -2916,6 +2915,14 @@ files = [
     {file = "SQLAlchemy-2.0.21-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:b69f1f754d92eb1cc6b50938359dead36b96a1dcf11a8670bff65fd9b21a4b09"},
     {file = "SQLAlchemy-2.0.21-cp311-cp311-win32.whl", hash = "sha256:af520a730d523eab77d754f5cf44cc7dd7ad2d54907adeb3233177eeb22f271b"},
     {file = "SQLAlchemy-2.0.21-cp311-cp311-win_amd64.whl", hash = "sha256:141675dae56522126986fa4ca713739d00ed3a6f08f3c2eb92c39c6dfec463ce"},
+    {file = "SQLAlchemy-2.0.21-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:56628ca27aa17b5890391ded4e385bf0480209726f198799b7e980c6bd473bd7"},
+    {file = "SQLAlchemy-2.0.21-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:db726be58837fe5ac39859e0fa40baafe54c6d54c02aba1d47d25536170b690f"},
+    {file = "SQLAlchemy-2.0.21-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7421c1bfdbb7214313919472307be650bd45c4dc2fcb317d64d078993de045b"},
+    {file = "SQLAlchemy-2.0.21-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:632784f7a6f12cfa0e84bf2a5003b07660addccf5563c132cd23b7cc1d7371a9"},
+    {file = "SQLAlchemy-2.0.21-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f6f7276cf26145a888f2182a98f204541b519d9ea358a65d82095d9c9e22f917"},
+    {file = "SQLAlchemy-2.0.21-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2a1f7ffac934bc0ea717fa1596f938483fb8c402233f9b26679b4f7b38d6ab6e"},
+    {file = "SQLAlchemy-2.0.21-cp312-cp312-win32.whl", hash = "sha256:bfece2f7cec502ec5f759bbc09ce711445372deeac3628f6fa1c16b7fb45b682"},
+    {file = "SQLAlchemy-2.0.21-cp312-cp312-win_amd64.whl", hash = "sha256:526b869a0f4f000d8d8ee3409d0becca30ae73f494cbb48801da0129601f72c6"},
     {file = "SQLAlchemy-2.0.21-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b4eae01faee9f2b17f08885e3f047153ae0416648f8e8c8bd9bc677c5ce64be9"},
     {file = "SQLAlchemy-2.0.21-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:3eb7c03fe1cd3255811cd4e74db1ab8dca22074d50cd8937edf4ef62d758cdf4"},
     {file = "SQLAlchemy-2.0.21-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c2d494b6a2a2d05fb99f01b84cc9af9f5f93bf3e1e5dbdafe4bed0c2823584c1"},
@@ -3132,11 +3139,12 @@ files = [
 
 [[package]]
 name = "types-pyasn1"
-version = "0.4.0.6"
+version = "0.5.0.0"
+requires_python = ">=3.7"
 summary = "Typing stubs for pyasn1"
 files = [
-    {file = "types-pyasn1-0.4.0.6.tar.gz", hash = "sha256:8f1965d0b79152f9d1efc89f9aa9a8cdda7cd28b2619df6737c095cbedeff98b"},
-    {file = "types_pyasn1-0.4.0.6-py3-none-any.whl", hash = "sha256:dd5fc818864e63a66cd714be0a7a59a493f4a81b87ee9ac978c41f1eaa9a0cef"},
+    {file = "types-pyasn1-0.5.0.0.tar.gz", hash = "sha256:4bfea6548206866302885c36aba945c0deaa40898a313112b5cff7f903a56d71"},
+    {file = "types_pyasn1-0.5.0.0-py3-none-any.whl", hash = "sha256:62f1ba64c9f8975de301014722e154ef1d6097463844de1ed733e719dfc87780"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,64 +1,72 @@
 [project]
-name = "litestar"
-version = "2.1.1"
-description = "Litestar - A production-ready, highly performant, extensible ASGI API Framework"
-readme = "docs/PYPI_README.md"
 authors = [
-    { name = "Cody Fincher", email = "cody.fincher@gmail.com" },
-    { name = "Jacob Coffee", email = "jacob@z7x.org" },
-    { name = "Janek Nouvertné", email = "provinzkraut@posteo.de" },
-    { name = "Na'aman Hirschfeld", email = "nhirschfeld@gmail.com" },
-    { name = "Peter Schutt", email = "peter.github@proton.me" },
+  {name = "Cody Fincher", email = "cody.fincher@gmail.com"},
+  {name = "Jacob Coffee", email = "jacob@z7x.org"},
+  {name = "Janek Nouvertné", email = "provinzkraut@posteo.de"},
+  {name = "Na'aman Hirschfeld", email = "nhirschfeld@gmail.com"},
+  {name = "Peter Schutt", email = "peter.github@proton.me"},
 ]
-maintainers = [
-    { name = "Cody Fincher", email = "cody.fincher@gmail.com" },
-    { name = "Jacob Coffee", email = "jacob@z7x.org" },
-    { name = "Janek Nouvertné", email = "provinzkraut@posteo.de" },
-    { name = "Peter Schutt", email = "peter.github@proton.me" },
-]
-keywords = ["api", "rest", "asgi", "litestar", "starlite"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Web Environment",
-    "License :: OSI Approved :: MIT License",
-    "Natural Language :: English",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python",
-    "Topic :: Internet :: WWW/HTTP",
-    "Topic :: Software Development :: Libraries",
-    "Topic :: Software Development",
-    "Typing :: Typed",
-    #    Pending trove-classifiers#148
-    #    "Framework :: Litestar",
-    #    "Framework :: Litestar :: 2",
-    "Intended Audience :: Developers",
-    "Intended Audience :: Information Technology",
-    "Intended Audience :: System Administrators",
-    "Topic :: Internet",
-    "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
-    "Topic :: Software Development :: Libraries :: Application Frameworks",
-    "Topic :: Software Development :: Libraries :: Python Modules",
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: Web Environment",
+  "License :: OSI Approved :: MIT License",
+  "Natural Language :: English",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python",
+  "Topic :: Internet :: WWW/HTTP",
+  "Topic :: Software Development :: Libraries",
+  "Topic :: Software Development",
+  "Typing :: Typed",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Information Technology",
+  "Intended Audience :: System Administrators",
+  "Topic :: Internet",
+  "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
+  "Topic :: Software Development :: Libraries :: Application Frameworks",
+  "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-license = { text = "MIT" }
-requires-python = ">=3.8,<4.0"
 dependencies = [
-    "anyio>=3",
-    "httpx>=0.22",
-    "importlib-metadata; python_version < \"3.10\"",
-    "importlib-resources>=5.12.0; python_version < \"3.9\"",
-    "msgspec>=0.18.2",
-    "multidict>=6.0.2",
-    "polyfactory>=2.6.3",
-    "pyyaml",
-    "typing-extensions",
-    "click",
-    "rich>=13.0.0",
-    "rich-click",
+  "anyio>=3",
+  "httpx>=0.22",
+  "importlib-metadata; python_version < \"3.10\"",
+  "importlib-resources>=5.12.0; python_version < \"3.9\"",
+  "msgspec>=0.18.2",
+  "multidict>=6.0.2",
+  "polyfactory>=2.6.3",
+  "pyyaml",
+  "typing-extensions",
+  "click",
+  "rich>=13.0.0",
+  "rich-click",
 ]
+description = "Litestar - A production-ready, highly performant, extensible ASGI API Framework"
+keywords = ["api", "rest", "asgi", "litestar", "starlite"]
+license = {text = "MIT"}
+maintainers = [
+  {name = "Cody Fincher", email = "cody.fincher@gmail.com"},
+  {name = "Jacob Coffee", email = "jacob@z7x.org"},
+  {name = "Janek Nouvertné", email = "provinzkraut@posteo.de"},
+  {name = "Peter Schutt", email = "peter.github@proton.me"},
+]
+name = "litestar"
+readme = "README.md"
+requires-python = ">=3.8,<4.0"
+version = "2.1.1"
+
+[project.urls]
+Blog = "https://blog.litestar.dev"
+Changelog = "https://github.com/litestar-org/litestar/releases/"
+Discord = "https://discord.gg/MmcwxztmQb"
+"Issue Tracker" = "https://github.com/litestar-org/litestar/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc"
+Reddit = "https://www.reddit.com/r/LitestarAPI"
+Twitter = "https://twitter.com/LitestarAPI"
+documentation = "https://docs.litestar.dev/"
+homepage = "https://litestar.dev/"
+repository = "https://github.com/litestar-org/litestar"
 
 [project.optional-dependencies]
 annotated-types = ["annotated-types"]
@@ -80,34 +88,71 @@ sqlalchemy = ["advanced-alchemy==0.2.2"]
 standard = ["jinja2", "jsbeautifier", "uvicorn", "fast-query-parsers>=1.0.2"]
 structlog = ["structlog"]
 
-[project.group.dev.dependencies.exceptiongroup]
-version = "*"
-python = "<3.11"
+[tool.pdm.dev-dependencies]
+dev = [
+  "beanie>=1.21.0",
+  "beautifulsoup4",
+  "fsspec",
+  "greenlet",
+  "hypothesis",
+  "python-dotenv",
+  "starlette",
+  "trio",
+  "exceptiongroup; python_version < \"3.11\"",
+]
+dev-contrib = ["opentelemetry-sdk", "httpx-sse"]
+docs = [
+  "sphinx>=7.1.2",
+  "sphinx-autobuild>=2021.3.14",
+  "sphinx-copybutton>=0.5.2",
+  "sphinx-toolbox>=3.5.0",
+  "blacken-docs>=1.16.0",
+  "sphinx-design>=0.5.0",
+  "sphinx-click>=4.4.0",
+  "sphinxcontrib-mermaid>=0.9.2",
+  "auto-pytabs[sphinx]>=0.4.0",
+  "litestar-sphinx-theme @ git+https://github.com/litestar-org/litestar-sphinx-theme.git",
+]
+linting = [
+  "ruff",
+  "black",
+  "mypy",
+  "pre-commit",
+  "slotscheck",
+  "sourcery",
+  "pyright",
+  "blacken-docs",
+  "asyncpg-stubs",
+  "types-beautifulsoup4",
+  "types-python-jose",
+  "types-pyyaml",
+  "types-redis",
+]
+test = [
+  "pytest",
+  "pytest-asyncio",
+  "pytest-cov",
+  "pytest-lazy-fixture",
+  "pytest-mock",
+  "pytest-rerunfailures",
+  "pytest-timeout",
+  "pytest-xdist",
+  "time-machine",
+]
 
 [project.scripts]
 litestar = "litestar.__main__:run_cli"
-
-[project.urls]
-"Issue Tracker" = "https://github.com/litestar-org/litestar/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc"
-Changelog = "https://github.com/litestar-org/litestar/releases/"
-Twitter = "https://twitter.com/LitestarAPI"
-Reddit = "https://www.reddit.com/r/LitestarAPI"
-Discord = "https://discord.gg/MmcwxztmQb"
-Blog = "https://blog.litestar.dev"
-homepage = "https://litestar.dev/"
-repository = "https://github.com/litestar-org/litestar"
-documentation = "https://docs.litestar.dev/"
 
 [tool.hatch.metadata]
 allow-direct-references = true
 
 [tool.hatch.build.targets.sdist]
 include = [
-    'docs/PYPI_README.md',
-    '/Makefile',
-    '/litestar',
-    '/tests',
-    '/CHANGELOG.rst',
+  'docs/PYPI_README.md',
+  '/Makefile',
+  '/litestar',
+  '/tests',
+  '/CHANGELOG.rst',
 ]
 
 [build-system]
@@ -115,150 +160,98 @@ build-backend = "hatchling.build"
 requires = ["hatchling"]
 
 [tool.pdm.scripts]
+ci = {composite = ["lint", "test"]}
+docs-serve = "sphinx-autobuild docs docs/_build/ -j auto --watch litestar --watch docs --watch tests --port 8002"
 lint = "pre-commit run --all-files"
 test = "pytest tests docs/examples"
-docs-serve = "sphinx-autobuild docs docs/_build/ -j auto --watch litestar --watch docs --watch tests --port 8002"
-ci = { composite = ["lint", "test"] }
-
-[tool.pdm.dev-dependencies]
-test = [
-    "pytest",
-    "pytest-asyncio",
-    "pytest-cov",
-    "pytest-lazy-fixture",
-    "pytest-mock",
-    "pytest-rerunfailures",
-    "pytest-timeout",
-    "pytest-xdist",
-    "time-machine",
-]
-docs = [
-    "sphinx>=7.1.2",
-    "sphinx-autobuild>=2021.3.14",
-    "sphinx-copybutton>=0.5.2",
-    "sphinx-toolbox>=3.5.0",
-    "blacken-docs>=1.16.0",
-    "sphinx-design>=0.5.0",
-    "sphinx-click>=4.4.0",
-    "sphinxcontrib-mermaid>=0.9.2",
-    "auto-pytabs[sphinx]>=0.4.0",
-    "litestar-sphinx-theme @ git+https://github.com/litestar-org/litestar-sphinx-theme.git",
-]
-linting = [
-    "ruff",
-    "black",
-    "mypy",
-    "pre-commit",
-    "slotscheck",
-    "sourcery",
-    "pyright",
-    "blacken-docs",
-    "asyncpg-stubs",
-    "types-beautifulsoup4",
-    "types-python-jose",
-    "types-pyyaml",
-    "types-redis",
-]
-dev = [
-    "beanie>=1.21.0",
-    "beautifulsoup4",
-    "fsspec",
-    "greenlet",
-    "hypothesis",
-    "python-dotenv",
-    "starlette",
-    "trio",
-    "exceptiongroup",
-]
-dev-contrib = ["opentelemetry-sdk", "httpx-sse"]
 
 [tool.black]
-line-length = 120
 include = '\.pyi?$'
+line-length = 120
 
 [tool.codespell]
 ignore-words-list = "selectin"
 skip = 'pdm.lock,docs/examples/contrib/sqlalchemy/us_state_lookup.json'
 
 [tool.coverage.run]
+concurrency = ["multiprocessing", "thread"]
 omit = ["*/tests/*"]
 parallel = true
-concurrency = ["multiprocessing", "thread"]
 
 [tool.coverage.report]
 exclude_lines = [
-    'pragma: no cover',
-    'if TYPE_CHECKING:',
-    'except ImportError as e:',
-    'except ImportError:',
-    '\.\.\.',
-    'raise NotImplementedError',
-    'if VERSION.startswith("1"):',
-    'if pydantic.VERSION.startswith("1"):',
+  'pragma: no cover',
+  'if TYPE_CHECKING:',
+  'except ImportError as e:',
+  'except ImportError:',
+  '\.\.\.',
+  'raise NotImplementedError',
+  'if VERSION.startswith("1"):',
+  'if pydantic.VERSION.startswith("1"):',
 ]
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers --strict-config --dist=loadgroup"
 asyncio_mode = "auto"
-xfail_strict = true
 filterwarnings = [
-    "ignore::trio.TrioDeprecationWarning:anyio._backends._trio*:",
-    "ignore::DeprecationWarning:pkg_resources.*",
-    "ignore::DeprecationWarning:google.rpc",
-    "ignore::DeprecationWarning:google.gcloud",
-    "ignore::DeprecationWarning:google.iam",
-    "ignore::DeprecationWarning:google",
-    "ignore::DeprecationWarning:sphinxcontrib",
-    "ignore::DeprecationWarning:litestar.*",
-    "ignore:The `__fields__` attribute is deprecated:DeprecationWarning:pydantic*",
-    "ignore:Support for class-based `config` is deprecated:DeprecationWarning:pydantic*",
-    "ignore:The `dict` method is deprecated:DeprecationWarning:",
-    "ignore:The `parse_obj` method is deprecated:DeprecationWarning:",
-    "ignore:The `json` method is deprecated:DeprecationWarning:",
-    "ignore:Extra keyword arguments on `Field` is deprecated:DeprecationWarning:pydantic*",
+  "ignore::trio.TrioDeprecationWarning:anyio._backends._trio*:",
+  "ignore::DeprecationWarning:pkg_resources.*",
+  "ignore::DeprecationWarning:google.rpc",
+  "ignore::DeprecationWarning:google.gcloud",
+  "ignore::DeprecationWarning:google.iam",
+  "ignore::DeprecationWarning:google",
+  "ignore::DeprecationWarning:sphinxcontrib",
+  "ignore::DeprecationWarning:litestar.*",
+  "ignore:The `__fields__` attribute is deprecated:DeprecationWarning:pydantic*",
+  "ignore:Support for class-based `config` is deprecated:DeprecationWarning:pydantic*",
+  "ignore:The `dict` method is deprecated:DeprecationWarning:",
+  "ignore:The `parse_obj` method is deprecated:DeprecationWarning:",
+  "ignore:The `json` method is deprecated:DeprecationWarning:",
+  "ignore:Extra keyword arguments on `Field` is deprecated:DeprecationWarning:pydantic*",
 ]
 markers = [
-    "sqlalchemy_integration: SQLAlchemy integration tests",
-    "sqlalchemy_asyncmy: SQLAlchemy MySQL (asyncmy) Tests",
-    "sqlalchemy_asyncpg: SQLAlchemy Postgres (asyncpg) Tests",
-    "sqlalchemy_psycopg_async: SQLAlchemy Postgres (psycopg async) Tests",
-    "sqlalchemy_aiosqlite: SQLAlchemy SQLite (aiosqlite) Tests",
-    "sqlalchemy_psycopg_sync: SQLAlchemy Postgres (psycopg sync) Tests",
-    "sqlalchemy_sqlite: SQLAlchemy SQLite (sqlite) Tests",
-    "sqlalchemy_oracledb: SQLAlchemy Oracle (oracledb) Tests",
-    "sqlalchemy_spanner: SQLAlchemy Google Cloud Spanner (sqlalchemy-spanner) Tests",
-    "sqlalchemy_duckdb: SQLAlchemy Duckdb (duckdb-engine) Tests",
+  "sqlalchemy_integration: SQLAlchemy integration tests",
+  "sqlalchemy_asyncmy: SQLAlchemy MySQL (asyncmy) Tests",
+  "sqlalchemy_asyncpg: SQLAlchemy Postgres (asyncpg) Tests",
+  "sqlalchemy_psycopg_async: SQLAlchemy Postgres (psycopg async) Tests",
+  "sqlalchemy_aiosqlite: SQLAlchemy SQLite (aiosqlite) Tests",
+  "sqlalchemy_psycopg_sync: SQLAlchemy Postgres (psycopg sync) Tests",
+  "sqlalchemy_sqlite: SQLAlchemy SQLite (sqlite) Tests",
+  "sqlalchemy_oracledb: SQLAlchemy Oracle (oracledb) Tests",
+  "sqlalchemy_spanner: SQLAlchemy Google Cloud Spanner (sqlalchemy-spanner) Tests",
+  "sqlalchemy_duckdb: SQLAlchemy Duckdb (duckdb-engine) Tests",
 ]
+xfail_strict = true
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]
 
-warn_unused_ignores = true
-warn_redundant_casts = true
-warn_unused_configs = true
-warn_unreachable = true
-warn_return_any = true
-strict = true
-disallow_untyped_decorators = true
 disallow_any_generics = false
+disallow_untyped_decorators = true
 implicit_reexport = false
 show_error_codes = true
+strict = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_configs = true
+warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
-module = ["tests.*.test_sqlalchemy", "tests.*.test_sqlalchemy"]
 disable_error_code = "attr-defined"
+module = ["tests.*.test_sqlalchemy", "tests.*.test_sqlalchemy"]
 
 [[tool.mypy.overrides]]
-module = "tests.unit.test_contrib.test_sqlalchemy.test_dto"
 disable_error_code = ["arg-type", "misc", "valid-type", "var-annotated"]
+module = "tests.unit.test_contrib.test_sqlalchemy.test_dto"
 
 [[tool.mypy.overrides]]
-module = "tests.*"
 disallow_untyped_decorators = false
+module = "tests.*"
 
 [[tool.mypy.overrides]]
-module = ["mako.*", "pytimeparse.*", "brotli.*", "jsbeautifier.*"]
 ignore_missing_imports = true
+module = ["mako.*", "pytimeparse.*", "brotli.*", "jsbeautifier.*"]
 
 [tool.pydantic-mypy]
 init_forbid_extra = true
@@ -267,71 +260,71 @@ warn_required_dynamic_aliases = true
 warn_untyped_fields = true
 
 [tool.pyright]
-include = ["litestar", "tests", "examples"]
 exclude = [
-    "examples/plugins/sqlalchemy_plugin",
-    "litestar/openapi",
-    "tests/unit/test_contrib/test_sqlalchemy/test_dto.py",
+  "examples/plugins/sqlalchemy_plugin",
+  "litestar/openapi",
+  "tests/unit/test_contrib/test_sqlalchemy/test_dto.py",
 ]
+include = ["litestar", "tests", "examples"]
 
 [tool.slotscheck]
 strict-imports = false
 
 [tool.ruff]
 select = [
-    "A",   # flake8-builtins
-    "B",   # flake8-bugbear
-    "BLE", # flake8-blind-except
-    "C4",  # flake8-comprehensions
-    "C90", # mccabe
-    "D",   # pydocstyle
-    "DJ",  # flake8-django
-    "DTZ", # flake8-datetimez
-    "E",   # pycodestyle errors
-    "ERA", # eradicate
-    "EXE", # flake8-executable
-    "F",   # pyflakes
-    "G",   # flake8-logging-format
-    "I",   # isort
-    "ICN", # flake8-import-conventions
-    "ISC", # flake8-implicit-str-concat
-    "N",   # pep8-naming
-    "PIE", # flake8-pie
-    "PLC", # pylint - convention
-    "PLE", # pylint - error
-    "PLW", # pylint - warning
-    "PTH", # flake8-use-pathlib
-    "Q",   # flake8-quotes
-    "RET", # flake8-return
-    "RUF", # Ruff-specific rules
-    "S",   # flake8-bandit
-    "SIM", # flake8-simplify
-    "T10", # flake8-debugger
-    "T20", # flake8-print
-    "TCH", # flake8-type-checking
-    "TID", # flake8-tidy-imports
-    "UP",  # pyupgrade
-    "W",   # pycodestyle - warning
-    "YTT", # flake8-2020
+  "A", # flake8-builtins
+  "B", # flake8-bugbear
+  "BLE", # flake8-blind-except
+  "C4", # flake8-comprehensions
+  "C90", # mccabe
+  "D", # pydocstyle
+  "DJ", # flake8-django
+  "DTZ", # flake8-datetimez
+  "E", # pycodestyle errors
+  "ERA", # eradicate
+  "EXE", # flake8-executable
+  "F", # pyflakes
+  "G", # flake8-logging-format
+  "I", # isort
+  "ICN", # flake8-import-conventions
+  "ISC", # flake8-implicit-str-concat
+  "N", # pep8-naming
+  "PIE", # flake8-pie
+  "PLC", # pylint - convention
+  "PLE", # pylint - error
+  "PLW", # pylint - warning
+  "PTH", # flake8-use-pathlib
+  "Q", # flake8-quotes
+  "RET", # flake8-return
+  "RUF", # Ruff-specific rules
+  "S", # flake8-bandit
+  "SIM", # flake8-simplify
+  "T10", # flake8-debugger
+  "T20", # flake8-print
+  "TCH", # flake8-type-checking
+  "TID", # flake8-tidy-imports
+  "UP", # pyupgrade
+  "W", # pycodestyle - warning
+  "YTT", # flake8-2020
 ]
 
 ignore = [
-    "A003",    # flake8-builtins - class attribute {name} is shadowing a python builtin
-    "B010",    # flake8-bugbear - do not call setattr with a constant attribute value
-    "D100",    # pydocstyle - missing docstring in public module
-    "D101",    # pydocstyle - missing docstring in public class
-    "D102",    # pydocstyle - missing docstring in public method
-    "D103",    # pydocstyle - missing docstring in public function
-    "D104",    # pydocstyle - missing docstring in public package
-    "D105",    # pydocstyle - missing docstring in magic method
-    "D106",    # pydocstyle - missing docstring in public nested class
-    "D107",    # pydocstyle - missing docstring in __init__
-    "D202",    # pydocstyle - no blank lines allowed after function docstring
-    "D205",    # pydocstyle - 1 blank line required between summary line and description
-    "D415",    # pydocstyle - first line should end with a period, question mark, or exclamation point
-    "E501",    # pycodestyle line too long, handled by black
-    "PLW2901", # pylint - for loop variable overwritten by assignment target
-    "RUF012",  # Ruff-specific rule - annotated with classvar
+  "A003", # flake8-builtins - class attribute {name} is shadowing a python builtin
+  "B010", # flake8-bugbear - do not call setattr with a constant attribute value
+  "D100", # pydocstyle - missing docstring in public module
+  "D101", # pydocstyle - missing docstring in public class
+  "D102", # pydocstyle - missing docstring in public method
+  "D103", # pydocstyle - missing docstring in public function
+  "D104", # pydocstyle - missing docstring in public package
+  "D105", # pydocstyle - missing docstring in magic method
+  "D106", # pydocstyle - missing docstring in public nested class
+  "D107", # pydocstyle - missing docstring in __init__
+  "D202", # pydocstyle - no blank lines allowed after function docstring
+  "D205", # pydocstyle - 1 blank line required between summary line and description
+  "D415", # pydocstyle - first line should end with a period, question mark, or exclamation point
+  "E501", # pycodestyle line too long, handled by black
+  "PLW2901", # pylint - for loop variable overwritten by assignment target
+  "RUF012", # Ruff-specific rule - annotated with classvar
 ]
 line-length = 120
 src = ["litestar", "tests", "docs/examples"]
@@ -345,53 +338,53 @@ max-complexity = 12
 
 [tool.ruff.pep8-naming]
 classmethod-decorators = [
-    "classmethod",
-    "pydantic.root_validator",
-    "pydantic.validator",
-    "sqlalchemy.ext.declarative.declared_attr",
-    "sqlalchemy.orm.declared_attr.directive",
-    "sqlalchemy.orm.declared_attr",
+  "classmethod",
+  "pydantic.root_validator",
+  "pydantic.validator",
+  "sqlalchemy.ext.declarative.declared_attr",
+  "sqlalchemy.orm.declared_attr.directive",
+  "sqlalchemy.orm.declared_attr",
 ]
 
 [tool.ruff.isort]
 known-first-party = ["litestar", "tests", "examples"]
 
 [tool.ruff.per-file-ignores]
-"tests/**/*.*" = [
-    "A",
-    "ARG",
-    "B",
-    "BLE",
-    "C901",
-    "D",
-    "DTZ",
-    "EM",
-    "FBT",
-    "G",
-    "N",
-    "PGH",
-    "PIE",
-    "PLR",
-    "PLW",
-    "PTH",
-    "RSE",
-    "S",
-    "S101",
-    "SIM",
-    "TCH",
-    "TRY",
-]
-"tests/unit/test_contrib/test_sqlalchemy/**/*.*" = ["UP006"]
-"docs/examples/application_hooks/before_send_hook.py" = ["UP006"]
-"docs/examples/contrib/sqlalchemy/plugins/**/*.*" = ["UP006"]
 "docs/**/*.*" = ["S", "B", "DTZ", "A", "TCH", "ERA", "D", "RET"]
 "docs/examples/**" = ["T201"]
+"docs/examples/application_hooks/before_send_hook.py" = ["UP006"]
+"docs/examples/contrib/sqlalchemy/plugins/**/*.*" = ["UP006"]
 "docs/examples/data_transfer_objects**/*.*" = ["UP006"]
+"litestar/_openapi/schema_generation/schema.py" = ["C901"]
 "litestar/exceptions/*.*" = ["N818"]
 "litestar/handlers/**/*.*" = ["N801"]
-"litestar/_openapi/schema_generation/schema.py" = ["C901"]
 "litestar/params.py" = ["N802"]
 "test_apps/**/*.*" = ["D", "TRY", "EM", "S", "PTH"]
+"tests/**/*.*" = [
+  "A",
+  "ARG",
+  "B",
+  "BLE",
+  "C901",
+  "D",
+  "DTZ",
+  "EM",
+  "FBT",
+  "G",
+  "N",
+  "PGH",
+  "PIE",
+  "PLR",
+  "PLW",
+  "PTH",
+  "RSE",
+  "S",
+  "S101",
+  "SIM",
+  "TCH",
+  "TRY",
+]
+"tests/unit/test_contrib/test_sqlalchemy/**/*.*" = ["UP006"]
 "tools/**/*.*" = ["D", "ARG", "EM", "TRY", "G", "FBT"]
 
 [tool.unasyncd]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ dev = [
   "python-dotenv",
   "starlette",
   "trio",
+  "aiosqlite",
   "exceptiongroup; python_version < \"3.11\"",
 ]
 dev-contrib = ["opentelemetry-sdk", "httpx-sse"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ prometheus = ["prometheus-client"]
 pydantic = ["pydantic[email]", "pydantic-extra-types"]
 redis = ["redis[hiredis]>=4.4.4"]
 sqlalchemy = ["advanced-alchemy==0.2.2"]
-standard = ["jinja2", "jsbeautifier", "uvicorn", "fast-query-parsers>=1.0.2"]
+standard = ["jinja2", "jsbeautifier", "uvicorn", "uvloop", "httptools", "fast-query-parsers>=1.0.2"]
 structlog = ["structlog"]
 
 [tool.pdm.dev-dependencies]
@@ -211,15 +211,6 @@ filterwarnings = [
 ]
 markers = [
   "sqlalchemy_integration: SQLAlchemy integration tests",
-  "sqlalchemy_asyncmy: SQLAlchemy MySQL (asyncmy) Tests",
-  "sqlalchemy_asyncpg: SQLAlchemy Postgres (asyncpg) Tests",
-  "sqlalchemy_psycopg_async: SQLAlchemy Postgres (psycopg async) Tests",
-  "sqlalchemy_aiosqlite: SQLAlchemy SQLite (aiosqlite) Tests",
-  "sqlalchemy_psycopg_sync: SQLAlchemy Postgres (psycopg sync) Tests",
-  "sqlalchemy_sqlite: SQLAlchemy SQLite (sqlite) Tests",
-  "sqlalchemy_oracledb: SQLAlchemy Oracle (oracledb) Tests",
-  "sqlalchemy_spanner: SQLAlchemy Google Cloud Spanner (sqlalchemy-spanner) Tests",
-  "sqlalchemy_duckdb: SQLAlchemy Duckdb (duckdb-engine) Tests",
 ]
 xfail_strict = true
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -7,46 +7,8 @@ services:
       - "5423:5432" # use a non-standard port here
     environment:
       POSTGRES_PASSWORD: super-secret
-  mysql:
-    image: mysql:latest
-    ports:
-      - "3360:3306" # use a non-standard port here
-    environment:
-      MYSQL_ROOT_PASSWORD: super-secret
-      MYSQL_PASSWORD: super-secret
-      MYSQL_USER: app
-      MYSQL_DATABASE: db
-      MYSQL_ROOT_HOST: "%"
-      LANG: C.UTF-8
-  oracle:
-    image: gvenzl/oracle-xe:18-slim-faststart
-    ports:
-      - "1512:1521" # use a non-standard port here
-    environment:
-      ORACLE_PASSWORD: super-secret
-      APP_USER_PASSWORD: super-secret
-      APP_USER: app
   redis:
     image: redis:latest
     restart: always
     ports:
       - "6397:6379" # use a non-standard port here
-  spanner:
-    image: gcr.io/cloud-spanner-emulator/emulator:latest
-    ports:
-      - "9010:9010"
-  # Init (Create Instance)
-  spanner_init:
-    image: gcr.io/google.com/cloudsdktool/cloud-sdk:332.0.0-slim
-    command: >
-      bash -c 'gcloud config configurations create emulator &&
-              gcloud config set auth/disable_credentials true &&
-              gcloud config set project $${PROJECT_ID} &&
-              gcloud config set auth/disable_credentials true &&
-              gcloud spanner instances create $${INSTANCE_NAME} --config=emulator-config --description=Emulator --nodes=1'
-    environment:
-      PROJECT_ID: emulator-test-project
-      INSTANCE_NAME: test-instance
-      DATABASE_NAME: test-database
-    depends_on:
-      - spanner


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

This PR does a variety of PDM cleanup activities
- Applies TOML linting to the `pyproject.toml` and validated against the `PyProject` specification
- Removed unsupported group attribute and pinned dev install of `exceptiongroup` to `<3.11`
- Removes `pre-commit install` from `Makefile`
- add `pdm install -G:all` to PDM installation to grab optional dev dependencies
- Remove PDM lock check from pre-commit.  This has a similar issue as with poetry and leads to many failures due to hash conflicts
- Adds `README.md` to codespell.  The latest updates a raising errors for proper names
- Adds `httptools` and `uvloop` to the `standard` group.  These are both performance optionals for `uvicorn` that normal come with the `standard` package.  `websockets` is the only `standard` dependency from `uvicorn` currently excluded.
- Removes `asyncmy`, `oracledb`, `spanner`, and `asyncmy` from dependencies
- Remove unused SQLAlchemy pytest markers
- Remove docker fixture references to Oracle, MySQL, and Spanner 

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
