### PR TITLE
refactor: remove pydantic DirectoryPath from TemplateEngineProtocol

### DIFF
--- a/litestar/contrib/jinja.py
+++ b/litestar/contrib/jinja.py
@@ -22,8 +22,9 @@ from jinja2 import Environment, FileSystemLoader, pass_context
 from jinja2 import TemplateNotFound as JinjaTemplateNotFound
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from jinja2 import Template as JinjaTemplate
-    from pydantic import DirectoryPath
 
 
 class JinjaTemplateEngine(TemplateEngineProtocol["JinjaTemplate"]):
@@ -31,7 +32,7 @@ class JinjaTemplateEngine(TemplateEngineProtocol["JinjaTemplate"]):
 
     def __init__(
         self,
-        directory: DirectoryPath | list[DirectoryPath] | None = None,
+        directory: Path | list[Path] | None = None,
         engine_instance: Environment | None = None,
     ) -> None:
         """Jinja based TemplateEngine.

--- a/litestar/contrib/mako.py
+++ b/litestar/contrib/mako.py
@@ -25,8 +25,9 @@ from mako.exceptions import TemplateLookupException as MakoTemplateNotFound
 from mako.lookup import TemplateLookup
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from mako.template import Template as _MakoTemplate
-    from pydantic import DirectoryPath
 
 
 class MakoTemplate(TemplateProtocol):
@@ -65,9 +66,7 @@ class MakoTemplate(TemplateProtocol):
 class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate]):
     """Mako based TemplateEngine."""
 
-    def __init__(
-        self, directory: DirectoryPath | list[DirectoryPath] | None = None, engine_instance: Any | None = None
-    ) -> None:
+    def __init__(self, directory: Path | list[Path] | None = None, engine_instance: Any | None = None) -> None:
         """Initialize template engine.
 
         Args:

--- a/litestar/contrib/minijinja.py
+++ b/litestar/contrib/minijinja.py
@@ -26,7 +26,6 @@ from minijinja import TemplateError as MiniJinjaTemplateNotFound
 
 if TYPE_CHECKING:
     from minijinja._lowlevel import State
-    from pydantic import DirectoryPath
 
 
 @pass_state  # type: ignore
@@ -63,9 +62,7 @@ class MiniJinjaTemplate(TemplateProtocol):
 class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate"]):
     """The engine instance."""
 
-    def __init__(
-        self, directory: DirectoryPath | list[DirectoryPath] | None = None, engine_instance: Environment | None = None
-    ) -> None:
+    def __init__(self, directory: Path | list[Path] | None = None, engine_instance: Environment | None = None) -> None:
         """Minijinja based TemplateEngine.
 
         Args:

--- a/litestar/template/base.py
+++ b/litestar/template/base.py
@@ -13,7 +13,7 @@ __all__ = (
 
 
 if TYPE_CHECKING:
-    from pydantic import DirectoryPath
+    from pathlib import Path
 
     from litestar.connection import Request
 
@@ -101,7 +101,7 @@ T_co = TypeVar("T_co", bound=TemplateProtocol, covariant=True)
 class TemplateEngineProtocol(Protocol[T_co]):  # pragma: no cover
     """Protocol for template engines."""
 
-    def __init__(self, directory: DirectoryPath | list[DirectoryPath] | None, engine_instance: Any | None) -> None:
+    def __init__(self, directory: Path | list[Path] | None, engine_instance: Any | None) -> None:
         """Initialize the template engine with a directory.
 
         Args:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->
This PR swaps use of `pydantic.DirectoryPath` for `pathlib.Path` as annotation for our `TemplateEngineProtocol`'s directory parameter.

Motivation is to decouple pydantic from template use.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
