### PR TITLE
fix: DTOData annotation without DTO

### DIFF
--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Callable, Mapping, Sequence, cast
 from litestar._signature import SignatureModel
 from litestar.config.app import ExperimentalFeatures
 from litestar.di import Provide
+from litestar.dto import DTOData
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.serialization import default_deserializer, default_serializer
 from litestar.types import (
@@ -526,6 +527,15 @@ class BaseRouteHandler:
 
     def _validate_handler_function(self) -> None:
         """Validate the route handler function once set by inspecting its return annotations."""
+        if (
+            self.parsed_data_field is not None
+            and self.parsed_data_field.is_subclass_of(DTOData)
+            and not self.resolve_data_dto()
+        ):
+            raise ImproperlyConfiguredException(
+                f"Handler function {self.handler_name} has a data parameter that is a subclass of DTOData but no "
+                "DTO has been registered for it."
+            )
 
     def __str__(self) -> str:
         """Return a unique identifier for the route handler.

--- a/tests/unit/test_handlers/test_base_handlers/test_validations.py
+++ b/tests/unit/test_handlers/test_base_handlers/test_validations.py
@@ -1,5 +1,9 @@
+from dataclasses import dataclass
+
 import pytest
 
+from litestar import Litestar, post
+from litestar.dto import DTOData
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.handlers.base import BaseRouteHandler
 
@@ -9,3 +13,19 @@ def test_raise_no_fn_validation() -> None:
 
     with pytest.raises(ImproperlyConfiguredException):
         handler.fn
+
+
+def test_dto_data_annotation_with_no_resolved_dto() -> None:
+    @dataclass
+    class Model:
+        """Example dataclass model."""
+
+        hello: str
+
+    @post("/")
+    async def async_hello_world(data: DTOData[Model]) -> Model:
+        """Route Handler that outputs hello world."""
+        return data.create_instance()
+
+    with pytest.raises(ImproperlyConfiguredException):
+        Litestar(route_handlers=[async_hello_world])


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

This PR resolves an issue where a handler would be allowed to be registered with a `DTOData` annotation, but no `dto` defined.

This is now a configuration error.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

Closes #2779
