### PR TITLE
fix: adjust rapidoc schema path

### DIFF
--- a/litestar/openapi/controller.py
+++ b/litestar/openapi/controller.py
@@ -457,10 +457,10 @@ class OpenAPIController(Controller):
           </head>
         """
 
-        body = f"""
+        body = """
           <body>
             <elements-api
-                apiDescriptionUrl="{self.path}/openapi.json"
+                apiDescriptionUrl="openapi.json"
                 router="hash"
                 layout="sidebar"
             />
@@ -489,9 +489,9 @@ class OpenAPIController(Controller):
           </head>
         """
 
-        body = f"""
+        body = """
           <body>
-            <rapi-doc spec-url="{self.path}/openapi.json" />
+            <rapi-doc spec-url="openapi.json" />
           </body>
         """
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- This attempts to fix an issue we have in production while using RapiDoc where the path is relative (?) to the open API config path but isnt picked up properly when behind a proxy.

<details>
<summary>Defaults</summary>
<img width="1499" alt="image" src="https://github.com/litestar-org/litestar/assets/45884264/ab55597a-029b-43b5-9b55-dbe7dbc0e322">
</details>

<details>
<summary>using correct path according to NGINX (works)</summary>
<img width="1503" alt="image" src="https://github.com/litestar-org/litestar/assets/45884264/dc8f3a53-b209-468f-ba12-35a38085765f">
</details>

<details>
<summary>Using just the file name because its already going to look at your relative path (works)</summary>
<img width="1496" alt="image" src="https://github.com/litestar-org/litestar/assets/45884264/6fbfaa36-87f1-484e-ba38-2b7c45f4b738">
</details>

This is what i've found works, but if this is a proxy issue, me issue, or can be fixed another way please let me know.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
