### PR TITLE
fix: pydantic version selection in tests

### DIFF
--- a/tests/unit/test_contrib/test_pydantic/__init__.py
+++ b/tests/unit/test_contrib/test_pydantic/__init__.py
@@ -1,0 +1,3 @@
+from typing import Literal
+
+PydanticVersion = Literal["v1", "v2"]

--- a/tests/unit/test_contrib/test_pydantic/conftest.py
+++ b/tests/unit/test_contrib/test_pydantic/conftest.py
@@ -5,12 +5,14 @@ import pytest
 from pydantic import v1 as pydantic_v1
 from pytest import FixtureRequest
 
+from . import PydanticVersion
+
 
 @pytest.fixture(params=["v1", "v2"])
-def pydantic_version(request: FixtureRequest) -> str:
+def pydantic_version(request: FixtureRequest) -> PydanticVersion:
     return request.param  # type: ignore[no-any-return]
 
 
 @pytest.fixture()
-def base_model(pydantic_version: str) -> type[pydantic.BaseModel | pydantic_v1.BaseModel]:
-    return pydantic_v1.BaseModel if pydantic_version == "1" else pydantic.BaseModel
+def base_model(pydantic_version: PydanticVersion) -> type[pydantic.BaseModel | pydantic_v1.BaseModel]:
+    return pydantic_v1.BaseModel if pydantic_version == "v1" else pydantic.BaseModel

--- a/tests/unit/test_contrib/test_pydantic/test_integration.py
+++ b/tests/unit/test_contrib/test_pydantic/test_integration.py
@@ -10,6 +10,8 @@ from litestar.status_codes import HTTP_400_BAD_REQUEST
 from litestar.testing import create_test_client
 from tests.unit.test_contrib.test_pydantic.models import PydanticPerson, PydanticV1Person
 
+from . import PydanticVersion
+
 
 def test_pydantic_v1_validation_error_raises_400() -> None:
     class Model(pydantic_v1.BaseModel):
@@ -99,7 +101,7 @@ def test_default_error_handling_v1() -> None:
 
 
 def test_signature_model_invalid_input(
-    base_model: Type[Union[pydantic_v2.BaseModel, pydantic_v1.BaseModel]], pydantic_version: str
+    base_model: Type[Union[pydantic_v2.BaseModel, pydantic_v1.BaseModel]], pydantic_version: PydanticVersion
 ) -> None:
     class OtherChild(base_model):  # type: ignore[misc, valid-type]
         val: List[int]
@@ -136,7 +138,7 @@ def test_signature_model_invalid_input(
         data = response.json()
 
         assert data
-        if pydantic_version == "1":
+        if pydantic_version == "v1":
             assert data["extra"] == [
                 {"key": "child.val", "message": "value is not a valid integer"},
                 {"key": "child.other_val", "message": "value is not a valid integer"},

--- a/tests/unit/test_contrib/test_pydantic/test_openapi.py
+++ b/tests/unit/test_contrib/test_pydantic/test_openapi.py
@@ -531,7 +531,7 @@ def test_create_schema_for_pydantic_model_with_annotated_model_attribute(
         f"""
 {'from __future__ import annotations' if with_future_annotations else ''}
 from typing_extensions import Annotated
-{'from pydantic import BaseModel' if pydantic_version == '1' else 'from pydantic.v1 import BaseModel'}
+{'from pydantic import BaseModel' if pydantic_version == 'v1' else 'from pydantic.v1 import BaseModel'}
 
 class Foo(BaseModel):
     foo: Annotated[int, "Foo description"]

--- a/tests/unit/test_contrib/test_pydantic/test_openapi.py
+++ b/tests/unit/test_contrib/test_pydantic/test_openapi.py
@@ -31,6 +31,8 @@ from tests.unit.test_contrib.test_pydantic.models import (
     PydanticV1Person,
 )
 
+from . import PydanticVersion
+
 AnyBaseModelType = Type[Union[pydantic_v1.BaseModel, pydantic_v2.BaseModel]]
 
 
@@ -141,20 +143,20 @@ def test_create_collection_constrained_field_schema_pydantic_v2(annotation: Any)
 
 
 @pytest.fixture()
-def conset(pydantic_version: str) -> Any:
-    return pydantic_v1.conset if pydantic_version == "1" else pydantic_v2.conset
+def conset(pydantic_version: PydanticVersion) -> Any:
+    return pydantic_v1.conset if pydantic_version == "v1" else pydantic_v2.conset
 
 
 @pytest.fixture()
-def conlist(pydantic_version: str) -> Any:
-    return pydantic_v1.conlist if pydantic_version == "1" else pydantic_v2.conlist
+def conlist(pydantic_version: PydanticVersion) -> Any:
+    return pydantic_v1.conlist if pydantic_version == "v1" else pydantic_v2.conlist
 
 
 def test_create_collection_constrained_field_schema_sub_fields(
-    pydantic_version: str, conset: Any, conlist: Any
+    pydantic_version: PydanticVersion, conset: Any, conlist: Any
 ) -> None:
     for pydantic_fn in [conset, conlist]:
-        if pydantic_version == "1":
+        if pydantic_version == "v1":
             annotation = pydantic_fn(Union[str, int], min_items=1, max_items=10)
         else:
             annotation = pydantic_fn(Union[str, int], min_length=1, max_length=10)
@@ -414,12 +416,12 @@ def test_schema_generation_v2(create_examples: bool) -> None:
         }
 
 
-def test_schema_by_alias(base_model: AnyBaseModelType, pydantic_version: str) -> None:
+def test_schema_by_alias(base_model: AnyBaseModelType, pydantic_version: PydanticVersion) -> None:
     class RequestWithAlias(base_model):  # type: ignore[misc, valid-type]
-        first: str = (pydantic_v1.Field if pydantic_version == "1" else pydantic_v2.Field)(alias="second")  # type: ignore[operator]
+        first: str = (pydantic_v1.Field if pydantic_version == "v1" else pydantic_v2.Field)(alias="second")  # type: ignore[operator]
 
     class ResponseWithAlias(base_model):  # type: ignore[misc, valid-type]
-        first: str = (pydantic_v1.Field if pydantic_version == "1" else pydantic_v2.Field)(alias="second")  # type: ignore[operator]
+        first: str = (pydantic_v1.Field if pydantic_version == "v1" else pydantic_v2.Field)(alias="second")  # type: ignore[operator]
 
     @post("/", signature_types=[RequestWithAlias, ResponseWithAlias])
     def handler(data: RequestWithAlias) -> ResponseWithAlias:
@@ -449,12 +451,12 @@ def test_schema_by_alias(base_model: AnyBaseModelType, pydantic_version: str) ->
         assert response.json() == {response_key: "foo"}
 
 
-def test_schema_by_alias_plugin_override(base_model: AnyBaseModelType, pydantic_version: str) -> None:
+def test_schema_by_alias_plugin_override(base_model: AnyBaseModelType, pydantic_version: PydanticVersion) -> None:
     class RequestWithAlias(base_model):  # type: ignore[misc, valid-type]
-        first: str = (pydantic_v1.Field if pydantic_version == "1" else pydantic_v2.Field)(alias="second")  # type: ignore[operator]
+        first: str = (pydantic_v1.Field if pydantic_version == "v1" else pydantic_v2.Field)(alias="second")  # type: ignore[operator]
 
     class ResponseWithAlias(base_model):  # type: ignore[misc, valid-type]
-        first: str = (pydantic_v1.Field if pydantic_version == "1" else pydantic_v2.Field)(alias="second")  # type: ignore[operator]
+        first: str = (pydantic_v1.Field if pydantic_version == "v1" else pydantic_v2.Field)(alias="second")  # type: ignore[operator]
 
     @post("/", signature_types=[RequestWithAlias, ResponseWithAlias])
     def handler(data: RequestWithAlias) -> ResponseWithAlias:
@@ -522,7 +524,7 @@ def test_create_schema_for_field_v2() -> None:
 
 @pytest.mark.parametrize("with_future_annotations", [True, False])
 def test_create_schema_for_pydantic_model_with_annotated_model_attribute(
-    with_future_annotations: bool, create_module: "Callable[[str], ModuleType]", pydantic_version: str
+    with_future_annotations: bool, create_module: "Callable[[str], ModuleType]", pydantic_version: PydanticVersion
 ) -> None:
     """Test that a model with an annotated attribute is correctly handled."""
     module = create_module(


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

The `pydantic_version` fixture returns strings of "v1" and "v2", however, we're using `if pydantic_version == "1"` as the branching condition in the tests.

This PR ensures that we are comparing the correct literal value in the tests.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
