### PR TITLE
build: run code coverage on min and max py vers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         pydantic-version: ["1", "2"]
     uses: ./.github/workflows/test.yml
     with:
-      coverage: ${{ matrix.python-version == '3.12' && matrix.pydantic-version == '2' }}
+      coverage: ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.8') && matrix.pydantic-version == '2' }}
       pydantic-version: ${{ matrix.pydantic-version }}
       python-version: ${{ matrix.python-version }}
 
@@ -117,10 +117,21 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
       - name: Download Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: coverage-xml
+          name: coverage-data
+
+      - name: Combine coverage files
+        run: |
+          python -Im pip install coverage
+          python -Im coverage combine
+          python -Im coverage xml -i
+
       - name: Fix coverage file for sonarcloud
         run: sed -i "s/home\/runner\/work\/litestar\/litestar/github\/workspace/g" coverage.xml
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,10 +75,14 @@ jobs:
 
       - name: Test with coverage
         if: inputs.coverage
-        run: pdm run pytest docs/examples tests --cov=litestar --cov-report=xml -n auto
+        run: pdm run pytest docs/examples tests --cov=litestar -n auto
+
+      - name: Rename coverage file
+        if: inputs.coverage
+        run: mv .coverage .coverage.${{ inputs.python-version }}
 
       - uses: actions/upload-artifact@v3
         if: inputs.coverage
         with:
-          name: coverage-xml
-          path: coverage.xml
+          name: coverage-data
+          path: .coverage.${{ inputs.python-version }}

--- a/litestar/channels/backends/redis.py
+++ b/litestar/channels/backends/redis.py
@@ -4,7 +4,7 @@ import asyncio
 import sys
 
 if sys.version_info < (3, 9):
-    import importlib_resources  # pragma: no cover
+    import importlib_resources
 else:
     import importlib.resources as importlib_resources
 from abc import ABC

--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -58,7 +58,7 @@ __all__ = (
 if sys.version_info >= (3, 10):
     from importlib.metadata import entry_points
 else:
-    from importlib_metadata import entry_points  # pragma: no cover
+    from importlib_metadata import entry_points
 
 
 if TYPE_CHECKING:

--- a/litestar/constants.py
+++ b/litestar/constants.py
@@ -36,5 +36,5 @@ try:
 
     UNDEFINED_SENTINELS.add(PydanticUndefined)
 
-except ImportError:  # pragma: no cover
+except ImportError:
     pass

--- a/litestar/events/emitter.py
+++ b/litestar/events/emitter.py
@@ -47,7 +47,7 @@ class BaseEventEmitterBackend(AsyncContextManager["BaseEventEmitterBackend"], AB
                 self.listeners[event_id].add(listener)
 
     @abstractmethod
-    def emit(self, event_id: str, *args: Any, **kwargs: Any) -> None:  # pragma: no cover
+    def emit(self, event_id: str, *args: Any, **kwargs: Any) -> None:
         """Emit an event to all attached listeners.
 
         Args:

--- a/litestar/logging/config.py
+++ b/litestar/logging/config.py
@@ -114,7 +114,7 @@ def _default_exception_logging_handler_factory(
     return _default_exception_logging_handler
 
 
-class BaseLoggingConfig(ABC):  # pragma: no cover
+class BaseLoggingConfig(ABC):
     """Abstract class that should be extended by logging configs."""
 
     __slots__ = ("log_exceptions", "traceback_line_limit", "exception_logging_handler")
@@ -255,7 +255,7 @@ def default_structlog_processors() -> list[Processor] | None:  # pyright: ignore
             structlog.processors.TimeStamper(fmt="iso"),
             structlog.processors.JSONRenderer(serializer=default_json_serializer),
         ]
-    except ImportError:  # pragma: no cover
+    except ImportError:
         return None
 
 
@@ -270,7 +270,7 @@ def default_wrapper_class() -> type[BindableLogger] | None:  # pyright: ignore
         import structlog
 
         return structlog.make_filtering_bound_logger(INFO)
-    except ImportError:  # pragma: no cover
+    except ImportError:
         return None
 
 
@@ -284,7 +284,7 @@ def default_logger_factory() -> Callable[..., WrappedLogger] | None:
         import structlog
 
         return structlog.BytesLoggerFactory()
-    except ImportError:  # pragma: no cover
+    except ImportError:
         return None
 
 

--- a/litestar/middleware/authentication.py
+++ b/litestar/middleware/authentication.py
@@ -90,7 +90,7 @@ class AbstractAuthenticationMiddleware(ABC):
         await self.app(scope, receive, send)
 
     @abstractmethod
-    async def authenticate_request(self, connection: ASGIConnection) -> AuthenticationResult:  # pragma: no cover
+    async def authenticate_request(self, connection: ASGIConnection) -> AuthenticationResult:
         """Receive the http connection and return an :class:`AuthenticationResult`.
 
         Notes:

--- a/litestar/middleware/base.py
+++ b/litestar/middleware/base.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 
 @runtime_checkable
-class MiddlewareProtocol(Protocol):  # pragma: no cover
+class MiddlewareProtocol(Protocol):
     """Abstract middleware protocol."""
 
     __slots__ = ("app",)

--- a/litestar/params.py
+++ b/litestar/params.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
-from typing import TYPE_CHECKING, Any, Hashable, Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Sequence
 
 from litestar.enums import RequestEncodingType
 from litestar.types import Empty
@@ -152,14 +152,6 @@ class ParameterKwarg(KwargDefinition):
     If set to False, None values will be allowed. Defaults to True.
     """
 
-    def __hash__(self) -> int:  # pragma: no cover
-        """Hash the dataclass in a safe way.
-
-        Returns:
-            A hash
-        """
-        return sum(hash(v) for v in asdict(self) if isinstance(v, Hashable))
-
 
 def Parameter(
     annotation: Any = Empty,
@@ -262,14 +254,6 @@ class BodyKwarg(KwargDefinition):
     multipart_form_part_limit: int | None = field(default=None)
     """The maximal number of allowed parts in a multipart/formdata request. This limit is intended to protect from DoS attacks."""
 
-    def __hash__(self) -> int:  # pragma: no cover
-        """Hash the dataclass in a safe way.
-
-        Returns:
-            A hash
-        """
-        return sum(hash(v) for v in asdict(self) if isinstance(v, Hashable))
-
 
 def Body(
     *,
@@ -361,14 +345,6 @@ class DependencyKwarg:
     """A default value."""
     skip_validation: bool = field(default=False)
     """Flag dictating whether to skip validation."""
-
-    def __hash__(self) -> int:
-        """Hash the dataclass in a safe way.
-
-        Returns:
-            A hash
-        """
-        return sum(hash(v) for v in asdict(self) if isinstance(v, Hashable))
 
 
 def Dependency(*, default: Any = Empty, skip_validation: bool = False) -> Any:

--- a/litestar/params.py
+++ b/litestar/params.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Sequence
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING, Any, Hashable, Sequence
 
 from litestar.enums import RequestEncodingType
 from litestar.types import Empty
@@ -152,6 +152,14 @@ class ParameterKwarg(KwargDefinition):
     If set to False, None values will be allowed. Defaults to True.
     """
 
+    def __hash__(self) -> int:  # pragma: no cover
+        """Hash the dataclass in a safe way.
+
+        Returns:
+            A hash
+        """
+        return sum(hash(v) for v in asdict(self) if isinstance(v, Hashable))
+
 
 def Parameter(
     annotation: Any = Empty,
@@ -254,6 +262,14 @@ class BodyKwarg(KwargDefinition):
     multipart_form_part_limit: int | None = field(default=None)
     """The maximal number of allowed parts in a multipart/formdata request. This limit is intended to protect from DoS attacks."""
 
+    def __hash__(self) -> int:  # pragma: no cover
+        """Hash the dataclass in a safe way.
+
+        Returns:
+            A hash
+        """
+        return sum(hash(v) for v in asdict(self) if isinstance(v, Hashable))
+
 
 def Body(
     *,
@@ -345,6 +361,14 @@ class DependencyKwarg:
     """A default value."""
     skip_validation: bool = field(default=False)
     """Flag dictating whether to skip validation."""
+
+    def __hash__(self) -> int:
+        """Hash the dataclass in a safe way.
+
+        Returns:
+            A hash
+        """
+        return sum(hash(v) for v in asdict(self) if isinstance(v, Hashable))
 
 
 def Dependency(*, default: Any = Empty, skip_validation: bool = False) -> Any:

--- a/litestar/routes/base.py
+++ b/litestar/routes/base.py
@@ -110,7 +110,7 @@ class BaseRoute(ABC):
         self.methods = set(methods or [])
 
     @abstractmethod
-    async def handle(self, scope: Scope, receive: Receive, send: Send) -> None:  # pragma: no cover
+    async def handle(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI App of the route.
 
         Args:

--- a/litestar/security/base.py
+++ b/litestar/security/base.py
@@ -150,7 +150,7 @@ class AbstractSecurityConfig(ABC, Generic[UserType, AuthType]):
 
     @property
     @abstractmethod
-    def openapi_components(self) -> Components:  # pragma: no cover
+    def openapi_components(self) -> Components:
         """Create OpenAPI documentation for the JWT auth schema used.
 
         Returns:
@@ -160,7 +160,7 @@ class AbstractSecurityConfig(ABC, Generic[UserType, AuthType]):
 
     @property
     @abstractmethod
-    def security_requirement(self) -> SecurityRequirement:  # pragma: no cover
+    def security_requirement(self) -> SecurityRequirement:
         """Return OpenAPI 3.1.
 
         :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>` for the auth
@@ -173,7 +173,7 @@ class AbstractSecurityConfig(ABC, Generic[UserType, AuthType]):
 
     @property
     @abstractmethod
-    def middleware(self) -> DefineMiddleware:  # pragma: no cover
+    def middleware(self) -> DefineMiddleware:
         """Create an instance of the config's ``authentication_middleware_class`` attribute and any required kwargs,
         wrapping it in Litestar's ``DefineMiddleware``.
 

--- a/litestar/stores/base.py
+++ b/litestar/stores/base.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 __all__ = ("Store", "NamespacedStore", "StorageObject")
 
 
-class Store(ABC):  # pragma: no cover
+class Store(ABC):
     """Thread and process safe asynchronous key/value store."""
 
     @abstractmethod

--- a/litestar/template/base.py
+++ b/litestar/template/base.py
@@ -85,7 +85,7 @@ def url_for_static_asset(context: Mapping[str, Any], /, name: str, file_path: st
     return _get_request_from_context(context).app.url_for_static_asset(name, file_path)
 
 
-class TemplateProtocol(Protocol):  # pragma: no cover
+class TemplateProtocol(Protocol):
     """Protocol Defining a ``Template``.
 
     Template is a class that has a render method which renders the template into a string.
@@ -101,7 +101,6 @@ class TemplateProtocol(Protocol):  # pragma: no cover
         Returns:
             The rendered template string
         """
-        ...
 
 
 P = ParamSpec("P")
@@ -113,7 +112,7 @@ TemplateCallableType: TypeAlias = Callable[Concatenate[ContextType, P], R]
 
 
 @runtime_checkable
-class TemplateEngineProtocol(Protocol[TemplateType_co, ContextType_co]):  # pragma: no cover
+class TemplateEngineProtocol(Protocol[TemplateType_co, ContextType_co]):
     """Protocol for template engines."""
 
     def __init__(self, directory: Path | list[Path] | None, engine_instance: Any | None) -> None:
@@ -124,7 +123,6 @@ class TemplateEngineProtocol(Protocol[TemplateType_co, ContextType_co]):  # prag
                 implementation has to create the engine instance.
             engine_instance: A template engine object, if provided the implementation has to use it.
         """
-        ...
 
     def get_template(self, template_name: str) -> TemplateType_co:
         """Retrieve a template by matching its name (dotted path) with files in the directory or directories provided.
@@ -138,7 +136,6 @@ class TemplateEngineProtocol(Protocol[TemplateType_co, ContextType_co]):  # prag
         Raises:
             TemplateNotFoundException: if no template is found.
         """
-        ...
 
     def register_template_callable(
         self, key: str, template_callable: TemplateCallableType[ContextType_co, P, R]

--- a/litestar/template/base.py
+++ b/litestar/template/base.py
@@ -101,6 +101,7 @@ class TemplateProtocol(Protocol):
         Returns:
             The rendered template string
         """
+        raise NotImplementedError
 
 
 P = ParamSpec("P")
@@ -136,6 +137,7 @@ class TemplateEngineProtocol(Protocol[TemplateType_co, ContextType_co]):
         Raises:
             TemplateNotFoundException: if no template is found.
         """
+        raise NotImplementedError
 
     def register_template_callable(
         self, key: str, template_callable: TemplateCallableType[ContextType_co, P, R]

--- a/litestar/types/protocols.py
+++ b/litestar/types/protocols.py
@@ -9,7 +9,7 @@ __all__ = (
 )
 
 
-class Logger(Protocol):  # pragma: no cover
+class Logger(Protocol):
     """Logger protocol."""
 
     def debug(self, event: str, *args: Any, **kwargs: Any) -> Any:

--- a/litestar/utils/compat.py
+++ b/litestar/utils/compat.py
@@ -15,7 +15,7 @@ D = TypeVar("D")
 
 try:
     async_next = anext  # type: ignore[name-defined]
-except NameError:  # pragma: no cover
+except NameError:
 
     async def async_next(gen: AsyncGenerator[T, Any], default: D | EmptyType = Empty) -> T | D:
         """Backwards compatibility shim for Python<3.10."""

--- a/litestar/utils/predicates.py
+++ b/litestar/utils/predicates.py
@@ -48,12 +48,12 @@ if TYPE_CHECKING:
 
 try:
     import pydantic
-except ImportError:  # pragma: no cover
+except ImportError:
     pydantic = Empty  # type: ignore
 
 try:
     import attrs
-except ImportError:  # pragma: no cover
+except ImportError:
     attrs = Empty  # type: ignore
 
 __all__ = (

--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -52,9 +52,7 @@ This allows users to include these names within an `if TYPE_CHECKING:` block in 
 """
 
 
-def _unwrap_implicit_optional_hints(
-    defaults: dict[str, Any], hints: dict[str, Any]
-) -> dict[str, Any]:
+def _unwrap_implicit_optional_hints(defaults: dict[str, Any], hints: dict[str, Any]) -> dict[str, Any]:
     """Unwrap implicit optional hints.
 
     On Python<3.11, if a function parameter annotation has a ``None`` default, it is unconditionally wrapped in an

--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -54,7 +54,7 @@ This allows users to include these names within an `if TYPE_CHECKING:` block in 
 
 def _unwrap_implicit_optional_hints(
     defaults: dict[str, Any], hints: dict[str, Any]
-) -> dict[str, Any]:  # pragma: no cover
+) -> dict[str, Any]:
     """Unwrap implicit optional hints.
 
     On Python<3.11, if a function parameter annotation has a ``None`` default, it is unconditionally wrapped in an
@@ -140,7 +140,7 @@ def get_fn_type_hints(fn: Any, namespace: dict[str, Any] | None = None) -> dict[
     }
     hints = get_type_hints(fn_to_inspect, globalns=namespace, include_extras=True)
 
-    if sys.version_info < (3, 11):  # pragma: no cover
+    if sys.version_info < (3, 11):
         # see https://github.com/litestar-org/litestar/pull/2516
         defaults = _get_defaults(fn_to_inspect)
         hints = _unwrap_implicit_optional_hints(defaults, hints)

--- a/litestar/utils/version.py
+++ b/litestar/utils/version.py
@@ -10,7 +10,7 @@ __all__ = ("Version", "get_version", "parse_version")
 if sys.version_info >= (3, 10):
     import importlib.metadata as importlib_metadata
 else:
-    import importlib_metadata  # pragma: no cover
+    import importlib_metadata
 
 
 _ReleaseLevel = Literal["alpha", "beta", "rc", "final"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,7 @@ exclude_lines = [
   'except ImportError as e:',
   'except ImportError:',
   '\.\.\.',
-  'raise NotImplementedError',
+  'raise NotImplementedError.*',
   'if VERSION.startswith("1"):',
   'if pydantic.VERSION.startswith("1"):',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,8 +188,7 @@ parallel = true
 exclude_lines = [
   'pragma: no cover',
   'if TYPE_CHECKING:',
-  'except ImportError as e:',
-  'except ImportError:',
+  'except ImportError.*',
   '\.\.\.',
   'raise NotImplementedError.*',
   'if VERSION.startswith("1"):',


### PR DESCRIPTION
We do a lot of `pragma: no cover` due to coverage only being reported on the highest version of python.

This PR modifies coverage reporting so that we run coverage tests on the lowest and highest supported versions, and combines the coverage reports.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

-

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
