### PR TITLE
fix: draft for fixing recursive models in OpenAPI schema generation

### DIFF
--- a/litestar/plugins.py
+++ b/litestar/plugins.py
@@ -138,6 +138,11 @@ class OpenAPISchemaPluginProtocol(Protocol):
         """
         raise NotImplementedError()
 
+    def get_field_definitions(self, field_definition: FieldDefinition, schema_creator: SchemaCreator) -> list[FieldDefinition]:
+        """TODO
+        """
+        raise NotImplementedError()
+    
     def to_openapi_schema(self, field_definition: FieldDefinition, schema_creator: SchemaCreator) -> Schema:
         """Given a type annotation, transform it into an OpenAPI schema class.
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

I made a proof of concept that has some additional logic in schema.py, which keeps track of the schemas that are being processed. If a schema B has a property of schema A, which we're currently processing, that property get's ignored to unblock the processing of schema B and break the circularity. The logic keeps track of that ignored property and adds it after the schema A has been processed to restore the circularity.
so if we had A which has a property b which references B and B which has a property a which references A, the flow looks as follows:

1. start processing A
2. process property b -> process B
3. start processing B
4. process property a -> ignore (since we're still processing A)
5. finish processing B
6. finish processing A
7. add previously ignored property a to B

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- Fixes #2429
