### PR TITLE
docs: remove unnecessary use of `sync_to_thread=True`.

### DIFF
--- a/docs/examples/contrib/sqlalchemy/plugins/sqlalchemy_sync_serialization_plugin.py
+++ b/docs/examples/contrib/sqlalchemy/plugins/sqlalchemy_sync_serialization_plugin.py
@@ -21,7 +21,7 @@ class TodoItem(Base):
     done: Mapped[bool]
 
 
-@post("/", sync_to_thread=True)
+@post("/", sync_to_thread=False)
 def add_item(data: TodoItem) -> List[TodoItem]:
     return [data]
 

--- a/docs/examples/contrib/sqlalchemy/plugins/sqlalchemy_sync_serialization_plugin_marking_fields.py
+++ b/docs/examples/contrib/sqlalchemy/plugins/sqlalchemy_sync_serialization_plugin_marking_fields.py
@@ -23,7 +23,7 @@ class TodoItem(Base):
     super_secret_value: Mapped[str] = mapped_column(info=dto_field("private"))
 
 
-@post("/", sync_to_thread=True)
+@post("/", sync_to_thread=False)
 def add_item(data: TodoItem) -> List[TodoItem]:
     data.super_secret_value = "This is a secret"
     return [data]

--- a/docs/examples/contrib/sqlalchemy/sqlalchemy_sync_repository.py
+++ b/docs/examples/contrib/sqlalchemy/sqlalchemy_sync_repository.py
@@ -117,7 +117,7 @@ def provide_limit_offset_pagination(
 class AuthorController(Controller):
     """Author CRUD"""
 
-    dependencies = {"authors_repo": Provide(provide_authors_repo, sync_to_thread=True)}
+    dependencies = {"authors_repo": Provide(provide_authors_repo, sync_to_thread=False)}
 
     @get(path="/authors")
     def list_authors(
@@ -151,7 +151,7 @@ class AuthorController(Controller):
     # we override the authors_repo to use the version that joins the Books in
     @get(
         path="/authors/{author_id:uuid}",
-        dependencies={"authors_repo": Provide(provide_author_details_repo, sync_to_thread=True)},
+        dependencies={"authors_repo": Provide(provide_author_details_repo, sync_to_thread=False)},
     )
     def get_author(
         self,
@@ -167,7 +167,7 @@ class AuthorController(Controller):
 
     @patch(
         path="/authors/{author_id:uuid}",
-        dependencies={"authors_repo": Provide(provide_author_details_repo, sync_to_thread=True)},
+        dependencies={"authors_repo": Provide(provide_author_details_repo, sync_to_thread=False)},
     )
     def update_author(
         self,


### PR DESCRIPTION

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

This PR removes any use of `sync_to_thread=True` from our sqlalchemy examples when there is no blocking IO in the dependency/handler.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
Closes #2508
