### PR TITLE
docs: Fix typo in pip install command

### DIFF
--- a/docs/tutorials/sqlalchemy/index.rst
+++ b/docs/tutorials/sqlalchemy/index.rst
@@ -14,7 +14,7 @@ Install SQLAlchemy
 ==================
 
 To follow this tutorial, you will need SQLAlchemy installed. You can install it with ``pip install 'sqlalchemy[aiosqlite]'``, or let
-Litestar install it for you by installing the ``sqlalchemy`` extra (e.g., ``pip install 'litestar[standard,sqlalchemy] aiosqlite'``).
+Litestar install it for you by installing the ``sqlalchemy`` extra (e.g., ``pip install 'litestar[standard,sqlalchemy]' aiosqlite``).
 
 What's in this tutorial?
 ========================


### PR DESCRIPTION
fixes issue introduced by https://github.com/litestar-org/litestar/pull/2558

Incorrect: 
```
pip install 'litestar[standard,sqlalchemy] aiosqlite'
```

> ERROR: Invalid requirement: 'litestar[standard,sqlalchemy] aiosqlite'

Correct:
```
pip install 'litestar[standard,sqlalchemy]' aiosqlite
```
