### PR TITLE
fix: setting props on schema using camelCase names

### DIFF
--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -290,13 +290,13 @@ def test_layered_parameters() -> None:
     assert router3.param_in == ParamType.HEADER
     assert router3.schema.type == OpenAPIType.NUMBER  # type: ignore
     assert router3.required
-    assert router3.schema.multipleOf == 5.0  # type: ignore
+    assert router3.schema.multiple_of == 5.0  # type: ignore
     assert router3.schema.examples  # type: ignore
 
     assert controller1.param_in == ParamType.QUERY
     assert controller1.schema.type == OpenAPIType.INTEGER  # type: ignore
     assert controller1.required
-    assert controller1.schema.exclusiveMaximum == 100.0  # type: ignore
+    assert controller1.schema.exclusive_maximum == 100.0  # type: ignore
     assert controller1.schema.examples  # type: ignore
 
     assert controller3.param_in == ParamType.QUERY


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

We have been setting properties on the schema object using camelCase names when they are declared with snake_case names.

We've been using this mapping:

https://github.com/litestar-org/litestar/blob/9f6ddf43928c6deb033f18fcec5aed21772192ff/litestar/_openapi/schema_generation/schema.py#L79-L98

...for converting values from the `KwargDefinition` object to the `Schema` object, where the keys are the names on `KwargDefinition` and the values are supposed to be the names on the `Schema` object. Which takes place here:

https://github.com/litestar-org/litestar/blob/9f6ddf43928c6deb033f18fcec5aed21772192ff/litestar/_openapi/schema_generation/schema.py#L640-L647

Note that some of the values in that mapping are pointing to camelCase names, but we define the names as snake_case on the schema type.

I'm pretty sure that this means that any of those camelCase schema values woudn't have been getting transferred into the schema correctly, rather they'd have been getting assigned to the schema instance, but not to any of the dataclass field names.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

-
