### PR TITLE
fix: add space to the exception text

### DIFF
--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -508,7 +508,7 @@ class HTTPRouteHandler(BaseRouteHandler):
 
         if return_type.annotation is Empty:
             raise ImproperlyConfiguredException(
-                "A return value of a route handler function should be type annotated."
+                "A return value of a route handler function should be type annotated. "
                 "If your function doesn't return a value, annotate it as returning 'None'."
             )
 
@@ -516,7 +516,7 @@ class HTTPRouteHandler(BaseRouteHandler):
             self.status_code < 200 or self.status_code in {HTTP_204_NO_CONTENT, HTTP_304_NOT_MODIFIED}
         ) and not return_type.is_subclass_of(NoneType):
             raise ImproperlyConfiguredException(
-                "A status code 204, 304 or in the range below 200 does not support a response body."
+                "A status code 204, 304 or in the range below 200 does not support a response body. "
                 "If the function should return a value, change the route handler status code to an appropriate value.",
             )
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- Fix spacing for exceptions raised

hit these at work at it was a bit jarring
<img width="1446" alt="image" src="https://github.com/litestar-org/litestar/assets/45884264/b0a0482c-b2bc-40d9-92c1-efc80ad7f317">


### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
