### PR TITLE
docs: Fix type checking command in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -107,7 +107,7 @@ enforce type safety. You can run them with:
 
 - ``make mypy``
 - ``make pyright``
-- ``make typecheck`` to run both
+- ``make type-check`` to run both
 - ``make lint`` to run pre-commit hooks and type checkers.
 
 Our type checkers are run on Python 3.8 in CI, so you should make sure to run them on the same version locally as well.


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description

Add a missing hyphen in the type checking `make` command.