### PR TITLE
fix(router): fix reference cycle in node validation

### DIFF
--- a/litestar/_asgi/routing_trie/validate.py
+++ b/litestar/_asgi/routing_trie/validate.py
@@ -42,4 +42,6 @@ def validate_node(node: RouteTrieNode) -> None:
         raise ImproperlyConfiguredException("Path parameters are not allowed under a static or mount route.")
 
     for child in node.children.values():
+        if child is node:
+            continue
         validate_node(node=child)

--- a/tests/e2e/test_routing/test_validations.py
+++ b/tests/e2e/test_routing/test_validations.py
@@ -2,8 +2,9 @@ from typing import Any
 
 import pytest
 
-from litestar import Controller, Litestar, WebSocket, get, websocket
+from litestar import Controller, Litestar, WebSocket, get, post, websocket
 from litestar.exceptions import ImproperlyConfiguredException
+from litestar.static_files import StaticFilesConfig
 from litestar.status_codes import HTTP_200_OK
 from litestar.testing import create_test_client
 
@@ -66,3 +67,19 @@ def test_controller_supports_websocket_and_http_handlers() -> None:
         with client.websocket_connect("/") as ws:
             ws_response = ws.receive_json()
             assert ws_response == {"hello": "world"}
+
+
+def test_validate_static_files_with_same_path_in_handler() -> None:
+    # make sure this works and does not lead to a recursion error
+    # https://github.com/litestar-org/litestar/issues/2629
+
+    @post("/uploads")
+    async def handler() -> None:
+        pass
+
+    Litestar(
+        [handler],
+        static_files_config=[
+            StaticFilesConfig(directories=["uploads"], path="/uploads"),
+        ],
+    )


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description

Fix a recursion error in the ASGI router's node validation caused by a reference cycle.

### Close Issue(s)


- #2629
