### PR TITLE
fix: Do not send None arguments to uvicorn when reloading.

### DIFF
--- a/litestar/cli/commands/core.py
+++ b/litestar/cli/commands/core.py
@@ -45,6 +45,8 @@ def _convert_uvicorn_args(args: dict[str, Any]) -> list[str]:
                 process_args.append(f"--{arg}")
         elif isinstance(value, tuple):
             process_args.extend(f"--{arg}={item}" for item in value)
+        elif value is None:
+            continue
         else:
             process_args.append(f"--{arg}={value}")
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- ❓  New code has 100% test coverage
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- Fixed a bug resulting in a `FileNotFoundError` when invoking `litestar run` with `--reload`, but without SSL `cert` or `key` files. 

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- Fixes #2613
