### PR TITLE
fix: correctly handle multiple file upload

### DIFF
--- a/litestar/_kwargs/extractors.py
+++ b/litestar/_kwargs/extractors.py
@@ -351,7 +351,13 @@ def create_multipart_extractor(
         )
 
         if field_definition.is_non_string_sequence:
-            return list(form_values.values())
+            values = list(form_values.values())
+            if field_definition.inner_types[0].annotation is UploadFile:
+                if isinstance(values[0], list):
+                    return values[0]
+                return values
+
+            return values
         if field_definition.is_simple_type and field_definition.annotation is UploadFile and form_values:
             return next(v for v in form_values.values() if isinstance(v, UploadFile))
 

--- a/litestar/_kwargs/extractors.py
+++ b/litestar/_kwargs/extractors.py
@@ -352,12 +352,11 @@ def create_multipart_extractor(
 
         if field_definition.is_non_string_sequence:
             values = list(form_values.values())
-            if field_definition.inner_types[0].annotation is UploadFile:
-                if isinstance(values[0], list):
-                    return values[0]
-                return values
+            if field_definition.inner_types[0].annotation is UploadFile and isinstance(values[0], list):
+                return values[0]
 
             return values
+
         if field_definition.is_simple_type and field_definition.annotation is UploadFile and form_values:
             return next(v for v in form_values.values() if isinstance(v, UploadFile))
 

--- a/tests/unit/test_datastructures/test_upload_file.py
+++ b/tests/unit/test_datastructures/test_upload_file.py
@@ -1,8 +1,6 @@
 from os import urandom
 from pathlib import Path
-from typing import List, Optional
-
-import pytest
+from typing import Optional
 
 from litestar import post
 from litestar.datastructures import UploadFile
@@ -38,22 +36,6 @@ async def test_upload_file_methods() -> None:
 
     await upload_file.close()
     assert upload_file.file.closed
-
-
-@pytest.mark.parametrize("file_count", (1, 2))
-def test_upload_multiple_files(file_count: int) -> None:
-    @post("/")
-    async def handler(data: List[UploadFile] = Body(media_type=RequestEncodingType.MULTI_PART)) -> None:
-        assert len(data) == file_count
-
-        for file in data:
-            assert await file.read() == b"1"
-
-    with create_test_client([handler]) as client:
-        files_to_upload = [("file", b"1") for _ in range(file_count)]
-        response = client.post("/", files=files_to_upload)
-
-        assert response.status_code == HTTP_201_CREATED
 
 
 def test_cleanup_is_being_performed(tmpdir: Path) -> None:

--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -394,6 +394,22 @@ def test_image_upload() -> None:
         assert response.status_code == HTTP_201_CREATED
 
 
+@pytest.mark.parametrize("file_count", (1, 2))
+def test_upload_multiple_files(file_count: int) -> None:
+    @post("/")
+    async def handler(data: List[UploadFile] = Body(media_type=RequestEncodingType.MULTI_PART)) -> None:
+        assert len(data) == file_count
+
+        for file in data:
+            assert await file.read() == b"1"
+
+    with create_test_client([handler]) as client:
+        files_to_upload = [("file", b"1") for _ in range(file_count)]
+        response = client.post("/", files=files_to_upload)
+
+        assert response.status_code == HTTP_201_CREATED
+
+
 def test_optional_formdata() -> None:
     @post("/", signature_types=[UploadFile])
     async def hello_world(data: Optional[UploadFile] = Body(media_type=RequestEncodingType.MULTI_PART)) -> None:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- properly handles multiple file uploads

When multiple files are uploaded, the following logic, causes the creation of a list of lists which is invalid for the type `list[UploadFile]`.

https://github.com/litestar-org/litestar/blob/df00253891b09c8831b2b9025cf7e5471e68ac07/litestar/_kwargs/extractors.py#L353-L354

However, if the annotation is `list[UploadFile]` and only one file is uploaded, then `list(form_values.values())` will give back a list of UploadFile instances due to the logic here:
https://github.com/litestar-org/litestar/blob/df00253891b09c8831b2b9025cf7e5471e68ac07/litestar/_multipart.py#L162

Furthermore, this PR assumes that if multiple files are being uploaded, then all the files will have the same value for "name" within the form data. This is the expected behavior as per [RFC 7578](https://www.rfc-editor.org/rfc/rfc7578#section-4.3).


### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
