### PR TITLE
chore: use dmypy to speed up local type checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ __pypackages__/
 # pyenv / rtx / asdf
 .tool-versions
 .python-version
+/.dmypy.json

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ lock:                                             ## Rebuild lockfiles from scra
 .PHONY: mypy
 mypy:                                               ## Run mypy
 	@echo "=> Running mypy"
-	@$(ENV_PREFIX)mypy
+	@$(ENV_PREFIX)dmypy run
 	@echo "=> mypy complete"
 
 .PHONY: pyright


### PR DESCRIPTION
Use the [mypy daemon](https://mypy.readthedocs.io/en/stable/mypy_daemon.html) to speed up type checking when running locally.