### PR TITLE
fix: logging default handler compat.

### DIFF
--- a/litestar/logging/config.py
+++ b/litestar/logging/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass, field
 from importlib.util import find_spec
@@ -40,9 +41,12 @@ default_handlers: dict[str, dict[str, Any]] = {
         "class": "litestar.logging.standard.QueueListenerHandler",
         "level": "DEBUG",
         "formatter": "standard",
-        "handlers": ["console"],
     },
 }
+
+if sys.version_info >= (3, 12, 0):
+    default_handlers["queue_listener"]["handlers"] = ["console"]
+
 
 default_picologging_handlers: dict[str, dict[str, Any]] = {
     "console": {


### PR DESCRIPTION
Only add "console" handler to `default_handlers["queue_listener"]` in >= 3.12.

Closes #2477

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

-

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
