### PR TITLE
refactor: OpenAPI type name trimming regex

### DIFF
--- a/litestar/_openapi/schema_generation/utils.py
+++ b/litestar/_openapi/schema_generation/utils.py
@@ -85,7 +85,7 @@ def _should_create_literal_schema(field_definition: FieldDefinition) -> bool:
 
 
 TYPE_NAME_NORMALIZATION_SUB_REGEX = re.compile(r"[^a-zA-Z0-9]+")
-TYPE_NAME_NORMALIZATION_TRIM_REGEX = re.compile(r"^(_+class_+|_+)|(_+)$")
+TYPE_NAME_NORMALIZATION_TRIM_REGEX = re.compile(r"^_+(class_+)?|_+$")
 
 
 def _get_normalized_schema_key(type_annotation_str: str) -> str:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

This regex is used to remove superfluous chars from the start and end of the schema keys that we generate for openapi.

Sonar reports two issues to do with the original implementation:

1. a reliability issue to do with operator precedence
2. a security issue to do with backtracking

This PR refactors the regex so that it has less parts and less scope for backtracking.

A follow up to #2706 

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
