### PR TITLE
feat: stronger typing for scope state utils.

### DIFF
--- a/litestar/connection/base.py
+++ b/litestar/connection/base.py
@@ -122,7 +122,7 @@ class ASGIConnection(Generic[HandlerT, UserT, AuthT, StateT]):
         """
         if self._url is Empty:
             if url := get_litestar_scope_state(self.scope, SCOPE_STATE_URL_KEY):
-                self._url = cast("URL", url)
+                self._url = url
             else:
                 self._url = URL.from_scope(self.scope)
                 set_litestar_scope_state(self.scope, SCOPE_STATE_URL_KEY, self._url)
@@ -139,7 +139,7 @@ class ASGIConnection(Generic[HandlerT, UserT, AuthT, StateT]):
         """
         if self._base_url is Empty:
             if base_url := get_litestar_scope_state(self.scope, SCOPE_STATE_BASE_URL_KEY):
-                self._base_url = cast("URL", base_url)
+                self._base_url = base_url
             else:
                 scope = cast(
                     "Scope",
@@ -172,7 +172,7 @@ class ASGIConnection(Generic[HandlerT, UserT, AuthT, StateT]):
         """
         if self._parsed_query is Empty:
             if (parsed_query := get_litestar_scope_state(self.scope, SCOPE_STATE_PARSED_QUERY_KEY, Empty)) is not Empty:
-                self._parsed_query = cast("tuple[tuple[str, str], ...]", parsed_query)
+                self._parsed_query = parsed_query
             else:
                 self._parsed_query = parse_query_string(self.scope.get("query_string", b""))
                 set_litestar_scope_state(self.scope, SCOPE_STATE_PARSED_QUERY_KEY, self._parsed_query)
@@ -196,7 +196,7 @@ class ASGIConnection(Generic[HandlerT, UserT, AuthT, StateT]):
         """
         if self._cookies is Empty:
             if (cookies := get_litestar_scope_state(self.scope, SCOPE_STATE_COOKIES_KEY, Empty)) is not Empty:
-                self._cookies = cast("dict[str, str]", cookies)
+                self._cookies = cookies
             else:
                 self._cookies = (
                     parse_cookie_string(cookie_header) if (cookie_header := self.headers.get("cookie")) else {}

--- a/litestar/connection/request.py
+++ b/litestar/connection/request.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Generic, cast
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Generic
 
 from litestar._multipart import parse_content_header, parse_multipart_form
 from litestar._parsers import parse_url_encoded_form_data
@@ -93,7 +93,7 @@ class Request(Generic[UserT, AuthT, StateT], ASGIConnection["HTTPRouteHandler", 
         """
         if self._content_type is Empty:
             if (content_type := get_litestar_scope_state(self.scope, SCOPE_STATE_CONTENT_TYPE_KEY, Empty)) is not Empty:
-                self._content_type = cast("tuple[str, dict[str, str]]", content_type)
+                self._content_type = content_type
             else:
                 self._content_type = parse_content_header(self.headers.get("Content-Type", ""))
                 set_litestar_scope_state(self.scope, SCOPE_STATE_CONTENT_TYPE_KEY, self._content_type)
@@ -108,7 +108,7 @@ class Request(Generic[UserT, AuthT, StateT], ASGIConnection["HTTPRouteHandler", 
         """
         if self._accept is Empty:
             if accept := get_litestar_scope_state(self.scope, SCOPE_STATE_ACCEPT_KEY):
-                self._accept = cast("Accept", accept)
+                self._accept = accept
             else:
                 self._accept = Accept(self.headers.get("Accept", "*/*"))
                 set_litestar_scope_state(self.scope, SCOPE_STATE_ACCEPT_KEY, self._accept)
@@ -185,7 +185,7 @@ class Request(Generic[UserT, AuthT, StateT], ASGIConnection["HTTPRouteHandler", 
         """
         if self._body is Empty:
             if (body := get_litestar_scope_state(self.scope, SCOPE_STATE_BODY_KEY)) is not None:
-                self._body = cast("bytes", body)
+                self._body = body
             else:
                 self._body = b"".join([c async for c in self.stream()])
                 set_litestar_scope_state(self.scope, SCOPE_STATE_BODY_KEY, self._body)
@@ -201,7 +201,7 @@ class Request(Generic[UserT, AuthT, StateT], ASGIConnection["HTTPRouteHandler", 
         """
         if self._form is Empty:
             if (form := get_litestar_scope_state(self.scope, SCOPE_STATE_FORM_KEY, Empty)) is not Empty:
-                self._form = cast("dict[str, str | list[str]]", form)
+                self._form = form
             else:
                 content_type, options = self.content_type
                 if content_type == RequestEncodingType.MULTI_PART:

--- a/litestar/constants.py
+++ b/litestar/constants.py
@@ -6,6 +6,25 @@ from msgspec import UnsetType
 
 from litestar.enums import MediaType
 from litestar.types import Empty
+from litestar.types.scope import (
+    AcceptKey,
+    BaseUrlKey,
+    BodyKey,
+    ContentTypeKey,
+    CookiesKey,
+    CsrfTokenKey,
+    DependencyCacheKey,
+    DoCacheKey,
+    FormKey,
+    HttpResponseBodyKey,
+    HttpResponseStartKey,
+    IsCachedKey,
+    JsonKey,
+    MsgpackKey,
+    ParsedQueryKey,
+    ResponseCompressedKey,
+    UrlKey,
+)
 
 DEFAULT_ALLOWED_CORS_HEADERS: Final = {"Accept", "Accept-Language", "Content-Language", "Content-Type"}
 DEFAULT_CHUNK_SIZE: Final = 1024 * 128  # 128KB
@@ -25,18 +44,20 @@ WEBSOCKET_DISCONNECT: Final = "websocket.disconnect"
 # keys for internal stuff that we store in the "__litestar__" namespace of the scope state
 SCOPE_STATE_NAMESPACE: Final = "__litestar__"
 
-SCOPE_STATE_ACCEPT_KEY: Final = "accept"
-SCOPE_STATE_BASE_URL_KEY: Final = "base_url"
-SCOPE_STATE_BODY_KEY: Final = "body"
-SCOPE_STATE_CONTENT_TYPE_KEY: Final = "content_type"
-SCOPE_STATE_COOKIES_KEY: Final = "cookies"
-SCOPE_STATE_CSRF_TOKEN_KEY: Final = "csrf_token"  # possible hardcoded password
-SCOPE_STATE_DEPENDENCY_CACHE: Final = "dependency_cache"
-SCOPE_STATE_DO_CACHE: Final = "do_cache"
-SCOPE_STATE_FORM_KEY: Final = "form"
-SCOPE_STATE_IS_CACHED: Final = "is_cached"
-SCOPE_STATE_JSON_KEY: Final = "json"
-SCOPE_STATE_MSGPACK_KEY: Final = "msgpack"
-SCOPE_STATE_PARSED_QUERY_KEY: Final = "parsed_query"
-SCOPE_STATE_RESPONSE_COMPRESSED: Final = "response_compressed"
-SCOPE_STATE_URL_KEY: Final = "url"
+SCOPE_STATE_ACCEPT_KEY: AcceptKey = "accept"
+SCOPE_STATE_BASE_URL_KEY: BaseUrlKey = "base_url"
+SCOPE_STATE_BODY_KEY: BodyKey = "body"
+SCOPE_STATE_CONTENT_TYPE_KEY: ContentTypeKey = "content_type"
+SCOPE_STATE_COOKIES_KEY: CookiesKey = "cookies"
+SCOPE_STATE_CSRF_TOKEN_KEY: CsrfTokenKey = "csrf_token"  # possible hardcoded password
+SCOPE_STATE_DEPENDENCY_CACHE: DependencyCacheKey = "dependency_cache"
+SCOPE_STATE_DO_CACHE: DoCacheKey = "do_cache"
+SCOPE_STATE_FORM_KEY: FormKey = "form"
+SCOPE_STATE_HTTP_RESPONSE_BODY_KEY: HttpResponseBodyKey = "http_response_body"
+SCOPE_STATE_HTTP_RESPONSE_START_KEY: HttpResponseStartKey = "http_response_start"
+SCOPE_STATE_IS_CACHED: IsCachedKey = "is_cached"
+SCOPE_STATE_JSON_KEY: JsonKey = "json"
+SCOPE_STATE_MSGPACK_KEY: MsgpackKey = "msgpack"
+SCOPE_STATE_PARSED_QUERY_KEY: ParsedQueryKey = "parsed_query"
+SCOPE_STATE_RESPONSE_COMPRESSED: ResponseCompressedKey = "response_compressed"
+SCOPE_STATE_URL_KEY: UrlKey = "url"

--- a/litestar/middleware/csrf.py
+++ b/litestar/middleware/csrf.py
@@ -121,7 +121,7 @@ class CSRFMiddleware(MiddlewareProtocol):
             set_litestar_scope_state(scope=scope, key=SCOPE_STATE_CSRF_TOKEN_KEY, value=token)
             await self.app(scope, receive, self.create_send_wrapper(send=send, csrf_cookie=csrf_cookie, token=token))
         elif self._csrf_tokens_match(existing_csrf_token, csrf_cookie):
-            set_litestar_scope_state(scope=scope, key=SCOPE_STATE_CSRF_TOKEN_KEY, value=existing_csrf_token)
+            set_litestar_scope_state(scope=scope, key=SCOPE_STATE_CSRF_TOKEN_KEY, value=existing_csrf_token or "")
             await self.app(scope, receive, send)
         else:
             raise PermissionDeniedException("CSRF token verification failed")

--- a/litestar/types/scope.py
+++ b/litestar/types/scope.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Literal
+
+AcceptKey = Literal["accept"]
+BaseUrlKey = Literal["base_url"]
+BodyKey = Literal["body"]
+ContentTypeKey = Literal["content_type"]
+CookiesKey = Literal["cookies"]
+CsrfTokenKey = Literal["csrf_token"]
+DependencyCacheKey = Literal["dependency_cache"]
+DoCacheKey = Literal["do_cache"]
+FormKey = Literal["form"]
+HttpResponseBodyKey = Literal["http_response_body"]
+HttpResponseStartKey = Literal["http_response_start"]
+IsCachedKey = Literal["is_cached"]
+JsonKey = Literal["json"]
+MsgpackKey = Literal["msgpack"]
+ParsedQueryKey = Literal["parsed_query"]
+ResponseCompressedKey = Literal["response_compressed"]
+UrlKey = Literal["url"]
+
+ScopeStateKeyType = Literal[
+    AcceptKey,
+    BaseUrlKey,
+    BodyKey,
+    ContentTypeKey,
+    CookiesKey,
+    CsrfTokenKey,
+    DependencyCacheKey,
+    DoCacheKey,
+    FormKey,
+    HttpResponseBodyKey,
+    HttpResponseStartKey,
+    IsCachedKey,
+    JsonKey,
+    MsgpackKey,
+    ParsedQueryKey,
+    ResponseCompressedKey,
+    UrlKey,
+]

--- a/litestar/utils/scope/__init__.py
+++ b/litestar/utils/scope/__init__.py
@@ -1,17 +1,23 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from litestar.constants import SCOPE_STATE_NAMESPACE
 from litestar.serialization import get_serializer
 
+from .get import get_litestar_scope_state
+from .pop import pop_litestar_scope_state
+from .set import set_litestar_scope_state
+
 if TYPE_CHECKING:
     from litestar.types import Scope, Serializer
+    from litestar.types.scope import ScopeStateKeyType
 
 __all__ = (
     "delete_litestar_scope_state",
     "get_serializer_from_scope",
     "get_litestar_scope_state",
+    "pop_litestar_scope_state",
     "set_litestar_scope_state",
 )
 
@@ -43,34 +49,7 @@ def get_serializer_from_scope(scope: Scope) -> Serializer:
     return get_serializer(type_encoders)
 
 
-def get_litestar_scope_state(scope: Scope, key: str, default: Any = None, pop: bool = False) -> Any:
-    """Get an internal value from connection scope state.
-
-    Args:
-        scope: The connection scope.
-        key: Key to get from internal namespace in scope state.
-        default: Default value to return.
-        pop: Boolean flag dictating whether the value should be deleted from the state.
-
-    Returns:
-        Value mapped to ``key`` in internal connection scope namespace.
-    """
-    namespace = scope["state"].setdefault(SCOPE_STATE_NAMESPACE, {})
-    return namespace.pop(key, default) if pop else namespace.get(key, default)
-
-
-def set_litestar_scope_state(scope: Scope, key: str, value: Any) -> None:
-    """Set an internal value in connection scope state.
-
-    Args:
-        scope: The connection scope.
-        key: Key to set under internal namespace in scope state.
-        value: Value for key.
-    """
-    scope["state"].setdefault(SCOPE_STATE_NAMESPACE, {})[key] = value
-
-
-def delete_litestar_scope_state(scope: Scope, key: str) -> None:
+def delete_litestar_scope_state(scope: Scope, key: ScopeStateKeyType) -> None:
     """Delete an internal value from connection scope state.
 
     Args:

--- a/litestar/utils/scope/get.py
+++ b/litestar/utils/scope/get.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypeVar, overload
+
+from litestar.constants import SCOPE_STATE_NAMESPACE
+
+if TYPE_CHECKING:
+    from litestar.datastructures import URL, Accept
+    from litestar.types import Scope
+    from litestar.types.asgi_types import HTTPResponseBodyEvent, HTTPResponseStartEvent
+    from litestar.types.scope import (
+        AcceptKey,
+        BaseUrlKey,
+        BodyKey,
+        ContentTypeKey,
+        CookiesKey,
+        CsrfTokenKey,
+        DependencyCacheKey,
+        DoCacheKey,
+        FormKey,
+        HttpResponseBodyKey,
+        HttpResponseStartKey,
+        IsCachedKey,
+        JsonKey,
+        MsgpackKey,
+        ParsedQueryKey,
+        ResponseCompressedKey,
+        ScopeStateKeyType,
+        UrlKey,
+    )
+
+__all__ = ("get_litestar_scope_state",)
+
+T = TypeVar("T")
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: AcceptKey) -> Accept | None:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: AcceptKey, default: T) -> Accept | T:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: BaseUrlKey) -> URL | None:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: BaseUrlKey, default: T) -> URL | T:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: BodyKey) -> bytes | None:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: BodyKey, default: T) -> bytes | T:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: ContentTypeKey) -> tuple[str, dict[str, str]] | None:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: ContentTypeKey, default: T) -> tuple[str, dict[str, str]] | T:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: CookiesKey) -> dict[str, str] | None:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: CookiesKey, default: T) -> dict[str, str] | T:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: CsrfTokenKey) -> str | None:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: CsrfTokenKey, default: T) -> str | T:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: DependencyCacheKey) -> dict[str, Any] | None:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: DependencyCacheKey, default: T) -> dict[str, Any] | T:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: DoCacheKey) -> bool | None:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: DoCacheKey, default: T) -> bool | T:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: FormKey) -> dict[str, str | list[str]] | None:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: FormKey, default: T) -> dict[str, str | list[str]] | T:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: HttpResponseBodyKey) -> HTTPResponseBodyEvent | None:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: HttpResponseBodyKey, default: T) -> HTTPResponseBodyEvent | T:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: HttpResponseStartKey) -> HTTPResponseStartEvent | None:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: HttpResponseStartKey, default: T) -> HTTPResponseStartEvent | T:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: IsCachedKey) -> bool | None:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: IsCachedKey, default: T) -> bool | T:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: JsonKey) -> Any | None:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: JsonKey, default: T) -> Any | T:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: MsgpackKey) -> Any | None:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: MsgpackKey, default: T) -> Any | T:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: ParsedQueryKey) -> tuple[tuple[str, str], ...] | None:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: ParsedQueryKey, default: T) -> tuple[tuple[str, str], ...] | T:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: ResponseCompressedKey) -> bool | None:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: ResponseCompressedKey, default: T) -> bool | T:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: UrlKey) -> URL | None:
+    ...
+
+
+@overload
+def get_litestar_scope_state(scope: Scope, key: UrlKey, default: T) -> URL | T:
+    ...
+
+
+def get_litestar_scope_state(scope: Scope, key: ScopeStateKeyType, default: T | None = None) -> Any | T:
+    """Get an internal value from connection scope state.
+
+    Args:
+        scope: The connection scope.
+        key: Key to get from internal namespace in scope state.
+        default: Default value to return.
+
+    Returns:
+        Value mapped to ``key`` in internal connection scope namespace.
+    """
+    namespace = scope["state"].setdefault(SCOPE_STATE_NAMESPACE, {})
+    return namespace.get(key, default)

--- a/litestar/utils/scope/pop.py
+++ b/litestar/utils/scope/pop.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypeVar, overload
+
+from litestar.constants import SCOPE_STATE_NAMESPACE
+from litestar.types.empty import Empty, EmptyType
+
+if TYPE_CHECKING:
+    from litestar.datastructures import URL, Accept
+    from litestar.types import Scope
+    from litestar.types.asgi_types import HTTPResponseBodyEvent, HTTPResponseStartEvent
+    from litestar.types.scope import (
+        AcceptKey,
+        BaseUrlKey,
+        BodyKey,
+        ContentTypeKey,
+        CookiesKey,
+        CsrfTokenKey,
+        DependencyCacheKey,
+        DoCacheKey,
+        FormKey,
+        HttpResponseBodyKey,
+        HttpResponseStartKey,
+        IsCachedKey,
+        JsonKey,
+        MsgpackKey,
+        ParsedQueryKey,
+        ResponseCompressedKey,
+        ScopeStateKeyType,
+        UrlKey,
+    )
+
+__all__ = ("pop_litestar_scope_state",)
+
+T = TypeVar("T")
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: AcceptKey) -> Accept:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: AcceptKey, default: T) -> Accept | T:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: BaseUrlKey) -> URL:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: BaseUrlKey, default: T) -> URL | T:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: BodyKey) -> bytes:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: BodyKey, default: T) -> bytes | T:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: ContentTypeKey) -> tuple[str, dict[str, str]]:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: ContentTypeKey, default: T) -> tuple[str, dict[str, str]] | T:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: CookiesKey) -> dict[str, str]:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: CookiesKey, default: T) -> dict[str, str] | T:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: CsrfTokenKey) -> str:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: CsrfTokenKey, default: T) -> str | T:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: DependencyCacheKey) -> dict[str, Any]:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: DependencyCacheKey, default: T) -> dict[str, Any] | T:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: DoCacheKey) -> bool:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: DoCacheKey, default: T) -> bool | T:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: FormKey) -> dict[str, str | list[str]]:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: FormKey, default: T) -> dict[str, str | list[str]] | T:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: HttpResponseBodyKey) -> HTTPResponseBodyEvent:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: HttpResponseBodyKey, default: T) -> HTTPResponseBodyEvent | T:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: HttpResponseStartKey) -> HTTPResponseStartEvent:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: HttpResponseStartKey, default: T) -> HTTPResponseStartEvent | T:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: IsCachedKey) -> bool:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: IsCachedKey, default: T) -> bool | T:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: JsonKey) -> Any:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: JsonKey, default: T) -> Any | T:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: MsgpackKey) -> Any:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: MsgpackKey, default: T) -> Any | T:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: ParsedQueryKey) -> tuple[tuple[str, str], ...]:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: ParsedQueryKey, default: T) -> tuple[tuple[str, str], ...] | T:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: ResponseCompressedKey) -> bool:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: ResponseCompressedKey, default: T) -> bool | T:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: UrlKey) -> URL:
+    ...
+
+
+@overload
+def pop_litestar_scope_state(scope: Scope, key: UrlKey, default: T) -> URL | T:
+    ...
+
+
+def pop_litestar_scope_state(scope: Scope, key: ScopeStateKeyType, default: T | EmptyType = Empty) -> Any | T:
+    """Get an internal value from connection scope state.
+
+    Args:
+        scope: The connection scope.
+        key: Key to get from internal namespace in scope state.
+        default: Default value to return.
+
+    Returns:
+        Value mapped to ``key`` in internal connection scope namespace.
+
+    Raises:
+        KeyError: If ``key`` is not in internal connection scope namespace and ``default`` is ``Empty``.
+    """
+    namespace = scope["state"].setdefault(SCOPE_STATE_NAMESPACE, {})
+    return namespace.pop(key) if default is Empty else namespace.pop(key, default)

--- a/litestar/utils/scope/set.py
+++ b/litestar/utils/scope/set.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypeVar, overload
+
+from litestar.constants import SCOPE_STATE_NAMESPACE
+
+if TYPE_CHECKING:
+    from litestar.datastructures import URL, Accept
+    from litestar.types import Scope
+    from litestar.types.asgi_types import HTTPResponseBodyEvent, HTTPResponseStartEvent
+    from litestar.types.scope import (
+        AcceptKey,
+        BaseUrlKey,
+        BodyKey,
+        ContentTypeKey,
+        CookiesKey,
+        CsrfTokenKey,
+        DependencyCacheKey,
+        DoCacheKey,
+        FormKey,
+        HttpResponseBodyKey,
+        HttpResponseStartKey,
+        IsCachedKey,
+        JsonKey,
+        MsgpackKey,
+        ParsedQueryKey,
+        ResponseCompressedKey,
+        ScopeStateKeyType,
+        UrlKey,
+    )
+
+__all__ = ("set_litestar_scope_state",)
+
+T = TypeVar("T")
+
+
+@overload
+def set_litestar_scope_state(scope: Scope, key: AcceptKey, value: Accept) -> None:
+    ...
+
+
+@overload
+def set_litestar_scope_state(scope: Scope, key: BaseUrlKey, value: URL) -> None:
+    ...
+
+
+@overload
+def set_litestar_scope_state(scope: Scope, key: BodyKey, value: bytes) -> None:
+    ...
+
+
+@overload
+def set_litestar_scope_state(scope: Scope, key: ContentTypeKey, value: tuple[str, dict[str, str]]) -> None:
+    ...
+
+
+@overload
+def set_litestar_scope_state(scope: Scope, key: CookiesKey, value: dict[str, str]) -> None:
+    ...
+
+
+@overload
+def set_litestar_scope_state(scope: Scope, key: CsrfTokenKey, value: str) -> None:
+    ...
+
+
+@overload
+def set_litestar_scope_state(scope: Scope, key: DependencyCacheKey, value: dict[str, Any]) -> None:
+    ...
+
+
+@overload
+def set_litestar_scope_state(scope: Scope, key: DoCacheKey, value: bool) -> None:
+    ...
+
+
+@overload
+def set_litestar_scope_state(scope: Scope, key: FormKey, value: dict[str, str | list[str]]) -> None:
+    ...
+
+
+@overload
+def set_litestar_scope_state(scope: Scope, key: HttpResponseBodyKey, value: HTTPResponseBodyEvent) -> None:
+    ...
+
+
+@overload
+def set_litestar_scope_state(scope: Scope, key: HttpResponseStartKey, value: HTTPResponseStartEvent) -> None:
+    ...
+
+
+@overload
+def set_litestar_scope_state(scope: Scope, key: IsCachedKey, value: bool) -> None:
+    ...
+
+
+@overload
+def set_litestar_scope_state(scope: Scope, key: JsonKey, value: Any) -> None:
+    ...
+
+
+@overload
+def set_litestar_scope_state(scope: Scope, key: MsgpackKey, value: Any) -> None:
+    ...
+
+
+@overload
+def set_litestar_scope_state(scope: Scope, key: ParsedQueryKey, value: tuple[tuple[str, str], ...]) -> None:
+    ...
+
+
+@overload
+def set_litestar_scope_state(scope: Scope, key: ResponseCompressedKey, value: bool) -> None:
+    ...
+
+
+@overload
+def set_litestar_scope_state(scope: Scope, key: UrlKey, value: URL) -> None:
+    ...
+
+
+def set_litestar_scope_state(scope: Scope, key: ScopeStateKeyType, value: Any) -> None:
+    """Set an internal value in connection scope state.
+
+    Args:
+        scope: The connection scope.
+        key: Key to set under internal namespace in scope state.
+        value: Value for key.
+    """
+    scope["state"].setdefault(SCOPE_STATE_NAMESPACE, {})[key] = value

--- a/tests/unit/test_connection/test_connection_caching.py
+++ b/tests/unit/test_connection/test_connection_caching.py
@@ -8,6 +8,7 @@ import pytest
 from litestar import Request, constants
 from litestar.testing import RequestFactory
 from litestar.types import Empty, HTTPReceiveMessage, Scope
+from litestar.types.scope import ScopeStateKeyType
 from litestar.utils import get_litestar_scope_state, set_litestar_scope_state
 
 
@@ -44,11 +45,11 @@ def create_connection_fixture(
     get_mock: MagicMock, set_mock: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> Callable[..., Request]:
     def create_connection(body_type: str = "json") -> Request:
-        def wrapped_get_litestar_scope_state(scope_: Scope, key: str, default: Any = None) -> Any:
+        def wrapped_get_litestar_scope_state(scope_: Scope, key: ScopeStateKeyType, default: Any = None) -> Any:
             get_mock(key)
             return get_litestar_scope_state(scope_, key, default)
 
-        def wrapped_set_litestar_scope_state(scope_: Scope, key: str, value: Any) -> None:
+        def wrapped_set_litestar_scope_state(scope_: Scope, key: ScopeStateKeyType, value: Any) -> None:
             set_mock(key, value)
             set_litestar_scope_state(scope_, key, value)
 
@@ -110,7 +111,7 @@ caching_tests = [
 
 @pytest.mark.parametrize(("state_key", "prop_name", "cache_attr_name", "is_coro"), caching_tests)
 async def test_connection_cached_properties_no_scope_or_connection_caching(
-    state_key: str,
+    state_key: ScopeStateKeyType,
     prop_name: str,
     cache_attr_name: str,
     is_coro: bool,
@@ -157,7 +158,7 @@ async def test_connection_cached_properties_no_scope_or_connection_caching(
 
 @pytest.mark.parametrize(("state_key", "prop_name", "cache_attr_name", "is_coro"), caching_tests)
 async def test_connection_cached_properties_cached_in_scope(
-    state_key: str,
+    state_key: ScopeStateKeyType,
     prop_name: str,
     cache_attr_name: str,
     is_coro: bool,
@@ -169,7 +170,7 @@ async def test_connection_cached_properties_cached_in_scope(
     # set the value in the scope and ensure empty on connection
     connection = create_connection()
 
-    set_litestar_scope_state(connection.scope, state_key, {"a": "b"})
+    set_litestar_scope_state(connection.scope, state_key, {"a": "b"})  # type: ignore[arg-type]
     setattr(connection, cache_attr_name, Empty)
 
     await get_value(connection, prop_name, is_coro)

--- a/tests/unit/test_template/test_csrf_token.py
+++ b/tests/unit/test_template/test_csrf_token.py
@@ -61,7 +61,7 @@ def test_csrf_input(engine: Any, template: str, tmp_path: Path) -> None:
 
     @get(path="/", media_type=MediaType.HTML)
     def handler(scope: Scope) -> Template:
-        token["value"] = get_litestar_scope_state(scope, SCOPE_STATE_CSRF_TOKEN_KEY)
+        token["value"] = get_litestar_scope_state(scope, SCOPE_STATE_CSRF_TOKEN_KEY, "")
         return Template(template_name="abc.html")
 
     csrf_config = CSRFConfig(secret="yaba daba do")

--- a/tests/unit/test_utils/test_scope.py
+++ b/tests/unit/test_utils/test_scope.py
@@ -3,8 +3,9 @@ from typing import TYPE_CHECKING
 import pytest
 
 from litestar.constants import SCOPE_STATE_NAMESPACE
-from litestar.utils import (
+from litestar.utils.scope import (
     get_litestar_scope_state,
+    pop_litestar_scope_state,
     set_litestar_scope_state,
 )
 
@@ -18,27 +19,25 @@ def scope() -> "HTTPScope":
 
 
 def test_get_litestar_scope_state_without_default_does_not_set_key_in_scope_state(scope: "HTTPScope") -> None:
-    get_litestar_scope_state(scope, "key")
+    get_litestar_scope_state(scope, "body")
     assert SCOPE_STATE_NAMESPACE in scope["state"]
-    assert "key" not in scope["state"][SCOPE_STATE_NAMESPACE]
+    assert "body" not in scope["state"][SCOPE_STATE_NAMESPACE]
 
 
 def test_get_litestar_scope_state_with_default_does_not_set_key_in_scope_state(scope: "HTTPScope") -> None:
-    value = get_litestar_scope_state(scope, "key", "value")
+    value = get_litestar_scope_state(scope, "body", "value")
     assert SCOPE_STATE_NAMESPACE in scope["state"]
     assert value == "value"
-    assert "key" not in scope["state"][SCOPE_STATE_NAMESPACE]
+    assert "body" not in scope["state"][SCOPE_STATE_NAMESPACE]
 
 
-def test_get_litestar_scope_state_removes_value_from_state(scope: "HTTPScope") -> None:
-    key = "test"
-    value = {"key": "value"}
-    scope["state"][SCOPE_STATE_NAMESPACE] = {key: value}
-    retrieved_value = get_litestar_scope_state(scope, key, pop=True)
-    assert retrieved_value == value
-    assert key not in scope["state"][SCOPE_STATE_NAMESPACE]
+def test_pop_litestar_scope_state_removes_value_from_state(scope: "HTTPScope") -> None:
+    scope["state"][SCOPE_STATE_NAMESPACE] = {"body": b""}
+    retrieved_value = pop_litestar_scope_state(scope, "body")
+    assert retrieved_value == b""
+    assert "body" not in scope["state"][SCOPE_STATE_NAMESPACE]
 
 
 def test_set_litestar_scope_state(scope: "HTTPScope") -> None:
-    set_litestar_scope_state(scope, "key", "value")
-    assert scope["state"][SCOPE_STATE_NAMESPACE]["key"] == "value"
+    set_litestar_scope_state(scope, "body", b"")
+    assert scope["state"][SCOPE_STATE_NAMESPACE]["body"] == b""


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

We use connection scope state to store a lot of different things for caching, auth, logging etc.

This PR improves the type safety of writing to, and retrieving from the scope state via the scope state utils and in doing so allows us to make another dozen or so improvements to our typing by removing casts and fixing existing type errors.

While this pattern of overloading the scope util methods for literal key arguments is quite verbose, the pattern is clear so I don't believe incremental changes to the data that we store in scope state will cause too much headache. 

To add a new key to store in scope state:

1. add a new key literal to `litestar.types.scopes`
2. add a new constant to `litestar.constants` typed as the literal key name
3. add appropriate overloads to the get/pop/set utilities.

Additionally, the PR removes the "pop" behavior from `get_litestar_scope_state()` in favor of adding a new utility `pop_litestar_scope_state()` so that both the get and pop utils share the same semantics as `dict.get()` and `dict.pop()`.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
