### PR TITLE
fix: raise config error when yield dependencies are cached

### DIFF
--- a/litestar/_kwargs/dependencies.py
+++ b/litestar/_kwargs/dependencies.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from inspect import isasyncgen, isgenerator
 from typing import TYPE_CHECKING, Any
 
 from litestar.utils.compat import async_next
@@ -65,10 +64,10 @@ async def resolve_dependency(
     )
     value = await dependency.provide(**dependency_kwargs)
 
-    if isgenerator(value):
+    if dependency.provide.has_sync_generator_dependency:
         cleanup_group.add(value)
         value = next(value)
-    elif isasyncgen(value):
+    elif dependency.provide.has_async_generator_dependency:
         cleanup_group.add(value)
         value = await async_next(value)
 

--- a/litestar/di.py
+++ b/litestar/di.py
@@ -62,7 +62,7 @@ class Provide:
         )
         has_generator_dependency = self.has_sync_generator_dependency or self.has_async_generator_dependency
 
-        if has_generator_dependency and use_cache is True:
+        if has_generator_dependency and use_cache:
             raise ImproperlyConfiguredException(
                 "Cannot cache generator dependency, consider using Lifespan Context instead."
             )

--- a/litestar/utils/__init__.py
+++ b/litestar/utils/__init__.py
@@ -5,6 +5,7 @@ from litestar.utils.deprecation import deprecated, warn_deprecation
 from .helpers import get_enum_string_value, get_name, unique_name_for_scope, url_quote
 from .path import join_paths, normalize_path
 from .predicates import (
+    _is_sync_or_async_generator,
     is_annotated_type,
     is_any,
     is_async_callable,
@@ -18,7 +19,6 @@ from .predicates import (
     is_non_string_iterable,
     is_non_string_sequence,
     is_optional_union,
-    is_sync_or_async_generator,
     is_undefined_sentinel,
     is_union,
 )
@@ -54,7 +54,6 @@ __all__ = (
     "is_non_string_iterable",
     "is_non_string_sequence",
     "is_optional_union",
-    "is_sync_or_async_generator",
     "is_undefined_sentinel",
     "is_union",
     "join_paths",
@@ -70,6 +69,7 @@ _deprecated_names = {
     "get_litestar_scope_state": _get_litestar_scope_state,
     "set_litestar_scope_state": _set_litestar_scope_state,
     "delete_litestar_scope_state": _delete_litestar_scope_state,
+    "is_sync_or_async_generator": _is_sync_or_async_generator,
 }
 
 
@@ -80,8 +80,7 @@ def __getattr__(name: str) -> Any:
             version="2.4",
             kind="import",
             removal_in="3.0",
-            info=f"'litestar.utils.{name}' is deprecated. The Litestar scope state is private and should not be used."
-            "Plugin authors should maintain their own scope state namespace.",
+            info=f"'litestar.utils.{name}' is deprecated.",
         )
         return globals()["_deprecated_names"][name]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")  # pragma: no cover

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -138,3 +138,11 @@ def test_utils_scope_deprecations() -> None:
             get_litestar_scope_state,
             set_litestar_scope_state,
         )
+
+
+def test_is_sync_or_async_generator_deprecation() -> None:
+    with pytest.warns(DeprecationWarning):
+        from litestar.utils.predicates import is_sync_or_async_generator  # noqa: F401
+
+    with pytest.warns(DeprecationWarning):
+        from litestar.utils import is_sync_or_async_generator as _  # noqa: F401

--- a/tests/unit/test_di.py
+++ b/tests/unit/test_di.py
@@ -153,3 +153,15 @@ def test_dependency_has_async_callable(dep: Any, exp: bool) -> None:
 def test_raises_when_dependency_is_not_callable() -> None:
     with pytest.raises(ImproperlyConfiguredException):
         Provide(123)  # type: ignore
+
+
+@pytest.mark.parametrize(
+    ("dep",),
+    [
+        (generator_func,),
+        (async_generator_func,),
+    ],
+)
+def test_raises_when_generator_dependency_is_cached(dep: Any) -> None:
+    with pytest.raises(ImproperlyConfiguredException):
+        Provide(dep, use_cache=True)


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

This PR makes it a configuration error to attempt to `use_cache=True` with generator dependencies.

Prior to this implementation, this would result in a 500 error at runtime.

The reason for making this a config error is that after the first use of the generator the cleanup code executes and so subsequent use of the generated value is dubious.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

Closes #2771