### PR TITLE
fix: handle non UTF-8 data when logging requests

### DIFF
--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -161,7 +161,7 @@ class LoggingMiddleware(AbstractMiddleware):
     def _serialize_value(self, serializer: Serializer | None, value: Any) -> Any:
         if not self.is_struct_logger and isinstance(value, (dict, list, tuple, set)):
             value = encode_json(value, serializer)
-        return value.decode("utf-8") if isinstance(value, bytes) else value
+        return value.decode("utf-8", errors="backslashreplace") if isinstance(value, bytes) else value
 
     async def extract_request_data(self, request: Request) -> dict[str, Any]:
         """Create a dictionary of values for the message.


### PR DESCRIPTION
When structlog is not installed, the body will not get parsed and shown as a byte sequence. This byte sequence is then serialized into a string with the assumption that it is valid UTF-8. This is not always the case, eg. when uploading a file.

Therefore, use backslashreplace to handle invalid UTF-8 sequences.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [X] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [X] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

I don't have a docker version that has the compose command installed, so those tests failed. I've checked that my changes do not cause more tests to fail then before. 
### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- Uploading binary files no longer causes an exception when request logging is active without structlog installed

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- Fixes #2529
