### PR TITLE
Docs: Explain how to work around the limitation of reserved keyword arguments for route handlers

### DIFF
--- a/docs/usage/routing/handlers.rst
+++ b/docs/usage/routing/handlers.rst
@@ -127,6 +127,10 @@ For example:
 
 .. tip::
 
+    If your parameters collide with any of the reserved keyword arguments above, you can :doc:`provide an alternative name <usage/routing/parameters:Alternative names and constraints>`
+
+.. tip::
+
     You can define a custom typing for your application state and then use it as a type instead of just using the
     State class from Litestar
 


### PR DESCRIPTION


<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- Explain how to work around the limitation of reserved keyword arguments for route handlers

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
Fixes #2766
-
