### PR TITLE
feat(template): add ``template_str`` for rendering from strings

### DIFF
--- a/docs/examples/templating/returning_templates_jinja.py
+++ b/docs/examples/templating/returning_templates_jinja.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Optional
 
 from litestar import Litestar, get
 from litestar.contrib.jinja import JinjaTemplateEngine
@@ -8,14 +7,11 @@ from litestar.template.config import TemplateConfig
 
 
 @get(path="/{template_type: str}", sync_to_thread=False)
-def index(name: str, template_type: Optional[str]) -> Template:
+def index(name: str, template_type: str) -> Template:
     if template_type == "file":
         return Template(template_name="hello.html.jinja2", context={"name": name})
     elif template_type == "string":
         return Template(template_str="Hello <strong>Jinja</strong> using strings", context={"name": name})
-    elif not template_type:
-        # Return something that should raise an error
-        return Template(template_str=None)
 
 
 app = Litestar(

--- a/docs/examples/templating/returning_templates_jinja.py
+++ b/docs/examples/templating/returning_templates_jinja.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from litestar import Litestar, get
@@ -7,11 +9,14 @@ from litestar.template.config import TemplateConfig
 
 
 @get(path="/{template_type: str}", sync_to_thread=False)
-def index(name: str, template_type: str) -> Template:
+def index(name: str, template_type: str | None) -> Template:
     if template_type == "file":
         return Template(template_name="hello.html.jinja2", context={"name": name})
     elif template_type == "string":
         return Template(template_str="Hello <strong>Jinja</strong> using strings", context={"name": name})
+    elif not template_type:
+        # Return something that should raise an error
+        return Template(template_str=None)
 
 
 app = Litestar(

--- a/docs/examples/templating/returning_templates_jinja.py
+++ b/docs/examples/templating/returning_templates_jinja.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 from pathlib import Path
+from typing import Optional
 
 from litestar import Litestar, get
 from litestar.contrib.jinja import JinjaTemplateEngine
@@ -9,7 +8,7 @@ from litestar.template.config import TemplateConfig
 
 
 @get(path="/{template_type: str}", sync_to_thread=False)
-def index(name: str, template_type: str | None) -> Template:
+def index(name: str, template_type: Optional[str]) -> Template:
     if template_type == "file":
         return Template(template_name="hello.html.jinja2", context={"name": name})
     elif template_type == "string":

--- a/docs/examples/templating/returning_templates_jinja.py
+++ b/docs/examples/templating/returning_templates_jinja.py
@@ -6,9 +6,12 @@ from litestar.response import Template
 from litestar.template.config import TemplateConfig
 
 
-@get(path="/", sync_to_thread=False)
-def index(name: str) -> Template:
-    return Template(template_name="hello.html.jinja2", context={"name": name})
+@get(path="/{template_type: str}", sync_to_thread=False)
+def index(name: str, template_type: str) -> Template:
+    if template_type == "file":
+        return Template(template_name="hello.html.jinja2", context={"name": name})
+    elif template_type == "string":
+        return Template(template_str="Hello <strong>Jinja</strong> using strings", context={"name": name})
 
 
 app = Litestar(

--- a/docs/examples/templating/returning_templates_mako.py
+++ b/docs/examples/templating/returning_templates_mako.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from litestar import Litestar, get
@@ -7,11 +9,14 @@ from litestar.template.config import TemplateConfig
 
 
 @get(path="/{template_type: str}", sync_to_thread=False)
-def index(name: str, template_type: str) -> Template:
+def index(name: str, template_type: str | None) -> Template:
     if template_type == "file":
         return Template(template_name="hello.html.mako", context={"name": name})
     elif template_type == "string":
         return Template(template_str="Hello <strong>Mako</strong> using strings", context={"name": name})
+    elif not template_type:
+        # Return something that should raise an error
+        return Template(template_str=None)
 
 
 app = Litestar(

--- a/docs/examples/templating/returning_templates_mako.py
+++ b/docs/examples/templating/returning_templates_mako.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
 
 from litestar import Litestar, get
 from litestar.contrib.mako import MakoTemplateEngine
@@ -10,14 +9,11 @@ from litestar.template.config import TemplateConfig
 
 
 @get(path="/{template_type: str}", sync_to_thread=False)
-def index(name: str, template_type: Optional[str]) -> Template:  # noqa: UP007
+def index(name: str, template_type: str) -> Template:
     if template_type == "file":
         return Template(template_name="hello.html.mako", context={"name": name})
     elif template_type == "string":
         return Template(template_str="Hello <strong>Mako</strong> using strings", context={"name": name})
-    elif not template_type:
-        # Return something that should raise an error
-        return Template(template_str=None)
 
 
 app = Litestar(

--- a/docs/examples/templating/returning_templates_mako.py
+++ b/docs/examples/templating/returning_templates_mako.py
@@ -6,9 +6,12 @@ from litestar.response import Template
 from litestar.template.config import TemplateConfig
 
 
-@get(path="/", sync_to_thread=False)
-def index(name: str) -> Template:
-    return Template(template_name="hello.html.mako", context={"name": name})
+@get(path="/{template_type: str}", sync_to_thread=False)
+def index(name: str, template_type: str) -> Template:
+    if template_type == "file":
+        return Template(template_name="hello.html.mako", context={"name": name})
+    elif template_type == "string":
+        return Template(template_str="Hello <strong>Mako</strong> using strings", context={"name": name})
 
 
 app = Litestar(

--- a/docs/examples/templating/returning_templates_mako.py
+++ b/docs/examples/templating/returning_templates_mako.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Optional
 
 from litestar import Litestar, get
 from litestar.contrib.mako import MakoTemplateEngine
@@ -9,7 +10,7 @@ from litestar.template.config import TemplateConfig
 
 
 @get(path="/{template_type: str}", sync_to_thread=False)
-def index(name: str, template_type: str | None) -> Template:
+def index(name: str, template_type: Optional[str]) -> Template:  # noqa: UP007
     if template_type == "file":
         return Template(template_name="hello.html.mako", context={"name": name})
     elif template_type == "string":

--- a/docs/examples/templating/returning_templates_minijinja.py
+++ b/docs/examples/templating/returning_templates_minijinja.py
@@ -6,9 +6,12 @@ from litestar.response import Template
 from litestar.template.config import TemplateConfig
 
 
-@get(path="/")
-def index(name: str) -> Template:
-    return Template(template_name="hello.html.minijinja", context={"name": name})
+@get(path="/{template_type: str}", sync_to_thread=False)
+def index(name: str, template_type: str) -> Template:
+    if template_type == "file":
+        return Template(template_name="hello.html.minijinja", context={"name": name})
+    elif template_type == "string":
+        return Template(template_str="Hello <strong>Minijinja</strong> using strings", context={"name": name})
 
 
 app = Litestar(

--- a/docs/examples/templating/returning_templates_minijinja.py
+++ b/docs/examples/templating/returning_templates_minijinja.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from litestar import Litestar, get
@@ -7,11 +9,14 @@ from litestar.template.config import TemplateConfig
 
 
 @get(path="/{template_type: str}", sync_to_thread=False)
-def index(name: str, template_type: str) -> Template:
+def index(name: str, template_type: str | None) -> Template:
     if template_type == "file":
         return Template(template_name="hello.html.minijinja", context={"name": name})
     elif template_type == "string":
         return Template(template_str="Hello <strong>Minijinja</strong> using strings", context={"name": name})
+    elif not template_type:
+        # Return something that should raise an error
+        return Template(template_str=None)
 
 
 app = Litestar(

--- a/docs/examples/templating/returning_templates_minijinja.py
+++ b/docs/examples/templating/returning_templates_minijinja.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Optional
 
 from litestar import Litestar, get
 from litestar.contrib.minijinja import MiniJinjaTemplateEngine
@@ -9,7 +10,7 @@ from litestar.template.config import TemplateConfig
 
 
 @get(path="/{template_type: str}", sync_to_thread=False)
-def index(name: str, template_type: str | None) -> Template:
+def index(name: str, template_type: Optional[str]) -> Template:  # noqa: UP007
     if template_type == "file":
         return Template(template_name="hello.html.minijinja", context={"name": name})
     elif template_type == "string":

--- a/docs/examples/templating/returning_templates_minijinja.py
+++ b/docs/examples/templating/returning_templates_minijinja.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
 
 from litestar import Litestar, get
 from litestar.contrib.minijinja import MiniJinjaTemplateEngine
@@ -10,14 +9,11 @@ from litestar.template.config import TemplateConfig
 
 
 @get(path="/{template_type: str}", sync_to_thread=False)
-def index(name: str, template_type: Optional[str]) -> Template:  # noqa: UP007
+def index(name: str, template_type: str) -> Template:
     if template_type == "file":
         return Template(template_name="hello.html.minijinja", context={"name": name})
     elif template_type == "string":
         return Template(template_str="Hello <strong>Minijinja</strong> using strings", context={"name": name})
-    elif not template_type:
-        # Return something that should raise an error
-        return Template(template_str=None)
 
 
 app = Litestar(

--- a/docs/usage/templating.rst
+++ b/docs/usage/templating.rst
@@ -2,8 +2,8 @@ Templating
 ==========
 
 Litestar has built-in support for `Jinja2 <https://jinja.palletsprojects.com/en/3.0.x/>`_
-, `Mako <https://www.makotemplates.org/>`_ and `Minijinja <https://github.com/mitsuhiko/minijinja/tree/main/minijinja-py>`_ template engines, as well as abstractions to
-make use of any template engine you wish.
+, `Mako <https://www.makotemplates.org/>`_ and `Minijinja <https://github.com/mitsuhiko/minijinja/tree/main/minijinja-py>`_
+template engines, as well as abstractions to make use of any template engine you wish.
 
 Template engines
 ----------------
@@ -186,7 +186,7 @@ Template Files vs. Strings
 
 When you define a template response, you can either pass a template file name or a string
 containing the template. The latter is useful if you want to define the template inline
-for small templates or :class:`HTMX <litestar.contrib.htmx>` responses for example.
+for small templates or :doc:`HTMX </usage/htmx>` responses for example.
 
 .. tab-set::
 

--- a/docs/usage/templating.rst
+++ b/docs/usage/templating.rst
@@ -209,24 +209,6 @@ for small templates or :doc:`HTMX </usage/htmx>` responses for example.
                     template_string = "{{ hello }}"
                     return Template(template_str=template_string, context={"hello": "world"})
 
-    .. tab-item:: File name and string
-
-            .. code-block:: python
-                :caption: When defining both, string will take precedence
-
-                @get()
-                async def example() -> Template:
-                    template_string = "{{ hello }}"
-                    return Template(
-                        template_name="test.html",
-                        template_str=template_string,
-                        context={"hello": "world"},
-                    )
-
-
-.. warning:: If you pass both ``template_str`` and ``template_name``, the ``template_str`` will
-    take precedence.
-
 Template context
 ----------------
 

--- a/docs/usage/templating.rst
+++ b/docs/usage/templating.rst
@@ -12,10 +12,28 @@ To stay lightweight, a Litestar installation does not include the *Jinja*, *Mako
 libraries themselves. Before you can start using them, you have to install it via the
 respective extra:
 
+.. tab-set::
 
-* ``pip install litestar[jinja]`` for Jinja2
-* ``pip install litestar[mako]`` for Mako
-* ``pip install litestar[minijinja]`` for Minijinja
+    .. tab-item:: Jinja
+        :sync: jinja
+
+        .. code-block:: shell
+
+            pip install litestar[jinja]
+
+    .. tab-item:: Mako
+        :sync: mako
+
+        .. code-block:: shell
+
+            pip install litestar[mako]
+
+    .. tab-item:: MiniJinja
+        :sync: minijinja
+
+        .. code-block:: shell
+
+            pip install litestar[minijinja]
 
 .. tip::
 
@@ -162,6 +180,52 @@ your route handlers:
   exception will be raised.
 * ``context`` is a dictionary containing arbitrary data that will be passed to the template
   engine's ``render`` method. For Jinja and Mako, this data will be available in the `template context <#template-context>`_
+
+Template Files vs. Strings
+--------------------------
+
+When you define a template response, you can either pass a template file name or a string
+containing the template. The latter is useful if you want to define the template inline
+for small templates or :class:`HTMX <litestar.contrib.htmx>` responses for example.
+
+.. tab-set::
+
+    .. tab-item:: File name
+
+            .. code-block:: python
+                :caption: Template via file
+
+                @get()
+                async def example() -> Template:
+                    return Template(template_name="test.html", context={"hello": "world"})
+
+    .. tab-item:: String
+
+            .. code-block:: python
+                :caption: Template via string
+
+                @get()
+                async def example() -> Template:
+                    template_string = "{{ hello }}"
+                    return Template(template_str=template_string, context={"hello": "world"})
+
+    .. tab-item:: File name and string
+
+            .. code-block:: python
+                :caption: When defining both, string will take precedence
+
+                @get()
+                async def example() -> Template:
+                    template_string = "{{ hello }}"
+                    return Template(
+                        template_name="test.html",
+                        template_str=template_string,
+                        context={"hello": "world"},
+                    )
+
+
+.. warning:: If you pass both ``template_str`` and ``template_name``, the ``template_str`` will
+    take precedence.
 
 Template context
 ----------------

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -46,7 +46,6 @@ from litestar.router import Router
 from litestar.routes import ASGIRoute, HTTPRoute, WebSocketRoute
 from litestar.static_files.base import StaticFiles
 from litestar.stores.registry import StoreRegistry
-from litestar.template import TemplateEngineProtocol
 from litestar.types import Empty, TypeDecodersSequence
 from litestar.types.internal_types import PathParameterDefinition
 from litestar.utils import deprecated, ensure_async_callable, join_paths, unique
@@ -69,6 +68,7 @@ if TYPE_CHECKING:
     from litestar.openapi.spec.open_api import OpenAPI
     from litestar.static_files.config import StaticFilesConfig
     from litestar.stores.base import Store
+    from litestar.template import TemplateEngineProtocol
     from litestar.template.config import TemplateConfig
     from litestar.types import (
         AfterExceptionHookHandler,

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -46,6 +46,7 @@ from litestar.router import Router
 from litestar.routes import ASGIRoute, HTTPRoute, WebSocketRoute
 from litestar.static_files.base import StaticFiles
 from litestar.stores.registry import StoreRegistry
+from litestar.template import TemplateEngineProtocol
 from litestar.types import Empty, TypeDecodersSequence
 from litestar.types.internal_types import PathParameterDefinition
 from litestar.utils import deprecated, ensure_async_callable, join_paths, unique
@@ -216,7 +217,7 @@ class Litestar(Router):
         static_files_config: Sequence[StaticFilesConfig] | None = None,
         stores: StoreRegistry | dict[str, Store] | None = None,
         tags: Sequence[str] | None = None,
-        template_config: TemplateConfig | None = None,
+        template_config: TemplateConfig[TemplateEngineProtocol] | None = None,
         type_encoders: TypeEncodersMap | None = None,
         type_decoders: TypeDecodersSequence | None = None,
         websocket_class: type[WebSocket] | None = None,

--- a/litestar/config/app.py
+++ b/litestar/config/app.py
@@ -8,7 +8,6 @@ from litestar.config.allowed_hosts import AllowedHostsConfig
 from litestar.config.response_cache import ResponseCacheConfig
 from litestar.datastructures import State
 from litestar.events.emitter import SimpleEventEmitter
-from litestar.template import TemplateEngineProtocol
 from litestar.types.empty import Empty
 
 if TYPE_CHECKING:
@@ -31,6 +30,7 @@ if TYPE_CHECKING:
     from litestar.static_files.config import StaticFilesConfig
     from litestar.stores.base import Store
     from litestar.stores.registry import StoreRegistry
+    from litestar.template import TemplateEngineProtocol
     from litestar.template.config import TemplateConfig
     from litestar.types import (
         AfterExceptionHookHandler,

--- a/litestar/config/app.py
+++ b/litestar/config/app.py
@@ -8,6 +8,7 @@ from litestar.config.allowed_hosts import AllowedHostsConfig
 from litestar.config.response_cache import ResponseCacheConfig
 from litestar.datastructures import State
 from litestar.events.emitter import SimpleEventEmitter
+from litestar.template import TemplateEngineProtocol
 from litestar.types.empty import Empty
 
 if TYPE_CHECKING:
@@ -196,7 +197,7 @@ class AppConfig:
     """
     tags: list[str] = field(default_factory=list)
     """A list of string tags that will be appended to the schema of all route handlers under the application."""
-    template_config: TemplateConfig | None = field(default=None)
+    template_config: TemplateConfig[TemplateEngineProtocol] | None = field(default=None)
     """An instance of :class:`TemplateConfig <.template.TemplateConfig>`."""
     type_encoders: TypeEncodersMap | None = field(default=None)
     """A mapping of types to callables that transform them into types supported for serialization."""

--- a/litestar/contrib/jinja.py
+++ b/litestar/contrib/jinja.py
@@ -88,7 +88,7 @@ class JinjaTemplateEngine(TemplateEngineProtocol["JinjaTemplate", Mapping[str, A
         """
         self.engine.globals[key] = pass_context(template_callable)
 
-    def render_string(self, template_string: str, context: Mapping[str, Any] | None = None) -> str:
+    def render_string(self, template_string: str, context: Mapping[str, Any]) -> str:
         """Render a template from a string with the given context.
 
         Args:
@@ -98,7 +98,6 @@ class JinjaTemplateEngine(TemplateEngineProtocol["JinjaTemplate", Mapping[str, A
         Returns:
             The rendered template as a string.
         """
-        context = context or {}
         template = self.engine.from_string(template_string)
         return template.render(context)
 

--- a/litestar/contrib/jinja.py
+++ b/litestar/contrib/jinja.py
@@ -38,7 +38,7 @@ class JinjaTemplateEngine(TemplateEngineProtocol["JinjaTemplate", Mapping[str, A
         directory: Path | list[Path] | None = None,
         engine_instance: Environment | None = None,
     ) -> None:
-        """Jinja based TemplateEngine.
+        """Jinja-based TemplateEngine.
 
         Args:
             directory: Direct path or list of directory paths from which to serve templates.
@@ -87,6 +87,21 @@ class JinjaTemplateEngine(TemplateEngineProtocol["JinjaTemplate", Mapping[str, A
             None
         """
         self.engine.globals[key] = pass_context(template_callable)
+
+    def render_string(self, template_string: str, context: Mapping[str, Any] | None = None) -> str:
+        """Render a template from a string with the given context.
+
+        Args:
+            template_string: The template string to render.
+            context: A dictionary of variables to pass to the template.
+
+        Returns:
+            The rendered template as a string.
+        """
+        if context is None:
+            context = {}
+        template = self.engine.from_string(template_string)
+        return template.render(context)
 
     @classmethod
     def from_environment(cls, jinja_environment: Environment) -> JinjaTemplateEngine:

--- a/litestar/contrib/jinja.py
+++ b/litestar/contrib/jinja.py
@@ -98,8 +98,7 @@ class JinjaTemplateEngine(TemplateEngineProtocol["JinjaTemplate", Mapping[str, A
         Returns:
             The rendered template as a string.
         """
-        if context is None:
-            context = {}
+        context = context or {}
         template = self.engine.from_string(template_string)
         return template.render(context)
 

--- a/litestar/contrib/mako.py
+++ b/litestar/contrib/mako.py
@@ -121,7 +121,7 @@ class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate, Mapping[str, Any]]
         self._template_callables.append((key, template_callable))
 
     @staticmethod
-    def render_string(template_string: str, context: Mapping[str, Any] | None = None) -> str:
+    def render_string(template_string: str, context: Mapping[str, Any]) -> str:
         """Render a template from a string with the given context.
 
         Args:
@@ -131,7 +131,6 @@ class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate, Mapping[str, Any]]
         Returns:
             The rendered template as a string.
         """
-        context = context or {}
         template = _MakoTemplate(template_string)
         return template.render(**context)  # type: ignore[no-any-return]
 

--- a/litestar/contrib/mako.py
+++ b/litestar/contrib/mako.py
@@ -18,13 +18,12 @@ from litestar.template.base import (
 try:
     from mako.exceptions import TemplateLookupException as MakoTemplateNotFound  # type: ignore[import-untyped]
     from mako.lookup import TemplateLookup  # type: ignore[import-untyped]
+    from mako.template import Template as _MakoTemplate  # type: ignore[import-untyped]
 except ImportError as e:
     raise MissingDependencyException("mako") from e
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    from mako.template import Template as _MakoTemplate  # type: ignore[import-untyped]
 
 __all__ = ("MakoTemplate", "MakoTemplateEngine")
 
@@ -64,7 +63,7 @@ class MakoTemplate(TemplateProtocol):
 
 
 class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate, Mapping[str, Any]]):
-    """Mako based TemplateEngine."""
+    """Mako-based TemplateEngine."""
 
     def __init__(self, directory: Path | list[Path] | None = None, engine_instance: Any | None = None) -> None:
         """Initialize template engine.
@@ -120,6 +119,22 @@ class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate, Mapping[str, Any]]
             None
         """
         self._template_callables.append((key, template_callable))
+
+    @staticmethod
+    def render_string(template_string: str, context: Mapping[str, Any] | None = None) -> str:
+        """Render a template from a string with the given context.
+
+        Args:
+            template_string: The template string to render.
+            context: A dictionary of variables to pass to the template.
+
+        Returns:
+            The rendered template as a string.
+        """
+        if context is None:
+            context = {}
+        template = _MakoTemplate(template_string)
+        return template.render(**context)
 
     @classmethod
     def from_template_lookup(cls, template_lookup: TemplateLookup) -> MakoTemplateEngine:

--- a/litestar/contrib/mako.py
+++ b/litestar/contrib/mako.py
@@ -131,8 +131,7 @@ class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate, Mapping[str, Any]]
         Returns:
             The rendered template as a string.
         """
-        if context is None:
-            context = {}
+        context = context or {}
         template = _MakoTemplate(template_string)
         return template.render(**context)
 

--- a/litestar/contrib/mako.py
+++ b/litestar/contrib/mako.py
@@ -133,7 +133,7 @@ class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate, Mapping[str, Any]]
         """
         context = context or {}
         template = _MakoTemplate(template_string)
-        return template.render(**context)
+        return template.render(**context)  # type: ignore[no-any-return]
 
     @classmethod
     def from_template_lookup(cls, template_lookup: TemplateLookup) -> MakoTemplateEngine:

--- a/litestar/contrib/minijinja.py
+++ b/litestar/contrib/minijinja.py
@@ -183,12 +183,17 @@ class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate", StateP
 
         Returns:
             The rendered template as a string.
+
+        Raises:
+            TemplateNotFoundException: if no template is found.
         """
         context = context or {}
 
+        if template_string is None:
+            raise TemplateNotFoundException("No template string provided", template_name="template_from_string")
+
         try:
             return self.engine.render_str(template_string, **context)  # type: ignore[no-any-return]
-
         except MiniJinjaTemplateNotFound as err:
             raise TemplateNotFoundException(
                 f"Error rendering template from string: {err}",

--- a/litestar/contrib/minijinja.py
+++ b/litestar/contrib/minijinja.py
@@ -184,9 +184,7 @@ class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate", StateP
         Returns:
             The rendered template as a string.
         """
-
-        if context is None:
-            context = {}
+        context = context or {}
 
         try:
             return self.engine.render_str(template_string, **context)

--- a/litestar/contrib/minijinja.py
+++ b/litestar/contrib/minijinja.py
@@ -174,6 +174,29 @@ class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate", StateP
         """
         self.engine.add_global(key, pass_state(template_callable))
 
+    def render_string(self, template_string: str, context: Mapping[str, Any] | None = None) -> str:
+        """Render a template from a string with the given context.
+
+        Args:
+            template_string: The template string to render.
+            context: A dictionary of variables to pass to the template.
+
+        Returns:
+            The rendered template as a string.
+        """
+
+        if context is None:
+            context = {}
+
+        try:
+            return self.engine.render_str(template_string, **context)
+
+        except MiniJinjaTemplateNotFound as err:
+            raise TemplateNotFoundException(
+                f"Error rendering template from string: {err}",
+                template_name="template_from_string",
+            ) from err
+
     @classmethod
     def from_environment(cls, minijinja_environment: Environment) -> MiniJinjaTemplateEngine:
         """Create a MiniJinjaTemplateEngine from an existing minijinja Environment instance.

--- a/litestar/contrib/minijinja.py
+++ b/litestar/contrib/minijinja.py
@@ -174,7 +174,7 @@ class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate", StateP
         """
         self.engine.add_global(key, pass_state(template_callable))
 
-    def render_string(self, template_string: str, context: Mapping[str, Any] | None = None) -> str:
+    def render_string(self, template_string: str, context: Mapping[str, Any]) -> str:
         """Render a template from a string with the given context.
 
         Args:
@@ -187,7 +187,6 @@ class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate", StateP
         Raises:
             TemplateNotFoundException: if no template is found.
         """
-        context = context or {}
 
         if template_string is None:
             raise TemplateNotFoundException("No template string provided", template_name="template_from_string")

--- a/litestar/contrib/minijinja.py
+++ b/litestar/contrib/minijinja.py
@@ -187,10 +187,6 @@ class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate", StateP
         Raises:
             TemplateNotFoundException: if no template is found.
         """
-
-        if template_string is None:
-            raise TemplateNotFoundException("No template string provided", template_name="template_from_string")
-
         try:
             return self.engine.render_str(template_string, **context)  # type: ignore[no-any-return]
         except MiniJinjaTemplateNotFound as err:

--- a/litestar/contrib/minijinja.py
+++ b/litestar/contrib/minijinja.py
@@ -187,7 +187,7 @@ class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate", StateP
         context = context or {}
 
         try:
-            return self.engine.render_str(template_string, **context)
+            return self.engine.render_str(template_string, **context)  # type: ignore[no-any-return]
 
         except MiniJinjaTemplateNotFound as err:
             raise TemplateNotFoundException(

--- a/litestar/response/template.py
+++ b/litestar/response/template.py
@@ -52,7 +52,7 @@ class Template(Response[bytes]):
 
         Args:
             template_name: Path-like name for the template to be rendered, e.g. ``index.html``.
-            template_str: A string representing the template.
+            template_str: A string representing the template, e.g. ``tmpl = "Hello <strong>World</strong>"``.
             background: A :class:`BackgroundTask <.background_tasks.BackgroundTask>` instance or
                 :class:`BackgroundTasks <.background_tasks.BackgroundTasks>` to execute after the response is finished.
                 Defaults to ``None``.

--- a/litestar/response/template.py
+++ b/litestar/response/template.py
@@ -134,7 +134,7 @@ class Template(Response[bytes]):
 
         if self.template_str is not None:
             body = self._render_from_string(self.template_str, request)
-            media_type = "text/html"
+            media_type = "text/html" if media_type == MediaType.TEXT else media_type
         else:
             if not self.template_name:
                 raise ValueError("Template name cannot be None when not using template_str")

--- a/litestar/response/template.py
+++ b/litestar/response/template.py
@@ -137,8 +137,8 @@ class Template(Response[bytes]):
             body = self._render_from_string(self.template_str, request)
             media_type = media_type or "text/html"
         else:
-            if not self.template_name:
-                raise ValueError("Template name cannot be None when not using template_str")
+            if not self.template_name and not self.template_str:
+                raise ValueError("Either template_name or template_str must be provided")
 
             template = request.app.template_engine.get_template(self.template_name)
             context = self.create_template_context(request)

--- a/litestar/response/template.py
+++ b/litestar/response/template.py
@@ -135,7 +135,7 @@ class Template(Response[bytes]):
 
         if self.template_str is not None:
             body = self._render_from_string(self.template_str, request)
-            media_type = "text/html" if media_type == MediaType.TEXT else media_type
+            media_type = media_type or "text/html"
         else:
             if not self.template_name:
                 raise ValueError("Template name cannot be None when not using template_str")

--- a/litestar/response/template.py
+++ b/litestar/response/template.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import itertools
 from mimetypes import guess_type
 from pathlib import PurePath
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable, cast
 
 from litestar.constants import SCOPE_STATE_CSRF_TOKEN_KEY
 from litestar.enums import MediaType
@@ -62,6 +62,9 @@ class Template(Response[bytes]):
                 the media type based on the template name. If this fails, fall back to ``text/plain``.
             status_code: A value for the response HTTP status code.
         """
+        if not (template_name or template_str):
+            raise ValueError("Either template_name or template_str must be provided.")
+
         if template_name and template_str:
             raise ValueError("Either template_name or template_str must be provided, not both.")
 
@@ -117,31 +120,32 @@ class Template(Response[bytes]):
                 alternative="request.app",
             )
 
-        if not request.app.template_engine:
+        if not (template_engine := request.app.template_engine):
             raise ImproperlyConfiguredException("Template engine is not configured")
 
         headers = {**headers, **self.headers} if headers is not None else self.headers
         cookies = self.cookies if cookies is None else itertools.chain(self.cookies, cookies)
 
         media_type = self.media_type or media_type
-        if not media_type and self.template_name:
-            suffixes = PurePath(self.template_name).suffixes
-            for suffix in suffixes:
-                if _type := guess_type(f"name{suffix}")[0]:
-                    media_type = _type
-                    break
+        if not media_type:
+            if self.template_name:
+                suffixes = PurePath(self.template_name).suffixes
+                for suffix in suffixes:
+                    if _type := guess_type(f"name{suffix}")[0]:
+                        media_type = _type
+                        break
+                else:
+                    media_type = MediaType.TEXT
             else:
-                media_type = MediaType.TEXT
+                media_type = MediaType.HTML
+
+        context = self.create_template_context(request)
 
         if self.template_str is not None:
-            body = self._render_from_string(self.template_str, request)
-            media_type = media_type or MediaType.HTML
+            body = template_engine.render_string(self.template_str, context)
         else:
-            if not self.template_name and not self.template_str:
-                raise ValueError("Either template_name or template_str must be provided")
-
-            template = request.app.template_engine.get_template(self.template_name)
-            context = self.create_template_context(request)
+            # cast to str b/c we know that either template_name cannot be None if template_str is None
+            template = template_engine.get_template(cast("str", self.template_name))
             body = template.render(**context).encode(self.encoding)
 
         return ASGIResponse(
@@ -156,8 +160,3 @@ class Template(Response[bytes]):
             media_type=media_type,
             status_code=self.status_code or status_code,
         )
-
-    def _render_from_string(self, template_str: str, request: Request) -> bytes:
-        """Render the template from a string."""
-        context = self.create_template_context(request)
-        return request.app.template_engine.render_string(template_str, context).encode(self.encoding)

--- a/litestar/response/template.py
+++ b/litestar/response/template.py
@@ -168,4 +168,4 @@ class Template(Response[bytes]):
             Rendered content as bytes.
         """
         context = self.create_template_context(request)
-        return request.app.template_engine.render_string(template_str, context).encode(self.encoding)
+        return request.app.template_engine.render_string(template_str, context).encode(self.encoding)  # type: ignore[no-any-return]

--- a/litestar/response/template.py
+++ b/litestar/response/template.py
@@ -169,6 +169,3 @@ class Template(Response[bytes]):
         """
         context = self.create_template_context(request)
         return request.app.template_engine.render_string(template_str, context).encode(self.encoding)
-
-    def test(self) -> str:
-        return f"Template(template_name={self.template_name}, context={self.context})"

--- a/litestar/response/template.py
+++ b/litestar/response/template.py
@@ -47,9 +47,6 @@ class Template(Response[bytes]):
     ) -> None:
         """Handle the rendering of a given template into a bytes string.
 
-            .. note:: Either ``template_name`` or ``template_str`` must be provided.
-                If both are provided, ``template_str`` will be used.
-
         Args:
             template_name: Path-like name for the template to be rendered, e.g. ``index.html``.
             template_str: A string representing the template, e.g. ``tmpl = "Hello <strong>World</strong>"``.
@@ -65,6 +62,9 @@ class Template(Response[bytes]):
                 the media type based on the template name. If this fails, fall back to ``text/plain``.
             status_code: A value for the response HTTP status code.
         """
+        if template_name and template_str:
+            raise ValueError("Either template_name or template_str must be provided, not both.")
+
         super().__init__(
             background=background,
             content=b"",

--- a/litestar/response/template.py
+++ b/litestar/response/template.py
@@ -47,7 +47,8 @@ class Template(Response[bytes]):
     ) -> None:
         """Handle the rendering of a given template into a bytes string.
 
-            .. note:: Either ``template_name`` or ``template_str`` must be provided, but not both.
+            .. note:: Either ``template_name`` or ``template_str`` must be provided.
+                If both are provided, ``template_str`` will be used.
 
         Args:
             template_name: Path-like name for the template to be rendered, e.g. ``index.html``.

--- a/litestar/response/template.py
+++ b/litestar/response/template.py
@@ -158,14 +158,6 @@ class Template(Response[bytes]):
         )
 
     def _render_from_string(self, template_str: str, request: Request) -> bytes:
-        """Render the template from a string.
-
-        Args:
-            template_str: A string representing the template.
-            request: A :class:`Request <.connection.Request>` instance.
-
-        Returns:
-            Rendered content as bytes.
-        """
+        """Render the template from a string."""
         context = self.create_template_context(request)
-        return request.app.template_engine.render_string(template_str, context).encode(self.encoding)  # type: ignore[no-any-return]
+        return request.app.template_engine.render_string(template_str, context).encode(self.encoding)

--- a/litestar/response/template.py
+++ b/litestar/response/template.py
@@ -135,7 +135,7 @@ class Template(Response[bytes]):
 
         if self.template_str is not None:
             body = self._render_from_string(self.template_str, request)
-            media_type = media_type or "text/html"
+            media_type = media_type or MediaType.HTML
         else:
             if not self.template_name and not self.template_str:
                 raise ValueError("Either template_name or template_str must be provided")

--- a/litestar/template/base.py
+++ b/litestar/template/base.py
@@ -141,6 +141,18 @@ class TemplateEngineProtocol(Protocol[TemplateType_co, ContextType_co]):
         """
         raise NotImplementedError
 
+    def render_string(self, template_string: str, context: Mapping[str, Any]) -> str:
+        """Render a template from a string with the given context.
+
+        Args:
+            template_string: The template string to render.
+            context: A dictionary of variables to pass to the template.
+
+        Returns:
+            The rendered template as a string.
+        """
+        raise NotImplementedError
+
     def register_template_callable(
         self, key: str, template_callable: TemplateCallableType[ContextType_co, P, R]
     ) -> None:

--- a/tests/examples/test_templating/test_returning_templates.py
+++ b/tests/examples/test_templating/test_returning_templates.py
@@ -6,7 +6,7 @@ from docs.examples.templating.returning_templates_minijinja import app as miniji
 from litestar.testing import TestClient
 
 
-@pytest.mark.parametrize("template_type", ["file", "string", ""])
+@pytest.mark.parametrize("template_type", ["file", "string", None])
 def test_returning_templates_jinja(template_type):
     with TestClient(jinja_app) as client:
         response = client.get(f"/{template_type}", params={"name": "Jinja"})
@@ -14,6 +14,9 @@ def test_returning_templates_jinja(template_type):
             assert response.text == "Hello <strong>Jinja</strong>"
         elif template_type == "string":
             assert response.text == "Hello <strong>Jinja</strong> using strings"
+        elif template_type is None:
+            assert response.status_code == 500
+            assert response.json() == {"detail": "Internal Server Error", "status_code": 500}
 
 
 @pytest.mark.parametrize("template_type", ["file", "string"])
@@ -24,6 +27,9 @@ def test_returning_templates_mako(template_type):
             assert response.text == "Hello <strong>Mako</strong>\n"
         elif template_type == "string":
             assert response.text.strip() == "Hello <strong>Mako</strong> using strings"
+        elif template_type is None:
+            assert response.status_code == 500
+            assert response.json() == {"detail": "Internal Server Error", "status_code": 500}
 
 
 @pytest.mark.parametrize("template_type", ["file", "string"])
@@ -34,3 +40,6 @@ def test_returning_templates_minijinja(template_type):
             assert response.text == "Hello <strong>Minijinja</strong>"
         elif template_type == "string":
             assert response.text.strip() == "Hello <strong>Minijinja</strong> using strings"
+        elif template_type is None:
+            assert response.status_code == 500
+            assert response.json() == {"detail": "Internal Server Error", "status_code": 500}

--- a/tests/examples/test_templating/test_returning_templates.py
+++ b/tests/examples/test_templating/test_returning_templates.py
@@ -1,3 +1,4 @@
+import pytest
 from docs.examples.templating.returning_templates_jinja import app as jinja_app
 from docs.examples.templating.returning_templates_jinja import app as minijinja_app
 from docs.examples.templating.returning_templates_mako import app as mako_app
@@ -5,19 +6,31 @@ from docs.examples.templating.returning_templates_mako import app as mako_app
 from litestar.testing import TestClient
 
 
-def test_returning_templates_jinja():
+@pytest.mark.parametrize("template_type", ["file", "string"])
+def test_returning_templates_jinja(template_type):
     with TestClient(jinja_app) as client:
-        response = client.get("/", params={"name": "Jinja"})
-        assert response.text == "Hello <strong>Jinja</strong>"
+        response = client.get(f"/{template_type}", params={"name": "Jinja"})
+        if template_type == "file":
+            assert response.text == "Hello <strong>Jinja</strong>"
+        elif template_type == "string":
+            assert response.text == "Hello <strong>Jinja</strong> using strings"
 
 
-def test_returning_templates_mako():
+@pytest.mark.parametrize("template_type", ["file", "string"])
+def test_returning_templates_mako(template_type):
     with TestClient(mako_app) as client:
-        response = client.get("/", params={"name": "Mako"})
-        assert response.text.strip() == "Hello <strong>Mako</strong>"
+        response = client.get(f"/{template_type}", params={"name": "Mako"})
+        if template_type == "file":
+            assert response.text == "Hello <strong>Mako</strong>\n"
+        elif template_type == "string":
+            assert response.text.strip() == "Hello <strong>Mako</strong> using strings"
 
 
-def test_returning_templates_minijinja():
+@pytest.mark.parametrize("template_type", ["file", "string"])
+def test_returning_templates_minijinja(template_type):
     with TestClient(minijinja_app) as client:
-        response = client.get("/", params={"name": "Minijinja"})
-        assert response.text == "Hello <strong>Minijinja</strong>"
+        response = client.get(f"/{template_type}", params={"name": "Minijinja"})
+        if template_type == "file":
+            assert response.text == "Hello <strong>Minijinja</strong>"
+        elif template_type == "string":
+            assert response.text.strip() == "Hello <strong>Minijinja</strong> using strings"

--- a/tests/examples/test_templating/test_returning_templates.py
+++ b/tests/examples/test_templating/test_returning_templates.py
@@ -1,7 +1,7 @@
 import pytest
 from docs.examples.templating.returning_templates_jinja import app as jinja_app
-from docs.examples.templating.returning_templates_jinja import app as minijinja_app
 from docs.examples.templating.returning_templates_mako import app as mako_app
+from docs.examples.templating.returning_templates_minijinja import app as minijinja_app
 
 from litestar.testing import TestClient
 

--- a/tests/examples/test_templating/test_returning_templates.py
+++ b/tests/examples/test_templating/test_returning_templates.py
@@ -13,7 +13,7 @@ apps_with_expected_responses = [
 
 
 @pytest.mark.parametrize("app, app_name, file_response, string_response", apps_with_expected_responses)
-@pytest.mark.parametrize("template_type", ["file", "string", None])
+@pytest.mark.parametrize("template_type", ["file", "string"])
 def test_returning_templates(app, app_name, file_response, string_response, template_type):
     with TestClient(app) as client:
         response = client.get(f"/{template_type}", params={"name": app_name})
@@ -21,7 +21,3 @@ def test_returning_templates(app, app_name, file_response, string_response, temp
             assert response.text == file_response
         elif template_type == "string":
             assert response.text.strip() == string_response
-        else:
-            # Test the scenario where template_type is None
-            assert response.status_code == 500
-            assert response.json() == {"detail": "Internal Server Error", "status_code": 500}

--- a/tests/examples/test_templating/test_returning_templates.py
+++ b/tests/examples/test_templating/test_returning_templates.py
@@ -6,7 +6,7 @@ from docs.examples.templating.returning_templates_minijinja import app as miniji
 from litestar.testing import TestClient
 
 
-@pytest.mark.parametrize("template_type", ["file", "string"])
+@pytest.mark.parametrize("template_type", ["file", "string", ""])
 def test_returning_templates_jinja(template_type):
     with TestClient(jinja_app) as client:
         response = client.get(f"/{template_type}", params={"name": "Jinja"})

--- a/tests/unit/test_contrib/test_minijinja.py
+++ b/tests/unit/test_contrib/test_minijinja.py
@@ -36,11 +36,11 @@ def test_mini_jinja_template_render_raises_template_not_found(tmp_path: Path) ->
 def test_mini_jinja_template_render_string_raises_template_not_found(tmp_path: Path) -> None:
     template_engine = MiniJinjaTemplateEngine(engine_instance=Environment())
 
-    good_template = template_engine.render_string("template as a string")
+    good_template = template_engine.render_string("template as a string", context={})
     assert good_template == "template as a string"
 
     with pytest.raises(TemplateNotFoundException):
-        template_engine.render_string(None)  # type: ignore[arg-type]
+        template_engine.render_string(None, context={})  # type: ignore[arg-type]
 
 
 def test_from_environment() -> None:

--- a/tests/unit/test_contrib/test_minijinja.py
+++ b/tests/unit/test_contrib/test_minijinja.py
@@ -39,7 +39,7 @@ def test_mini_jinja_template_render_string_raises_template_not_found(tmp_path: P
     good_template = template_engine.render_string("template as a string", context={})
     assert good_template == "template as a string"
 
-    with pytest.raises(TemplateNotFoundException):
+    with pytest.raises(TypeError):
         template_engine.render_string(None, context={})  # type: ignore[arg-type]
 
 

--- a/tests/unit/test_contrib/test_minijinja.py
+++ b/tests/unit/test_contrib/test_minijinja.py
@@ -33,6 +33,16 @@ def test_mini_jinja_template_render_raises_template_not_found(tmp_path: Path) ->
         tmpl.render()
 
 
+def test_mini_jinja_template_render_string_raises_template_not_found(tmp_path: Path) -> None:
+    template_engine = MiniJinjaTemplateEngine(engine_instance=Environment())
+
+    good_template = template_engine.render_string("template as a string")
+    assert good_template == "template as a string"
+
+    with pytest.raises(TemplateNotFoundException):
+        template_engine.render_string(None)  # type: ignore[arg-type]
+
+
 def test_from_environment() -> None:
     engine = Environment()
     template_engine = MiniJinjaTemplateEngine.from_environment(engine)

--- a/tests/unit/test_template/test_template.py
+++ b/tests/unit/test_template/test_template.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Type, Union
@@ -32,8 +34,9 @@ def test_handler_raise_for_no_template_engine() -> None:
 def test_engine_passed_to_callback(tmp_path: "Path") -> None:
     received_engine: Optional[JinjaTemplateEngine] = None
 
-    def callback(engine: JinjaTemplateEngine) -> None:
+    def callback(engine: TemplateEngineProtocol) -> None:
         nonlocal received_engine
+        assert isinstance(engine, JinjaTemplateEngine), "Engine must be a JinjaTemplateEngine"
         received_engine = engine
 
     app = Litestar(

--- a/tests/unit/test_template/test_template.py
+++ b/tests/unit/test_template/test_template.py
@@ -151,7 +151,7 @@ test_cases = [
 
 
 @pytest.mark.parametrize("engine", (JinjaTemplateEngine, MakoTemplateEngine, MiniJinjaTemplateEngine))
-@pytest.mark.parametrize("test_case", test_cases, ids=[case["name"] for case in test_cases])
+@pytest.mark.parametrize("test_case", test_cases, ids=[case["name"] for case in test_cases])  # type: ignore[index]
 def test_template_scenarios(tmp_path: Path, engine: TemplateEngineProtocol, test_case: dict) -> None:
     if test_case["template_name"]:
         template_loc = tmp_path / test_case["template_name"]

--- a/tests/unit/test_template/test_template.py
+++ b/tests/unit/test_template/test_template.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Type, Union
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -31,8 +31,8 @@ def test_handler_raise_for_no_template_engine() -> None:
         assert response.json() == {"detail": "Internal Server Error", "status_code": 500}
 
 
-def test_engine_passed_to_callback(tmp_path: "Path") -> None:
-    received_engine: Optional[JinjaTemplateEngine] = None
+def test_engine_passed_to_callback(tmp_path: Path) -> None:
+    received_engine: JinjaTemplateEngine | None = None
 
     def callback(engine: TemplateEngineProtocol) -> None:
         nonlocal received_engine
@@ -53,7 +53,7 @@ def test_engine_passed_to_callback(tmp_path: "Path") -> None:
 
 
 @pytest.mark.parametrize("engine", (JinjaTemplateEngine, MakoTemplateEngine, MiniJinjaTemplateEngine))
-def test_engine_instance(engine: Type["TemplateEngineProtocol"], tmp_path: "Path") -> None:
+def test_engine_instance(engine: type[TemplateEngineProtocol], tmp_path: Path) -> None:
     engine_instance = engine(directory=tmp_path, engine_instance=None)
     if isinstance(engine_instance, JinjaTemplateEngine):
         assert engine_instance.engine.autoescape is True
@@ -66,19 +66,19 @@ def test_engine_instance(engine: Type["TemplateEngineProtocol"], tmp_path: "Path
 
 
 @pytest.mark.parametrize("engine", (JinjaTemplateEngine, MakoTemplateEngine, MiniJinjaTemplateEngine))
-def test_directory_validation(engine: Type["TemplateEngineProtocol"], tmp_path: "Path") -> None:
+def test_directory_validation(engine: type[TemplateEngineProtocol], tmp_path: Path) -> None:
     with pytest.raises(ImproperlyConfiguredException):
         TemplateConfig(engine=engine)
 
 
 @pytest.mark.parametrize("engine", (JinjaTemplateEngine, MakoTemplateEngine, MiniJinjaTemplateEngine))
-def test_instance_and_directory_validation(engine: Type["TemplateEngineProtocol"], tmp_path: "Path") -> None:
+def test_instance_and_directory_validation(engine: type[TemplateEngineProtocol], tmp_path: Path) -> None:
     with pytest.raises(ImproperlyConfiguredException):
         TemplateConfig(engine=engine, instance=engine(directory=tmp_path, engine_instance=None))
 
 
 @pytest.mark.parametrize("media_type", [MediaType.HTML, MediaType.TEXT, "text/arbitrary"])
-def test_media_type(media_type: Union[MediaType, str], tmp_path: Path) -> None:
+def test_media_type(media_type: MediaType | str, tmp_path: Path) -> None:
     (tmp_path / "hello.tpl").write_text("hello")
 
     @get("/", media_type=media_type)
@@ -129,7 +129,7 @@ def test_media_type_inferred(extension: str, expected_type: MediaType, tmp_path:
 def test_before_request_handler_content_type(tmp_path: Path) -> None:
     template_loc = tmp_path / "about.html"
 
-    def before_request_handler(_: "Request") -> None:
+    def before_request_handler(_: Request) -> None:
         template_loc.write_text("before request")
 
     @get("/", before_request=before_request_handler)


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [x] New code has 100% test coverage
- [x] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [x] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- Adds a method to render HTML templates from strings

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- Closes #2687 
