### PR TITLE
fix: multiple validation error messages

### DIFF
--- a/litestar/_signature/model.py
+++ b/litestar/_signature/model.py
@@ -198,7 +198,7 @@ class SignatureModel(Struct):
             for field_name, exc in cls._collect_errors(deserializer=deserializer, **kwargs):  # type: ignore[assignment]
                 match = ERR_RE.search(str(exc))
                 keys = [field_name, str(match.group(1))] if match else [field_name]
-                message = cls._build_error_message(keys=keys, exc_msg=str(e), connection=connection)
+                message = cls._build_error_message(keys=keys, exc_msg=str(exc), connection=connection)
                 messages.append(message)
             raise cls._create_exception(messages=messages, connection=connection) from e
 

--- a/tests/unit/test_signature/test_validation.py
+++ b/tests/unit/test_signature/test_validation.py
@@ -226,7 +226,7 @@ def test_invalid_input_dataclass() -> None:
         assert data["extra"] == [
             {"message": "Expected `int`, got `str`", "key": "child.val", "source": "body"},
             {"message": "Expected `int`, got `str`", "key": "int_param", "source": "query"},
-            {"message": "Expected `int`, got `str`", "key": "length_param", "source": "query"},
+            {"message": "Expected `str` of length >= 2", "key": "length_param", "source": "query"},
             {"message": "Expected `int`, got `str`", "key": "int_header", "source": "header"},
             {"message": "Expected `int`, got `str`", "key": "int_cookie", "source": "cookie"},
         ]
@@ -271,7 +271,7 @@ def test_invalid_input_typed_dict() -> None:
         assert data["extra"] == [
             {"message": "Expected `int`, got `str`", "key": "child.val", "source": "body"},
             {"message": "Expected `int`, got `str`", "key": "int_param", "source": "query"},
-            {"message": "Expected `int`, got `str`", "key": "length_param", "source": "query"},
+            {"message": "Expected `str` of length >= 2", "key": "length_param", "source": "query"},
             {"message": "Expected `int`, got `str`", "key": "int_header", "source": "header"},
             {"message": "Expected `int`, got `str`", "key": "int_cookie", "source": "cookie"},
         ]

--- a/tests/unit/test_signature/test_validation.py
+++ b/tests/unit/test_signature/test_validation.py
@@ -3,11 +3,12 @@ from typing import List, Optional
 
 import pytest
 from attr import define
-from typing_extensions import TypedDict
+from typing_extensions import Annotated, TypedDict
 
 from litestar import get, post
 from litestar._signature import SignatureModel
 from litestar.di import Provide
+from litestar.enums import ParamType
 from litestar.exceptions import ImproperlyConfiguredException, ValidationException
 from litestar.params import Dependency, Parameter
 from litestar.status_codes import HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
@@ -274,3 +275,23 @@ def test_invalid_input_typed_dict() -> None:
             {"message": "Expected `int`, got `str`", "key": "int_header", "source": "header"},
             {"message": "Expected `int`, got `str`", "key": "int_cookie", "source": "cookie"},
         ]
+
+
+def test_parse_values_from_connection_kwargs_with_multiple_errors() -> None:
+    def fn(a: Annotated[int, Parameter(gt=5)], b: Annotated[int, Parameter(lt=5)]) -> None:
+        pass
+
+    model = SignatureModel.create(
+        dependency_name_set=set(),
+        fn=fn,
+        data_dto=None,
+        parsed_signature=ParsedSignature.from_fn(fn, {}),
+        type_decoders=[],
+    )
+    with pytest.raises(ValidationException) as exc:
+        model.parse_values_from_connection_kwargs(connection=RequestFactory().get(), a=0, b=9)
+
+    assert exc.value.extra == [
+        {"message": "Expected `int` >= 6", "key": "a", "source": ParamType.QUERY},
+        {"message": "Expected `int` <= 4", "key": "b", "source": ParamType.QUERY},
+    ]


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

This PR corrects an issue where multiple validation errors would receive the same error message in the validation error's "extra" detail.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

Closes #2714
