### PR TITLE
fix: add missing mark literal to `dto_field()` signature

### DIFF
--- a/litestar/dto/field.py
+++ b/litestar/dto/field.py
@@ -34,7 +34,7 @@ class DTOField:
     """Mark the field as read-only, or private."""
 
 
-def dto_field(mark: Literal["read-only", "private"] | Mark) -> dict[str, DTOField]:
+def dto_field(mark: Literal["read-only", "write-only", "private"] | Mark) -> dict[str, DTOField]:
     """Create a field metadata mapping.
 
     Args:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- Adds the missing `write-only` mark string literal to `dto_field()` signature.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
