### PR TITLE
feat: `signature_types` application arg.

### DIFF
--- a/docs/examples/signature_namespace/app.py
+++ b/docs/examples/signature_namespace/app.py
@@ -5,4 +5,4 @@ from litestar import Litestar
 from .controller import MyController
 from .domain import Model
 
-app = Litestar(route_handlers=[MyController], signature_namespace={"Model": Model})
+app = Litestar(route_handlers=[MyController], signature_types=[Model])

--- a/docs/usage/routing/handlers.rst
+++ b/docs/usage/routing/handlers.rst
@@ -592,6 +592,13 @@ should reference our domain ``Model`` type.
 .. literalinclude:: /examples/signature_namespace/app.py
     :language: python
 
+.. tip::
+
+    If you want to map your type to a name that is different from its ``__name__`` attribute, you can use the
+    ``signature_namespace`` parameter, e.g. ``app = Litestar(signature_namespace={"FooModel": Model})``.
+
+    This enables import patterns like ``from domain.foo import Model as FooModel`` inside ``if TYPE_CHECKING`` blocks.
+
 Default signature namespace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/usage/routing/handlers.rst
+++ b/docs/usage/routing/handlers.rst
@@ -571,7 +571,7 @@ the module scope at runtime. We can address this on a case-by-case basis by sile
     # Choose the appropriate noqa directive according to your linter
     from domain import Model  # noqa: TCH002
 
-However, this approach can get tedious, so as an alternative, Litestar accepts a ``signature_namespace`` mapping at
+However, this approach can get tedious, so as an alternative, Litestar accepts a ``signature_types`` sequence at
 every :ref:`layer <layered-architecture>` of the application. The following is a demonstration of how to use this
 pattern.
 

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -205,6 +205,7 @@ class Litestar(Router):
         return_dto: type[AbstractDTO] | None | EmptyType = Empty,
         security: Sequence[SecurityRequirement] | None = None,
         signature_namespace: Mapping[str, Any] | None = None,
+        signature_types: Sequence[Any] | None = None,
         state: State | None = None,
         static_files_config: Sequence[StaticFilesConfig] | None = None,
         stores: StoreRegistry | dict[str, Store] | None = None,
@@ -291,6 +292,8 @@ class Litestar(Router):
                 See
                 :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>` for details.
             signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
+            signature_types: A sequence of types for use in forward reference resolution during signature modelling.
+                These types will be added to the signature namespace using their ``__name__`` attribute.
             state: An optional :class:`State <.datastructures.State>` for application state.
             static_files_config: A sequence of :class:`StaticFilesConfig <.static_files.StaticFilesConfig>`
             stores: Central registry of :class:`Store <.stores.base.Store>` that will be available throughout the
@@ -356,6 +359,7 @@ class Litestar(Router):
             route_handlers=list(route_handlers) if route_handlers is not None else [],
             security=list(security or []),
             signature_namespace=dict(signature_namespace or {}),
+            signature_types=list(signature_types or []),
             state=state or State(),
             static_files_config=list(static_files_config or []),
             stores=stores,
@@ -432,6 +436,7 @@ class Litestar(Router):
             route_handlers=[],
             security=config.security,
             signature_namespace=config.signature_namespace,
+            signature_types=config.signature_types,
             tags=config.tags,
             type_encoders=config.type_encoders,
             type_decoders=config.type_decoders,

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -291,8 +291,8 @@ class Litestar(Router):
             security: A sequence of dicts that will be added to the schema of all route handlers in the application.
                 See
                 :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>` for details.
-            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
-            signature_types: A sequence of types for use in forward reference resolution during signature modelling.
+            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modeling.
+            signature_types: A sequence of types for use in forward reference resolution during signature modeling.
                 These types will be added to the signature namespace using their ``__name__`` attribute.
             state: An optional :class:`State <.datastructures.State>` for application state.
             static_files_config: A sequence of :class:`StaticFilesConfig <.static_files.StaticFilesConfig>`

--- a/litestar/config/app.py
+++ b/litestar/config/app.py
@@ -180,6 +180,11 @@ class AppConfig:
     """
     signature_namespace: dict[str, Any] = field(default_factory=dict)
     """A mapping of names to types for use in forward reference resolution during signature modelling."""
+    signature_types: list[Any] = field(default_factory=list)
+    """A sequence of types for use in forward reference resolution during signature modelling.
+
+    These types will be added to the signature namespace using their ``__name__`` attribute.
+    """
     state: State = field(default_factory=State)
     """A :class:`State` <.datastructures.State>` instance holding application state."""
     static_files_config: list[StaticFilesConfig] = field(default_factory=list)

--- a/litestar/config/app.py
+++ b/litestar/config/app.py
@@ -179,9 +179,9 @@ class AppConfig:
     :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>` for details.
     """
     signature_namespace: dict[str, Any] = field(default_factory=dict)
-    """A mapping of names to types for use in forward reference resolution during signature modelling."""
+    """A mapping of names to types for use in forward reference resolution during signature modeling."""
     signature_types: list[Any] = field(default_factory=list)
-    """A sequence of types for use in forward reference resolution during signature modelling.
+    """A sequence of types for use in forward reference resolution during signature modeling.
 
     These types will be added to the signature namespace using their ``__name__`` attribute.
     """

--- a/litestar/controller.py
+++ b/litestar/controller.py
@@ -145,7 +145,7 @@ class Controller:
     """A sequence of dictionaries that to the schema of all route handlers under the controller."""
     signature_namespace: dict[str, Any]
     """A mapping of names to types for use in forward reference resolution during signature modeling."""
-    signature_types: list[Any] | None
+    signature_types: Sequence[Any]
     """A sequence of types for use in forward reference resolution during signature modeling.
 
     These types will be added to the signature namespace using their ``__name__`` attribute.
@@ -179,16 +179,16 @@ class Controller:
         if not hasattr(self, "include_in_schema"):
             self.include_in_schema = Empty
 
+        self.signature_namespace = add_types_to_signature_namespace(
+            getattr(self, "signature_types", []), getattr(self, "signature_namespace", {})
+        )
+
         for key in self.__slots__:
             if not hasattr(self, key):
                 setattr(self, key, None)
 
         self.response_cookies = narrow_response_cookies(self.response_cookies)
         self.response_headers = narrow_response_headers(self.response_headers)
-        self.signature_namespace = add_types_to_signature_namespace(
-            getattr(self, "signature_types", None) or [], self.signature_namespace or {}
-        )
-
         self.path = normalize_path(self.path or "/")
         self.owner = owner
 

--- a/litestar/controller.py
+++ b/litestar/controller.py
@@ -144,9 +144,9 @@ class Controller:
     security: Sequence[SecurityRequirement] | None
     """A sequence of dictionaries that to the schema of all route handlers under the controller."""
     signature_namespace: dict[str, Any]
-    """A mapping of names to types for use in forward reference resolution during signature modelling."""
+    """A mapping of names to types for use in forward reference resolution during signature modeling."""
     signature_types: list[Any] | None
-    """A sequence of types for use in forward reference resolution during signature modelling.
+    """A sequence of types for use in forward reference resolution during signature modeling.
 
     These types will be added to the signature namespace using their ``__name__`` attribute.
     """

--- a/litestar/controller.py
+++ b/litestar/controller.py
@@ -13,6 +13,7 @@ from litestar.handlers.http_handlers import HTTPRouteHandler
 from litestar.handlers.websocket_handlers import WebsocketRouteHandler
 from litestar.types.empty import Empty
 from litestar.utils import AsyncCallable, normalize_path
+from litestar.utils.signature import add_types_to_signature_namespace
 
 __all__ = ("Controller",)
 
@@ -144,6 +145,11 @@ class Controller:
     """A sequence of dictionaries that to the schema of all route handlers under the controller."""
     signature_namespace: dict[str, Any]
     """A mapping of names to types for use in forward reference resolution during signature modelling."""
+    signature_types: list[Any] | None
+    """A sequence of types for use in forward reference resolution during signature modelling.
+
+    These types will be added to the signature namespace using their ``__name__`` attribute.
+    """
     type_encoders: TypeEncodersMap | None
     """A mapping of types to callables that transform them into types supported for serialization."""
     type_decoders: TypeDecodersSequence | None
@@ -179,7 +185,9 @@ class Controller:
 
         self.response_cookies = narrow_response_cookies(self.response_cookies)
         self.response_headers = narrow_response_headers(self.response_headers)
-        self.signature_namespace = self.signature_namespace or {}
+        self.signature_namespace = add_types_to_signature_namespace(
+            getattr(self, "signature_types", None) or [], self.signature_namespace or {}
+        )
 
         self.path = normalize_path(self.path or "/")
         self.owner = owner

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -142,7 +142,7 @@ class BaseRouteHandler:
         self.owner: Controller | Router | None = None
         self.return_dto = return_dto
         self.signature_namespace = add_types_to_signature_namespace(
-            list(signature_types or []), dict(signature_namespace or {})
+            signature_types or [], dict(signature_namespace or {})
         )
         self.type_decoders = type_decoders
         self.type_encoders = type_encoders

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -22,7 +22,7 @@ from litestar.types import (
 from litestar.typing import FieldDefinition
 from litestar.utils import AsyncCallable, Ref, get_name, normalize_path
 from litestar.utils.helpers import unwrap_partial
-from litestar.utils.signature import ParsedSignature
+from litestar.utils.signature import ParsedSignature, add_types_to_signature_namespace
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -88,6 +88,7 @@ class BaseRouteHandler:
         opt: Mapping[str, Any] | None = None,
         return_dto: type[AbstractDTO] | None | EmptyType = Empty,
         signature_namespace: Mapping[str, Any] | None = None,
+        signature_types: Sequence[Any] | None = None,
         type_encoders: TypeEncodersMap | None = None,
         type_decoders: TypeDecodersSequence | None = None,
         **kwargs: Any,
@@ -111,6 +112,8 @@ class BaseRouteHandler:
                 outbound response data.
             signature_namespace: A mapping of names to types for use in forward reference resolution during signature
                 modelling.
+            signature_types: A sequence of types for use in forward reference resolution during signature modelling.
+                These types will be added to the signature namespace using their ``__name__`` attribute.
             type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             type_decoders: A sequence of tuples, each composed of a predicate testing for type identity and a msgspec hook for deserialization.
             **kwargs: Any additional kwarg - will be set in the opt dictionary.
@@ -138,7 +141,9 @@ class BaseRouteHandler:
         self.opt.update(**kwargs)
         self.owner: Controller | Router | None = None
         self.return_dto = return_dto
-        self.signature_namespace = signature_namespace or {}
+        self.signature_namespace = add_types_to_signature_namespace(
+            list(signature_types or []), dict(signature_namespace or {})
+        )
         self.type_decoders = type_decoders
         self.type_encoders = type_encoders
 

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -112,7 +112,7 @@ class BaseRouteHandler:
                 outbound response data.
             signature_namespace: A mapping of names to types for use in forward reference resolution during signature
                 modelling.
-            signature_types: A sequence of types for use in forward reference resolution during signature modelling.
+            signature_types: A sequence of types for use in forward reference resolution during signature modeling.
                 These types will be added to the signature namespace using their ``__name__`` attribute.
             type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             type_decoders: A sequence of tuples, each composed of a predicate testing for type identity and a msgspec hook for deserialization.

--- a/litestar/router.py
+++ b/litestar/router.py
@@ -13,6 +13,7 @@ from litestar.handlers.websocket_handlers import WebsocketListener, WebsocketRou
 from litestar.routes import ASGIRoute, HTTPRoute, WebSocketRoute
 from litestar.types.empty import Empty
 from litestar.utils import find_index, is_class_and_subclass, join_paths, normalize_path, unique
+from litestar.utils.signature import add_types_to_signature_namespace
 from litestar.utils.sync import AsyncCallable
 
 __all__ = ("Router",)
@@ -101,6 +102,7 @@ class Router:
         route_handlers: Sequence[ControllerRouterHandler],
         security: Sequence[SecurityRequirement] | None = None,
         signature_namespace: Mapping[str, Any] | None = None,
+        signature_types: Sequence[Any] | None = None,
         tags: Sequence[str] | None = None,
         type_encoders: TypeEncodersMap | None = None,
         type_decoders: TypeDecodersSequence | None = None,
@@ -148,6 +150,8 @@ class Router:
                 See :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>`
                 for details.
             signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
+            signature_types: A sequence of types for use in forward reference resolution during signature modelling.
+                These types will be added to the signature namespace using their ``__name__`` attribute.
             tags: A sequence of string tags that will be appended to the schema of all route handlers under the
                 application.
             type_encoders: A mapping of types to callables that transform them into types supported for serialization.
@@ -175,7 +179,9 @@ class Router:
         self.return_dto = return_dto
         self.routes: list[HTTPRoute | ASGIRoute | WebSocketRoute] = []
         self.security = list(security or [])
-        self.signature_namespace = signature_namespace or {}
+        self.signature_namespace = add_types_to_signature_namespace(
+            list(signature_types or []), dict(signature_namespace or {})
+        )
         self.tags = list(tags or [])
         self.registered_route_handler_ids: set[int] = set()
         self.type_encoders = dict(type_encoders) if type_encoders is not None else None

--- a/litestar/router.py
+++ b/litestar/router.py
@@ -180,7 +180,7 @@ class Router:
         self.routes: list[HTTPRoute | ASGIRoute | WebSocketRoute] = []
         self.security = list(security or [])
         self.signature_namespace = add_types_to_signature_namespace(
-            list(signature_types or []), dict(signature_namespace or {})
+            signature_types or [], dict(signature_namespace or {})
         )
         self.tags = list(tags or [])
         self.registered_route_handler_ids: set[int] = set()

--- a/litestar/router.py
+++ b/litestar/router.py
@@ -149,8 +149,8 @@ class Router:
             security: A sequence of dicts that will be added to the schema of all route handlers in the application.
                 See :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>`
                 for details.
-            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
-            signature_types: A sequence of types for use in forward reference resolution during signature modelling.
+            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modeling.
+            signature_types: A sequence of types for use in forward reference resolution during signature modeling.
                 These types will be added to the signature namespace using their ``__name__`` attribute.
             tags: A sequence of string tags that will be appended to the schema of all route handlers under the
                 application.

--- a/litestar/testing/helpers.py
+++ b/litestar/testing/helpers.py
@@ -100,6 +100,7 @@ def create_test_client(
     security: Sequence[SecurityRequirement] | None = None,
     session_config: BaseBackendConfig | None = None,
     signature_namespace: Mapping[str, Any] | None = None,
+    signature_types: Sequence[Any] | None = None,
     state: State | None = None,
     static_files_config: Sequence[StaticFilesConfig] | None = None,
     stores: StoreRegistry | dict[str, Store] | None = None,
@@ -215,6 +216,8 @@ def create_test_client(
             See
             :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>` for details.
         signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
+        signature_types: A sequence of types for use in forward reference resolution during signature modelling.
+            These types will be added to the signature namespace using their ``__name__`` attribute.
         state: An optional :class:`State <.datastructures.State>` for application state.
         static_files_config: A sequence of :class:`StaticFilesConfig <.static_files.StaticFilesConfig>`
         stores: Central registry of :class:`Store <.stores.base.Store>` that will be available throughout the
@@ -279,6 +282,7 @@ def create_test_client(
         route_handlers=route_handlers,
         security=security,
         signature_namespace=signature_namespace,
+        signature_types=signature_types,
         state=state,
         static_files_config=static_files_config,
         stores=stores,
@@ -349,6 +353,7 @@ def create_async_test_client(
     security: Sequence[SecurityRequirement] | None = None,
     session_config: BaseBackendConfig | None = None,
     signature_namespace: Mapping[str, Any] | None = None,
+    signature_types: Sequence[Any] | None = None,
     state: State | None = None,
     static_files_config: Sequence[StaticFilesConfig] | None = None,
     stores: StoreRegistry | dict[str, Store] | None = None,
@@ -464,6 +469,8 @@ def create_async_test_client(
             See
             :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>` for details.
         signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
+        signature_types: A sequence of types for use in forward reference resolution during signature modelling.
+            These types will be added to the signature namespace using their ``__name__`` attribute.
         state: An optional :class:`State <.datastructures.State>` for application state.
         static_files_config: A sequence of :class:`StaticFilesConfig <.static_files.StaticFilesConfig>`
         stores: Central registry of :class:`Store <.stores.base.Store>` that will be available throughout the
@@ -527,6 +534,7 @@ def create_async_test_client(
         route_handlers=route_handlers,
         security=security,
         signature_namespace=signature_namespace,
+        signature_types=signature_types,
         state=state,
         static_files_config=static_files_config,
         stores=stores,

--- a/litestar/testing/helpers.py
+++ b/litestar/testing/helpers.py
@@ -215,8 +215,8 @@ def create_test_client(
         security: A sequence of dicts that will be added to the schema of all route handlers in the application.
             See
             :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>` for details.
-        signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
-        signature_types: A sequence of types for use in forward reference resolution during signature modelling.
+        signature_namespace: A mapping of names to types for use in forward reference resolution during signature modeling.
+        signature_types: A sequence of types for use in forward reference resolution during signature modeling.
             These types will be added to the signature namespace using their ``__name__`` attribute.
         state: An optional :class:`State <.datastructures.State>` for application state.
         static_files_config: A sequence of :class:`StaticFilesConfig <.static_files.StaticFilesConfig>`
@@ -468,8 +468,8 @@ def create_async_test_client(
         security: A sequence of dicts that will be added to the schema of all route handlers in the application.
             See
             :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>` for details.
-        signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
-        signature_types: A sequence of types for use in forward reference resolution during signature modelling.
+        signature_namespace: A mapping of names to types for use in forward reference resolution during signature modeling.
+        signature_types: A sequence of types for use in forward reference resolution during signature modeling.
             These types will be added to the signature namespace using their ``__name__`` attribute.
         state: An optional :class:`State <.datastructures.State>` for application state.
         static_files_config: A sequence of :class:`StaticFilesConfig <.static_files.StaticFilesConfig>`

--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -172,7 +172,7 @@ def add_types_to_signature_namespace(signature_types: list[Any], signature_names
         The updated signature namespace.
     """
     for typ in signature_types or []:
-        if type.__name__ in signature_namespace:
+        if typ.__name__ in signature_namespace:
             raise ImproperlyConfiguredException(f"Type {typ.__name__} is already defined in the signature namespace")
         signature_namespace[typ.__name__] = typ
     return signature_namespace

--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -162,7 +162,7 @@ def infer_request_encoding_from_field_definition(field_definition: FieldDefiniti
 
 
 def add_types_to_signature_namespace(signature_types: list[Any], signature_namespace: dict[str, Any]) -> dict[str, Any]:
-    """Add types from a signature to a signature namespace.
+    """Add types from the list to a signature namespace.
 
     Args:
         signature_types: A list of types to add to the signature namespace.

--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -18,6 +18,8 @@ from litestar.types import Empty
 from litestar.typing import FieldDefinition
 
 if typing.TYPE_CHECKING:
+    from typing import Sequence
+
     from litestar.types import AnyCallable
 
 __all__ = (
@@ -161,18 +163,26 @@ def infer_request_encoding_from_field_definition(field_definition: FieldDefiniti
     return RequestEncodingType.JSON
 
 
-def add_types_to_signature_namespace(signature_types: list[Any], signature_namespace: dict[str, Any]) -> dict[str, Any]:
-    """Add types from the list to a signature namespace.
+def add_types_to_signature_namespace(
+    signature_types: Sequence[Any], signature_namespace: dict[str, Any]
+) -> dict[str, Any]:
+    """Add types to ith signature namespace mapping.
+
+    Types are added mapped to their `__name__` attribute.
 
     Args:
         signature_types: A list of types to add to the signature namespace.
         signature_namespace: The signature namespace to add types to.
 
+    Raises:
+        ImproperlyConfiguredException: If a type is already defined in the signature namespace.
+        AttributeError: If a type does not have a `__name__` attribute.
+
     Returns:
         The updated signature namespace.
     """
-    for typ in signature_types or []:
-        if typ.__name__ in signature_namespace:
-            raise ImproperlyConfiguredException(f"Type {typ.__name__} is already defined in the signature namespace")
-        signature_namespace[typ.__name__] = typ
+    for typ in signature_types:
+        if (name := typ.__name__) in signature_namespace:
+            raise ImproperlyConfiguredException(f"Type '{name}' is already defined in the signature namespace")
+        signature_namespace[name] = typ
     return signature_namespace

--- a/tests/unit/test_connection/test_websocket.py
+++ b/tests/unit/test_connection/test_websocket.py
@@ -73,7 +73,7 @@ async def test_custom_request_class() -> None:
             super().__init__(*args, **kwargs)
             self.scope["called"] = True  # type: ignore
 
-    @websocket("/", signature_namespace={"MyWebSocket": MyWebSocket})
+    @websocket("/", signature_types=[MyWebSocket])
     async def handler(socket: MyWebSocket) -> None:
         value["called"] = socket.scope.get("called")
         await socket.accept()

--- a/tests/unit/test_dto/test_integration.py
+++ b/tests/unit/test_dto/test_integration.py
@@ -25,7 +25,7 @@ def experimental_features(use_experimental_dto_backend: bool) -> list[Experiment
 def test_dto_defined_on_handler(
     ModelDataDTO: type[AbstractDTO], experimental_features: list[ExperimentalFeatures]
 ) -> None:
-    @post(dto=ModelDataDTO, signature_namespace={"Model": Model})
+    @post(dto=ModelDataDTO, signature_types=[Model])
     def handler(data: Model) -> Model:
         assert data == Model(a=1, b="2")
         return data
@@ -123,7 +123,7 @@ def test_dto_and_return_dto(
 
 
 def test_enable_experimental_backend(ModelDataDTO: type[AbstractDTO], use_experimental_dto_backend: bool) -> None:
-    @post(dto=ModelDataDTO, signature_namespace={"Model": Model})
+    @post(dto=ModelDataDTO, signature_types=[Model])
     def handler(data: Model) -> Model:
         return data
 
@@ -142,7 +142,7 @@ def test_enable_experimental_backend(ModelDataDTO: type[AbstractDTO], use_experi
 def test_enable_experimental_backend_override_in_dto_config(ModelDataDTO: type[AbstractDTO]) -> None:
     ModelDataDTO.config = DTOConfig(experimental_codegen_backend=False)
 
-    @post(dto=ModelDataDTO, signature_namespace={"Model": Model})
+    @post(dto=ModelDataDTO, signature_types=[Model])
     def handler(data: Model) -> Model:
         return data
 

--- a/tests/unit/test_handlers/test_websocket_handlers/test_listeners.py
+++ b/tests/unit/test_handlers/test_websocket_handlers/test_listeners.py
@@ -115,9 +115,7 @@ def test_listener_receive_with_dto(receive_mode: WebSocketMode) -> None:
     user_dto = DataclassDTO[User]
     value: Any = None
 
-    @websocket_listener(
-        "/", receive_mode=receive_mode, dto=user_dto, return_dto=None, signature_namespace={"User": User}
-    )
+    @websocket_listener("/", receive_mode=receive_mode, dto=user_dto, return_dto=None)
     def handler(data: User) -> None:
         nonlocal value
         value = data

--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -166,7 +166,7 @@ def test_msgspec_schema_generation(create_examples: bool) -> None:
             version="1.0.0",
             create_examples=create_examples,
         ),
-        signature_namespace={"Lookup": Lookup},
+        signature_types=[Lookup],
     ) as client:
         response = client.get("/schema/openapi.json")
         assert response.status_code == HTTP_200_OK

--- a/tests/unit/test_utils/test_signature.py
+++ b/tests/unit/test_utils/test_signature.py
@@ -20,6 +20,7 @@ from litestar.types.empty import Empty
 from litestar.typing import FieldDefinition
 from litestar.utils.signature import (
     ParsedSignature,
+    add_types_to_signature_namespace,
     get_fn_type_hints,
     infer_request_encoding_from_field_definition,
 )
@@ -150,3 +151,21 @@ def xtest_infer_request_encoding_type_from_parameter(
         )
         == expected
     )
+
+
+def test_add_types_to_signature_namespace() -> None:
+    """Test add_types_to_signature_namespace."""
+    ns = add_types_to_signature_namespace([int, str], {})
+    assert ns == {"int": int, "str": str}
+
+
+def test_add_types_to_signature_namespace_with_existing_types() -> None:
+    """Test add_types_to_signature_namespace with existing types."""
+    ns = add_types_to_signature_namespace([str], {"int": int})
+    assert ns == {"int": int, "str": str}
+
+
+def test_add_types_to_signature_namespace_with_existing_types_raises() -> None:
+    """Test add_types_to_signature_namespace with existing types raises."""
+    with pytest.raises(ImproperlyConfiguredException):
+        add_types_to_signature_namespace([int], {"int": int})


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [x] New code has 100% test coverage
- [x] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [x] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- This PR adds a new argument to the app and layers, `signature_types`.

Types in this collection are added to `signature_namespace` using the type's `__name__` attribute.

The objective is to provide a nicer interface when adding names to the signature namespace without modifying the type name, e.g.: `signature_namespace={"Model": Model}` is equivalent to `signature_types=[Model]`.

The implementation makes it an error to supply a type in `signature_types` that has a value for `__name__` already in the signature namespace.

It will also throw an error if an item in `signature_types` has no `__name__` attribute.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
