### PR TITLE
fix: type narrowing in csrf middleware

### DIFF
--- a/litestar/middleware/csrf.py
+++ b/litestar/middleware/csrf.py
@@ -119,9 +119,12 @@ class CSRFMiddleware(MiddlewareProtocol):
         ):
             token = connection_state.csrf_token = csrf_cookie or generate_csrf_token(secret=self.config.secret)
             await self.app(scope, receive, self.create_send_wrapper(send=send, csrf_cookie=csrf_cookie, token=token))
-        elif self._csrf_tokens_match(existing_csrf_token, csrf_cookie):
-            # we haven't properly narrowed the type of `existing_csrf_token` to be non-None, but we know it is
-            connection_state.csrf_token = existing_csrf_token  # type: ignore[assignment]
+        elif (
+            existing_csrf_token is not None
+            and csrf_cookie is not None
+            and self._csrf_tokens_match(existing_csrf_token, csrf_cookie)
+        ):
+            connection_state.csrf_token = existing_csrf_token
             await self.app(scope, receive, send)
         else:
             raise PermissionDeniedException("CSRF token verification failed")
@@ -177,11 +180,8 @@ class CSRFMiddleware(MiddlewareProtocol):
         expected_hash = generate_csrf_hash(token=token_secret, secret=self.config.secret)
         return token_secret if compare_digest(existing_hash, expected_hash) else None
 
-    def _csrf_tokens_match(self, request_csrf_token: str | None, cookie_csrf_token: str | None) -> bool:
+    def _csrf_tokens_match(self, request_csrf_token: str, cookie_csrf_token: str) -> bool:
         """Take the CSRF tokens from the request and the cookie and verify both are valid and identical."""
-        if not (request_csrf_token and cookie_csrf_token):
-            return False
-
         decoded_request_token = self._decode_csrf_token(request_csrf_token)
         decoded_cookie_token = self._decode_csrf_token(cookie_csrf_token)
         if decoded_request_token is None or decoded_cookie_token is None:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

This PR makes a small change to the CSRF middleware. By moving the test for `None` values outside of the `_csrf_tokens_match()` method we can appropriately narrow the type of `existing_csrf_token` removing the need for a `type: ignore`.

This also makes it more explicit that the tokens don't match when either are `None`.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

Closes #2770
