### PR TITLE
fix: rename `contrib.minijnja` to `contrib.minijinja`

### DIFF
--- a/docs/examples/templating/engine_instance_minijinja.py
+++ b/docs/examples/templating/engine_instance_minijinja.py
@@ -1,4 +1,4 @@
-from litestar.contrib.minijnja import MiniJinjaTemplateEngine
+from litestar.contrib.minijinja import MiniJinjaTemplateEngine
 from litestar.template.config import TemplateConfig
 
 template_config = TemplateConfig(engine=MiniJinjaTemplateEngine, directory="templates")

--- a/docs/examples/templating/returning_templates_minijinja.py
+++ b/docs/examples/templating/returning_templates_minijinja.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from litestar import Litestar, get
-from litestar.contrib.minijnja import MiniJinjaTemplateEngine
+from litestar.contrib.minijinja import MiniJinjaTemplateEngine
 from litestar.response import Template
 from litestar.template.config import TemplateConfig
 

--- a/docs/examples/templating/template_engine_minijinja.py
+++ b/docs/examples/templating/template_engine_minijinja.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from litestar import Litestar
-from litestar.contrib.minijnja import MiniJinjaTemplateEngine
+from litestar.contrib.minijinja import MiniJinjaTemplateEngine
 from litestar.template.config import TemplateConfig
 
 app = Litestar(

--- a/docs/examples/templating/template_functions_minijinja.py
+++ b/docs/examples/templating/template_functions_minijinja.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from litestar import Litestar, get
-from litestar.contrib.minijnja import MiniJinjaTemplateEngine, minijinja_from_state
+from litestar.contrib.minijinja import MiniJinjaTemplateEngine, minijinja_from_state
 from litestar.response import Template
 from litestar.template.config import TemplateConfig
 

--- a/litestar/contrib/minijinja.py
+++ b/litestar/contrib/minijinja.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import functools
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, cast
+
+from litestar.exceptions import ImproperlyConfiguredException, MissingDependencyException, TemplateNotFoundException
+from litestar.template.base import (
+    TemplateEngineProtocol,
+    TemplateProtocol,
+    csrf_token,
+    url_for,
+    url_for_static_asset,
+)
+
+__all__ = ("MiniJinjaTemplateEngine",)
+
+
+try:
+    import minijinja as m  # noqa: F401
+except ImportError as e:
+    raise MissingDependencyException("minijinja") from e
+
+from minijinja import Environment, pass_state
+from minijinja import TemplateError as MiniJinjaTemplateNotFound
+
+if TYPE_CHECKING:
+    from minijinja._lowlevel import State
+    from pydantic import DirectoryPath
+
+
+@pass_state  # type: ignore
+def minijinja_from_state(func: Callable, state: State, *args: Any, **kwargs: Any) -> str:
+    template_context = {"request": state.lookup("request"), "csrf_input": state.lookup("csrf_input")}
+    return cast(str, func(template_context, *args, **kwargs))
+
+
+class MiniJinjaTemplate(TemplateProtocol):
+    """Initialize a template.
+
+    Args:
+        template: Base ``MiniJinjaTemplate`` used by the underlying minijinja engine
+    """
+
+    def __init__(self, engine: Environment, template_name: str) -> None:
+        super().__init__()
+        self.engine = engine
+        self.template_name = template_name
+
+    def render(self, *args: Any, **kwargs: Any) -> str:
+        """Render a template.
+
+        Args:
+            args: Positional arguments passed to the engines ``render`` function
+            kwargs: Keyword arguments passed to the engines ``render`` function
+
+        Returns:
+            Rendered template as a string
+        """
+        return str(self.engine.render_template(self.template_name, *args, **kwargs))
+
+
+class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate"]):
+    """The engine instance."""
+
+    def __init__(
+        self, directory: DirectoryPath | list[DirectoryPath] | None = None, engine_instance: Environment | None = None
+    ) -> None:
+        """Minijinja based TemplateEngine.
+
+        Args:
+            directory: Direct path or list of directory paths from which to serve templates.
+            engine_instance: A Minijinja Environment instance.
+        """
+        super().__init__(directory, engine_instance)
+        if directory and engine_instance:
+            raise ImproperlyConfiguredException(
+                "You must provide either a directory or a minijinja Environment instance."
+            )
+        if directory:
+
+            def _loader(name: str) -> str:
+                """Load a template from a directory.
+
+                Args:
+                    name: The name of the template
+
+                Returns:
+                    The template as a string
+
+                Raises:
+                    TemplateNotFoundException: if no template is found.
+                """
+                directories = directory if isinstance(directory, list) else [directory]
+
+                for d in directories:
+                    template_path = Path(d) / name  # pyright: ignore[reportGeneralTypeIssues]
+                    if template_path.exists():
+                        return template_path.read_text()
+                raise TemplateNotFoundException(template_name=name)
+
+            self.engine = Environment(loader=_loader)
+        elif engine_instance:
+            self.engine = engine_instance
+
+        self.register_template_callable(
+            key="url_for", template_callable=functools.partial(minijinja_from_state, url_for)
+        )
+        self.register_template_callable(
+            key="url_for_static_asset", template_callable=functools.partial(minijinja_from_state, url_for_static_asset)
+        )
+        self.register_template_callable(
+            key="csrf_token", template_callable=functools.partial(minijinja_from_state, csrf_token)
+        )
+
+    def get_template(self, template_name: str) -> MiniJinjaTemplate:
+        """Retrieve a template by matching its name (dotted path) with files in the directory or directories provided.
+
+        Args:
+            template_name: A dotted path
+
+        Returns:
+            MiniJinjaTemplate instance
+
+        Raises:
+            TemplateNotFoundException: if no template is found.
+        """
+        try:
+            return MiniJinjaTemplate(self.engine, template_name)
+        except MiniJinjaTemplateNotFound as exc:
+            raise TemplateNotFoundException(template_name=template_name) from exc
+
+    def register_template_callable(self, key: str, template_callable: Callable[[dict[str, Any]], Any]) -> None:
+        """Register a callable on the template engine.
+
+        Args:
+            key: The callable key, i.e. the value to use inside the template to call the callable.
+            template_callable: A callable to register.
+
+        Returns:
+            None
+        """
+        self.engine.add_global(key, pass_state(template_callable))
+
+    @classmethod
+    def from_environment(cls, minijinja_environment: Environment) -> MiniJinjaTemplateEngine:
+        """Create a MiniJinjaTemplateEngine from an existing minijinja Environment instance.
+
+        Args:
+            minijinja_environment (Environment): A minijinja Environment instance.
+
+        Returns:
+            MiniJinjaTemplateEngine instance
+        """
+        return cls(directory=None, engine_instance=minijinja_environment)

--- a/litestar/contrib/minijnja.py
+++ b/litestar/contrib/minijnja.py
@@ -1,155 +1,18 @@
 from __future__ import annotations
 
-import functools
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import Any
 
-from litestar.exceptions import ImproperlyConfiguredException, MissingDependencyException, TemplateNotFoundException
-from litestar.template.base import (
-    TemplateEngineProtocol,
-    TemplateProtocol,
-    csrf_token,
-    url_for,
-    url_for_static_asset,
-)
+from litestar.utils.deprecation import warn_deprecation
 
-__all__ = ("MiniJinjaTemplateEngine",)
+from . import minijinja as _minijinja
 
 
-try:
-    import minijinja as m  # noqa: F401
-except ImportError as e:
-    raise MissingDependencyException("minijinja") from e
-
-from minijinja import Environment, pass_state
-from minijinja import TemplateError as MiniJinjaTemplateNotFound
-
-if TYPE_CHECKING:
-    from minijinja._lowlevel import State
-    from pydantic import DirectoryPath
-
-
-@pass_state  # type: ignore
-def minijinja_from_state(func: Callable, state: State, *args: Any, **kwargs: Any) -> str:
-    template_context = {"request": state.lookup("request"), "csrf_input": state.lookup("csrf_input")}
-    return cast(str, func(template_context, *args, **kwargs))
-
-
-class MiniJinjaTemplate(TemplateProtocol):
-    """Initialize a template.
-
-    Args:
-        template: Base ``MiniJinjaTemplate`` used by the underlying minijinja engine
-    """
-
-    def __init__(self, engine: Environment, template_name: str) -> None:
-        super().__init__()
-        self.engine = engine
-        self.template_name = template_name
-
-    def render(self, *args: Any, **kwargs: Any) -> str:
-        """Render a template.
-
-        Args:
-            args: Positional arguments passed to the engines ``render`` function
-            kwargs: Keyword arguments passed to the engines ``render`` function
-
-        Returns:
-            Rendered template as a string
-        """
-        return str(self.engine.render_template(self.template_name, *args, **kwargs))
-
-
-class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate"]):
-    """The engine instance."""
-
-    def __init__(
-        self, directory: DirectoryPath | list[DirectoryPath] | None = None, engine_instance: Environment | None = None
-    ) -> None:
-        """Minijinja based TemplateEngine.
-
-        Args:
-            directory: Direct path or list of directory paths from which to serve templates.
-            engine_instance: A Minijinja Environment instance.
-        """
-        super().__init__(directory, engine_instance)
-        if directory and engine_instance:
-            raise ImproperlyConfiguredException(
-                "You must provide either a directory or a minijinja Environment instance."
-            )
-        if directory:
-
-            def _loader(name: str) -> str:
-                """Load a template from a directory.
-
-                Args:
-                    name: The name of the template
-
-                Returns:
-                    The template as a string
-
-                Raises:
-                    TemplateNotFoundException: if no template is found.
-                """
-                directories = directory if isinstance(directory, list) else [directory]
-
-                for d in directories:
-                    template_path = Path(d) / name  # pyright: ignore[reportGeneralTypeIssues]
-                    if template_path.exists():
-                        return template_path.read_text()
-                raise TemplateNotFoundException(template_name=name)
-
-            self.engine = Environment(loader=_loader)
-        elif engine_instance:
-            self.engine = engine_instance
-
-        self.register_template_callable(
-            key="url_for", template_callable=functools.partial(minijinja_from_state, url_for)
-        )
-        self.register_template_callable(
-            key="url_for_static_asset", template_callable=functools.partial(minijinja_from_state, url_for_static_asset)
-        )
-        self.register_template_callable(
-            key="csrf_token", template_callable=functools.partial(minijinja_from_state, csrf_token)
-        )
-
-    def get_template(self, template_name: str) -> MiniJinjaTemplate:
-        """Retrieve a template by matching its name (dotted path) with files in the directory or directories provided.
-
-        Args:
-            template_name: A dotted path
-
-        Returns:
-            MiniJinjaTemplate instance
-
-        Raises:
-            TemplateNotFoundException: if no template is found.
-        """
-        try:
-            return MiniJinjaTemplate(self.engine, template_name)
-        except MiniJinjaTemplateNotFound as exc:
-            raise TemplateNotFoundException(template_name=template_name) from exc
-
-    def register_template_callable(self, key: str, template_callable: Callable[[dict[str, Any]], Any]) -> None:
-        """Register a callable on the template engine.
-
-        Args:
-            key: The callable key, i.e. the value to use inside the template to call the callable.
-            template_callable: A callable to register.
-
-        Returns:
-            None
-        """
-        self.engine.add_global(key, pass_state(template_callable))
-
-    @classmethod
-    def from_environment(cls, minijinja_environment: Environment) -> MiniJinjaTemplateEngine:
-        """Create a MiniJinjaTemplateEngine from an existing minijinja Environment instance.
-
-        Args:
-            minijinja_environment (Environment): A minijinja Environment instance.
-
-        Returns:
-            MiniJinjaTemplateEngine instance
-        """
-        return cls(directory=None, engine_instance=minijinja_environment)
+def __getattr__(name: str) -> Any:
+    warn_deprecation(
+        "2.3.0",
+        "contrib.minijnja",
+        "import",
+        removal_in="3.0.0",
+        alternative="contrib.minijinja",
+    )
+    return getattr(_minijinja, name)

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -100,3 +100,8 @@ def test_repository_deprecations(import_path: str, import_name: str) -> None:
 def test_litestar_type_deprecation() -> None:
     with pytest.warns(DeprecationWarning):
         from litestar.types.internal_types import LitestarType  # noqa: F401
+
+
+def test_contrib_minijnja_deprecation() -> None:
+    with pytest.warns(DeprecationWarning):
+        from litestar.contrib.minijnja import MiniJinjaTemplateEngine  # noqa: F401

--- a/tests/unit/test_template/test_built_in.py
+++ b/tests/unit/test_template/test_built_in.py
@@ -9,7 +9,7 @@ from mako.lookup import TemplateLookup
 from litestar import get
 from litestar.contrib.jinja import JinjaTemplateEngine
 from litestar.contrib.mako import MakoTemplateEngine
-from litestar.contrib.minijnja import MiniJinjaTemplateEngine
+from litestar.contrib.minijinja import MiniJinjaTemplateEngine
 from litestar.response.template import Template
 from litestar.template.config import TemplateConfig
 from litestar.testing import create_test_client

--- a/tests/unit/test_template/test_builtin_functions.py
+++ b/tests/unit/test_template/test_builtin_functions.py
@@ -7,7 +7,7 @@ import pytest
 from litestar import get
 from litestar.contrib.jinja import JinjaTemplateEngine
 from litestar.contrib.mako import MakoTemplateEngine
-from litestar.contrib.minijnja import MiniJinjaTemplateEngine
+from litestar.contrib.minijinja import MiniJinjaTemplateEngine
 from litestar.response.template import Template
 from litestar.static_files.config import StaticFilesConfig
 from litestar.status_codes import HTTP_200_OK, HTTP_500_INTERNAL_SERVER_ERROR

--- a/tests/unit/test_template/test_context.py
+++ b/tests/unit/test_template/test_context.py
@@ -6,7 +6,7 @@ import pytest
 from litestar import MediaType, get
 from litestar.contrib.jinja import JinjaTemplateEngine
 from litestar.contrib.mako import MakoTemplateEngine
-from litestar.contrib.minijnja import MiniJinjaTemplateEngine
+from litestar.contrib.minijinja import MiniJinjaTemplateEngine
 from litestar.response.template import Template
 from litestar.template.config import TemplateConfig
 from litestar.testing import create_test_client

--- a/tests/unit/test_template/test_csrf_token.py
+++ b/tests/unit/test_template/test_csrf_token.py
@@ -8,7 +8,7 @@ from litestar import MediaType, get
 from litestar.config.csrf import CSRFConfig
 from litestar.contrib.jinja import JinjaTemplateEngine
 from litestar.contrib.mako import MakoTemplateEngine
-from litestar.contrib.minijnja import MiniJinjaTemplateEngine
+from litestar.contrib.minijinja import MiniJinjaTemplateEngine
 from litestar.middleware.csrf import generate_csrf_token
 from litestar.response.template import Template
 from litestar.template.config import TemplateConfig

--- a/tests/unit/test_template/test_template.py
+++ b/tests/unit/test_template/test_template.py
@@ -7,7 +7,7 @@ import pytest
 from litestar import Litestar, MediaType, get
 from litestar.contrib.jinja import JinjaTemplateEngine
 from litestar.contrib.mako import MakoTemplateEngine
-from litestar.contrib.minijnja import MiniJinjaTemplateEngine
+from litestar.contrib.minijinja import MiniJinjaTemplateEngine
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.response.template import Template
 from litestar.template.config import TemplateConfig


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

This PR corrects the misspelled module name, while leaving the incorrect namespace available but deprecated.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

Closes #2484
