### PR TITLE
fix: skip headers validation for OPTIONS requests

### DIFF
--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -44,7 +44,10 @@ from litestar.types import (
 from litestar.types.builtin_types import NoneType
 from litestar.utils import ensure_async_callable
 from litestar.utils.predicates import is_async_callable
-from litestar.utils.warnings import warn_implicit_sync_to_thread, warn_sync_to_thread_with_async_callable
+from litestar.utils.warnings import (
+    warn_implicit_sync_to_thread,
+    warn_sync_to_thread_with_async_callable,
+)
 
 if TYPE_CHECKING:
     from typing import Any, Awaitable, Callable, Sequence
@@ -54,10 +57,12 @@ if TYPE_CHECKING:
     from litestar.config.response_cache import CACHE_FOREVER
     from litestar.connection import Request
     from litestar.datastructures import CacheControlHeader, ETag
+    from litestar.di import Provide
     from litestar.dto import AbstractDTO
     from litestar.openapi.datastructures import ResponseSpec
     from litestar.openapi.spec import SecurityRequirement
     from litestar.types.callable_types import AsyncAnyCallable, OperationIDCreator
+    from litestar.typing import FieldDefinition
 
 __all__ = ("HTTPRouteHandler", "route")
 
@@ -278,7 +283,10 @@ class HTTPRouteHandler(BaseRouteHandler):
         # memoized attributes, defaulted to Empty
         self._resolved_after_response: AsyncAnyCallable | None | EmptyType = Empty
         self._resolved_before_request: AsyncAnyCallable | None | EmptyType = Empty
-        self._response_handler_mapping: ResponseHandlerMap = {"default_handler": Empty, "response_type_handler": Empty}
+        self._response_handler_mapping: ResponseHandlerMap = {
+            "default_handler": Empty,
+            "response_type_handler": Empty,
+        }
         self._resolved_include_in_schema: bool | EmptyType = Empty
 
     def __call__(self, fn: AnyCallable) -> HTTPRouteHandler:
@@ -534,3 +542,11 @@ class HTTPRouteHandler(BaseRouteHandler):
 
 
 route = HTTPRouteHandler
+
+
+class AutoOptionsHttpRouteHandler(HTTPRouteHandler):
+    def resolve_layered_parameters(self) -> dict[str, FieldDefinition]:
+        return {}
+
+    def resolve_dependencies(self) -> dict[str, Provide]:
+        return {}

--- a/tests/unit/test_kwargs/test_params_with_options_request.py
+++ b/tests/unit/test_kwargs/test_params_with_options_request.py
@@ -1,0 +1,35 @@
+from litestar import get, Router
+from litestar.app import Litestar
+from litestar.config.cors import CORSConfig
+from litestar.params import Parameter
+from litestar.status_codes import HTTP_204_NO_CONTENT
+from litestar.testing import create_test_client
+
+
+@get(path="/test")
+def a_handler(tenant: str) -> None:
+    assert tenant
+
+
+router = Router(
+    "/",
+    route_handlers=[a_handler],
+    parameters={
+        "tenant": Parameter(str, header="TENANT", required=True),
+    },
+)
+
+app = Litestar(
+    route_handlers=[router],
+    openapi_config=None,
+    cors_config=CORSConfig(),
+)
+
+
+def test_header_params_with_options_request() -> None:
+    with create_test_client(app) as client:
+        response = client.options(
+            f"/test",
+            headers={},
+        )
+        assert response.status_code == HTTP_204_NO_CONTENT

--- a/tests/unit/test_kwargs/test_params_with_options_request.py
+++ b/tests/unit/test_kwargs/test_params_with_options_request.py
@@ -1,4 +1,4 @@
-from litestar import get, Router
+from litestar import Router, get
 from litestar.app import Litestar
 from litestar.config.cors import CORSConfig
 from litestar.params import Parameter
@@ -29,7 +29,7 @@ app = Litestar(
 def test_header_params_with_options_request() -> None:
     with create_test_client(app) as client:
         response = client.options(
-            f"/test",
+            "/test",
             headers={},
         )
         assert response.status_code == HTTP_204_NO_CONTENT


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [X] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- The behaviour doesn't happen if the required header is defined on the handler rather than the upper layers.
- Browsers sending the pre-flight CORS `OPTIONS` request by excluding the original headers and including specific ones seems to be part of a [standard](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request).
- The proposed solution skips validation of required headers when the request method is `OPTIONS`.
- One drawback of the proposed solution: developers who have an explicit handler for `OPTIONS` will lose the validation features. If we see this as important, then perhaps the solution can be changed to only skip validation for the [automatically created](https://github.com/litestar-org/litestar/blob/main/litestar/routes/http.py#L235) `OPTIONS` handler.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

#2739 

-
