### PR TITLE
fix: openapi schema for literal and enum unions with None.

### DIFF
--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -228,10 +228,7 @@ def create_schema_for_annotation(annotation: Any) -> Schema:
         A schema instance or None.
     """
 
-    if annotation in TYPE_MAP:
-        return copy(TYPE_MAP[annotation])
-
-    return Schema()
+    return copy(TYPE_MAP[annotation]) if annotation in TYPE_MAP else Schema()
 
 
 class SchemaCreator:

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -42,6 +42,11 @@ from litestar._openapi.schema_generation.constrained_fields import (
     create_numerical_constrained_field_schema,
     create_string_constrained_field_schema,
 )
+from litestar._openapi.schema_generation.utils import (
+    _do_enum_schema,
+    _do_literal_schema,
+    _type_or_first_not_none_inner_type,
+)
 from litestar.datastructures.upload_file import UploadFile
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.openapi.spec import Reference
@@ -159,40 +164,6 @@ def _get_type_schema_name(field_definition: FieldDefinition) -> str:
     return name
 
 
-def _first_not_none_inner_type(field_definition: FieldDefinition) -> FieldDefinition:
-    """Get the first inner type that is not None.
-
-    Args:
-        field_definition: A field definition instance.
-
-    Returns:
-        A field definition instance.
-    """
-    return next(t for t in field_definition.inner_types if not t.is_none_type)
-
-
-def _do_enum_schema(field_definition: FieldDefinition) -> bool:
-    """Predicate to determine if we should create an enum schema for the field def, or not.
-
-    This returns true if the field definition is an enum, or if the field definition is a union
-    of an enum and ``None``.
-
-    When an annotation is ``SomeEnum | None`` we should create a schema for the enum that includes ``null``
-    in the enum values.
-
-    Args:
-        field_definition: A field definition instance.
-
-    Returns:
-        A boolean
-    """
-    return field_definition.is_subclass_of(Enum) or (
-        field_definition.is_optional
-        and len(field_definition.args) == 2
-        and field_definition.has_inner_subclass_of(Enum)
-    )
-
-
 def create_enum_schema(annotation: EnumMeta, include_null: bool = False) -> Schema:
     """Create a schema instance for an enum.
 
@@ -208,28 +179,6 @@ def create_enum_schema(annotation: EnumMeta, include_null: bool = False) -> Sche
         enum_values.append(None)
     openapi_type = OpenAPIType.STRING if isinstance(enum_values[0], str) else OpenAPIType.INTEGER
     return Schema(type=openapi_type, enum=enum_values)
-
-
-def _do_literal_schema(field_definition: FieldDefinition) -> bool:
-    """Predicate to determine if we should creat a literal schema for the field def, or not.
-
-    This returns ``True`` if the field definition is an literal, or if the field definition is a union
-    of a literal and None.
-
-    When an annotation is `Literal["anything"] | None` we should create a schema for the literal that includes `null`
-    in the enum values.
-
-    Args:
-        field_definition: A field definition instance.
-
-    Returns:
-        A boolean
-    """
-    return (
-        field_definition.is_literal
-        or field_definition.is_optional
-        and all(inner.is_literal for inner in field_definition.inner_types if not inner.is_none_type)
-    )
 
 
 def _iter_flat_literal_args(annotation: Any) -> Iterable[Any]:
@@ -354,18 +303,10 @@ class SchemaCreator:
         if plugin_for_annotation := self.get_plugin_for(field_definition):
             result = self.for_plugin(field_definition, plugin_for_annotation)
         elif _do_enum_schema(field_definition):
-            annotation = (
-                _first_not_none_inner_type(field_definition).annotation
-                if field_definition.is_optional
-                else field_definition.annotation
-            )
+            annotation = _type_or_first_not_none_inner_type(field_definition)
             result = create_enum_schema(annotation, include_null=field_definition.is_optional)
         elif _do_literal_schema(field_definition):
-            annotation = (
-                _first_not_none_inner_type(field_definition).annotation
-                if field_definition.is_optional
-                else field_definition.annotation
-            )
+            annotation = _type_or_first_not_none_inner_type(field_definition)
             result = create_literal_schema(annotation, include_null=field_definition.is_optional)
         elif field_definition.is_optional:
             result = self.for_optional_field(field_definition)

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -306,7 +306,11 @@ class SchemaCreator:
             annotation = _type_or_first_not_none_inner_type(field_definition)
             result = create_enum_schema(annotation, include_null=field_definition.is_optional)
         elif _do_literal_schema(field_definition):
-            annotation = _type_or_first_not_none_inner_type(field_definition)
+            annotation = (
+                make_non_optional_union(field_definition.annotation)
+                if field_definition.is_optional
+                else field_definition.annotation
+            )
             result = create_literal_schema(annotation, include_null=field_definition.is_optional)
         elif field_definition.is_optional:
             result = self.for_optional_field(field_definition)

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -43,8 +43,8 @@ from litestar._openapi.schema_generation.constrained_fields import (
     create_string_constrained_field_schema,
 )
 from litestar._openapi.schema_generation.utils import (
-    _do_enum_schema,
-    _do_literal_schema,
+    _should_create_enum_schema,
+    _should_create_literal_schema,
     _type_or_first_not_none_inner_type,
 )
 from litestar.datastructures.upload_file import UploadFile
@@ -299,10 +299,10 @@ class SchemaCreator:
 
         if plugin_for_annotation := self.get_plugin_for(field_definition):
             result = self.for_plugin(field_definition, plugin_for_annotation)
-        elif _do_enum_schema(field_definition):
+        elif _should_create_enum_schema(field_definition):
             annotation = _type_or_first_not_none_inner_type(field_definition)
             result = create_enum_schema(annotation, include_null=field_definition.is_optional)
-        elif _do_literal_schema(field_definition):
+        elif _should_create_literal_schema(field_definition):
             annotation = (
                 make_non_optional_union(field_definition.annotation)
                 if field_definition.is_optional

--- a/litestar/_openapi/schema_generation/utils.py
+++ b/litestar/_openapi/schema_generation/utils.py
@@ -37,7 +37,7 @@ def _type_or_first_not_none_inner_type(field_definition: FieldDefinition) -> Any
     return inner.annotation
 
 
-def _do_enum_schema(field_definition: FieldDefinition) -> bool:
+def _should_create_enum_schema(field_definition: FieldDefinition) -> bool:
     """Predicate to determine if we should create an enum schema for the field def, or not.
 
     This returns true if the field definition is an enum, or if the field definition is a union

--- a/litestar/_openapi/schema_generation/utils.py
+++ b/litestar/_openapi/schema_generation/utils.py
@@ -31,7 +31,10 @@ def _type_or_first_not_none_inner_type(field_definition: FieldDefinition) -> Any
     """
     if not field_definition.is_optional:
         return field_definition.annotation
-    return next(t for t in field_definition.inner_types if not t.is_none_type).annotation
+    inner = next((t for t in field_definition.inner_types if not t.is_none_type), None)
+    if inner is None:
+        raise ValueError("Field definition has no inner type that is not None")
+    return inner.annotation
 
 
 def _do_enum_schema(field_definition: FieldDefinition) -> bool:

--- a/litestar/_openapi/schema_generation/utils.py
+++ b/litestar/_openapi/schema_generation/utils.py
@@ -12,8 +12,8 @@ if TYPE_CHECKING:
 __all__ = (
     "sort_schemas_and_references",
     "_type_or_first_not_none_inner_type",
-    "_do_enum_schema",
-    "_do_literal_schema",
+    "_should_create_enum_schema",
+    "_should_create_literal_schema",
 )
 
 

--- a/litestar/_openapi/schema_generation/utils.py
+++ b/litestar/_openapi/schema_generation/utils.py
@@ -1,16 +1,12 @@
-
 from __future__ import annotations
 
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from litestar.openapi.spec import Reference, Schema
-
 if TYPE_CHECKING:
     from litestar.typing import FieldDefinition
 
 __all__ = (
-    "sort_schemas_and_references",
     "_type_or_first_not_none_inner_type",
     "_should_create_enum_schema",
     "_should_create_literal_schema",

--- a/litestar/_openapi/schema_generation/utils.py
+++ b/litestar/_openapi/schema_generation/utils.py
@@ -60,7 +60,7 @@ def _do_enum_schema(field_definition: FieldDefinition) -> bool:
 
 
 def _do_literal_schema(field_definition: FieldDefinition) -> bool:
-    """Predicate to determine if we should creat a literal schema for the field def, or not.
+    """Predicate to determine if we should create a literal schema for the field def, or not.
 
     This returns ``True`` if the field definition is an literal, or if the field definition is a union
     of a literal and None.

--- a/litestar/_openapi/schema_generation/utils.py
+++ b/litestar/_openapi/schema_generation/utils.py
@@ -59,7 +59,7 @@ def _should_create_enum_schema(field_definition: FieldDefinition) -> bool:
     )
 
 
-def _do_literal_schema(field_definition: FieldDefinition) -> bool:
+def _should_create_literal_schema(field_definition: FieldDefinition) -> bool:
     """Predicate to determine if we should create a literal schema for the field def, or not.
 
     This returns ``True`` if the field definition is an literal, or if the field definition is a union

--- a/litestar/_openapi/schema_generation/utils.py
+++ b/litestar/_openapi/schema_generation/utils.py
@@ -1,0 +1,78 @@
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from litestar.openapi.spec import Reference, Schema
+
+if TYPE_CHECKING:
+    from litestar.typing import FieldDefinition
+
+__all__ = (
+    "sort_schemas_and_references",
+    "_type_or_first_not_none_inner_type",
+    "_do_enum_schema",
+    "_do_literal_schema",
+)
+
+
+def _type_or_first_not_none_inner_type(field_definition: FieldDefinition) -> Any:
+    """Get the first inner type that is not None.
+
+    This is a narrow focussed utility to be used when we know that a field definition either represents
+    a single type, or a single type in a union with `None`, and we want the single type.
+
+    Args:
+        field_definition: A field definition instance.
+
+    Returns:
+        A field definition instance.
+    """
+    if not field_definition.is_optional:
+        return field_definition.annotation
+    return next(t for t in field_definition.inner_types if not t.is_none_type).annotation
+
+
+def _do_enum_schema(field_definition: FieldDefinition) -> bool:
+    """Predicate to determine if we should create an enum schema for the field def, or not.
+
+    This returns true if the field definition is an enum, or if the field definition is a union
+    of an enum and ``None``.
+
+    When an annotation is ``SomeEnum | None`` we should create a schema for the enum that includes ``null``
+    in the enum values.
+
+    Args:
+        field_definition: A field definition instance.
+
+    Returns:
+        A boolean
+    """
+    return field_definition.is_subclass_of(Enum) or (
+        field_definition.is_optional
+        and len(field_definition.args) == 2
+        and field_definition.has_inner_subclass_of(Enum)
+    )
+
+
+def _do_literal_schema(field_definition: FieldDefinition) -> bool:
+    """Predicate to determine if we should creat a literal schema for the field def, or not.
+
+    This returns ``True`` if the field definition is an literal, or if the field definition is a union
+    of a literal and None.
+
+    When an annotation is `Literal["anything"] | None` we should create a schema for the literal that includes `null`
+    in the enum values.
+
+    Args:
+        field_definition: A field definition instance.
+
+    Returns:
+        A boolean
+    """
+    return (
+        field_definition.is_literal
+        or field_definition.is_optional
+        and all(inner.is_literal for inner in field_definition.inner_types if not inner.is_none_type)
+    )

--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -7,7 +7,7 @@ from inspect import Parameter, Signature
 from typing import Any, AnyStr, Callable, Collection, ForwardRef, Literal, Mapping, Protocol, Sequence, TypeVar, cast
 
 from msgspec import UnsetType
-from typing_extensions import Annotated, NotRequired, Required, Self, get_args, get_origin, get_type_hints, is_typeddict
+from typing_extensions import NotRequired, Required, Self, get_args, get_origin, get_type_hints, is_typeddict
 
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.openapi.spec import Example
@@ -336,12 +336,12 @@ class FieldDefinition:
     @property
     def is_annotated(self) -> bool:
         """Check if the field type is Annotated."""
-        return Annotated in self.type_wrappers  # type: ignore[comparison-overlap]
+        return bool(self.metadata)
 
     @property
     def is_literal(self) -> bool:
         """Check if the field type is Literal."""
-        return get_origin(self.annotation) is Literal
+        return self.origin is Literal
 
     @property
     def is_forward_ref(self) -> bool:
@@ -372,6 +372,11 @@ class FieldDefinition:
     def is_optional(self) -> bool:
         """Whether the annotation is Optional or not."""
         return bool(self.is_union and NoneType in self.args)
+
+    @property
+    def is_none_type(self) -> bool:
+        """Whether the annotation is NoneType or not."""
+        return self.annotation is NoneType
 
     @property
     def is_collection(self) -> bool:

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -2,7 +2,20 @@ import sys
 from dataclasses import dataclass
 from datetime import date
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Any, Dict, Generic, List, Literal, Optional, Tuple, TypedDict, TypeVar, Union
+from typing import (  # type: ignore[attr-defined]
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generic,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    TypedDict,
+    TypeVar,
+    Union,
+    _GenericAlias,  # pyright: ignore
+)
 
 import annotated_types
 import msgspec
@@ -16,6 +29,7 @@ from litestar._openapi.schema_generation.schema import (
     SchemaCreator,
     _get_type_schema_name,
 )
+from litestar._openapi.schema_generation.utils import _type_or_first_not_none_inner_type
 from litestar.app import DEFAULT_OPENAPI_CONFIG
 from litestar.di import Provide
 from litestar.enums import ParamType
@@ -26,6 +40,7 @@ from litestar.openapi.spec.schema import Schema
 from litestar.pagination import ClassicPagination, CursorPagination, OffsetPagination
 from litestar.params import BodyKwarg, Parameter, ParameterKwarg
 from litestar.testing import create_test_client
+from litestar.types.builtin_types import NoneType
 from litestar.typing import FieldDefinition
 from litestar.utils.helpers import get_name
 from tests.models import DataclassPerson, DataclassPet
@@ -112,7 +127,7 @@ def test_get_schema_for_annotation_enum() -> None:
         opt2 = "opt2"
 
     schema = SchemaCreator().for_field_definition(FieldDefinition.from_annotation(Opts))
-    assert schema
+    assert isinstance(schema, Schema)
     assert schema.enum == ["opt1", "opt2"]
 
 
@@ -279,6 +294,8 @@ def test_literal_enums() -> None:
         B = auto()
 
     schema = SchemaCreator().for_field_definition(FieldDefinition.from_annotation(List[Literal[Foo.A]]))
+    assert isinstance(schema, Schema)
+    assert isinstance(schema.items, Schema)
     assert schema.items.const == 1
 
 
@@ -410,11 +427,31 @@ def test_optional_enum() -> None:
         B = 2
 
     schema = SchemaCreator().for_field_definition(FieldDefinition.from_annotation(Optional[Foo]))
+    assert isinstance(schema, Schema)
     assert schema.type == OpenAPIType.INTEGER
     assert schema.enum == [1, 2, None]
 
 
 def test_optional_literal() -> None:
     schema = SchemaCreator().for_field_definition(FieldDefinition.from_annotation(Optional[Literal[1]]))
+    assert isinstance(schema, Schema)
     assert schema.type == OpenAPIType.INTEGER
     assert schema.enum == [1, None]
+
+
+@pytest.mark.parametrize(
+    ("in_type", "out_type"),
+    [
+        (FieldDefinition.from_annotation(Optional[int]), int),
+        (FieldDefinition.from_annotation(Union[None, int]), int),
+        (FieldDefinition.from_annotation(int), int),
+        # hack to create a union of NoneType, NoneType to hit a branch for coverage
+        (FieldDefinition.from_annotation(_GenericAlias(Union, (NoneType, NoneType))), ValueError),
+    ],
+)
+def test_type_or_first_not_none_inner_type_utility(in_type: Any, out_type: Any) -> None:
+    if out_type is ValueError:
+        with pytest.raises(out_type):
+            _type_or_first_not_none_inner_type(in_type)
+    else:
+        assert _type_or_first_not_none_inner_type(in_type) == out_type


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->
Existing behavior is to make the schema for every type that is a union with `None` a "one_of" schema, that includes `OpenAPIType.NULL` in the "one_of" types.

https://github.com/litestar-org/litestar/blob/5db8d81fbf24788d38d210e90300e5f0926f830a/litestar/_openapi/schema_generation/schema.py#L319-L340

When a `Literal` or `Enum` type is in a union with `None`, this behavior is not desirable, as we want to have `null` available in the list of available options on the type's schema.

This PR changes literal and enum schema generation so that it can be identified that the types are in a union with `None`, allowing `null` to be included in `Schema.enum` values.


### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

Closes #2546

