### PR TITLE
chore: Updates pdm.lock content hash.

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -6,8 +6,7 @@ groups = ["default", "annotated-types", "attrs", "brotli", "cli", "cryptography"
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:e2649eb5938b6214e8412ded8642678006e9baef9a999afe1bfe7bc51505c0c4"
-
+content_hash = "sha256:105738a0948d2a54c82cf60edcc5a41ae512c1e79c1c4f2be3f4b3fddc2619a5"
 
 [[package]]
 name = "accessible-pygments"


### PR DESCRIPTION
I believe this is the cause of the current error building dev docs: https://github.com/litestar-org/litestar/actions/runs/6520536684/job/17708175205#step:8:116

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

-

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
