### PR TITLE
 build: extend build timeout for platform compat CI. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
       python-version: ${{ matrix.python-version }}
 
   test-platform-compat:
-    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       python-version: "3.12"
       pydantic-version: "2"
       os: ${{ matrix.os }}
+      timeout: 15
 
   sonar:
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,15 @@ on:
         required: false
         type: string
         default: "ubuntu-latest"
+      timeout:
+        required: false
+        type: number
+        default: 10
 
 jobs:
   test:
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 10
+    timeout-minutes: ${{ inputs.timeout }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

I've experienced multiple consecutive timeouts on the windows compat CI step.

This PR makes "timeout" an input for the test workflow, and extends it for the compat tests.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
