### PR TITLE
docs: fix docs/usage/testing code indent

### DIFF
--- a/docs/usage/testing.rst
+++ b/docs/usage/testing.rst
@@ -449,10 +449,9 @@ pydantic models and dataclasses based on type annotations. With it, we could rew
             def get_one(self) -> Item:
                 return item
 
-
-    with create_test_client(
-        route_handlers=get_item, dependencies={"service": Provide(lambda: MyService())}
-    ) as client:
-        response = client.get("/item")
-        assert response.status_code == HTTP_200_OK
-        assert response.json() == item.dict()
+        with create_test_client(
+            route_handlers=get_item, dependencies={"service": Provide(lambda: MyService())}
+        ) as client:
+            response = client.get("/item")
+            assert response.status_code == HTTP_200_OK
+            assert response.json() == item.dict()


### PR DESCRIPTION
The last code example at the docs/usage/testing has a little code formating error: wrong indent

![image](https://github.com/litestar-org/litestar/assets/44573917/d589ac02-601f-4afc-b20e-7a7b64fa70d2)

It is just a little fix for it
