### PR TITLE
fix: get_type_hints() optional param compatibility

### DIFF
--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -52,7 +52,9 @@ This allows users to include these names within an `if TYPE_CHECKING:` block in 
 """
 
 
-def _unwrap_implicit_optional_hints(defaults: dict[str, Any], hints: dict[str, Any]) -> dict[str, Any]:
+def _unwrap_implicit_optional_hints(
+    defaults: dict[str, Any], hints: dict[str, Any]
+) -> dict[str, Any]:  # pragma: no cover
     """Unwrap implicit optional hints.
 
     On python <3.11, if a function param annotation has a `None` default, it is unconditionally wrapped in an
@@ -121,7 +123,7 @@ def get_fn_type_hints(fn: Any, namespace: dict[str, Any] | None = None) -> dict[
     }
     hints = get_type_hints(fn_to_inspect, globalns=namespace, include_extras=True)
 
-    if sys.version_info < (3, 11):
+    if sys.version_info < (3, 11):  # pragma: no cover
         # see https://github.com/litestar-org/litestar/pull/2516
         defaults = _get_defaults(fn_to_inspect)
         hints = _unwrap_implicit_optional_hints(defaults, hints)

--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -57,8 +57,8 @@ def _unwrap_implicit_optional_hints(
 ) -> dict[str, Any]:  # pragma: no cover
     """Unwrap implicit optional hints.
 
-    On python <3.11, if a function param annotation has a `None` default, it is unconditionally wrapped in an
-    `Optional` type. This function reverses that process.
+    On Python<3.11, if a function parameter annotation has a ``None`` default, it is unconditionally wrapped in an
+    ``Optional`` type. This function reverses that process.
 
     Args:
         defaults: Mapping of names to default values.

--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -27,8 +27,8 @@ if sys.version_info < (3, 11):
     from typing import _get_defaults  # type: ignore[attr-defined]
 else:
 
-    def _get_defaults(_: Any) -> dict[str, Any]:
-        return {}
+    def _get_defaults(_: Any) -> Any:
+        ...
 
 
 __all__ = (
@@ -97,7 +97,6 @@ def get_fn_type_hints(fn: Any, namespace: dict[str, Any] | None = None) -> dict[
         Mapping of names to types.
     """
     fn_to_inspect: Any = fn
-    defaults = _get_defaults(fn_to_inspect)
 
     module_name = fn_to_inspect.__module__
 
@@ -121,8 +120,12 @@ def get_fn_type_hints(fn: Any, namespace: dict[str, Any] | None = None) -> dict[
         **(namespace or {}),
     }
     hints = get_type_hints(fn_to_inspect, globalns=namespace, include_extras=True)
-    if defaults:
+
+    if sys.version_info < (3, 11):
+        # see https://github.com/litestar-org/litestar/pull/2516
+        defaults = _get_defaults(fn_to_inspect)
         hints = _unwrap_implicit_optional_hints(defaults, hints)
+
     return hints
 
 

--- a/tests/unit/test_utils/test_signature.py
+++ b/tests/unit/test_utils/test_signature.py
@@ -68,20 +68,26 @@ def test_get_fn_type_hints_class_no_init() -> None:
 def test_get_fn_type_hints_with_none_default() -> None:
     def fn(
         a: Annotated[Optional[str], ...] = None,
-        b: Optional[str] = None,
-        c: Union[str, None] = None,
-        d: Union[str, int, None] = None,
-        e: Optional[Union[str, int]] = None,
+        b: Annotated[Union[str, None], ...] = None,
+        c: Annotated[Union[str, int, None], ...] = None,
+        d: Annotated[Optional[Union[str, int]], ...] = None,
+        e: Optional[str] = None,
+        f: Union[str, None] = None,
+        g: Union[str, int, None] = None,
+        h: Optional[Union[str, int]] = None,
     ) -> None:
         ...
 
     hints = get_fn_type_hints(fn)
     assert hints == {
         "a": Annotated[Union[str, NoneType], ...],
-        "b": Union[str, NoneType],
-        "c": Union[str, NoneType],
-        "d": Union[str, int, NoneType],
-        "e": Union[str, int, NoneType],
+        "b": Annotated[Union[str, NoneType], ...],
+        "c": Annotated[Union[str, int, NoneType], ...],
+        "d": Annotated[Union[str, int, NoneType], ...],
+        "e": Union[str, NoneType],
+        "f": Union[str, NoneType],
+        "g": Union[str, int, NoneType],
+        "h": Union[str, int, NoneType],
         "return": NoneType,
     }
 

--- a/tests/unit/test_utils/test_signature.py
+++ b/tests/unit/test_utils/test_signature.py
@@ -65,6 +65,27 @@ def test_get_fn_type_hints_class_no_init() -> None:
     assert get_fn_type_hints(C) == {}
 
 
+def test_get_fn_type_hints_with_none_default() -> None:
+    def fn(
+        a: Annotated[Optional[str], ...] = None,
+        b: Optional[str] = None,
+        c: Union[str, None] = None,
+        d: Union[str, int, None] = None,
+        e: Optional[Union[str, int]] = None,
+    ) -> None:
+        ...
+
+    hints = get_fn_type_hints(fn)
+    assert hints == {
+        "a": Annotated[Union[str, NoneType], ...],
+        "b": Union[str, NoneType],
+        "c": Union[str, NoneType],
+        "d": Union[str, int, NoneType],
+        "e": Union[str, int, NoneType],
+        "return": NoneType,
+    }
+
+
 class _TD(TypedDict):
     req_int: Required[int]
     req_list_int: Required[List[int]]


### PR DESCRIPTION
Prior to python 3.11, if a func or method param has a default of `None`, then `get_type_hints()` will automagically wrap the annotation in `Union[T, NoneType]`.

Sometimes this is flattened out before we receive the type back:

```python-console
Python 3.8.17 (default, Sep 14 2023, 13:58:34)
[GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from typing import Optional
>>> from typing_extensions import Annotated, get_type_hints
>>>
>>> def simple(p: Optional[str] = None) -> None: ...
...
>>> get_type_hints(simple)
{'p': typing.Union[str, NoneType], 'return': <class 'NoneType'>}
```
However, if that type is annotated:

```python-console
>>> def annotated(p: Annotated[Optional[str], ...] = None) -> None: ...
...
>>> get_type_hints(annotated)
{'p': typing.Union[typing.Union[str, NoneType], NoneType], 'return': <class 'NoneType'>}
```

Which gets more convoluted if `include_extras=True`:

```python-console
>>> get_type_hints(annotated, include_extras=True)
{'p': typing.Union[typing_extensions.Annotated[typing.Union[str, NoneType], Ellipsis], NoneType], 'return': <class 'NoneType'>}
```

This means that when we parse one of these types into a `FieldDefinition`, we get different behavior b/w <3.11 and 3.11+:

```python
hints = get_type_hints(annotated, include_extra=True)
t = FieldDefinition.from_annotation(hints["p"])
# on 3.8-3.10
print(t.metadata)  # ()
# on 3.11+
print(t.metadata)  # (Ellipsis,)
```

...which I suspect may be playing a part in #2514.

This PR reverses the magic optional wrapping performed by `get_type_hints()` on versions < 3.11, so that we can treat the annotation the same downstream.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

-

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
