### PR TITLE
ci: use better name for `test` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         run: pre-commit run --show-diff-on-failure --color=always --all-files
 
   test:
+    name: "test (${{ matrix.python-version }}, pydantic@${{ matrix.pydantic-version }})"
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
Right now the name of the job is quite cryptic (especially the `1` / `2` part):
<img width="296" alt="Снимок экрана 2023-10-14 в 09 26 02" src="https://github.com/litestar-org/litestar/assets/4660275/076fac74-6e4d-4368-9f9b-14775a31a2d1">

With this change it will be a bit more verbose and readable.