### PR TITLE
refactor: a new empty sentinel

### DIFF
--- a/litestar/_kwargs/extractors.py
+++ b/litestar/_kwargs/extractors.py
@@ -15,7 +15,7 @@ from litestar.datastructures.upload_file import UploadFile
 from litestar.enums import ParamType, RequestEncodingType
 from litestar.exceptions import ValidationException
 from litestar.params import BodyKwarg
-from litestar.types import Empty
+from litestar.types.empty import _EMPTY
 from litestar.utils.scope import set_litestar_scope_state
 
 if TYPE_CHECKING:
@@ -149,12 +149,12 @@ def parse_connection_query_params(connection: ASGIConnection, kwargs_model: Kwar
     """
     parsed_query = (
         connection._parsed_query
-        if connection._parsed_query is not Empty
+        if connection._parsed_query is not _EMPTY
         else parse_query_string(connection.scope.get("query_string", b""))
     )
     set_litestar_scope_state(connection.scope, SCOPE_STATE_PARSED_QUERY_KEY, parsed_query)
     return create_query_default_dict(
-        parsed_query=parsed_query,  # type: ignore[arg-type]
+        parsed_query=parsed_query,
         sequence_query_parameter_names=kwargs_model.sequence_query_parameter_names,
     )
 

--- a/litestar/datastructures/url.py
+++ b/litestar/datastructures/url.py
@@ -7,11 +7,13 @@ from urllib.parse import SplitResult, urlencode, urlsplit, urlunsplit
 from litestar._parsers import parse_query_string
 from litestar.datastructures import MultiDict
 from litestar.types import Empty
+from litestar.types.empty import _EMPTY
 
 if TYPE_CHECKING:
     from typing_extensions import Self
 
     from litestar.types import EmptyType, Scope
+    from litestar.types.empty import _LiteralEmpty
 
 __all__ = ("Address", "URL")
 
@@ -60,7 +62,7 @@ class URL:
         "username",
     )
 
-    _query_params: EmptyType | MultiDict
+    _query_params: _LiteralEmpty | MultiDict
     _parsed_url: str | None
 
     scheme: str
@@ -111,7 +113,7 @@ class URL:
         instance.password = result.password
         instance.port = result.port
         instance.hostname = result.hostname
-        instance._query_params = Empty
+        instance._query_params = _EMPTY
 
         return instance
 
@@ -245,9 +247,9 @@ class URL:
                 If you want to modify query parameters, make  modifications in the
                 multidict and pass them back to :meth:`with_replacements`
         """
-        if self._query_params is Empty:
+        if self._query_params is _EMPTY:
             self._query_params = MultiDict(parse_query_string(query_string=self.query.encode()))
-        return cast("MultiDict", self._query_params)
+        return self._query_params
 
     def __str__(self) -> str:
         return self._url

--- a/litestar/types/empty.py
+++ b/litestar/types/empty.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-__all__ = ("Empty", "EmptyType")
+__all__ = ("_EMPTY", "_LiteralEmpty", "Empty", "EmptyType")
 
-from typing import TYPE_CHECKING, Type, final
+from enum import Enum
+from typing import TYPE_CHECKING, Literal, Type, final
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
@@ -14,3 +15,13 @@ class Empty:
 
 
 EmptyType: TypeAlias = Type[Empty]
+
+
+class _EmptyEnum(Enum):
+    """A sentinel enum used as placeholder."""
+
+    EMPTY = 0
+
+
+_LiteralEmpty = Literal[_EmptyEnum.EMPTY]
+_EMPTY = _EmptyEnum.EMPTY


### PR DESCRIPTION
WIP

The current `Empty` and `EmptyType` sentinel values and type are unable to be appropriately narrowed away, resulting in a lot of calls to `cast()`, particularly when accessing cached attributes on our core types.

This PR introduces a new empty sentinel, the adoption of which will allow us to properly narrow down from unions with itself.

This first stage implements the sentinels for our internal attribute caching only, and on transition to 3.0, `Empty` would alias `_EMPTY` and `EmptyType` would alias ``_LiteralEmpty`, so there shouldn't much downstream disruption.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

-

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
