### PR TITLE
refactor: Deprecate `LitestarType`.

### DIFF
--- a/litestar/types/asgi_types.py
+++ b/litestar/types/asgi_types.py
@@ -100,7 +100,7 @@ if TYPE_CHECKING:
     from litestar.enums import ScopeType
     from litestar.types.empty import EmptyType
 
-    from .internal_types import LitestarType, RouteHandlerType
+    from .internal_types import RouteHandlerType
     from .serialization import DataContainerType
 
 Method: TypeAlias = Union[Literal["GET", "POST", "DELETE", "PATCH", "PUT", "HEAD", "TRACE", "OPTIONS"], HttpMethod]
@@ -123,7 +123,7 @@ class HeaderScope(TypedDict):
 class BaseScope(HeaderScope):
     """Base ASGI-scope."""
 
-    app: LitestarType
+    app: Litestar
     asgi: ASGIVersion
     auth: Any
     client: tuple[str, int] | None

--- a/litestar/types/callable_types.py
+++ b/litestar/types/callable_types.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Gene
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
+    from litestar.app import Litestar
     from litestar.config.app import AppConfig
     from litestar.connection.base import ASGIConnection
     from litestar.connection.request import Request
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
     from litestar.response.base import Response
     from litestar.types.asgi_types import ASGIApp, Message, Method, Scope
     from litestar.types.helper_types import SyncOrAsyncUnion
-    from litestar.types.internal_types import LitestarType, PathParameterDefinition
+    from litestar.types.internal_types import PathParameterDefinition
     from litestar.types.protocols import Logger
 
 
@@ -32,7 +33,7 @@ ExceptionHandler: TypeAlias = "Callable[[Request, Exception], Response]"
 ExceptionLoggingHandler: TypeAlias = "Callable[[Logger, Scope, list[str]], None]"
 GetLogger: TypeAlias = "Callable[..., Logger]"
 Guard: TypeAlias = "Callable[[ASGIConnection, BaseRouteHandler], SyncOrAsyncUnion[None]]"
-LifespanHook: TypeAlias = "Callable[[LitestarType], SyncOrAsyncUnion[Any]] | Callable[[], SyncOrAsyncUnion[Any]]"
+LifespanHook: TypeAlias = "Callable[[Litestar], SyncOrAsyncUnion[Any]] | Callable[[], SyncOrAsyncUnion[Any]]"
 OnAppInitHandler: TypeAlias = "Callable[[AppConfig], AppConfig]"
 OperationIDCreator: TypeAlias = "Callable[[HTTPRouteHandler, Method, list[str | PathParameterDefinition]], str]"
 Serializer: TypeAlias = Callable[[Any], Any]

--- a/litestar/types/internal_types.py
+++ b/litestar/types/internal_types.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable, Literal, NamedTuple
 
+from litestar.utils.deprecation import warn_deprecation
+
 __all__ = (
     "ControllerRouterHandler",
-    "LitestarType",
     "PathParameterDefinition",
     "PathParameterDefinition",
     "ReservedKwargs",
@@ -12,7 +13,6 @@ __all__ = (
     "RouteHandlerMapItem",
     "RouteHandlerType",
 )
-
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
@@ -27,11 +27,13 @@ if TYPE_CHECKING:
     from litestar.types import Method
 
 ReservedKwargs: TypeAlias = Literal["request", "socket", "headers", "query", "cookies", "state", "data"]
-LitestarType: TypeAlias = "Litestar"
 RouteHandlerType: TypeAlias = "HTTPRouteHandler | WebsocketRouteHandler | ASGIRouteHandler"
 ResponseType: TypeAlias = "type[Response]"
 ControllerRouterHandler: TypeAlias = "type[Controller] | RouteHandlerType | Router | Callable[..., Any]"
 RouteHandlerMapItem: TypeAlias = 'dict[Method | Literal["websocket", "asgi"], RouteHandlerType]'
+
+# deprecated
+_LitestarType: TypeAlias = "Litestar"
 
 
 class PathParameterDefinition(NamedTuple):
@@ -41,3 +43,16 @@ class PathParameterDefinition(NamedTuple):
     full: str
     type: type
     parser: Callable[[str], Any] | None
+
+
+def __getattr__(name: str) -> Any:
+    if name == "LitestarType":
+        warn_deprecation(
+            "2.3.0",
+            "LitestarType",
+            "import",
+            removal_in="3.0.0",
+            alternative="Litestar",
+        )
+        return _LitestarType
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -95,3 +95,8 @@ import pytest
 def test_repository_deprecations(import_path: str, import_name: str) -> None:
     module = importlib.import_module(import_path)
     assert getattr(module, import_name)
+
+
+def test_litestar_type_deprecation() -> None:
+    with pytest.warns(DeprecationWarning):
+        from litestar.types.internal_types import LitestarType  # noqa: F401


### PR DESCRIPTION
`LitestarType` currently exists as an alias for `Litestar`, though the rationale behind its existence is unclear. This alias might introduce confusion as the name would more appropriately alias `type[Litestar]`.

This PR removes internal use of, and deprecates `LitestarType`.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

-

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
