### PR TITLE
fix: app `template_config` parameter type

### DIFF
--- a/litestar/app.py
+++ b/litestar/app.py
@@ -47,7 +47,7 @@ from litestar.routes import ASGIRoute, HTTPRoute, WebSocketRoute
 from litestar.static_files.base import StaticFiles
 from litestar.stores.registry import StoreRegistry
 from litestar.types import Empty, TypeDecodersSequence
-from litestar.types.internal_types import PathParameterDefinition
+from litestar.types.internal_types import PathParameterDefinition, TemplateConfigType
 from litestar.utils import deprecated, ensure_async_callable, join_paths, unique
 from litestar.utils.dataclass import extract_dataclass_items
 from litestar.utils.predicates import is_async_callable
@@ -68,8 +68,6 @@ if TYPE_CHECKING:
     from litestar.openapi.spec.open_api import OpenAPI
     from litestar.static_files.config import StaticFilesConfig
     from litestar.stores.base import Store
-    from litestar.template import TemplateEngineProtocol
-    from litestar.template.config import TemplateConfig
     from litestar.types import (
         AfterExceptionHookHandler,
         AfterRequestHookHandler,
@@ -217,7 +215,7 @@ class Litestar(Router):
         static_files_config: Sequence[StaticFilesConfig] | None = None,
         stores: StoreRegistry | dict[str, Store] | None = None,
         tags: Sequence[str] | None = None,
-        template_config: TemplateConfig[TemplateEngineProtocol] | None = None,
+        template_config: TemplateConfigType | None = None,
         type_encoders: TypeEncodersMap | None = None,
         type_decoders: TypeDecodersSequence | None = None,
         websocket_class: type[WebSocket] | None = None,

--- a/litestar/config/app.py
+++ b/litestar/config/app.py
@@ -30,8 +30,6 @@ if TYPE_CHECKING:
     from litestar.static_files.config import StaticFilesConfig
     from litestar.stores.base import Store
     from litestar.stores.registry import StoreRegistry
-    from litestar.template import TemplateEngineProtocol
-    from litestar.template.config import TemplateConfig
     from litestar.types import (
         AfterExceptionHookHandler,
         AfterRequestHookHandler,
@@ -51,6 +49,7 @@ if TYPE_CHECKING:
     from litestar.types.callable_types import LifespanHook
     from litestar.types.composite_types import TypeDecodersSequence
     from litestar.types.empty import EmptyType
+    from litestar.types.internal_types import TemplateConfigType
 
 
 __all__ = (
@@ -197,7 +196,7 @@ class AppConfig:
     """
     tags: list[str] = field(default_factory=list)
     """A list of string tags that will be appended to the schema of all route handlers under the application."""
-    template_config: TemplateConfig[TemplateEngineProtocol] | None = field(default=None)
+    template_config: TemplateConfigType | None = field(default=None)
     """An instance of :class:`TemplateConfig <.template.TemplateConfig>`."""
     type_encoders: TypeEncodersMap | None = field(default=None)
     """A mapping of types to callables that transform them into types supported for serialization."""

--- a/litestar/template/config.py
+++ b/litestar/template/config.py
@@ -13,24 +13,24 @@ __all__ = ("TemplateConfig",)
 if TYPE_CHECKING:
     from litestar.types import PathType
 
-T = TypeVar("T", bound=TemplateEngineProtocol)
+EngineType = TypeVar("EngineType", bound=TemplateEngineProtocol)
 
 
 @dataclass
-class TemplateConfig(Generic[T]):
+class TemplateConfig(Generic[EngineType]):
     """Configuration for Templating.
 
     To enable templating, pass an instance of this class to the :class:`Litestar <litestar.app.Litestar>` constructor using the
     'template_config' key.
     """
 
-    engine: type[T] | T | None = field(default=None)
+    engine: type[EngineType] | EngineType | None = field(default=None)
     """A template engine adhering to the :class:`TemplateEngineProtocol <litestar.template.base.TemplateEngineProtocol>`."""
     directory: PathType | list[PathType] | None = field(default=None)
     """A directory or list of directories from which to serve templates."""
-    engine_callback: Callable[[T], None] | None = field(default=None)
+    engine_callback: Callable[[EngineType], None] | None = field(default=None)
     """A callback function that allows modifying the instantiated templating protocol."""
-    instance: T | None = field(default=None)
+    instance: EngineType | None = field(default=None)
     """An instance of the templating protocol."""
 
     def __post_init__(self) -> None:
@@ -41,16 +41,17 @@ class TemplateConfig(Generic[T]):
         if self.instance is not None and self.directory is not None:
             raise ImproperlyConfiguredException("directory cannot be set if instance is")
 
-    def to_engine(self) -> T:
+    def to_engine(self) -> EngineType:
         """Instantiate the template engine."""
         template_engine = cast(
-            "T", self.engine(directory=self.directory, engine_instance=None) if isclass(self.engine) else self.engine
+            "EngineType",
+            self.engine(directory=self.directory, engine_instance=None) if isclass(self.engine) else self.engine,
         )
         if callable(self.engine_callback):
             self.engine_callback(template_engine)
         return template_engine
 
     @cached_property
-    def engine_instance(self) -> T:
+    def engine_instance(self) -> EngineType:
         """Return the template engine instance."""
         return self.to_engine() if self.instance is None else self.instance

--- a/litestar/types/internal_types.py
+++ b/litestar/types/internal_types.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
     from litestar.handlers.websocket_handlers import WebsocketRouteHandler
     from litestar.response import Response
     from litestar.router import Router
+    from litestar.template import TemplateConfig
+    from litestar.template.config import EngineType
     from litestar.types import Method
 
 ReservedKwargs: TypeAlias = Literal["request", "socket", "headers", "query", "cookies", "state", "data"]
@@ -31,6 +33,7 @@ RouteHandlerType: TypeAlias = "HTTPRouteHandler | WebsocketRouteHandler | ASGIRo
 ResponseType: TypeAlias = "type[Response]"
 ControllerRouterHandler: TypeAlias = "type[Controller] | RouteHandlerType | Router | Callable[..., Any]"
 RouteHandlerMapItem: TypeAlias = 'dict[Method | Literal["websocket", "asgi"], RouteHandlerType]'
+TemplateConfigType: TypeAlias = "TemplateConfig[EngineType]"
 
 # deprecated
 _LitestarType: TypeAlias = "Litestar"


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

Currently, this code:

```py
template_config = TemplateConfig(instance=JinjaTemplateEngine())

app = Litestar(route_handlers=[], template_config=template_config)
```

Reports:

```
app.py:10: error: Argument "template_config" to "Litestar" has incompatible type "TemplateConfig[JinjaTemplateEngine]"; expected "Optional[TemplateConfig[TemplateEngineProtocol[Any, Any]]]"  [arg-type]
```

This PR modifies the annotation to use a bound generic instead of directly typing the template engine type as `TemplateEngineProtocol`.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
