### PR TITLE
fix(channels): Performance issue with polling without subscriptions

### DIFF
--- a/litestar/channels/backends/memory.py
+++ b/litestar/channels/backends/memory.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from asyncio import Queue
 from collections import defaultdict, deque
 from typing import Any, AsyncGenerator, Iterable

--- a/litestar/channels/backends/memory.py
+++ b/litestar/channels/backends/memory.py
@@ -65,9 +65,6 @@ class MemoryChannelsBackend(ChannelsBackend):
     async def stream_events(self) -> AsyncGenerator[tuple[str, Any], None]:
         """Return a generator, iterating over events of subscribed channels as they become available"""
         while self._queue:
-            if not len(self._channels):
-                await asyncio.sleep(0)
-                continue
             yield await self._queue.get()
             self._queue.task_done()
 

--- a/litestar/channels/backends/redis.py
+++ b/litestar/channels/backends/redis.py
@@ -98,7 +98,9 @@ class RedisChannelsPubSubBackend(RedisChannelsBackend):
         """
 
         while True:
-            message = await self._pub_sub.get_message(ignore_subscribe_messages=True, timeout=self._stream_sleep_no_subscriptions)
+            message = await self._pub_sub.get_message(
+                ignore_subscribe_messages=True, timeout=self._stream_sleep_no_subscriptions
+            )
             if message is None:
                 continue
 

--- a/litestar/channels/backends/redis.py
+++ b/litestar/channels/backends/redis.py
@@ -24,7 +24,14 @@ _XADD_EXPIRE_SCRIPT = (_resource_path / "_redis_xadd_expire.lua").read_text()
 
 
 class _LazyEvent:
-    """A lazy proxy to asyncio.Event that only creates the event once it's accessed"""
+    """A lazy proxy to asyncio.Event that only creates the event once it's accessed.
+
+    It ensures that the Event is created within a running event loop. If it's not, there can be an issue where a future
+    within the event itself is attached to a different loop.
+
+    This happens in our tests and could also happen when a user creates an instance of the backend outside an event loop
+    in their application.
+    """
 
     def __init__(self) -> None:
         self.__event: asyncio.Event | None = None

--- a/tests/unit/test_channels/test_backends.py
+++ b/tests/unit/test_channels/test_backends.py
@@ -74,6 +74,10 @@ async def test_pub_sub_shutdown_leftover_messages(channels_backend_instance: Cha
     await asyncio.wait_for(channels_backend_instance.on_shutdown(), timeout=0.1)
 
 
+async def test_unsubscribe_without_subscription(channels_backend: ChannelsBackend) -> None:
+    await channels_backend.unsubscribe(["foo"])
+
+
 @pytest.mark.parametrize("history_limit,expected_history_length", [(None, 10), (1, 1), (5, 5), (10, 10)])
 async def test_get_history(
     channels_backend: ChannelsBackend, history_limit: int | None, expected_history_length: int


### PR DESCRIPTION
Fix an issue with the channels backends where they would poll for new subscribers too frequently when no channel subscriptions were present, resulting in a high CPU load.

Fixes #2503