### PR TITLE
fix(pydantic): Decouple Pydantic integration

### DIFF
--- a/litestar/constants.py
+++ b/litestar/constants.py
@@ -26,21 +26,3 @@ SKIP_VALIDATION_NAMES: Final = {"request", "socket", "scope", "receive", "send"}
 UNDEFINED_SENTINELS: Final = {Signature.empty, Empty, Ellipsis, MISSING, UnsetType}
 WEBSOCKET_CLOSE: Final = "websocket.close"
 WEBSOCKET_DISCONNECT: Final = "websocket.disconnect"
-
-
-try:
-    from pydantic.fields import PydanticUndefined as Pydantic2Undefined  # type: ignore[attr-defined]
-    from pydantic.v1.fields import Undefined as Pydantic1Undefined
-
-    PYDANTIC_UNDEFINED_SENTINELS = {Pydantic1Undefined, Pydantic2Undefined}
-except ImportError:
-    try:
-        from pydantic.v1.fields import Undefined as Pydantic1Undefined
-
-        PYDANTIC_UNDEFINED_SENTINELS = {Pydantic1Undefined}
-
-    except ImportError:  # pyright: ignore
-        PYDANTIC_UNDEFINED_SENTINELS = set()
-
-
-UNDEFINED_SENTINELS.update(PYDANTIC_UNDEFINED_SENTINELS)

--- a/litestar/contrib/pydantic/pydantic_dto_factory.py
+++ b/litestar/contrib/pydantic/pydantic_dto_factory.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Collection, Generic, TypeVar
 
 from typing_extensions import TypeAlias, override
 
-from litestar.constants import PYDANTIC_UNDEFINED_SENTINELS
+from litestar.contrib.pydantic.utils import is_pydantic_undefined
 from litestar.dto.base_dto import AbstractDTO
 from litestar.dto.data_structures import DTOFieldDefinition
 from litestar.dto.field import DTO_FIELD_META_KEY, DTOField
@@ -82,7 +82,7 @@ class PydanticDTO(AbstractDTO[T], Generic[T]):
             field_definition = model_field_definitions[field_name]
             dto_field = (field_definition.extra or {}).pop(DTO_FIELD_META_KEY, DTOField())
 
-            if field_info.default not in PYDANTIC_UNDEFINED_SENTINELS:
+            if not is_pydantic_undefined(field_info.default):
                 default = field_info.default
             elif field_definition.is_optional:
                 default = None
@@ -95,7 +95,7 @@ class PydanticDTO(AbstractDTO[T], Generic[T]):
                     dto_field=dto_field,
                     model_name=model_type.__name__,
                     default_factory=field_info.default_factory
-                    if field_info.default_factory and field_info.default_factory not in PYDANTIC_UNDEFINED_SENTINELS
+                    if field_info.default_factory and not is_pydantic_undefined(field_info.default_factory)
                     else Empty,
                 ),
                 default=default,

--- a/litestar/contrib/pydantic/pydantic_init_plugin.py
+++ b/litestar/contrib/pydantic/pydantic_init_plugin.py
@@ -8,7 +8,7 @@ from msgspec import ValidationError
 from typing_extensions import Buffer, TypeGuard
 
 from litestar._signature.types import ExtendedMsgSpecValidationError
-from litestar.contrib.pydantic.utils import is_pydantic_constrained_field, is_pydantic_field_info
+from litestar.contrib.pydantic.utils import is_pydantic_constrained_field
 from litestar.exceptions import MissingDependencyException
 from litestar.plugins import InitPluginProtocol
 from litestar.typing import _KWARG_META_EXTRACTORS
@@ -90,7 +90,7 @@ _base_encoders: dict[Any, Callable[[Any], Any]] = {
     pydantic_v1.ByteSize: lambda val: val.real,
 }
 
-if pydantic_v2 is not None:
+if pydantic_v2 is not None:  # pragma: no cover
     _base_encoders.update(
         {
             pydantic_v2.EmailStr: str,
@@ -106,16 +106,6 @@ def is_pydantic_v1_model_class(annotation: Any) -> TypeGuard[type[pydantic_v1.Ba
 
 def is_pydantic_v2_model_class(annotation: Any) -> TypeGuard[type[pydantic_v2.BaseModel]]:
     return is_class_and_subclass(annotation, pydantic_v2.BaseModel)
-
-
-class FieldInfoMetaExtractor:
-    @staticmethod
-    def matches(annotation: Any, name: str | None, default: Any) -> bool:
-        return is_pydantic_field_info(default)
-
-    @staticmethod
-    def extract(annotation: Any, default: Any) -> Any:
-        return [default]
 
 
 class ConstrainedFieldMetaExtractor:
@@ -137,7 +127,7 @@ class PydanticInitPlugin(InitPluginProtocol):
     @classmethod
     def encoders(cls, prefer_alias: bool = False) -> dict[Any, Callable[[Any], Any]]:
         encoders = {**_base_encoders, **cls._create_pydantic_v1_encoders(prefer_alias)}
-        if pydantic_v2 is not None:
+        if pydantic_v2 is not None:  # pragma: no cover
             encoders.update(cls._create_pydantic_v2_encoders(prefer_alias))
         return encoders
 
@@ -147,7 +137,7 @@ class PydanticInitPlugin(InitPluginProtocol):
             (is_pydantic_v1_model_class, _dec_pydantic_v1)
         ]
 
-        if pydantic_v2 is not None:
+        if pydantic_v2 is not None:  # pragma: no cover
             decoders.append((is_pydantic_v2_model_class, _dec_pydantic_v2))
 
         decoders.append((_is_pydantic_v1_uuid, _dec_pydantic_uuid))
@@ -186,5 +176,5 @@ class PydanticInitPlugin(InitPluginProtocol):
         app_config.type_encoders = {**self.encoders(self.prefer_alias), **(app_config.type_encoders or {})}
         app_config.type_decoders = [*self.decoders(), *(app_config.type_decoders or [])]
 
-        _KWARG_META_EXTRACTORS.update({ConstrainedFieldMetaExtractor, FieldInfoMetaExtractor})
+        _KWARG_META_EXTRACTORS.add(ConstrainedFieldMetaExtractor)
         return app_config

--- a/litestar/contrib/pydantic/utils.py
+++ b/litestar/contrib/pydantic/utils.py
@@ -111,18 +111,6 @@ def is_pydantic_constrained_field(annotation: Any) -> bool:
     )
 
 
-def is_pydantic_field_info(
-    obj: Any,
-) -> TypeGuard[pydantic_v1.fields.FieldInfo | pydantic_v2.fields.FieldInfo]:  # pyright: ignore
-    if pydantic_v1 is Empty:  # type: ignore[comparison-overlap] # pragma: no cover
-        return False
-
-    if pydantic_v2 is Empty:  # type: ignore[comparison-overlap] # pragma: no cover
-        return isinstance(obj, pydantic_v1.fields.FieldInfo)
-
-    return isinstance(obj, (pydantic_v1.fields.FieldInfo, pydantic_v2.fields.FieldInfo))
-
-
 def pydantic_unwrap_and_get_origin(annotation: Any) -> Any | None:
     if pydantic_v2 is Empty or is_class_and_subclass(annotation, pydantic_v1.BaseModel):  # type: ignore[comparison-overlap]
         return get_origin_or_inner_type(annotation)

--- a/litestar/contrib/pydantic/utils.py
+++ b/litestar/contrib/pydantic/utils.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     try:
         import pydantic as pydantic_v1  # type: ignore[no-redef]
-        from pydantic.fields import Undefined as Pydantic1Undefined
+        from pydantic.fields import Undefined as Pydantic1Undefined  # type: ignore[attr-defined, no-redef]
 
         pydantic_v2 = Empty  # type: ignore[assignment]
         PYDANTIC_UNDEFINED_SENTINELS = {Pydantic1Undefined}

--- a/litestar/contrib/pydantic/utils.py
+++ b/litestar/contrib/pydantic/utils.py
@@ -20,15 +20,22 @@ from litestar.utils.typing import (
 try:
     from pydantic import v1 as pydantic_v1
     import pydantic as pydantic_v2
+    from pydantic.fields import PydanticUndefined as Pydantic2Undefined  # type: ignore[attr-defined]
+    from pydantic.v1.fields import Undefined as Pydantic1Undefined
+
+    PYDANTIC_UNDEFINED_SENTINELS = {Pydantic1Undefined, Pydantic2Undefined}
 except ImportError:
     try:
         import pydantic as pydantic_v1  # type: ignore[no-redef]
+        from pydantic.fields import Undefined as Pydantic1Undefined
 
         pydantic_v2 = Empty  # type: ignore[assignment]
+        PYDANTIC_UNDEFINED_SENTINELS = {Pydantic1Undefined}
 
     except ImportError:  # pyright: ignore
         pydantic_v1 = Empty  # type: ignore[assignment]
         pydantic_v2 = Empty  # type: ignore[assignment]
+        PYDANTIC_UNDEFINED_SENTINELS = set()
 # isort: on
 
 
@@ -76,7 +83,7 @@ def is_pydantic_model_instance(
     return isinstance(annotation, (pydantic_v1.BaseModel, pydantic_v2.BaseModel))
 
 
-def is_pydantic_constrained_field(annotation: Any) -> Any:
+def is_pydantic_constrained_field(annotation: Any) -> bool:
     """Check if the given annotation is a constrained pydantic type.
 
     Args:
@@ -169,3 +176,7 @@ def is_pydantic_2_model(
     obj: type[pydantic_v1.BaseModel | pydantic_v2.BaseModel],  # pyright: ignore
 ) -> TypeGuard[pydantic_v2.BaseModel]:  # pyright: ignore
     return issubclass(obj, pydantic_v2.BaseModel)  # pyright: ignore
+
+
+def is_pydantic_undefined(value: Any) -> bool:
+    return value in PYDANTIC_UNDEFINED_SENTINELS

--- a/litestar/plugins.py
+++ b/litestar/plugins.py
@@ -15,6 +15,7 @@ __all__ = (
     "SerializationPluginProtocol",
     "InitPluginProtocol",
     "OpenAPISchemaPluginProtocol",
+    "OpenAPISchemaPlugin",
     "PluginProtocol",
     "CLIPluginProtocol",
     "PluginRegistry",
@@ -122,7 +123,7 @@ class SerializationPluginProtocol(Protocol):
 
 @runtime_checkable
 class OpenAPISchemaPluginProtocol(Protocol):
-    """Plugin to extend the support of OpenAPI schema generation for non-library types."""
+    """Plugin protocol to extend the support of OpenAPI schema generation for non-library types."""
 
     __slots__ = ()
 
@@ -151,10 +152,27 @@ class OpenAPISchemaPluginProtocol(Protocol):
         raise NotImplementedError()
 
 
+class OpenAPISchemaPlugin(OpenAPISchemaPluginProtocol):
+    """Plugin to extend the support of OpenAPI schema generation for non-library types."""
+
+    @staticmethod
+    def is_undefined_sentinel(value: Any) -> bool:
+        """Return ``True`` if ``value`` should be treated as an undefined field"""
+        return False
+
+    @staticmethod
+    def is_constrained_field(field_definition: FieldDefinition) -> bool:
+        """Return ``True`` if the field should be treated as constrained. If returning
+        ``True``, constraints should be defined in the field's extras
+        """
+        return False
+
+
 PluginProtocol = Union[
     SerializationPluginProtocol,
     InitPluginProtocol,
     OpenAPISchemaPluginProtocol,
+    OpenAPISchemaPlugin,
     CLIPluginProtocol,
 ]
 

--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -4,7 +4,7 @@ from collections import abc, deque
 from copy import deepcopy
 from dataclasses import dataclass, is_dataclass, replace
 from inspect import Parameter, Signature
-from typing import Any, AnyStr, Callable, Collection, ForwardRef, Literal, Mapping, Sequence, TypeVar, cast
+from typing import Any, AnyStr, Callable, Collection, ForwardRef, Literal, Mapping, Protocol, Sequence, TypeVar, cast
 
 from msgspec import UnsetType
 from typing_extensions import Annotated, NotRequired, Required, Self, get_args, get_origin, get_type_hints, is_typeddict
@@ -33,6 +33,19 @@ from litestar.utils.typing import (
 __all__ = ("FieldDefinition",)
 
 T = TypeVar("T", bound=KwargDefinition)
+
+
+class _KwargMetaExtractor(Protocol):
+    @staticmethod
+    def matches(annotation: Any, name: str | None, default: Any) -> bool:
+        ...
+
+    @staticmethod
+    def extract(annotation: Any, default: Any) -> Any:
+        ...
+
+
+_KWARG_META_EXTRACTORS: set[_KwargMetaExtractor] = set()
 
 
 def _unpack_predicate(value: Any) -> dict[str, Any]:
@@ -220,15 +233,20 @@ class FieldDefinition:
     def _extract_metadata(
         cls, annotation: Any, name: str | None, default: Any, metadata: tuple[Any, ...], extra: dict[str, Any] | None
     ) -> tuple[KwargDefinition | None, dict[str, Any]]:
-        from litestar.contrib.pydantic.utils import is_pydantic_constrained_field, is_pydantic_field_info
         from litestar.dto.base_dto import AbstractDTO
 
         model = BodyKwarg if name == "data" else ParameterKwarg
 
-        if is_pydantic_field_info(default):
-            return _create_metadata_from_type(metadata=[default], model=model, annotation=annotation, extra=extra)
+        for extractor in _KWARG_META_EXTRACTORS:
+            if extractor.matches(annotation=annotation, name=name, default=default):
+                return _create_metadata_from_type(
+                    extractor.extract(annotation=annotation, default=default),
+                    model=model,
+                    annotation=annotation,
+                    extra=extra,
+                )
 
-        if is_pydantic_constrained_field(annotation) or isinstance(annotation, AbstractDTO):
+        if isinstance(annotation, AbstractDTO):
             return _create_metadata_from_type(metadata=[annotation], model=model, annotation=annotation, extra=extra)
 
         if any(isinstance(arg, KwargDefinition) for arg in get_args(annotation)):

--- a/tests/unit/test_contrib/test_pydantic/test_schema_plugin.py
+++ b/tests/unit/test_contrib/test_pydantic/test_schema_plugin.py
@@ -1,7 +1,10 @@
-from typing import Dict, Generic, Optional, Type, TypeVar, Union
+import datetime
+from decimal import Decimal
+from typing import Any, Dict, Generic, Optional, Type, TypeVar, Union
 
 import pydantic as pydantic_v2
 import pytest
+from pydantic import v1 as pydantic_v1
 from pydantic.v1.generics import GenericModel
 from typing_extensions import Annotated
 
@@ -47,3 +50,26 @@ def test_schema_generation_with_generic_classes(model: Type[Union[PydanticV1Gene
     assert properties["foo"] == expected_foo_schema
     assert properties["annotated_foo"] == expected_foo_schema
     assert properties["optional_foo"] == expected_optional_foo_schema
+
+
+@pytest.mark.parametrize(
+    "constrained",
+    [
+        pydantic_v1.constr(regex="^[a-zA-Z]$"),
+        pydantic_v1.conlist(int, min_items=1),
+        pydantic_v1.conset(int, min_items=1),
+        pydantic_v1.conint(gt=10, lt=100),
+        pydantic_v1.confloat(gt=10, lt=100),
+        pydantic_v1.condecimal(gt=Decimal("10")),
+        pydantic_v1.condate(gt=datetime.date.today()),
+        pydantic_v2.constr(pattern="^[a-zA-Z]$"),
+        pydantic_v2.conlist(int, min_length=1),
+        pydantic_v2.conset(int, min_length=1),
+        pydantic_v2.conint(gt=10, lt=100),
+        pydantic_v2.confloat(ge=10, le=100),
+        pydantic_v2.condecimal(gt=Decimal("10")),
+        pydantic_v2.condate(gt=datetime.date.today()),
+    ],
+)
+def test_is_pydantic_constrained_field(constrained: Any) -> None:
+    PydanticSchemaPlugin.is_constrained_field(FieldDefinition.from_annotation(constrained))

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -6,10 +6,12 @@ import pytest
 from click import Group
 
 from litestar import Litestar, MediaType, get
+from litestar.constants import UNDEFINED_SENTINELS
 from litestar.contrib.pydantic import PydanticInitPlugin, PydanticSchemaPlugin
 from litestar.contrib.sqlalchemy.plugins import SQLAlchemySerializationPlugin
-from litestar.plugins import CLIPluginProtocol, InitPluginProtocol, PluginRegistry
+from litestar.plugins import CLIPluginProtocol, InitPluginProtocol, OpenAPISchemaPlugin, PluginRegistry
 from litestar.testing import create_test_client
+from litestar.typing import FieldDefinition
 
 if TYPE_CHECKING:
     from litestar.config.app import AppConfig
@@ -76,3 +78,12 @@ def test_plugin_registry_get() -> None:
         PluginRegistry([]).get(CLIPlugin)
 
     assert PluginRegistry([cli_plugin]).get(CLIPlugin) is cli_plugin
+
+
+def test_openapi_schema_plugin_is_constrained_field() -> None:
+    assert OpenAPISchemaPlugin.is_constrained_field(FieldDefinition.from_annotation(str)) is False
+
+
+def test_openapi_schema_plugin_is_undefined_sentinel() -> None:
+    for value in UNDEFINED_SENTINELS:
+        assert OpenAPISchemaPlugin.is_undefined_sentinel(value) is False


### PR DESCRIPTION
Decouple the Pydantic integration from the core logic.

In previous versions, Pydantic integration was baked into the core schema generation, causing issues when trying to run Litestar without it. A recent PR (#2487) surfaced some of these issues, causing an `ImportError` when Pydantic was not installed.

This PR is an attempt to remove all direct references to Pydantic from Litestar's core, although due to other constraints, some of these should be seen as temporary workarounds.

<hr>

One major issue preventing a clean solution here is the merging of the `ParseType` util into `FieldDefinition` that happened in #1912. This causes `FieldDefinition` to require information specific to Pydantic, which is not available to it, since this information is contained within the plugin, `FieldDefinition` however is an ubiquitous utility, used in places where an application context and therefore installed plugins aren't available (nor should they be).

A permanent solution to this would require unmerging these utilities again, creating a separation of concerns between field definitions and metadata and type information.