### PR TITLE
fix: concurrent event listener execution

### DIFF
--- a/litestar/events/emitter.py
+++ b/litestar/events/emitter.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import math
 import sys
 from abc import ABC, abstractmethod
@@ -26,8 +25,6 @@ if TYPE_CHECKING:
     from litestar.events.listener import EventListener
 
 __all__ = ("BaseEventEmitterBackend", "SimpleEventEmitter")
-
-logger = logging.getLogger(__name__)
 
 
 class BaseEventEmitterBackend(AsyncContextManager["BaseEventEmitterBackend"], ABC):
@@ -85,19 +82,12 @@ class SimpleEventEmitter(BaseEventEmitterBackend):
         Returns:
             None
         """
-        async with receive_stream:
+        async with receive_stream, anyio.create_task_group() as task_group:
             async for item in receive_stream:
-                await self._run_listener_in_task_group(*item)
-
-    @staticmethod
-    async def _run_listener_in_task_group(fn: Any, args: tuple[Any], kwargs: dict[str, Any]) -> None:
-        try:
-            async with anyio.create_task_group() as task_group:
+                fn, args, kwargs = item
                 if kwargs:
                     fn = partial(fn, **kwargs)
                 task_group.start_soon(fn, *args)
-        except Exception as exc:
-            logger.exception("Error in event listener: %s", exc)
 
     async def __aenter__(self) -> SimpleEventEmitter:
         self._exit_stack = AsyncExitStack()


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

This PR corrects an implementation made in #2810 that prevented listeners from running concurrently.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

For #2809
