### PR TITLE
refactor: ws receive disconnect exc type

### DIFF
--- a/litestar/connection/websocket.py
+++ b/litestar/connection/websocket.py
@@ -11,7 +11,7 @@ from litestar.connection.base import (
     empty_send,
 )
 from litestar.datastructures.headers import Headers
-from litestar.exceptions import WebSocketDisconnect, WebSocketException
+from litestar.exceptions import WebSocketDisconnect
 from litestar.serialization import decode_json, decode_msgpack, default_serializer, encode_json, encode_msgpack
 from litestar.status_codes import WS_1000_NORMAL_CLOSURE
 
@@ -72,7 +72,7 @@ class WebSocket(Generic[UserT, AuthT, StateT], ASGIConnection["WebsocketRouteHan
 
         async def wrapped_receive() -> ReceiveMessage:
             if self.connection_state == "disconnect":
-                raise WebSocketException(detail=DISCONNECT_MESSAGE)
+                raise WebSocketDisconnect(detail=DISCONNECT_MESSAGE)
             message = await receive()
             if message["type"] == "websocket.connect":
                 self.connection_state = "connect"
@@ -167,8 +167,6 @@ class WebSocket(Generic[UserT, AuthT, StateT], ASGIConnection["WebsocketRouteHan
         event = cast("WebSocketReceiveEvent | WebSocketDisconnectEvent", await self.receive())
         if event["type"] == "websocket.disconnect":
             raise WebSocketDisconnect(detail="disconnect event", code=event["code"])
-        if self.connection_state == "disconnect":
-            raise WebSocketDisconnect(detail=DISCONNECT_MESSAGE)  # pragma: no cover
         return event.get("text") or "" if mode == "text" else event.get("bytes") or b""
 
     @overload


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

Modifies `WebSocket.wrapped_receive()` to raise `WebSocketDisconnect` instead of `WebSocketException` where `receive()` is called after a disconnect message has already been received.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
