### PR TITLE
refactor: use `{get,set}_litestar_scope_state()` for storing csrf tokens

### DIFF
--- a/litestar/constants.py
+++ b/litestar/constants.py
@@ -17,6 +17,7 @@ OPENAPI_NOT_INITIALIZED: Final = "Litestar has not been instantiated with OpenAP
 REDIRECT_STATUS_CODES: Final = {301, 302, 303, 307, 308}
 REDIRECT_ALLOWED_MEDIA_TYPES: Final = {MediaType.TEXT, MediaType.HTML, MediaType.JSON}
 RESERVED_KWARGS: Final = {"state", "headers", "cookies", "request", "socket", "data", "query", "scope", "body"}
+SCOPE_STATE_CSRF_TOKEN_KEY = "csrf_token"  # noqa: S105  # possible hardcoded password
 SCOPE_STATE_DEPENDENCY_CACHE: Final = "dependency_cache"
 SCOPE_STATE_NAMESPACE: Final = "__litestar__"
 SCOPE_STATE_RESPONSE_COMPRESSED: Final = "response_compressed"

--- a/litestar/response/template.py
+++ b/litestar/response/template.py
@@ -5,10 +5,12 @@ from mimetypes import guess_type
 from pathlib import PurePath
 from typing import TYPE_CHECKING, Any, Iterable
 
+from litestar.constants import SCOPE_STATE_CSRF_TOKEN_KEY
 from litestar.enums import MediaType
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.response.base import ASGIResponse, Response
 from litestar.status_codes import HTTP_200_OK
+from litestar.utils import get_litestar_scope_state
 from litestar.utils.deprecation import warn_deprecation
 
 if TYPE_CHECKING:
@@ -78,7 +80,7 @@ class Template(Response[bytes]):
         Returns:
             A dictionary holding the template context
         """
-        csrf_token = request.scope.get("_csrf_token", "")
+        csrf_token = get_litestar_scope_state(scope=request.scope, key=SCOPE_STATE_CSRF_TOKEN_KEY, default="")
         return {
             **self.context,
             "request": request,

--- a/litestar/template/base.py
+++ b/litestar/template/base.py
@@ -4,7 +4,14 @@ from typing import TYPE_CHECKING, Any, Callable, Mapping, Protocol, TypedDict, T
 
 from typing_extensions import Concatenate, ParamSpec, TypeAlias
 
+from litestar.constants import SCOPE_STATE_CSRF_TOKEN_KEY
+from litestar.utils import get_litestar_scope_state
 from litestar.utils.deprecation import warn_deprecation
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from litestar.connection import Request
 
 __all__ = (
     "TemplateCallableType",
@@ -14,12 +21,6 @@ __all__ = (
     "url_for",
     "url_for_static_asset",
 )
-
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-    from litestar.connection import Request
 
 
 def _get_request_from_context(context: Mapping[str, Any]) -> Request:
@@ -65,7 +66,8 @@ def csrf_token(context: Mapping[str, Any], /) -> str:
     Returns:
         A CSRF token if the app level ``csrf_config`` is set, otherwise an empty string.
     """
-    return _get_request_from_context(context).scope.get("_csrf_token", "")  # type: ignore[return-value]
+    scope = _get_request_from_context(context).scope
+    return cast("str", get_litestar_scope_state(scope=scope, key=SCOPE_STATE_CSRF_TOKEN_KEY, default=""))
 
 
 def url_for_static_asset(context: Mapping[str, Any], /, name: str, file_path: str) -> str:

--- a/tests/unit/test_template/test_csrf_token.py
+++ b/tests/unit/test_template/test_csrf_token.py
@@ -6,6 +6,7 @@ import pytest
 
 from litestar import MediaType, get
 from litestar.config.csrf import CSRFConfig
+from litestar.constants import SCOPE_STATE_CSRF_TOKEN_KEY
 from litestar.contrib.jinja import JinjaTemplateEngine
 from litestar.contrib.mako import MakoTemplateEngine
 from litestar.contrib.minijinja import MiniJinjaTemplateEngine
@@ -14,6 +15,7 @@ from litestar.response.template import Template
 from litestar.template.config import TemplateConfig
 from litestar.testing import create_test_client
 from litestar.types import Scope
+from litestar.utils import get_litestar_scope_state
 
 
 @pytest.mark.parametrize(
@@ -59,7 +61,7 @@ def test_csrf_input(engine: Any, template: str, tmp_path: Path) -> None:
 
     @get(path="/", media_type=MediaType.HTML)
     def handler(scope: Scope) -> Template:
-        token["value"] = scope.get("_csrf_token", "")  # type: ignore
+        token["value"] = get_litestar_scope_state(scope, SCOPE_STATE_CSRF_TOKEN_KEY)
         return Template(template_name="abc.html")
 
     csrf_config = CSRFConfig(secret="yaba daba do")


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

Current behavior is to add the token directly into scope with a private key, "_csrf_token". However, this causes type errors as scope is a typed dict and does not define that key.

We have an internal namespace inside scope state, this PR refactors csrf token management to use it.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
Closes #2499
