### PR TITLE
refactor(utils): Remove `Ref` 

### DIFF
--- a/litestar/_openapi/path_item.py
+++ b/litestar/_openapi/path_item.py
@@ -36,7 +36,7 @@ def get_description_for_handler(route_handler: HTTPRouteHandler, use_handler_doc
     """
     handler_description = route_handler.description
     if handler_description is None and use_handler_docstrings:
-        fn = unwrap_partial(route_handler.fn.value)
+        fn = unwrap_partial(route_handler.fn)
         return cleandoc(fn.__doc__) if fn.__doc__ else None
     return handler_description
 

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -763,7 +763,7 @@ class Litestar(Router):
         if handler_index is None:
             raise NoRouteMatchFoundException(f"Static handler {name} can not be found")
 
-        handler_fn = cast("AnyCallable", handler_index["handler"].fn.value)
+        handler_fn = cast("AnyCallable", handler_index["handler"].fn)
         if not isinstance(handler_fn, StaticFiles):
             raise NoRouteMatchFoundException(f"Handler with name {name} is not a static files handler")
 

--- a/litestar/cli/commands/core.py
+++ b/litestar/cli/commands/core.py
@@ -257,7 +257,7 @@ def routes_command(app: Litestar) -> None:  # pragma: no cover
                     f"[blue]{handler.name or handler.handler_name}[/blue]",
                 ]
 
-                if inspect.iscoroutinefunction(unwrap_partial(handler.fn.value)):
+                if inspect.iscoroutinefunction(unwrap_partial(handler.fn)):
                     handler_info.append("[magenta]async[/magenta]")
                 else:
                     handler_info.append("[yellow]sync[/yellow]")

--- a/litestar/controller.py
+++ b/litestar/controller.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import types
 from collections import defaultdict
 from copy import deepcopy
-from functools import partial
 from operator import attrgetter
 from typing import TYPE_CHECKING, Any, Mapping, Sequence, cast
 
@@ -209,7 +209,9 @@ class Controller:
         self_handlers.sort(key=attrgetter("handler_id"))
         for self_handler in self_handlers:
             route_handler = deepcopy(self_handler)
-            route_handler.fn.value = partial(route_handler.fn.value, self)
+            # at the point we get a reference to the handler function, it's unbound, so
+            # we replace it with a regular bound method here
+            route_handler._fn = types.MethodType(route_handler._fn, self)
             route_handler.owner = self
             route_handlers.append(route_handler)
 

--- a/litestar/di.py
+++ b/litestar/di.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types import Empty
-from litestar.utils import Ref, ensure_async_callable
+from litestar.utils import ensure_async_callable
 from litestar.utils.predicates import is_async_callable, is_sync_or_async_generator
 from litestar.utils.warnings import (
     warn_implicit_sync_to_thread,
@@ -35,7 +35,7 @@ class Provide:
     )
 
     signature_model: type[SignatureModel]
-    dependency: Ref[AnyCallable]
+    dependency: AnyCallable
 
     def __init__(
         self,
@@ -64,10 +64,10 @@ class Provide:
             warn_implicit_sync_to_thread(dependency, stacklevel=3)
 
         if sync_to_thread and has_sync_callable:
-            self.dependency = Ref["AnyCallable"](ensure_async_callable(dependency))  # pyright: ignore
+            self.dependency = ensure_async_callable(dependency)  # pyright: ignore
             self.has_sync_callable = False
         else:
-            self.dependency = Ref["AnyCallable"](dependency)  # pyright: ignore
+            self.dependency = dependency  # pyright: ignore
             self.has_sync_callable = has_sync_callable
 
         self.sync_to_thread = bool(sync_to_thread)
@@ -81,9 +81,9 @@ class Provide:
             return self.value
 
         if self.has_sync_callable:
-            value = self.dependency.value(**kwargs)
+            value = self.dependency(**kwargs)
         else:
-            value = await self.dependency.value(**kwargs)
+            value = await self.dependency(**kwargs)
 
         if self.use_cache:
             self.value = value

--- a/litestar/handlers/asgi_handlers.py
+++ b/litestar/handlers/asgi_handlers.py
@@ -83,7 +83,7 @@ class ASGIRouteHandler(BaseRouteHandler):
             raise ImproperlyConfiguredException(
                 "ASGI handler functions should define 'scope', 'send' and 'receive' arguments"
             )
-        if not is_async_callable(self.fn.value):
+        if not is_async_callable(self.fn):
             raise ImproperlyConfiguredException("Functions decorated with 'asgi' must be async functions")
 
 

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -14,13 +14,12 @@ from litestar.types import (
     Empty,
     ExceptionHandlersMap,
     Guard,
-    MaybePartial,
     Middleware,
     TypeDecodersSequence,
     TypeEncodersMap,
 )
 from litestar.typing import FieldDefinition
-from litestar.utils import Ref, ensure_async_callable, get_name, normalize_path
+from litestar.utils import ensure_async_callable, get_name, normalize_path
 from litestar.utils.helpers import unwrap_partial
 from litestar.utils.signature import ParsedSignature, add_types_to_signature_namespace
 
@@ -155,7 +154,7 @@ class BaseRouteHandler:
 
     def __call__(self, fn: AsyncAnyCallable) -> Self:
         """Replace a function with itself."""
-        self._fn = Ref["MaybePartial[AsyncAnyCallable]"](fn)
+        self._fn = fn
         return self
 
     @property
@@ -194,7 +193,7 @@ class BaseRouteHandler:
         if self._signature_model is Empty:
             self._signature_model = SignatureModel.create(
                 dependency_name_set=self.dependency_name_set,
-                fn=cast("AnyCallable", self.fn.value),
+                fn=cast("AnyCallable", self.fn),
                 parsed_signature=self.parsed_fn_signature,
                 data_dto=self.resolve_data_dto(),
                 type_decoders=self.resolve_type_decoders(),
@@ -202,7 +201,7 @@ class BaseRouteHandler:
         return cast("type[SignatureModel]", self._signature_model)
 
     @property
-    def fn(self) -> Ref[MaybePartial[AsyncAnyCallable]]:
+    def fn(self) -> AsyncAnyCallable:
         """Get the handler function.
 
         Raises:
@@ -226,7 +225,7 @@ class BaseRouteHandler:
         """
         if self._parsed_fn_signature is Empty:
             self._parsed_fn_signature = ParsedSignature.from_fn(
-                unwrap_partial(self.fn.value), self.resolve_signature_namespace()
+                unwrap_partial(self.fn), self.resolve_signature_namespace()
             )
 
         return cast("ParsedSignature", self._parsed_fn_signature)
@@ -253,7 +252,7 @@ class BaseRouteHandler:
         Returns:
             Name of the handler function
         """
-        return get_name(unwrap_partial(self.fn.value))
+        return get_name(unwrap_partial(self.fn))
 
     @property
     def dependency_name_set(self) -> set[str]:
@@ -537,7 +536,7 @@ class BaseRouteHandler:
             A string
         """
         target: type[AsyncAnyCallable] | AsyncAnyCallable  # pyright: ignore
-        target = unwrap_partial(self.fn.value)
+        target = unwrap_partial(self.fn)
         if not hasattr(target, "__qualname__"):
             target = type(target)
         return f"{target.__module__}.{target.__qualname__}"

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -357,9 +357,9 @@ class BaseRouteHandler:
                     if not getattr(provider, "signature_model", None):
                         provider.signature_model = SignatureModel.create(
                             dependency_name_set=self.dependency_name_set,
-                            fn=provider.dependency.value,
+                            fn=provider.dependency,
                             parsed_signature=ParsedSignature.from_fn(
-                                unwrap_partial(provider.dependency.value), self.resolve_signature_namespace()
+                                unwrap_partial(provider.dependency), self.resolve_signature_namespace()
                             ),
                             data_dto=self.resolve_data_dto(),
                             type_decoders=self.resolve_type_decoders(),

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -490,10 +490,10 @@ class HTTPRouteHandler(BaseRouteHandler):
         super().on_registration(app)
         self.resolve_after_response()
         self.resolve_include_in_schema()
-        self.has_sync_callable = not is_async_callable(self.fn.value)
+        self.has_sync_callable = not is_async_callable(self.fn)
 
         if self.has_sync_callable and self.sync_to_thread:
-            self.fn.value = ensure_async_callable(self.fn.value)
+            self._fn = ensure_async_callable(self.fn)
             self.has_sync_callable = False
 
     def _validate_handler_function(self) -> None:

--- a/litestar/handlers/websocket_handlers/listener.py
+++ b/litestar/handlers/websocket_handlers/listener.py
@@ -255,7 +255,7 @@ class WebsocketListenerRouteHandler(WebsocketRouteHandler):
         if self._signature_model is Empty:
             self._signature_model = SignatureModel.create(
                 dependency_name_set=self.dependency_name_set,
-                fn=cast("AnyCallable", self.fn.value),
+                fn=cast("AnyCallable", self.fn),
                 parsed_signature=self.parsed_fn_signature,
                 type_decoders=self.resolve_type_decoders(),
             )

--- a/litestar/handlers/websocket_handlers/route_handler.py
+++ b/litestar/handlers/websocket_handlers/route_handler.py
@@ -74,7 +74,7 @@ class WebsocketRouteHandler(BaseRouteHandler):
             if param in self.parsed_fn_signature.parameters:
                 raise ImproperlyConfiguredException(f"The {param} kwarg is not supported with websocket handlers")
 
-        if not is_async_callable(self.fn.value):
+        if not is_async_callable(self.fn):
             raise ImproperlyConfiguredException("Functions decorated with 'websocket' must be async functions")
 
 

--- a/litestar/routes/asgi.py
+++ b/litestar/routes/asgi.py
@@ -51,4 +51,4 @@ class ASGIRoute(BaseRoute):
             connection = ASGIConnection["ASGIRouteHandler", Any, Any, Any](scope=scope, receive=receive)
             await self.route_handler.authorize_connection(connection=connection)
 
-        await self.route_handler.fn.value(scope=scope, receive=receive, send=send)
+        await self.route_handler.fn(scope=scope, receive=receive, send=send)

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -191,14 +191,14 @@ class HTTPRoute(BaseRoute):
         if cleanup_group:
             async with cleanup_group:
                 data = (
-                    route_handler.fn.value(**parsed_kwargs)
+                    route_handler.fn(**parsed_kwargs)
                     if route_handler.has_sync_callable
-                    else await route_handler.fn.value(**parsed_kwargs)
+                    else await route_handler.fn(**parsed_kwargs)
                 )
         elif route_handler.has_sync_callable:
-            data = route_handler.fn.value(**parsed_kwargs)
+            data = route_handler.fn(**parsed_kwargs)
         else:
-            data = await route_handler.fn.value(**parsed_kwargs)
+            data = await route_handler.fn(**parsed_kwargs)
 
         return data, cleanup_group
 

--- a/litestar/routes/websocket.py
+++ b/litestar/routes/websocket.py
@@ -77,7 +77,7 @@ class WebSocketRoute(BaseRoute):
 
         if cleanup_group:
             async with cleanup_group:
-                await self.route_handler.fn.value(**parsed_kwargs)
+                await self.route_handler.fn(**parsed_kwargs)
             await cleanup_group.cleanup()
         else:
-            await self.route_handler.fn.value(**parsed_kwargs)
+            await self.route_handler.fn(**parsed_kwargs)

--- a/litestar/utils/__init__.py
+++ b/litestar/utils/__init__.py
@@ -1,6 +1,6 @@
 from litestar.utils.deprecation import deprecated, warn_deprecation
 
-from .helpers import Ref, get_enum_string_value, get_name, unique_name_for_scope, url_quote
+from .helpers import get_enum_string_value, get_name, unique_name_for_scope, url_quote
 from .path import join_paths, normalize_path
 from .predicates import (
     is_annotated_type,
@@ -33,7 +33,6 @@ from .typing import get_origin_or_inner_type, make_non_optional_union
 __all__ = (
     "ensure_async_callable",
     "AsyncIteratorWrapper",
-    "Ref",
     "delete_litestar_scope_state",
     "deprecated",
     "find_index",

--- a/litestar/utils/helpers.py
+++ b/litestar/utils/helpers.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from enum import Enum
 from functools import partial
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 from urllib.parse import quote
 
 from litestar.utils.typing import get_origin_or_inner_type
@@ -14,7 +13,6 @@ if TYPE_CHECKING:
     from litestar.types import MaybePartial
 
 __all__ = (
-    "Ref",
     "get_enum_string_value",
     "get_name",
     "unwrap_partial",
@@ -58,16 +56,6 @@ def get_enum_string_value(value: Enum | str) -> str:
         A string.
     """
     return value.value if isinstance(value, Enum) else value  # type:ignore
-
-
-@dataclass
-class Ref(Generic[T]):
-    """A helper class that encapsulates a value."""
-
-    __slots__ = ("value",)
-
-    value: T
-    """The value wrapped by the ref."""
 
 
 def unwrap_partial(value: MaybePartial[T]) -> T:

--- a/litestar/utils/sync.py
+++ b/litestar/utils/sync.py
@@ -22,7 +22,6 @@ __all__ = ("ensure_async_callable", "AsyncIteratorWrapper", "AsyncCallable", "is
 P = ParamSpec("P")
 T = TypeVar("T")
 
-
 def ensure_async_callable(fn: Callable[P, T]) -> Callable[P, Awaitable[T]]:
     """Ensure that ``fn`` is an asynchronous callable.
     If it is an asynchronous, return the original object, else wrap it in an

--- a/litestar/utils/sync.py
+++ b/litestar/utils/sync.py
@@ -22,6 +22,7 @@ __all__ = ("ensure_async_callable", "AsyncIteratorWrapper", "AsyncCallable", "is
 P = ParamSpec("P")
 T = TypeVar("T")
 
+
 def ensure_async_callable(fn: Callable[P, T]) -> Callable[P, Awaitable[T]]:
     """Ensure that ``fn`` is an asynchronous callable.
     If it is an asynchronous, return the original object, else wrap it in an

--- a/tests/unit/test_kwargs/test_query_params.py
+++ b/tests/unit/test_kwargs/test_query_params.py
@@ -145,7 +145,7 @@ def test_query_param_arrays(expected_type: Any, provided_value: Any, default: An
 
     test_method = test_method_without_default if default is ... else test_method_with_default
     # Set the type annotation of 'param' in a way mypy can deal with
-    test_method.fn.value.__annotations__["param"] = expected_type
+    test_method.fn.__annotations__["param"] = expected_type
 
     with create_test_client(test_method) as client:
         params = urlencode({"param": provided_value}, doseq=True)

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -28,7 +28,7 @@ def _create_parameters(app: Litestar, path: str) -> List["OpenAPIParameter"]:
     route = app.routes[index]
     route_handler = route.route_handler_map["GET"][0]  # type: ignore
 
-    handler = route_handler.fn.value
+    handler = route_handler.fn
     assert callable(handler)
 
     handler_fields = SignatureModel.create(

--- a/tests/unit/test_response/test_response_to_asgi_response.py
+++ b/tests/unit/test_response/test_response_to_asgi_response.py
@@ -81,14 +81,14 @@ async def test_to_response_async_await(anyio_backend: str) -> None:
     person_instance = DataclassPersonFactory.build()
     handler._signature_model = SignatureModel.create(
         dependency_name_set=set(),
-        fn=handler.fn.value,
+        fn=handler.fn,
         data_dto=None,
-        parsed_signature=ParsedSignature.from_fn(handler.fn.value, {}),
+        parsed_signature=ParsedSignature.from_fn(handler.fn, {}),
         type_decoders=[],
     )
 
     response = await handler.to_response(
-        data=handler.fn.value(data=person_instance),
+        data=handler.fn(data=person_instance),
         app=Litestar(route_handlers=[handler]),
         request=RequestFactory().get(route_handler=handler),
     )
@@ -104,7 +104,7 @@ async def test_to_response_returning_litestar_response() -> None:
         http_route: HTTPRoute = client.app.routes[0]
         route_handler = http_route.route_handlers[0]
         response = await route_handler.to_response(
-            data=route_handler.fn.value(), app=client.app, request=RequestFactory().get()
+            data=route_handler.fn(), app=client.app, request=RequestFactory().get()
         )
         assert isinstance(response, ASGIResponse)
 
@@ -129,7 +129,7 @@ async def test_to_response_returning_starlette_response(
         http_route: HTTPRoute = client.app.routes[0]
         route_handler = http_route.route_handlers[0]
         response = await route_handler.to_response(
-            data=route_handler.fn.value(), app=client.app, request=RequestFactory().get()
+            data=route_handler.fn(), app=client.app, request=RequestFactory().get()
         )
         assert isinstance(response, StarletteResponse)
         assert response is expected_response  # type: ignore[unreachable]
@@ -156,7 +156,7 @@ async def test_to_response_returning_redirect_response(anyio_backend: str) -> No
         route: HTTPRoute = client.app.routes[0]
         route_handler = route.route_handlers[0]
         response = await route_handler.to_response(
-            data=route_handler.fn.value(), app=client.app, request=RequestFactory().get()
+            data=route_handler.fn(), app=client.app, request=RequestFactory().get()
         )
         encoded_headers = response.encode_headers()  # type: ignore[attr-defined]
 
@@ -210,7 +210,7 @@ async def test_to_response_returning_file_response(anyio_backend: str) -> None:
         route: HTTPRoute = client.app.routes[0]
         route_handler = route.route_handlers[0]
         response = await route_handler.to_response(
-            data=route_handler.fn.value(), app=client.app, request=RequestFactory().get()
+            data=route_handler.fn(), app=client.app, request=RequestFactory().get()
         )
         assert isinstance(response, ASGIFileResponse)
         assert response.file_info
@@ -267,12 +267,10 @@ async def test_to_response_streaming_response(iterator: Any, should_raise: bool,
         route_handler = route.route_handlers[0]
         if should_raise:
             with pytest.raises(TypeError):
-                await route_handler.to_response(
-                    data=route_handler.fn.value(), app=client.app, request=RequestFactory().get()
-                )
+                await route_handler.to_response(data=route_handler.fn(), app=client.app, request=RequestFactory().get())
         else:
             response = await route_handler.to_response(
-                data=route_handler.fn.value(), app=client.app, request=RequestFactory().get()
+                data=route_handler.fn(), app=client.app, request=RequestFactory().get()
             )
             assert isinstance(response, ASGIStreamingResponse)
             encoded_headers = response.encode_headers()
@@ -318,7 +316,7 @@ async def test_to_response_template_response(anyio_backend: str, tmp_path: Path)
         route: HTTPRoute = client.app.routes[0]
         route_handler = route.route_handlers[0]
         response = await route_handler.to_response(
-            data=route_handler.fn.value(), app=client.app, request=RequestFactory(app=app).get()
+            data=route_handler.fn(), app=client.app, request=RequestFactory(app=app).get()
         )
         assert isinstance(response, ASGIResponse)
         encoded_headers = response.encode_headers()
@@ -369,7 +367,7 @@ async def test_to_response_sse_events(content: str | bytes | StreamType[str | by
         route: HTTPRoute = client.app.routes[0]
         route_handler = route.route_handlers[0]
         response = await route_handler.to_response(
-            data=route_handler.fn.value(), app=client.app, request=RequestFactory().get()
+            data=route_handler.fn(), app=client.app, request=RequestFactory().get()
         )
         encoded_headers = response.encode_headers()  # type: ignore[attr-defined]
 
@@ -414,7 +412,7 @@ async def test_sse_events_content(content: str | bytes | StreamType[str | bytes]
         route: HTTPRoute = client.app.routes[0]
         route_handler = route.route_handlers[0]
         response = await route_handler.to_response(
-            data=route_handler.fn.value(), app=client.app, request=RequestFactory().get()
+            data=route_handler.fn(), app=client.app, request=RequestFactory().get()
         )
         assert isinstance(response, ASGIStreamingResponse)
         async for value in response.iterator:

--- a/tests/unit/test_signature/test_parsing.py
+++ b/tests/unit/test_signature/test_parsing.py
@@ -21,9 +21,9 @@ def test_create_function_signature_model_parameter_parsing() -> None:
 
     model = SignatureModel.create(
         dependency_name_set=set(),
-        fn=my_fn.fn.value,
+        fn=my_fn.fn,
         data_dto=None,
-        parsed_signature=ParsedSignature.from_fn(my_fn.fn.value, {}),
+        parsed_signature=ParsedSignature.from_fn(my_fn.fn, {}),
         type_decoders=[],
     )
     fields = model._fields
@@ -48,9 +48,9 @@ def test_create_function_signature_model_ignore_return_annotation() -> None:
 
     signature_model_type = SignatureModel.create(
         dependency_name_set=set(),
-        fn=health_check.fn.value,
+        fn=health_check.fn,
         data_dto=None,
-        parsed_signature=ParsedSignature.from_fn(health_check.fn.value, {}),
+        parsed_signature=ParsedSignature.from_fn(health_check.fn, {}),
         type_decoders=[],
     )
     assert signature_model_type().to_dict() == {}

--- a/tests/unit/test_signature/test_validation.py
+++ b/tests/unit/test_signature/test_validation.py
@@ -38,9 +38,9 @@ def test_create_signature_validation() -> None:
     with pytest.raises(ImproperlyConfiguredException):
         SignatureModel.create(
             dependency_name_set=set(),
-            fn=my_fn.fn.value,
+            fn=my_fn.fn,
             data_dto=None,
-            parsed_signature=ParsedSignature.from_fn(my_fn.fn.value, {}),
+            parsed_signature=ParsedSignature.from_fn(my_fn.fn, {}),
             type_decoders=[],
         )
 
@@ -124,7 +124,7 @@ def test_validation_error_exception_key() -> None:
         dependency_name_set=set(),
         fn=handler,
         data_dto=None,
-        parsed_signature=ParsedSignature.from_fn(handler.fn.value, {}),
+        parsed_signature=ParsedSignature.from_fn(handler.fn, {}),
         type_decoders=[],
     )
 

--- a/tests/unit/test_utils/test_predicates.py
+++ b/tests/unit/test_utils/test_predicates.py
@@ -65,8 +65,8 @@ class Sub(C):
     "args, expected",
     (
         ((Sub, C), True),
-        ((Signature.from_callable(cast("Any", naive_handler.fn.value)).return_annotation, C), False),
-        ((Signature.from_callable(cast("Any", response_handler.fn.value)).return_annotation, Response), True),
+        ((Signature.from_callable(cast("Any", naive_handler.fn)).return_annotation, C), False),
+        ((Signature.from_callable(cast("Any", response_handler.fn)).return_annotation, Response), True),
         ((Dict[str, Any], C), False),
         ((C(), C), False),
     ),


### PR DESCRIPTION
Remove the `Ref` helper as it is not actually needed, saving us quite a bit of extra attribute lookups and complexity. 

<hr>

*Note: This branch is currently targetting `simplify-async-utils` (#2621) but should be merged into `main` after that branch is merged*