### PR TITLE
ci: validate feature PR target

### DIFF
--- a/.github/workflows/pr-target.yml
+++ b/.github/workflows/pr-target.yml
@@ -6,6 +6,8 @@ on:
       - opened
       - edited
       - synchronize
+    branches:
+      - main
 
 permissions:
   pull-requests: read
@@ -16,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR target
-        if: ${{ startsWith(github.event.pull_request.title, 'feat') && github.base_ref == 'main' }}
+        if: ${{ startsWith(github.event.pull_request.title, 'feat') }}
         uses: actions/github-script@v3
         with:
           script: |

--- a/.github/workflows/pr-target.yml
+++ b/.github/workflows/pr-target.yml
@@ -1,0 +1,23 @@
+name: "Validate PR target"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR target branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR target
+        if: ${{ startsWith(github.event.pull_request.title, 'feat') && github.base_ref != 'develop' }}
+        uses: actions/github-script@v3
+        with:
+          script: |
+              core.setFailed('Invalid target branch for feature PR')

--- a/.github/workflows/pr-target.yml
+++ b/.github/workflows/pr-target.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR target
-        if: ${{ startsWith(github.event.pull_request.title, 'feat') && github.base_ref != 'develop' }}
+        if: ${{ startsWith(github.event.pull_request.title, 'feat') && github.base_ref == 'main' }}
         uses: actions/github-script@v3
         with:
           script: |
-              core.setFailed('Invalid target branch for feature PR')
+              core.setFailed('Cannot merge feature type PR into main. Merge into a feature branch or develop')


### PR DESCRIPTION
Add an action that ensures `feat`-type PRs cannot be merged into `main` directly. Instead, they should be merge into `develop` or a feature branch.