### PR TITLE
fix(docs): fix code-block directive error preventing Examples from di…

### DIFF
--- a/litestar/app.py
+++ b/litestar/app.py
@@ -639,9 +639,11 @@ class Litestar(Router):
 
                 from litestar import Litestar, get
 
+
                 @get("/", name="my-handler")
                 def handler() -> None:
                     pass
+
 
                 app = Litestar(route_handlers=[handler])
 
@@ -674,9 +676,11 @@ class Litestar(Router):
 
                 from litestar import Litestar, get
 
+
                 @get("/group/{group_id:int}/user/{user_id:int}", name="get_membership_details")
                 def get_membership_details(group_id: int, user_id: int) -> None:
                     pass
+
 
                 app = Litestar(route_handlers=[get_membership_details])
 

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -635,7 +635,7 @@ class Litestar(Router):
         list of paths sorted lexically.
 
         Examples:
-            .. code-block: python
+            .. code-block:: python
 
                 from litestar import Litestar, get
 
@@ -670,7 +670,7 @@ class Litestar(Router):
         parameters.
 
         Examples:
-            .. code-block: python
+            .. code-block:: python
 
                 from litestar import Litestar, get
 
@@ -735,7 +735,7 @@ class Litestar(Router):
         """Receives a static files handler name, an asset file path and returns resolved url path to the asset.
 
         Examples:
-            .. code-block: python
+            .. code-block:: python
 
                 from litestar import Litestar
                 from litestar.static_files.config import StaticFilesConfig

--- a/litestar/datastructures/state.py
+++ b/litestar/datastructures/state.py
@@ -34,7 +34,7 @@ class ImmutableState(Mapping[str, Any]):
              deep_copy: Whether to 'deepcopy' the passed in state.
 
         Examples:
-            .. code-block: python
+            .. code-block:: python
 
                 from litestar.datastructures import ImmutableState
 
@@ -189,7 +189,7 @@ class State(ImmutableState, MutableMapping[str, Any]):
              deep_copy: Whether to 'deepcopy' the passed in state.
 
         Examples:
-        .. code-block: python
+        .. code-block:: python
 
             from litestar.datastructures import State
 

--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -335,7 +335,7 @@ class LoggingMiddlewareConfig:
         """Use this property to insert the config into a middleware list on one of the application layers.
 
         Examples:
-            .. code-block: python
+            .. code-block::  python
 
                 from litestar import Litestar, Request, get
                 from litestar.logging import LoggingConfig

--- a/litestar/middleware/rate_limit.py
+++ b/litestar/middleware/rate_limit.py
@@ -249,7 +249,7 @@ class RateLimitConfig:
         """Use this property to insert the config into a middleware list on one of the application layers.
 
         Examples:
-            .. code-block: python
+            .. code-block::  python
 
                 from litestar import Litestar, Request, get
                 from litestar.middleware.rate_limit import RateLimitConfig

--- a/litestar/middleware/session/base.py
+++ b/litestar/middleware/session/base.py
@@ -74,7 +74,7 @@ class BaseBackendConfig(ABC, Generic[BaseSessionBackendT]):
         """Use this property to insert the config into a middleware list on one of the application layers.
 
         Examples:
-            .. code-block: python
+            .. code-block:: python
 
                 from os import urandom
 

--- a/litestar/plugins/base.py
+++ b/litestar/plugins/base.py
@@ -37,18 +37,22 @@ class InitPluginProtocol(Protocol):
                 from litestar.di import Provide
                 from litestar.plugins import InitPluginProtocol
 
+
                 def get_name() -> str:
                     return "world"
+
 
                 @get("/my-path")
                 def my_route_handler(name: str) -> dict[str, str]:
                     return {"hello": name}
+
 
                 class MyPlugin(InitPluginProtocol):
                     def on_app_init(self, app_config: AppConfig) -> AppConfig:
                         app_config.dependencies["name"] = Provide(get_name)
                         app_config.route_handlers.append(my_route_handler)
                         return app_config
+
 
                 app = Litestar(plugins=[MyPlugin()])
 

--- a/litestar/plugins/base.py
+++ b/litestar/plugins/base.py
@@ -32,7 +32,7 @@ class InitPluginProtocol(Protocol):
         """Receive the :class:`AppConfig<.config.app.AppConfig>` instance after `on_app_init` hooks have been called.
 
         Examples:
-            .. code-block: python
+            .. code-block:: python
                 from litestar import Litestar, get
                 from litestar.di import Provide
                 from litestar.plugins import InitPluginProtocol

--- a/litestar/security/session_auth/auth.py
+++ b/litestar/security/session_auth/auth.py
@@ -66,7 +66,7 @@ class SessionAuth(Generic[UserType, BaseSessionBackendT], AbstractSecurityConfig
         """Use this property to insert the config into a middleware list on one of the application layers.
 
         Examples:
-            .. code-block: python
+            .. code-block:: python
 
                 from typing import Any
                 from os import urandom

--- a/litestar/testing/client/async_client.py
+++ b/litestar/testing/client/async_client.py
@@ -475,7 +475,7 @@ class AsyncTestClient(AsyncClient, BaseTestClient, Generic[T]):  # type: ignore[
             A dictionary containing session data.
 
         Examples:
-            .. code-block: python
+            .. code-block:: python
 
                 from litestar import Litestar, post
                 from litestar.middleware.session.memory_backend import MemoryBackendConfig
@@ -509,7 +509,7 @@ class AsyncTestClient(AsyncClient, BaseTestClient, Generic[T]):  # type: ignore[
             None
 
         Examples:
-            .. code-block: python
+            .. code-block:: python
 
                 from litestar import Litestar, get
                 from litestar.middleware.session.memory_backend import MemoryBackendConfig

--- a/litestar/testing/client/sync_client.py
+++ b/litestar/testing/client/sync_client.py
@@ -535,7 +535,7 @@ class TestClient(Client, BaseTestClient, Generic[T]):  # type: ignore[misc]
             None
 
         Examples:
-            .. code-block: python
+            .. code-block:: python
 
                 from litestar import Litestar, get
                 from litestar.middleware.session.memory_backend import MemoryBackendConfig
@@ -567,7 +567,7 @@ class TestClient(Client, BaseTestClient, Generic[T]):  # type: ignore[misc]
             A dictionary containing session data.
 
         Examples:
-            .. code-block: python
+            .. code-block:: python
 
                 from litestar import Litestar, post
                 from litestar.middleware.session.memory_backend import MemoryBackendConfig

--- a/litestar/testing/helpers.py
+++ b/litestar/testing/helpers.py
@@ -125,9 +125,11 @@ def create_test_client(
             from litestar import get
             from litestar.testing import create_test_client
 
+
             @get("/some-path")
             def my_handler() -> dict[str, str]:
                 return {"hello": "world"}
+
 
             def test_my_handler() -> None:
                 with create_test_client(my_handler) as client:
@@ -378,9 +380,11 @@ def create_async_test_client(
             from litestar import get
             from litestar.testing import create_test_client
 
+
             @get("/some-path")
             def my_handler() -> dict[str, str]:
                 return {"hello": "world"}
+
 
             def test_my_handler() -> None:
                 with create_test_client(my_handler) as client:

--- a/litestar/testing/helpers.py
+++ b/litestar/testing/helpers.py
@@ -120,7 +120,7 @@ def create_test_client(
             handled correctly.
 
     Examples:
-        .. code-block: python
+        .. code-block:: python
 
             from litestar import get
             from litestar.testing import create_test_client
@@ -373,7 +373,7 @@ def create_async_test_client(
             handled correctly.
 
     Examples:
-        .. code-block: python
+        .. code-block:: python
 
             from litestar import get
             from litestar.testing import create_test_client

--- a/litestar/testing/request_factory.py
+++ b/litestar/testing/request_factory.py
@@ -83,7 +83,7 @@ class RequestFactory:
              handler_kwargs: Kwargs to pass to the route handler created for the request
 
         Examples:
-            .. code-block: python
+            .. code-block:: python
 
                 from litestar import Litestar
                 from litestar.enums import RequestEncodingType


### PR DESCRIPTION

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description

- Fix code-block directive error preventing Examples from displaying
    1. I used `grep -r -E "code-block: " litestar/` command to find out all `code-block` directive errors
    2. then changed them from `code-block: python` to `code-block:: python`
    3. correct doc page example
        > <img width="905" alt="Screen Shot 2023-11-14 at 12 35 40 AM" src="https://github.com/litestar-org/litestar/assets/13620348/c711b1f6-df87-4f3b-98e7-e991cd465239">


### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- Closes #2669
