### PR TITLE
refactor: replace `msgspec.inspect.type_info()` with `msgspec.structs.fields()`

### DIFF
--- a/litestar/dto/msgspec_dto.py
+++ b/litestar/dto/msgspec_dto.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from typing import TYPE_CHECKING, Collection, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Generic, TypeVar
 
-from msgspec import NODEFAULT, Struct, inspect
+from msgspec import NODEFAULT, Struct, structs
 
 from litestar.dto.base_dto import AbstractDTO
 from litestar.dto.data_structures import DTOFieldDefinition
@@ -11,7 +11,7 @@ from litestar.dto.field import DTO_FIELD_META_KEY, DTOField
 from litestar.types.empty import Empty
 
 if TYPE_CHECKING:
-    from typing import Any, Generator
+    from typing import Any, Collection, Generator
 
     from litestar.typing import FieldDefinition
 
@@ -26,7 +26,7 @@ class MsgspecDTO(AbstractDTO[T], Generic[T]):
 
     @classmethod
     def generate_field_definitions(cls, model_type: type[Struct]) -> Generator[DTOFieldDefinition, None, None]:
-        msgspec_fields = {f.name: f for f in cast("inspect.StructType", inspect.type_info(model_type)).fields}
+        msgspec_fields = {f.name: f for f in structs.fields(model_type)}
 
         def default_or_empty(value: Any) -> Any:
             return Empty if value is NODEFAULT else value


### PR DESCRIPTION
As suggested [here](https://github.com/jcrist/msgspec/pull/566#pullrequestreview-1671507706), the `type_info()` function is overkill for this application.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

-

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
