### PR TITLE
refactor: improve _unwrap_implicit_optional_hints impl

### DIFF
--- a/tests/unit/test_utils/test_signature.py
+++ b/tests/unit/test_utils/test_signature.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import sys
 from inspect import Parameter
 from typing import Any, List, Optional, TypeVar, Union
 
@@ -68,6 +69,7 @@ def test_get_fn_type_hints_with_none_default() -> None:
         f: Union[str, None] = None,
         g: Union[str, int, None] = None,
         h: Optional[Union[str, int]] = None,
+        i: Union[str, int] = None,  # type: ignore[assignment]  # noqa: RUF013  # linters don't like, but we support it
     ) -> None:
         ...
 
@@ -81,6 +83,7 @@ def test_get_fn_type_hints_with_none_default() -> None:
         "f": Union[str, NoneType],
         "g": Union[str, int, NoneType],
         "h": Union[str, int, NoneType],
+        "i": Union[str, int, NoneType] if sys.version_info < (3, 11) else Union[str, int],
         "return": NoneType,
     }
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

This PR changes the implementation `_unwrap_implicit_optional_hints()` so that it will flatten or remove any outer optional union, if an inner annotated union exists.

E.g., `Union[Annotated[Union[str, int], ...], NoneType]` becomes `Annotated[Union[str, int, Nonetype], ...]`.

Also, the case where a non-union annotated annotation is wrapped in an optional union, we move the outer union into the annotated type. e.g., the following func def:

```py
def fn(a: Annotated[int, ...] = None) -> ...
```
Will be parsed as `Union[Annotated[int, ...], NoneType]` by `get_type_hints()` prior to py 3.11. We convert it to `Annotated[Union[int, NoneType], ...]`.

Refactors the test suite to test that for any given annotation, after processing, the type argument to annotated is the same as the type that would be returned from `get_fn_type_hints()` if the annotation was not annotated.

See https://github.com/litestar-org/litestar/pull/2516 for context on why `_unwrap_implicit_optional_hints()` exists in the first place.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
