### PR TITLE
fix: OpenaAPI handle tuple with ellipsis annotation

### DIFF
--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -372,7 +372,9 @@ class SchemaCreator:
             )
 
         if field_definition.is_non_string_sequence or field_definition.is_non_string_iterable:
-            items = list(map(self.for_field_definition, field_definition.inner_types or ()))
+            # filters out ellipsis from tuple[int, ...] type annotations
+            inner_types = (f for f in field_definition.inner_types if f.annotation is not Ellipsis)
+            items = list(map(self.for_field_definition, inner_types or ()))
             return Schema(
                 type=OpenAPIType.ARRAY,
                 items=Schema(one_of=sort_schemas_and_references(items)) if len(items) > 1 else items[0],

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -2,7 +2,7 @@ import sys
 from dataclasses import dataclass
 from datetime import date
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Any, Dict, Generic, List, Literal, Optional, TypedDict, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, Generic, List, Literal, Optional, Tuple, TypedDict, TypeVar, Union
 
 import annotated_types
 import msgspec
@@ -397,3 +397,10 @@ def test_schema_generation_with_pagination(annotation: Any) -> None:
     assert properties["foo"] == expected_foo_schema
     assert properties["annotated_foo"] == expected_foo_schema
     assert properties["optional_foo"] == expected_optional_foo_schema
+
+
+def test_schema_generation_with_ellipsis() -> None:
+    schema = SchemaCreator().for_field_definition(FieldDefinition.from_annotation(Tuple[int, ...]))
+    assert isinstance(schema, Schema)
+    assert isinstance(schema.items, Schema)
+    assert schema.items.type == OpenAPIType.INTEGER


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

PR fixes issue where we were treating an annotation such as `tuple[int, ...]` same as a heterogeneous tuple like `tuple[int, str]`.
 
### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

Closes #2460
