### PR TITLE
chore(minijinja): Refactor error handling for `render_string`

### DIFF
--- a/litestar/contrib/minijinja.py
+++ b/litestar/contrib/minijinja.py
@@ -183,17 +183,8 @@ class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate", StateP
 
         Returns:
             The rendered template as a string.
-
-        Raises:
-            TemplateNotFoundException: if no template is found.
         """
-        try:
-            return self.engine.render_str(template_string, **context)  # type: ignore[no-any-return]
-        except MiniJinjaTemplateNotFound as err:
-            raise TemplateNotFoundException(
-                f"Error rendering template from string: {err}",
-                template_name="template_from_string",
-            ) from err
+        return self.engine.render_str(template_string, **context)  # type: ignore[no-any-return]
 
     @classmethod
     def from_environment(cls, minijinja_environment: Environment) -> MiniJinjaTemplateEngine:

--- a/tests/unit/test_contrib/test_minijinja.py
+++ b/tests/unit/test_contrib/test_minijinja.py
@@ -33,14 +33,11 @@ def test_mini_jinja_template_render_raises_template_not_found(tmp_path: Path) ->
         tmpl.render()
 
 
-def test_mini_jinja_template_render_string_raises_template_not_found(tmp_path: Path) -> None:
+def test_mini_jinja_template_render_string(tmp_path: Path) -> None:
     template_engine = MiniJinjaTemplateEngine(engine_instance=Environment())
 
-    good_template = template_engine.render_string("template as a string", context={})
+    good_template = template_engine.render_string("template as a {{value}}", context={"value": "string"})
     assert good_template == "template as a string"
-
-    with pytest.raises(TypeError):
-        template_engine.render_string(None, context={})  # type: ignore[arg-type]
 
 
 def test_from_environment() -> None:


### PR DESCRIPTION
### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description

Refactor the error handling of `render_string` to not catch `MiniJinjaTemplateNotFound`, which is not raised at that point, and adjust the test for it.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
