### PR TITLE
fix(cache): Caching route handlers with the same path but different methods

### DIFF
--- a/litestar/config/response_cache.py
+++ b/litestar/config/response_cache.py
@@ -28,7 +28,8 @@ class CACHE_FOREVER:  # noqa: N801
 
 
 def default_cache_key_builder(request: Request[Any, Any, Any]) -> str:
-    """Given a request object, returns a cache key by combining the path with the sorted query params.
+    """Given a request object, returns a cache key by combining
+    the request method and path with the sorted query params.
 
     Args:
         request: request used to generate cache key.

--- a/litestar/config/response_cache.py
+++ b/litestar/config/response_cache.py
@@ -38,7 +38,7 @@ def default_cache_key_builder(request: Request[Any, Any, Any]) -> str:
     """
     query_params: list[tuple[str, Any]] = list(request.query_params.dict().items())
     query_params.sort(key=lambda x: x[0])
-    return request.url.path + urlencode(query_params, doseq=True)
+    return request.method + request.url.path + urlencode(query_params, doseq=True)
 
 
 def default_do_cache_predicate(_: HTTPScope, status_code: int) -> bool:

--- a/tests/e2e/test_response_caching.py
+++ b/tests/e2e/test_response_caching.py
@@ -8,12 +8,12 @@ from uuid import uuid4
 import msgspec
 import pytest
 
-from litestar import Litestar, Request, Response, get
+from litestar import Litestar, Request, Response, get, post
 from litestar.config.compression import CompressionConfig
 from litestar.config.response_cache import CACHE_FOREVER, ResponseCacheConfig
 from litestar.enums import CompressionEncoding
 from litestar.middleware.response_cache import ResponseCacheMiddleware
-from litestar.status_codes import HTTP_200_OK, HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
+from litestar.status_codes import HTTP_200_OK, HTTP_201_CREATED, HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
 from litestar.stores.base import Store
 from litestar.stores.memory import MemoryStore
 from litestar.testing import TestClient, create_test_client
@@ -111,9 +111,9 @@ def test_default_expiration_none(
         client.get("/cached")
 
     if expected_expiration is None:
-        assert memory_store._store["/cached"].expires_at is None
+        assert memory_store._store["GET/cached"].expires_at is None
     else:
-        assert memory_store._store["/cached"].expires_at
+        assert memory_store._store["GET/cached"].expires_at
 
 
 def test_cache_forever(memory_store: MemoryStore) -> None:
@@ -126,7 +126,7 @@ def test_cache_forever(memory_store: MemoryStore) -> None:
     with TestClient(app) as client:
         client.get("/cached")
 
-    assert memory_store._store["/cached"].expires_at is None
+    assert memory_store._store["GET/cached"].expires_at is None
 
 
 @pytest.mark.parametrize("sync_to_thread", (True, False))
@@ -164,7 +164,7 @@ async def test_non_default_store_name(mock: MagicMock) -> None:
 
         assert mock.call_count == 1
 
-    assert await app.stores.get("some_store").exists("/")
+    assert await app.stores.get("some_store").exists("GET/")
 
 
 async def test_with_stores(store: Store, mock: MagicMock) -> None:
@@ -243,7 +243,7 @@ async def test_compression_applies_before_cache() -> None:
     with TestClient(app) as client:
         client.get("/", headers={"Accept-Encoding": str(CompressionEncoding.GZIP.value)})
 
-    stored_value = await app.response_cache_config.get_store_from_app(app).get("/")
+    stored_value = await app.response_cache_config.get_store_from_app(app).get("GET/")
     assert stored_value
     stored_messages = msgspec.msgpack.decode(stored_value)
     assert gzip.decompress(stored_messages[1]["body"]).decode() == return_value
@@ -285,4 +285,37 @@ def test_custom_do_response_cache_predicate(mock: MagicMock) -> None:
     ) as client:
         client.get("/")
         client.get("/")
+        assert mock.call_count == 2
+
+
+def test_on_multiple_handlers(mock: MagicMock) -> None:
+    @get("/cached-local", cache=10)
+    async def handler() -> str:
+        mock()
+        return "get_response"
+
+    @post("/cached-local", cache=10)
+    async def handler_post() -> str:
+        mock()
+        return "post_response"
+
+    with create_test_client([handler, handler_post], after_request=after_request_handler) as client:
+        # POST request to have this cached
+        first_post_response = client.post("/cached-local")
+        assert first_post_response.status_code == HTTP_201_CREATED
+        assert first_post_response.text == "post_response"
+        assert mock.call_count == 1
+
+        # GET request to verify it doesn't use the cache created by the previous POST request
+        get_response = client.get("/cached-local")
+        assert get_response.status_code == HTTP_200_OK
+        assert get_response.text == "get_response"
+        assert first_post_response.headers["unique-identifier"] != get_response.headers["unique-identifier"]
+        assert mock.call_count == 2
+
+        # POST request to verify it uses the cache generated during the initial POST request
+        second_post_response = client.post("/cached-local")
+        assert second_post_response.status_code == HTTP_201_CREATED
+        assert second_post_response.text == "post_response"
+        assert first_post_response.headers["unique-identifier"] == second_post_response.headers["unique-identifier"]
         assert mock.call_count == 2


### PR DESCRIPTION
- Fixes the bug(s?) in the linked issues by adding the HTTP method to the default key builder function `default_cache_key_builder`. Solution suggested by @provinzkraut  :innocent:
- Changes a few existing test cases that were dependent on the old format of key generation (without the HTTP method)

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [x] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

### Description
Closes #2588 and #2573

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- Closes #2588 and #2573
