### PR TITLE
feat: set app env on startup

### DIFF
--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -120,9 +120,7 @@ class LitestarEnv:
             import dotenv
 
             dotenv.load_dotenv()
-        app_path = app_path or getenv("LITESTAR_APP")
-        if app_path and getenv("LITESTAR_APP") is None:
-            os.environ["LITESTAR_APP"] = app_path
+        app_path = os.environ["LITESTAR_APP"] = app_path or getenv("LITESTAR_APP")
         if app_path:
             console.print(f"Using Litestar app from env: [bright_blue]{app_path!r}")
             loaded_app = _load_app_from_path(app_path)

--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -120,7 +120,7 @@ class LitestarEnv:
             import dotenv
 
             dotenv.load_dotenv()
-        app_path = os.environ["LITESTAR_APP"] = app_path or getenv("LITESTAR_APP")
+        app_path = os.environ["LITESTAR_APP"] = cast("str", app_path or getenv("LITESTAR_APP"))
         if app_path:
             console.print(f"Using Litestar app from env: [bright_blue]{app_path!r}")
             loaded_app = _load_app_from_path(app_path)

--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import importlib
 import inspect
+import os
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -120,6 +121,8 @@ class LitestarEnv:
 
             dotenv.load_dotenv()
         app_path = app_path or getenv("LITESTAR_APP")
+        if app_path and getenv("LITESTAR_APP") is None:
+            os.environ["LITESTAR_APP"] = app_path
         if app_path:
             console.print(f"Using Litestar app from env: [bright_blue]{app_path!r}")
             loaded_app = _load_app_from_path(app_path)
@@ -345,11 +348,13 @@ def _autodiscover_app(cwd: Path) -> LoadedApp:
         ):
             if isinstance(value, Litestar):
                 app_string = f"{import_path}:{attr}"
+                os.environ["LITESTAR_APP"] = app_string
                 console.print(f"Using Litestar app from [bright_blue]{app_string}")
                 return LoadedApp(app=value, app_path=app_string, is_factory=False)
 
         if hasattr(module, "create_app"):
             app_string = f"{import_path}:create_app"
+            os.environ["LITESTAR_APP"] = app_string
             console.print(f"Using Litestar factory [bright_blue]{app_string}")
             return LoadedApp(app=module.create_app(), app_path=app_string, is_factory=True)
 
@@ -363,6 +368,7 @@ def _autodiscover_app(cwd: Path) -> LoadedApp:
                 continue
             if return_annotation in ("Litestar", Litestar):
                 app_string = f"{import_path}:{attr}"
+                os.environ["LITESTAR_APP"] = app_string
                 console.print(f"Using Litestar factory [bright_blue]{app_string}")
                 return LoadedApp(app=value(), app_path=f"{app_string}", is_factory=True)
 

--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -120,7 +120,9 @@ class LitestarEnv:
             import dotenv
 
             dotenv.load_dotenv()
-        app_path = os.environ["LITESTAR_APP"] = cast("str", app_path or getenv("LITESTAR_APP"))
+        app_path = app_path or getenv("LITESTAR_APP")
+        if app_path and getenv("LITESTAR_APP") is None:
+            os.environ["LITESTAR_APP"] = app_path
         if app_path:
             console.print(f"Using Litestar app from env: [bright_blue]{app_path!r}")
             loaded_app = _load_app_from_path(app_path)

--- a/tests/unit/test_cli/conftest.py
+++ b/tests/unit/test_cli/conftest.py
@@ -28,6 +28,11 @@ if TYPE_CHECKING:
     from litestar.cli._utils import LitestarGroup
 
 
+@pytest.fixture(autouse=True)
+def reset_litestar_app_env(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.delenv("LITESTAR_APP", raising=False)
+
+
 @pytest.fixture()
 def root_command() -> LitestarGroup:
     import litestar.cli.main

--- a/tests/unit/test_cli/test_core_commands.py
+++ b/tests/unit/test_cli/test_core_commands.py
@@ -67,7 +67,7 @@ def test_run_command(
     mock_subprocess_run: MagicMock,
     mock_uvicorn_run: MagicMock,
     tmp_project_dir: Path,
-) -> None:
+) -> None:  # sourcery skip: low-code-quality
     args = []
     if custom_app_file:
         args.extend(["--app", f"{custom_app_file.stem}:app"])


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- This PR allows for registered CLI plugins to be visible in the `help` menus of the click commands.  Without it, you must set the `app` and `app-dir` setting on the command before the extra CLI commands are visible.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
