### PR TITLE
refactor(utils): Simplify sync utils

### DIFF
--- a/litestar/_kwargs/cleanup.py
+++ b/litestar/_kwargs/cleanup.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from inspect import Traceback, isasyncgen
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Coroutine, Generator
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Generator
 
 from anyio import create_task_group
 
-from litestar.utils import AsyncCallable
+from litestar.utils import ensure_async_callable
 from litestar.utils.compat import async_next
 
 __all__ = ("DependencyCleanupGroup",)
@@ -49,7 +49,7 @@ class DependencyCleanupGroup:
         self._generators.append(generator)
 
     @staticmethod
-    def _wrap_next(generator: AnyGenerator) -> Callable[[], Coroutine[None, None, None]]:
+    def _wrap_next(generator: AnyGenerator) -> Callable[[], Awaitable[None]]:
         if isasyncgen(generator):
 
             async def wrapped_async() -> None:
@@ -60,7 +60,7 @@ class DependencyCleanupGroup:
         def wrapped() -> None:
             next(generator, None)  # type: ignore[arg-type]
 
-        return AsyncCallable(wrapped)
+        return ensure_async_callable(wrapped)
 
     async def cleanup(self) -> None:
         """Execute cleanup by calling :func:`next` / :func:`anext` on all generators.

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -42,7 +42,7 @@ from litestar.static_files.base import StaticFiles
 from litestar.stores.registry import StoreRegistry
 from litestar.types import Empty, TypeDecodersSequence
 from litestar.types.internal_types import PathParameterDefinition
-from litestar.utils import AsyncCallable, deprecated, join_paths, unique
+from litestar.utils import deprecated, ensure_async_callable, join_paths, unique
 from litestar.utils.dataclass import extract_dataclass_items
 from litestar.utils.predicates import is_async_callable
 from litestar.utils.warnings import warn_pdb_on_exception
@@ -388,9 +388,9 @@ class Litestar(Router):
         self.asgi_router = ASGIRouter(app=self)
 
         self.allowed_hosts = cast("AllowedHostsConfig | None", config.allowed_hosts)
-        self.after_exception = [AsyncCallable(h) for h in config.after_exception]
+        self.after_exception = [ensure_async_callable(h) for h in config.after_exception]
         self.allowed_hosts = cast("AllowedHostsConfig | None", config.allowed_hosts)
-        self.before_send = [AsyncCallable(h) for h in config.before_send]
+        self.before_send = [ensure_async_callable(h) for h in config.before_send]
         self.compression_config = config.compression_config
         self.cors_config = config.cors_config
         self.csrf_config = config.csrf_config

--- a/litestar/background_tasks.py
+++ b/litestar/background_tasks.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Iterable
 from anyio import create_task_group
 from typing_extensions import ParamSpec
 
-from litestar.utils.sync import AsyncCallable
+from litestar.utils.sync import ensure_async_callable
 
 __all__ = ("BackgroundTask", "BackgroundTasks")
 
@@ -27,7 +27,7 @@ class BackgroundTask:
             *args: Args to pass to the func.
             **kwargs: Kwargs to pass to the func
         """
-        self.fn = AsyncCallable(fn)
+        self.fn = ensure_async_callable(fn)
         self.args = args
         self.kwargs = kwargs
 

--- a/litestar/contrib/jwt/middleware.py
+++ b/litestar/contrib/jwt/middleware.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Awaitable, Callable, Sequence
 
 from litestar.contrib.jwt.jwt_token import Token
 from litestar.exceptions import NotAuthorizedException
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 
     from litestar.connection import ASGIConnection
     from litestar.types import ASGIApp, Method, Scopes
-    from litestar.utils import AsyncCallable
 
 
 class JWTAuthenticationMiddleware(AbstractAuthenticationMiddleware):
@@ -41,7 +40,7 @@ class JWTAuthenticationMiddleware(AbstractAuthenticationMiddleware):
         exclude: str | list[str] | None,
         exclude_http_methods: Sequence[Method] | None,
         exclude_opt_key: str,
-        retrieve_user_handler: AsyncCallable[[Token, ASGIConnection[Any, Any, Any, Any]], Any],
+        retrieve_user_handler: Callable[[Token, ASGIConnection[Any, Any, Any, Any]], Awaitable[Any]],
         scopes: Scopes,
         token_secret: str,
     ) -> None:
@@ -135,7 +134,7 @@ class JWTCookieAuthenticationMiddleware(JWTAuthenticationMiddleware):
         exclude: str | list[str] | None,
         exclude_opt_key: str,
         exclude_http_methods: Sequence[Method] | None,
-        retrieve_user_handler: AsyncCallable[[Token, ASGIConnection[Any, Any, Any, Any]], Any],
+        retrieve_user_handler: Callable[[Token, ASGIConnection[Any, Any, Any, Any]], Awaitable[Any]],
         scopes: Scopes,
         token_secret: str,
     ) -> None:

--- a/litestar/controller.py
+++ b/litestar/controller.py
@@ -12,7 +12,7 @@ from litestar.handlers.base import BaseRouteHandler
 from litestar.handlers.http_handlers import HTTPRouteHandler
 from litestar.handlers.websocket_handlers import WebsocketRouteHandler
 from litestar.types.empty import Empty
-from litestar.utils import AsyncCallable, normalize_path
+from litestar.utils import ensure_async_callable, normalize_path
 from litestar.utils.signature import add_types_to_signature_namespace
 
 __all__ = ("Controller",)
@@ -168,7 +168,7 @@ class Controller:
         for key in ("after_request", "after_response", "before_request"):
             cls_value = getattr(type(self), key, None)
             if callable(cls_value):
-                setattr(self, key, AsyncCallable(cls_value))
+                setattr(self, key, ensure_async_callable(cls_value))
 
         if not hasattr(self, "dto"):
             self.dto = Empty

--- a/litestar/di.py
+++ b/litestar/di.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types import Empty
-from litestar.utils import Ref, async_partial
+from litestar.utils import Ref, ensure_async_callable
 from litestar.utils.predicates import is_async_callable, is_sync_or_async_generator
 from litestar.utils.warnings import (
     warn_implicit_sync_to_thread,
@@ -64,7 +64,7 @@ class Provide:
             warn_implicit_sync_to_thread(dependency, stacklevel=3)
 
         if sync_to_thread and has_sync_callable:
-            self.dependency = Ref["AnyCallable"](async_partial(dependency))  # pyright: ignore
+            self.dependency = Ref["AnyCallable"](ensure_async_callable(dependency))  # pyright: ignore
             self.has_sync_callable = False
         else:
             self.dependency = Ref["AnyCallable"](dependency)  # pyright: ignore

--- a/litestar/events/listener.py
+++ b/litestar/events/listener.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from litestar.exceptions import ImproperlyConfiguredException
-from litestar.utils import AsyncCallable
+from litestar.utils import ensure_async_callable
 
 __all__ = ("EventListener", "listener")
 
 
 if TYPE_CHECKING:
-    from litestar.types import AnyCallable
+    from litestar.types import AnyCallable, AsyncAnyCallable
 
 
 class EventListener:
@@ -17,7 +17,7 @@ class EventListener:
 
     __slots__ = ("event_ids", "fn", "listener_id")
 
-    fn: AsyncCallable[Any, Any]
+    fn: AsyncAnyCallable
 
     def __init__(self, *event_ids: str) -> None:
         """Create a decorator for event handlers.
@@ -40,7 +40,7 @@ class EventListener:
         if not callable(fn):
             raise ImproperlyConfiguredException("EventListener instance should be called as a decorator on a callable")
 
-        self.fn = AsyncCallable(fn)
+        self.fn = ensure_async_callable(fn)
 
         return self
 

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -20,7 +20,7 @@ from litestar.types import (
     TypeEncodersMap,
 )
 from litestar.typing import FieldDefinition
-from litestar.utils import AsyncCallable, Ref, get_name, normalize_path
+from litestar.utils import Ref, ensure_async_callable, get_name, normalize_path
 from litestar.utils.helpers import unwrap_partial
 from litestar.utils.signature import ParsedSignature, add_types_to_signature_namespace
 
@@ -335,7 +335,9 @@ class BaseRouteHandler:
             for layer in self.ownership_layers:
                 self._resolved_guards.extend(layer.guards or [])  # pyright: ignore
 
-            self._resolved_guards = cast("list[Guard]", [AsyncCallable(guard) for guard in self._resolved_guards])
+            self._resolved_guards = cast(
+                "list[Guard]", [ensure_async_callable(guard) for guard in self._resolved_guards]
+            )
 
         return self._resolved_guards  # type:ignore
 

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -42,7 +42,7 @@ from litestar.types import (
     TypeEncodersMap,
 )
 from litestar.types.builtin_types import NoneType
-from litestar.utils import AsyncCallable, async_partial
+from litestar.utils import ensure_async_callable
 from litestar.utils.predicates import is_async_callable
 from litestar.utils.warnings import warn_implicit_sync_to_thread, warn_sync_to_thread_with_async_callable
 
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
     from litestar.dto import AbstractDTO
     from litestar.openapi.datastructures import ResponseSpec
     from litestar.openapi.spec import SecurityRequirement
-    from litestar.types.callable_types import OperationIDCreator
+    from litestar.types.callable_types import AsyncAnyCallable, OperationIDCreator
 
 __all__ = ("HTTPRouteHandler", "route")
 
@@ -247,10 +247,10 @@ class HTTPRouteHandler(BaseRouteHandler):
             **kwargs,
         )
 
-        self.after_request = AsyncCallable(after_request) if after_request else None  # pyright: ignore
-        self.after_response = AsyncCallable(after_response) if after_response else None
+        self.after_request = ensure_async_callable(after_request) if after_request else None  # pyright: ignore
+        self.after_response = ensure_async_callable(after_response) if after_response else None
         self.background = background
-        self.before_request = AsyncCallable(before_request) if before_request else None
+        self.before_request = ensure_async_callable(before_request) if before_request else None
         self.cache = cache
         self.cache_control = cache_control
         self.cache_key_builder = cache_key_builder
@@ -276,8 +276,8 @@ class HTTPRouteHandler(BaseRouteHandler):
         self.security = security
         self.responses = responses
         # memoized attributes, defaulted to Empty
-        self._resolved_after_response: AsyncCallable | None | EmptyType = Empty
-        self._resolved_before_request: AsyncCallable | None | EmptyType = Empty
+        self._resolved_after_response: AsyncAnyCallable | None | EmptyType = Empty
+        self._resolved_before_request: AsyncAnyCallable | None | EmptyType = Empty
         self._response_handler_mapping: ResponseHandlerMap = {"default_handler": Empty, "response_type_handler": Empty}
         self._resolved_include_in_schema: bool | EmptyType = Empty
 
@@ -356,7 +356,7 @@ class HTTPRouteHandler(BaseRouteHandler):
                     response_cookies.update(cast("set[Cookie]", layer_response_cookies))
         return frozenset(response_cookies)
 
-    def resolve_before_request(self) -> AsyncCallable | None:
+    def resolve_before_request(self) -> AsyncAnyCallable | None:
         """Resolve the before_handler handler by starting from the route handler and moving up.
 
         If a handler is found it is returned, otherwise None is set.
@@ -366,13 +366,11 @@ class HTTPRouteHandler(BaseRouteHandler):
             An optional :class:`before request lifecycle hook handler <.types.BeforeRequestHookHandler>`
         """
         if self._resolved_before_request is Empty:
-            before_request_handlers: list[AsyncCallable] = [
-                layer.before_request for layer in self.ownership_layers if layer.before_request  # type: ignore[misc]
-            ]
+            before_request_handlers = [layer.before_request for layer in self.ownership_layers if layer.before_request]
             self._resolved_before_request = before_request_handlers[-1] if before_request_handlers else None
-        return cast("AsyncCallable | None", self._resolved_before_request)
+        return cast("AsyncAnyCallable | None", self._resolved_before_request)
 
-    def resolve_after_response(self) -> AsyncCallable | None:
+    def resolve_after_response(self) -> AsyncAnyCallable | None:
         """Resolve the after_response handler by starting from the route handler and moving up.
 
         If a handler is found it is returned, otherwise None is set.
@@ -382,12 +380,12 @@ class HTTPRouteHandler(BaseRouteHandler):
             An optional :class:`after response lifecycle hook handler <.types.AfterResponseHookHandler>`
         """
         if self._resolved_after_response is Empty:
-            after_response_handlers: list[AsyncCallable] = [
+            after_response_handlers: list[AsyncAnyCallable] = [
                 layer.after_response for layer in self.ownership_layers if layer.after_response  # type: ignore[misc]
             ]
             self._resolved_after_response = after_response_handlers[-1] if after_response_handlers else None
 
-        return cast("AsyncCallable | None", self._resolved_after_response)
+        return cast("AsyncAnyCallable | None", self._resolved_after_response)
 
     def resolve_include_in_schema(self) -> bool:
         """Resolve the 'include_in_schema' property by starting from the route handler and moving up.
@@ -418,7 +416,7 @@ class HTTPRouteHandler(BaseRouteHandler):
             Async Callable to handle an HTTP Request
         """
         if self._response_handler_mapping["default_handler"] is Empty:
-            after_request_handlers: list[AsyncCallable] = [
+            after_request_handlers: list[AsyncAnyCallable] = [
                 layer.after_request for layer in self.ownership_layers if layer.after_request  # type: ignore[misc]
             ]
             after_request = cast(
@@ -492,12 +490,11 @@ class HTTPRouteHandler(BaseRouteHandler):
         super().on_registration(app)
         self.resolve_after_response()
         self.resolve_include_in_schema()
+        self.has_sync_callable = not is_async_callable(self.fn.value)
 
-        if self.sync_to_thread and not is_async_callable(self.fn.value):
-            self.fn.value = async_partial(self.fn.value)
+        if self.has_sync_callable and self.sync_to_thread:
+            self.fn.value = ensure_async_callable(self.fn.value)
             self.has_sync_callable = False
-        else:
-            self.has_sync_callable = not is_async_callable(self.fn.value)
 
     def _validate_handler_function(self) -> None:
         """Validate the route handler function once it is set by inspecting its return annotations."""

--- a/litestar/handlers/websocket_handlers/_utils.py
+++ b/litestar/handlers/websocket_handlers/_utils.py
@@ -9,7 +9,7 @@ from msgspec.json import Encoder as JsonEncoder
 from litestar.di import Provide
 from litestar.serialization import decode_json
 from litestar.types.builtin_types import NoneType
-from litestar.utils import AsyncCallable
+from litestar.utils import ensure_async_callable
 from litestar.utils.helpers import unwrap_partial
 
 if TYPE_CHECKING:
@@ -88,7 +88,7 @@ class ListenerHandler:
         namespace: dict[str, Any],
     ) -> None:
         self._can_send_data = not parsed_signature.return_type.is_subclass_of(NoneType)
-        self._fn = AsyncCallable(fn)
+        self._fn = ensure_async_callable(fn)
         self._listener = listener
         self._pass_socket = "socket" in parsed_signature.parameters
 

--- a/litestar/handlers/websocket_handlers/listener.py
+++ b/litestar/handlers/websocket_handlers/listener.py
@@ -27,7 +27,7 @@ from litestar.types import (
     Middleware,
     TypeEncodersMap,
 )
-from litestar.utils import AsyncCallable
+from litestar.utils import ensure_async_callable
 from litestar.utils.signature import ParsedSignature, get_fn_type_hints
 
 from ._utils import (
@@ -182,8 +182,8 @@ class WebsocketListenerRouteHandler(WebsocketRouteHandler):
         self._receive_handler: Callable[[WebSocket], Any] | EmptyType = Empty
 
         self.connection_accept_handler = connection_accept_handler
-        self.on_accept = AsyncCallable(on_accept) if on_accept else None
-        self.on_disconnect = AsyncCallable(on_disconnect) if on_disconnect else None
+        self.on_accept = ensure_async_callable(on_accept) if on_accept else None
+        self.on_disconnect = ensure_async_callable(on_disconnect) if on_disconnect else None
         self.type_encoders = type_encoders
 
         listener_dependencies = dict(dependencies or {})
@@ -193,10 +193,10 @@ class WebsocketListenerRouteHandler(WebsocketRouteHandler):
         )
 
         if self.on_accept:
-            listener_dependencies["on_accept_dependencies"] = create_stub_dependency(self.on_accept.ref.value)
+            listener_dependencies["on_accept_dependencies"] = create_stub_dependency(self.on_accept)
 
         if self.on_disconnect:
-            listener_dependencies["on_disconnect_dependencies"] = create_stub_dependency(self.on_disconnect.ref.value)
+            listener_dependencies["on_disconnect_dependencies"] = create_stub_dependency(self.on_disconnect)
 
         super().__init__(
             path=path,

--- a/litestar/middleware/rate_limit.py
+++ b/litestar/middleware/rate_limit.py
@@ -9,7 +9,7 @@ from litestar.enums import ScopeType
 from litestar.exceptions import TooManyRequestsException
 from litestar.middleware.base import AbstractMiddleware, DefineMiddleware
 from litestar.serialization import decode_json, encode_json
-from litestar.utils import AsyncCallable
+from litestar.utils import ensure_async_callable
 
 __all__ = ("CacheObject", "RateLimitConfig", "RateLimitMiddleware")
 
@@ -242,7 +242,7 @@ class RateLimitConfig:
 
     def __post_init__(self) -> None:
         if self.check_throttle_handler:
-            self.check_throttle_handler = AsyncCallable(self.check_throttle_handler)  # type: ignore
+            self.check_throttle_handler = ensure_async_callable(self.check_throttle_handler)  # type: ignore
 
     @property
     def middleware(self) -> DefineMiddleware:

--- a/litestar/router.py
+++ b/litestar/router.py
@@ -14,7 +14,7 @@ from litestar.routes import ASGIRoute, HTTPRoute, WebSocketRoute
 from litestar.types.empty import Empty
 from litestar.utils import find_index, is_class_and_subclass, join_paths, normalize_path, unique
 from litestar.utils.signature import add_types_to_signature_namespace
-from litestar.utils.sync import AsyncCallable
+from litestar.utils.sync import ensure_async_callable
 
 __all__ = ("Router",)
 
@@ -158,9 +158,9 @@ class Router:
             type_decoders: A sequence of tuples, each composed of a predicate testing for type identity and a msgspec hook for deserialization.
         """
 
-        self.after_request = AsyncCallable(after_request) if after_request else None  # pyright: ignore
-        self.after_response = AsyncCallable(after_response) if after_response else None
-        self.before_request = AsyncCallable(before_request) if before_request else None
+        self.after_request = ensure_async_callable(after_request) if after_request else None  # pyright: ignore
+        self.after_response = ensure_async_callable(after_response) if after_response else None
+        self.before_request = ensure_async_callable(before_request) if before_request else None
         self.cache_control = cache_control
         self.dto = dto
         self.etag = etag

--- a/litestar/routes/asgi.py
+++ b/litestar/routes/asgi.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 from litestar.connection import ASGIConnection
 from litestar.enums import ScopeType
 from litestar.routes.base import BaseRoute
-from litestar.utils.helpers import unwrap_partial
 
 if TYPE_CHECKING:
     from litestar.handlers.asgi_handlers import ASGIRouteHandler
@@ -33,7 +32,7 @@ class ASGIRoute(BaseRoute):
         super().__init__(
             path=path,
             scope_type=ScopeType.ASGI,
-            handler_names=[unwrap_partial(route_handler.handler_name)],
+            handler_names=[route_handler.handler_name],
         )
 
     async def handle(self, scope: Scope, receive: Receive, send: Send) -> None:

--- a/litestar/security/base.py
+++ b/litestar/security/base.py
@@ -6,7 +6,7 @@ from dataclasses import field
 from typing import TYPE_CHECKING, Any, Callable, Generic, Iterable, Sequence, TypeVar, cast
 
 from litestar import Response
-from litestar.utils.sync import AsyncCallable
+from litestar.utils.sync import ensure_async_callable
 
 if TYPE_CHECKING:
     from litestar.config.app import AppConfig
@@ -146,7 +146,7 @@ class AbstractSecurityConfig(ABC, Generic[UserType, AuthType]):
         )
 
     def __post_init__(self) -> None:
-        self.retrieve_user_handler = AsyncCallable(self.retrieve_user_handler)
+        self.retrieve_user_handler = ensure_async_callable(self.retrieve_user_handler)
 
     @property
     @abstractmethod

--- a/litestar/security/session_auth/middleware.py
+++ b/litestar/security/session_auth/middleware.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Sequence
 
 from litestar.exceptions import NotAuthorizedException
 from litestar.middleware.authentication import (
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from litestar.connection import ASGIConnection
     from litestar.security.session_auth.auth import SessionAuth
     from litestar.types import ASGIApp, Receive, Scope, Send
-    from litestar.utils import AsyncCallable
 
 
 class MiddlewareWrapper:
@@ -79,7 +78,7 @@ class SessionAuthMiddleware(AbstractAuthenticationMiddleware):
         exclude: str | list[str] | None,
         exclude_http_methods: Sequence[Method] | None,
         exclude_opt_key: str,
-        retrieve_user_handler: AsyncCallable[[dict[str, Any], ASGIConnection[Any, Any, Any, Any]], Any],
+        retrieve_user_handler: Callable[[dict[str, Any], ASGIConnection[Any, Any, Any, Any]], Awaitable[Any]],
         scopes: Scopes | None,
     ) -> None:
         """Session based authentication middleware.

--- a/litestar/utils/__init__.py
+++ b/litestar/utils/__init__.py
@@ -29,15 +29,15 @@ from .scope import (
     set_litestar_scope_state,
 )
 from .sequence import find_index, unique
-from .sync import AsyncCallable, AsyncIteratorWrapper, async_partial
+from .sync import AsyncCallable, AsyncIteratorWrapper, ensure_async_callable
 from .typing import annotation_is_iterable_of_type, get_origin_or_inner_type, make_non_optional_union
 
 __all__ = (
-    "AsyncCallable",
+    "ensure_async_callable",
     "AsyncIteratorWrapper",
     "Ref",
     "annotation_is_iterable_of_type",
-    "async_partial",
+    "AsyncCallable",
     "delete_litestar_scope_state",
     "deprecated",
     "find_index",

--- a/litestar/utils/helpers.py
+++ b/litestar/utils/helpers.py
@@ -82,9 +82,9 @@ def unwrap_partial(value: MaybePartial[T]) -> T:
     Returns:
         Callable
     """
-    from litestar.utils.sync import async_partial
+    from litestar.utils.sync import AsyncCallable
 
-    return cast("T", value.func if isinstance(value, (partial, async_partial)) else value)
+    return cast("T", value.func if isinstance(value, (partial, AsyncCallable)) else value)
 
 
 def filter_cookies(local_cookies: Iterable[Cookie], layered_cookies: Iterable[Cookie]) -> list[Cookie]:

--- a/litestar/utils/sync.py
+++ b/litestar/utils/sync.py
@@ -28,9 +28,7 @@ def ensure_async_callable(fn: Callable[P, T]) -> Callable[P, Awaitable[T]]:
     If it is an asynchronous, return the original object, else wrap it in an
     ``AsyncCallable``
     """
-    if is_async_callable(fn):
-        return fn
-    return AsyncCallable(fn)  # pyright: ignore
+    return fn if is_async_callable(fn) else AsyncCallable(fn)
 
 
 class AsyncCallable:

--- a/litestar/utils/sync.py
+++ b/litestar/utils/sync.py
@@ -28,7 +28,9 @@ def ensure_async_callable(fn: Callable[P, T]) -> Callable[P, Awaitable[T]]:
     If it is an asynchronous, return the original object, else wrap it in an
     ``AsyncCallable``
     """
-    return fn if is_async_callable(fn) else AsyncCallable(fn)  # pyright: ignore
+    if is_async_callable(fn):  # sourcery skip
+        return fn
+    return AsyncCallable(fn)  # pyright: ignore
 
 
 class AsyncCallable:

--- a/litestar/utils/sync.py
+++ b/litestar/utils/sync.py
@@ -28,7 +28,7 @@ def ensure_async_callable(fn: Callable[P, T]) -> Callable[P, Awaitable[T]]:
     If it is an asynchronous, return the original object, else wrap it in an
     ``AsyncCallable``
     """
-    return fn if is_async_callable(fn) else AsyncCallable(fn)
+    return fn if is_async_callable(fn) else AsyncCallable(fn)  # pyright: ignore
 
 
 class AsyncCallable:

--- a/litestar/utils/sync.py
+++ b/litestar/utils/sync.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
-from inspect import getfullargspec, ismethod
 from typing import (
-    TYPE_CHECKING,
-    Any,
     AsyncGenerator,
     Awaitable,
     Callable,
@@ -12,87 +9,41 @@ from typing import (
     Iterable,
     Iterator,
     TypeVar,
-    cast,
 )
 
 from anyio.to_thread import run_sync
 from typing_extensions import ParamSpec
 
-from litestar.exceptions import ImproperlyConfiguredException
-from litestar.types import Empty
-from litestar.utils.helpers import Ref, unwrap_partial
 from litestar.utils.predicates import is_async_callable
 
-if TYPE_CHECKING:
-    from litestar.types.empty import EmptyType
-    from litestar.utils.signature import ParsedSignature
-
-__all__ = ("AsyncCallable", "AsyncIteratorWrapper", "async_partial", "is_async_callable")
+__all__ = ("ensure_async_callable", "AsyncIteratorWrapper", "AsyncCallable", "is_async_callable")
 
 
 P = ParamSpec("P")
 T = TypeVar("T")
 
 
-class AsyncCallable(Generic[P, T]):
-    """Wrap a callable into an asynchronous callable."""
-
-    __slots__ = ("args", "kwargs", "ref", "is_method", "num_expected_args", "_parsed_signature")
-
-    def __init__(self, fn: Callable[P, T]) -> None:
-        """Initialize the wrapper from any callable.
-
-        Args:
-            fn: Callable to wrap - can be any sync or async callable.
-        """
-        self._parsed_signature: ParsedSignature | EmptyType = Empty
-        self.is_method = ismethod(fn) or (callable(fn) and ismethod(fn.__call__))  # type: ignore
-        self.num_expected_args = len(getfullargspec(fn).args) - (1 if self.is_method else 0)
-        self.ref = Ref[Callable[..., Awaitable[T]]](fn if is_async_callable(fn) else async_partial(fn))  # type: ignore
-
-    async def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:
-        """Proxy the wrapped function's call method.
-
-        Args:
-            *args: Args of the wrapped function.
-            **kwargs: Kwargs of the wrapper function.
-
-        Returns:
-            The return value of the wrapped function.
-        """
-        return await self.ref.value(*args, **kwargs)
-
-    @property
-    def parsed_signature(self) -> ParsedSignature:
-        if self._parsed_signature is Empty:
-            raise ImproperlyConfiguredException(
-                "Parsed signature is not set. Call `set_parsed_signature()` at an appropriate time during handler"
-                "registration."
-            )
-        return cast("ParsedSignature", self._parsed_signature)
-
-    def set_parsed_signature(self, namespace: dict[str, Any]) -> None:
-        """Set the parsed signature of the wrapped function.
-
-        Args:
-            namespace: Namespace for forward ref resolution.
-        """
-        from litestar.utils.signature import ParsedSignature
-
-        self._parsed_signature = ParsedSignature.from_fn(unwrap_partial(self.ref.value), namespace)
+def ensure_async_callable(fn: Callable[P, T]) -> Callable[P, Awaitable[T]]:
+    """Ensure that ``fn`` is an asynchronous callable.
+    If it is an asynchronous, return the original object, else wrap it in an
+    ``AsyncCallable``
+    """
+    if is_async_callable(fn):
+        return fn
+    return AsyncCallable(fn)  # pyright: ignore
 
 
-class async_partial:  # noqa: N801
-    """Wrap a given sync function making it async.
-    In difference to the :func:`anyio.run_sync` function, it allows for passing kwargs.
+class AsyncCallable:
+    """Wrap a given callable to be called in a thread pool using
+    ``anyio.to_thread.run_sync``, keeping a reference to the original callable as
+    :attr:`func`
     """
 
     def __init__(self, fn: Callable[P, T]) -> None:  # pyright: ignore
         self.func = fn
 
-    async def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:  # pyright: ignore
-        applied_kwarg = partial(self.func, **kwargs)
-        return await run_sync(applied_kwarg, *args)  # pyright: ignore
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> Awaitable[T]:  # pyright: ignore
+        return run_sync(partial(self.func, **kwargs), *args)  # pyright: ignore
 
 
 class AsyncIteratorWrapper(Generic[T]):

--- a/tests/docker_service_fixtures.py
+++ b/tests/docker_service_fixtures.py
@@ -14,7 +14,7 @@ import pytest
 from redis.asyncio import Redis as AsyncRedis
 from redis.exceptions import ConnectionError as RedisConnectionError
 
-from litestar.utils import AsyncCallable
+from litestar.utils import ensure_async_callable
 
 
 async def wait_until_responsive(
@@ -81,7 +81,7 @@ class DockerServiceRegistry:
             self._running_services.add(name)
 
             await wait_until_responsive(
-                check=AsyncCallable(check),
+                check=ensure_async_callable(check),
                 timeout=timeout,
                 pause=pause,
                 host=self.docker_ip,

--- a/tests/examples/test_contrib/test_sqlalchemy/plugins/test_example_apps.py
+++ b/tests/examples/test_contrib/test_sqlalchemy/plugins/test_example_apps.py
@@ -90,7 +90,7 @@ def test_sqlalchemy_async_before_send_handler() -> None:
 
     from litestar.contrib.sqlalchemy.plugins.init.config.asyncio import autocommit_before_send_handler
 
-    assert autocommit_before_send_handler is app.before_send[0].ref.value
+    assert autocommit_before_send_handler is app.before_send[0]
 
 
 def test_sqlalchemy_sync_before_send_handler() -> None:
@@ -98,7 +98,7 @@ def test_sqlalchemy_sync_before_send_handler() -> None:
 
     from litestar.contrib.sqlalchemy.plugins.init.config.sync import autocommit_before_send_handler
 
-    assert autocommit_before_send_handler is app.before_send[0].ref.value.func
+    assert autocommit_before_send_handler is app.before_send[0].func
 
 
 def test_sqlalchemy_async_serialization_plugin(data: dict[str, Any]) -> None:

--- a/tests/unit/test_utils/test_sync.py
+++ b/tests/unit/test_utils/test_sync.py
@@ -1,7 +1,4 @@
-import pytest
-
-from litestar.exceptions import ImproperlyConfiguredException
-from litestar.utils.sync import AsyncCallable
+from litestar.utils.sync import ensure_async_callable
 
 
 async def test_function_wrapper_wraps_method_correctly() -> None:
@@ -14,7 +11,7 @@ async def test_function_wrapper_wraps_method_correctly() -> None:
 
     instance = MyClass()
 
-    wrapped_method = AsyncCallable(instance.my_method)
+    wrapped_method = ensure_async_callable(instance.my_method)
 
     await wrapped_method(1)
     assert instance.value == 1
@@ -33,7 +30,7 @@ async def test_function_wrapper_wraps_async_method_correctly() -> None:
 
     instance = MyClass()
 
-    wrapped_method = AsyncCallable(instance.my_method)
+    wrapped_method = ensure_async_callable(instance.my_method)
 
     await wrapped_method(1)  # type: ignore
     assert instance.value == 1
@@ -48,7 +45,7 @@ async def test_function_wrapper_wraps_function_correctly() -> None:
     def my_function(new_value: int) -> None:
         obj["value"] = new_value
 
-    wrapped_function = AsyncCallable(my_function)
+    wrapped_function = ensure_async_callable(my_function)
 
     await wrapped_function(1)
     assert obj["value"] == 1
@@ -63,7 +60,7 @@ async def test_function_wrapper_wraps_async_function_correctly() -> None:
     async def my_function(new_value: int) -> None:
         obj["value"] = new_value
 
-    wrapped_function = AsyncCallable(my_function)
+    wrapped_function = ensure_async_callable(my_function)
 
     await wrapped_function(1)  # type: ignore
     assert obj["value"] == 1
@@ -81,7 +78,7 @@ async def test_function_wrapper_wraps_class_correctly() -> None:
 
     instance = MyCallable()
 
-    wrapped_class = AsyncCallable(instance)
+    wrapped_class = ensure_async_callable(instance)
 
     await wrapped_class(1)
     assert instance.value == 1
@@ -99,16 +96,10 @@ async def test_function_wrapper_wraps_async_class_correctly() -> None:
 
     instance = MyCallable()
 
-    wrapped_class = AsyncCallable(instance)
+    wrapped_class = ensure_async_callable(instance)
 
     await wrapped_class(1)  # type: ignore
     assert instance.value == 1
 
     await wrapped_class(new_value=10)  # type: ignore
     assert instance.value == 10
-
-
-def test_raises_improper_config_if_set_parsed_signature_not_called() -> None:
-    wrapped = AsyncCallable(lambda: None)
-    with pytest.raises(ImproperlyConfiguredException):
-        wrapped.parsed_signature


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- Remove unused functionality from `AsyncCallable`
- Remove `async_partial`
- Introduce `ensure_async_callable` helper function

Previously, we used the `AsyncCallable` to ensure a callable was async, always wrapping the receive callable. This PR moves to the `ensure_async_partial` function which simply returns the original callable if it's already an async callable, and only wraps it in a greatly simplified `AsyncPartial` if necessary.

This removes some layers of indirection and allows us to simplify how we're dealing with the callables passed to us.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
