### PR TITLE
build: implement covdefaults coverage plugin.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Combine coverage files
         run: |
-          python -Im pip install coverage
+          python -Im pip install coverage covdefaults
           python -Im coverage combine
           python -Im coverage xml -i
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Test with coverage
         if: inputs.coverage
-        run: pdm run pytest docs/examples tests --cov=litestar -n auto
+        run: pdm run pytest docs/examples tests --cov -n auto
 
       - name: Rename coverage file
         if: inputs.coverage

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ lint: pre-commit type-check 						## Run all linting
 .PHONY: coverage
 coverage:  											## Run the tests and generate coverage report
 	@echo "=> Running tests with coverage"
-	@$(ENV_PREFIX)pytest tests --cov=litestar -n auto
+	@$(ENV_PREFIX)pytest tests --cov -n auto
 	@$(ENV_PREFIX)coverage html
 	@$(ENV_PREFIX)coverage xml
 	@echo "=> Coverage report generated"

--- a/litestar/__main__.py
+++ b/litestar/__main__.py
@@ -1,10 +1,10 @@
-from litestar.cli.main import litestar_group  # pragma: no cover
+from litestar.cli.main import litestar_group
 
 
-def run_cli() -> None:  # pragma: no cover
+def run_cli() -> None:
     """Application Entrypoint."""
     litestar_group()
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":
     run_cli()

--- a/pdm.lock
+++ b/pdm.lock
@@ -6,7 +6,7 @@ groups = ["default", "annotated-types", "attrs", "brotli", "cli", "cryptography"
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:ab4e2f40f96896b2eb789c932e0cd67f4f10897113890c9cc7d4b033684ec362"
+content_hash = "sha256:fb3b18dfb5d0cd4a5e5ba715faab0ab578bb5c56e99c1bec4b292679005a5395"
 
 [[package]]
 name = "accessible-pygments"
@@ -637,6 +637,19 @@ summary = "Cross-platform colored terminal text."
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+
+[[package]]
+name = "covdefaults"
+version = "2.3.0"
+requires_python = ">=3.7"
+summary = "A coverage plugin to provide sensible default settings"
+dependencies = [
+    "coverage>=6.0.2",
+]
+files = [
+    {file = "covdefaults-2.3.0-py2.py3-none-any.whl", hash = "sha256:2832961f6ffcfe4b57c338bc3418a3526f495c26fb9c54565409c5532f7c41be"},
+    {file = "covdefaults-2.3.0.tar.gz", hash = "sha256:4e99f679f12d792bc62e5510fa3eb59546ed47bd569e36e4fddc4081c9c3ebf7"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ linting = [
   "types-redis",
 ]
 test = [
+  "covdefaults",
   "pytest",
   "pytest-asyncio",
   "pytest-cov",
@@ -183,17 +184,16 @@ skip = 'pdm.lock,docs/examples/contrib/sqlalchemy/us_state_lookup.json'
 concurrency = ["multiprocessing", "thread"]
 omit = ["*/tests/*"]
 parallel = true
+plugins = ["covdefaults"]
+source  = ["litestar"]
 
 [tool.coverage.report]
 exclude_lines = [
-  'pragma: no cover',
-  'if TYPE_CHECKING:',
-  'except ImportError.*',
-  '\.\.\.',
-  'raise NotImplementedError.*',
+  'except ImportError\b',
   'if VERSION.startswith("1"):',
   'if pydantic.VERSION.startswith("1"):',
 ]
+fail_under = 96
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers --strict-config --dist=loadgroup"


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

This PR adds the [covdefaults](https://github.com/asottile/covdefaults) plugin to our coverage config.

The plugin offers default configs for `[tool.coverage.run]` and `[tool.coverage.report]`.

For "run", the main difference is that it activates branch coverage. This is something I always run on other projects and I think would be a nice addition to our config. Our overall coverage score takes a hit, but it's not as bad as I thought it might be.

For reporting, it adds a `fail_under` value - which we don't currently have as we let sonar handle that. We can override their default of 100, so I set it to 96 which is our current baseline after branch coverage activated.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
