### PR TITLE
docs: Removed extra sentence in 'Rate-Limit Middleware' Section

### DIFF
--- a/docs/usage/middleware/builtin-middleware.rst
+++ b/docs/usage/middleware/builtin-middleware.rst
@@ -186,7 +186,7 @@ To use the rate limit middleware, use the :class:`RateLimitConfig <litestar.midd
     :language: python
 
 The only required configuration kwarg is ``rate_limit``, which expects a tuple containing a time-unit (``second``,
-``minute``, ``hour``, ``day``\ ) and a value for the request quota (integer). For the other configuration options.
+``minute``, ``hour``, ``day``\ ) and a value for the request quota (integer).
 
 
 Logging Middleware


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

Removed extra sentence at the end of Rate-Limit Middleware in `/docs/usage/middleware/builtin-middleware.rst`

-

### Close Issue(s) #2697
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
