### PR TITLE
docs: remove unused parameter from 'Template' response

### DIFF
--- a/litestar/response/template.py
+++ b/litestar/response/template.py
@@ -56,7 +56,6 @@ class Template(Response[bytes]):
             media_type: A string or member of the :class:`MediaType <.enums.MediaType>` enum. If not set, try to infer
                 the media type based on the template name. If this fails, fall back to ``text/plain``.
             status_code: A value for the response HTTP status code.
-            template_engine: The template engine class to use to render the response.
         """
         super().__init__(
             background=background,


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- Remove the unused `template_engine` parameter from the docstring of `Template` response class.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- Closes #2454 
