### PR TITLE
feat: Improve ASGI extension interface

### DIFF
--- a/litestar/connection/base.py
+++ b/litestar/connection/base.py
@@ -86,7 +86,7 @@ class ASGIConnection(Generic[HandlerT, UserT, AuthT, StateT]):
         self._url: URL | EmptyType = Empty
         self._parsed_query: tuple[tuple[str, str], ...] | EmptyType = Empty
         self._cookies: dict[str, str] | EmptyType = Empty
-        self._server_extensions = scope.get("extensions", {})
+        self._server_extensions = scope.get("extensions") or {}  # extensions may be None
 
     @property
     def app(self) -> Litestar:

--- a/litestar/connection/base.py
+++ b/litestar/connection/base.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from litestar.types.asgi_types import Message, Receive, Scope, Send
     from litestar.types.protocols import Logger
 
+
 __all__ = ("ASGIConnection", "empty_receive", "empty_send")
 
 UserT = TypeVar("UserT")
@@ -61,7 +62,7 @@ async def empty_send(_: Message) -> NoReturn:  # pragma: no cover
 class ASGIConnection(Generic[HandlerT, UserT, AuthT, StateT]):
     """The base ASGI connection container."""
 
-    __slots__ = ("scope", "receive", "send", "_base_url", "_url", "_parsed_query", "_cookies")
+    __slots__ = ("scope", "receive", "send", "_base_url", "_url", "_parsed_query", "_cookies", "_server_extensions")
 
     scope: Scope
     """The ASGI scope attached to the connection."""
@@ -85,6 +86,7 @@ class ASGIConnection(Generic[HandlerT, UserT, AuthT, StateT]):
         self._url: URL | EmptyType = Empty
         self._parsed_query: tuple[tuple[str, str], ...] | EmptyType = Empty
         self._cookies: dict[str, str] | EmptyType = Empty
+        self._server_extensions = scope.get("extensions", {})
 
     @property
     def app(self) -> Litestar:

--- a/litestar/enums.py
+++ b/litestar/enums.py
@@ -76,3 +76,15 @@ class CompressionEncoding(str, Enum):
 
     GZIP = "gzip"
     BROTLI = "br"
+
+
+class ASGIExtension(str, Enum):
+    """ASGI extension keys: https://asgi.readthedocs.io/en/latest/extensions.html"""
+
+    WS_DENIAL = "websocket.http.response"
+    SERVER_PUSH = "http.response.push"
+    ZERO_COPY_SEND_EXTENSION = "http.response.zerocopysend"
+    PATH_SEND = "http.response.pathsend"
+    TLS = "tls"
+    EARLY_HINTS = "http.response.early_hint"
+    HTTP_TRAILERS = "http.response.trailers"


### PR DESCRIPTION
To improve the handling of [ASGI extensions](https://asgi.readthedocs.io/en/latest/extensions.html), this PR:

- Introduces an `ASGIExtension` enum, holding the names of ASGI extensions
- Adds a `_server_extensions` attribute to `ASGIConnection`
- Adds a `supports_server_push` attribute to `Request`, allowing to check if it is supported before attempting to push. Additionally, a warning is raised when push is not supported. Optionally, this method can now be configured to raise an exception instead of a warning; This behaviour should be made the default in 3.0
