### PR TITLE
fix: asgi redirect response in documentation

### DIFF
--- a/docs/usage/middleware/creating-middleware.rst
+++ b/docs/usage/middleware/creating-middleware.rst
@@ -116,7 +116,7 @@ explore another example - redirecting the request to a different url from a midd
                await self.app(scope, receive, send)
 
 As you can see in the above, given some condition (request.session being None) we create a
-:class:`Redirect <litestar.response.ASGIRedirectResponse>` and then await it. Otherwise, we await ``self.app``
+:class:`ASGIRedirectResponse <litestar.response.ASGIRedirectResponse>` and then await it. Otherwise, we await ``self.app``
 
 
 Modifying ASGI Requests and Responses using the MiddlewareProtocol

--- a/docs/usage/middleware/creating-middleware.rst
+++ b/docs/usage/middleware/creating-middleware.rst
@@ -98,7 +98,7 @@ explore another example - redirecting the request to a different url from a midd
 
    from litestar.types import ASGIApp, Receive, Scope, Send
 
-   from litestar.response import Redirect
+   from litestar.response.redirect import ASGIRedirectResponse
    from litestar import Request
    from litestar.middleware.base import MiddlewareProtocol
 
@@ -110,13 +110,13 @@ explore another example - redirecting the request to a different url from a midd
 
        async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
            if Request(scope).session is None:
-               response = Redirect(path="/login")
+               response = ASGIRedirectResponse(path="/login")
                await response(scope, receive, send)
            else:
                await self.app(scope, receive, send)
 
 As you can see in the above, given some condition (request.session being None) we create a
-:class:`Redirect <litestar.response.Redirect>` and then await it. Otherwise, we await ``self.app``
+:class:`Redirect <litestar.response.ASGIRedirectResponse>` and then await it. Otherwise, we await ``self.app``
 
 
 Modifying ASGI Requests and Responses using the MiddlewareProtocol


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
Edited the section on responding with middleware to use `litestar.response.redirect.ASGIRedirectResponse` instead of `litestar.response.redirect.Redirect`

### Close Issue(s)
Closes #2709 
