### PR TITLE
fix: event handler error breaks stream

### DIFF
--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -109,3 +109,36 @@ async def test_raises_when_not_listener_are_registered_for_an_event_id(async_lis
     with create_test_client(route_handlers=[], listeners=[async_listener]) as client:
         with pytest.raises(ImproperlyConfiguredException):
             client.app.emit("x")
+
+
+async def test_event_listener_raises_exception(async_listener: EventListener, mock: MagicMock) -> None:
+    """Test that an event listener that raises an exception does not prevent other listeners from being called.
+
+    https://github.com/litestar-org/litestar/issues/2809
+    """
+
+    error_mock = MagicMock()
+
+    @listener("error_event")
+    async def raising_listener(*args: Any, **kwargs: Any) -> None:
+        error_mock()
+        raise ValueError("test")
+
+    @get("/error")
+    def route_handler_1(request: Request[Any, Any, Any]) -> None:
+        request.app.emit("error_event")
+
+    @get("/no-error")
+    def route_handler_2(request: Request[Any, Any, Any]) -> None:
+        request.app.emit("test_event")
+
+    with create_test_client(
+        route_handlers=[route_handler_1, route_handler_2], listeners=[async_listener, raising_listener]
+    ) as client:
+        first_response = client.get("/error")
+        second_response = client.get("/no-error")
+        assert first_response.status_code == HTTP_200_OK
+        assert second_response.status_code == HTTP_200_OK
+
+    error_mock.assert_called()
+    mock.assert_called()


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

This PR prevents exceptions raised from within event handlers from closing the event receive stream, and from further propagation beyond the event emitter backend.

When an exception is caught from an event handler, we log it at ERROR level.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

Closes #2809