### PR TITLE
fix: Explicit grouping for regex in OpenAPI type name normalization

### DIFF
--- a/litestar/_openapi/schema_generation/utils.py
+++ b/litestar/_openapi/schema_generation/utils.py
@@ -100,9 +100,7 @@ def _get_normalized_schema_key(type_annotation_str: str) -> str:
         A normalized version of the input string
     """
     # Use a regular expression to replace non-alphanumeric characters with underscores
-    return TYPE_NAME_NORMALIZATION_TRIM_REGEX.sub(
-        "", TYPE_NAME_NORMALIZATION_SUB_REGEX.sub("_", type_annotation_str)
-    )
+    return TYPE_NAME_NORMALIZATION_TRIM_REGEX.sub("", TYPE_NAME_NORMALIZATION_SUB_REGEX.sub("_", type_annotation_str))
 
 
 def get_formatted_examples(field_definition: FieldDefinition, examples: Sequence[Example]) -> Mapping[str, Example]:

--- a/litestar/_openapi/schema_generation/utils.py
+++ b/litestar/_openapi/schema_generation/utils.py
@@ -85,7 +85,7 @@ def _should_create_literal_schema(field_definition: FieldDefinition) -> bool:
 
 
 TYPE_NAME_NORMALIZATION_SUB_REGEX = re.compile(r"[^a-zA-Z0-9]+")
-TYPE_NAME_NORMALIZATION_TRIM_REGEX = re.compile(r"^(_+class_+|_+)|_+$")
+TYPE_NAME_NORMALIZATION_TRIM_REGEX = re.compile(r"^(_+class_+|_+)|(_+)$")
 
 
 def _get_normalized_schema_key(type_annotation_str: str) -> str:

--- a/litestar/_openapi/schema_generation/utils.py
+++ b/litestar/_openapi/schema_generation/utils.py
@@ -89,17 +89,19 @@ TYPE_NAME_NORMALIZATION_TRIM_REGEX = re.compile(r"^(_+class_+|_+)|(_+)$")
 
 
 def _get_normalized_schema_key(type_annotation_str: str) -> str:
-    """Normalize a type annotation, replacing all non-alphanumeric with underscores. Existing underscores will be left as-is
+    """Normalize a type annotation, replacing all non-alphanumeric with underscores.
+    Existing underscores will be left as-is
 
     Args:
-        type_annotation_str (str): A string representing a type annotation (i.e. 'typing.Dict[str, typing.Any]' or '<class 'model.Foo'>')
+        type_annotation_str: A string representing a type annotation
+            (i.e. 'typing.Dict[str, typing.Any]' or '<class 'model.Foo'>')
 
     Returns:
-        str: A normalized version of the input string
+        A normalized version of the input string
     """
     # Use a regular expression to replace non-alphanumeric characters with underscores
-    return re.sub(
-        TYPE_NAME_NORMALIZATION_TRIM_REGEX, "", re.sub(TYPE_NAME_NORMALIZATION_SUB_REGEX, "_", type_annotation_str)
+    return TYPE_NAME_NORMALIZATION_TRIM_REGEX.sub(
+        "", TYPE_NAME_NORMALIZATION_SUB_REGEX.sub("_", type_annotation_str)
     )
 
 


### PR DESCRIPTION
### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description

#2475 introduced a new regex with a potential for "catastrophic backtracking" ([SonarCloud analysis](https://sonarcloud.io/project/issues?resolved=false&severities=BLOCKER%2CCRITICAL%2CMAJOR%2CMINOR&sinceLeakPeriod=true&types=BUG&id=litestar-org_litestar&open=AYvgiwx-edsUYnEP43pU)). This is fixed by introducing explicit grouping.

