### PR TITLE
fix(pydantic): Support URL types in OpenAPI and serialization

### DIFF
--- a/litestar/contrib/pydantic/pydantic_init_plugin.py
+++ b/litestar/contrib/pydantic/pydantic_init_plugin.py
@@ -155,6 +155,7 @@ class PydanticInitPlugin(InitPluginProtocol):
             pydantic_v1.color.Color: str,
             pydantic_v1.ConstrainedBytes: lambda val: val.decode("utf-8"),
             pydantic_v1.ConstrainedDate: lambda val: val.isoformat(),
+            pydantic_v1.AnyUrl: str,
         }
 
     @staticmethod
@@ -163,6 +164,7 @@ class PydanticInitPlugin(InitPluginProtocol):
             pydantic_v2.BaseModel: lambda model: model.model_dump(mode="json", by_alias=prefer_alias),
             pydantic_v2.types.SecretStr: lambda val: "**********" if val else "",
             pydantic_v2.types.SecretBytes: lambda val: "**********" if val else "",
+            pydantic_v2.AnyUrl: str,
         }
 
         with suppress(ImportError):

--- a/litestar/contrib/pydantic/pydantic_schema_plugin.py
+++ b/litestar/contrib/pydantic/pydantic_schema_plugin.py
@@ -188,6 +188,7 @@ if pydantic_v2 is not None:  # pragma: no cover
             pydantic_v2.NameEmail: Schema(
                 type=OpenAPIType.STRING, format=OpenAPIFormat.EMAIL, description="Name and email"
             ),
+            pydantic_v2.AnyUrl: Schema(type=OpenAPIType.STRING, format=OpenAPIFormat.URL),
         }
     )
 

--- a/tests/unit/test_contrib/test_pydantic/test_openapi.py
+++ b/tests/unit/test_contrib/test_pydantic/test_openapi.py
@@ -613,5 +613,5 @@ class Model(BaseModel):
 def test_create_for_url_v2(field_type: Any) -> None:
     field_definition = FieldDefinition.from_annotation(field_type)
     schema = SchemaCreator(plugins=[PydanticSchemaPlugin()]).for_field_definition(field_definition)
-    assert schema.type == OpenAPIType.STRING
-    assert schema.format == OpenAPIFormat.URL
+    assert schema.type == OpenAPIType.STRING  # type: ignore[union-attr]
+    assert schema.format == OpenAPIFormat.URL  # type: ignore[union-attr]

--- a/tests/unit/test_contrib/test_pydantic/test_openapi.py
+++ b/tests/unit/test_contrib/test_pydantic/test_openapi.py
@@ -607,3 +607,11 @@ class Model(BaseModel):
     assert "list_default" in schema.properties
     assert "list_default_in_field" in schema.properties
     assert "list_default_in_factory" in schema.properties
+
+
+@pytest.mark.parametrize("field_type", [pydantic_v2.AnyUrl, pydantic_v2.AnyHttpUrl, pydantic_v2.HttpUrl])
+def test_create_for_url_v2(field_type: Any) -> None:
+    field_definition = FieldDefinition.from_annotation(field_type)
+    schema = SchemaCreator(plugins=[PydanticSchemaPlugin()]).for_field_definition(field_definition)
+    assert schema.type == OpenAPIType.STRING
+    assert schema.format == OpenAPIFormat.URL

--- a/tests/unit/test_contrib/test_pydantic/test_plugin_serialization.py
+++ b/tests/unit/test_contrib/test_pydantic/test_plugin_serialization.py
@@ -151,8 +151,8 @@ def model(pydantic_version: PydanticVersion) -> ModelV1 | ModelV2:
             confrozenset=frozenset([1]),
             conint=1,
             conlist=[1],
-            url="some://example.org/",
-            http_url="http://example.org/",
+            url="some://example.org/",  # type: ignore[arg-type]
+            http_url="http://example.org/",  # type: ignore[arg-type]
         )
     return ModelV2(
         path=Path("example"),
@@ -172,8 +172,8 @@ def model(pydantic_version: PydanticVersion) -> ModelV1 | ModelV2:
         confrozenset=frozenset([1]),
         conint=1,
         conlist=[1],
-        url="some://example.org/",
-        http_url="http://example.org/",
+        url="some://example.org/",  # type: ignore[arg-type]
+        http_url="http://example.org/",  # type: ignore[arg-type]
     )
 
 

--- a/tests/unit/test_contrib/test_pydantic/test_plugin_serialization.py
+++ b/tests/unit/test_contrib/test_pydantic/test_plugin_serialization.py
@@ -90,6 +90,9 @@ class ModelV1(pydantic_v1.BaseModel):
 
     conint: pydantic_v1.conint(ge=0)  # type: ignore[valid-type]
 
+    url: pydantic_v1.AnyUrl
+    http_url: pydantic_v1.HttpUrl
+
 
 class ModelV2(pydantic_v2.BaseModel):
     model_config = {"arbitrary_types_allowed": True}
@@ -114,6 +117,9 @@ class ModelV2(pydantic_v2.BaseModel):
     confloat: pydantic_v2.confloat(ge=0)  # type: ignore[valid-type]
 
     conint: pydantic_v2.conint(ge=0)  # type: ignore[valid-type]
+
+    url: pydantic_v2.AnyUrl
+    http_url: pydantic_v2.HttpUrl
 
 
 serializer = partial(default_serializer, type_encoders=PydanticInitPlugin.encoders())
@@ -145,6 +151,8 @@ def model(pydantic_version: PydanticVersion) -> ModelV1 | ModelV2:
             confrozenset=frozenset([1]),
             conint=1,
             conlist=[1],
+            url="some://example.org/",
+            http_url="http://example.org/",
         )
     return ModelV2(
         path=Path("example"),
@@ -164,6 +172,8 @@ def model(pydantic_version: PydanticVersion) -> ModelV1 | ModelV2:
         confrozenset=frozenset([1]),
         conint=1,
         conlist=[1],
+        url="some://example.org/",
+        http_url="http://example.org/",
     )
 
 
@@ -185,6 +195,8 @@ def model(pydantic_version: PydanticVersion) -> ModelV1 | ModelV2:
         ("conset", {1}),
         ("confrozenset", frozenset([1])),
         ("conint", 1),
+        ("url", "some://example.org/"),
+        ("http_url", "http://example.org/"),
     ],
 )
 def test_default_serializer(model: ModelV1 | ModelV2, attribute_name: str, expected: Any) -> None:


### PR DESCRIPTION
### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description

Add missing support for Pydantic's URL types (`AnyUrl` and its descendants) for both serialization and OpenAPI schema generation. These types were only partially supported previously; Serialization support was lacking for v1 and v2, and OpenAPI support was missing for v2.

### Close Issue(s)

- #2664
