### PR TITLE
fix: components schema key names

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -293,7 +293,7 @@ Example Applications
   Litestar projects, this application is open to contributions, big and small.
 * `litestar-fullstack <https://github.com/litestar-org/litestar-fullstack>`_ : A fully-capable, production-ready fullstack
   Litestar web application configured with best practices. It includes SQLAlchemy 2.0, VueJS, `Vite <https://vitejs.dev/>`_,
-  :doc:`SAQ job queue <https://saq-py.readthedocs.io/en/latest/>`_, ``Jinja`` templates and more.
+  `SAQ job queue <https://saq-py.readthedocs.io/en/latest/>`_, ``Jinja`` templates and more.
   `Read more <https://litestar-org.github.io/litestar-fullstack/latest/>`_.
 * `litestar-hello-world <https://github.com/litestar-org/litestar-hello-world>`_: A bare-minimum application setup.
   Great for testing and POC work.

--- a/litestar/_openapi/datastructures.py
+++ b/litestar/_openapi/datastructures.py
@@ -159,11 +159,9 @@ class OpenAPIContext:
         self,
         openapi_config: OpenAPIConfig,
         plugins: Sequence[OpenAPISchemaPluginProtocol],
-        schemas: dict[str, Schema],
     ) -> None:
         self.openapi_config = openapi_config
         self.plugins = plugins
-        self.schemas = schemas
         self.operation_ids: set[str] = set()
         self.schema_registry = SchemaRegistry()
 

--- a/litestar/_openapi/datastructures.py
+++ b/litestar/_openapi/datastructures.py
@@ -26,9 +26,6 @@ class RegisteredSchema:
         self.schema = schema
         self.references = references
 
-    def __repr__(self) -> str:
-        return f"<RegisteredSchema key={self.key}>"
-
 
 class SchemaRegistry:
     """A registry for object schemas.
@@ -61,17 +58,6 @@ class SchemaRegistry:
         self._schema_key_map[key] = registered_schema = RegisteredSchema(key, schema, [reference])
         self._schema_reference_map[id(reference)] = registered_schema
         self._model_name_groups[key[-1]].append(registered_schema)
-
-    def get(self, key: tuple[str, ...]) -> RegisteredSchema:
-        """Get a registered schema by its key.
-
-        Args:
-            key: The key of the schema to get.
-
-        Returns:
-            A RegisteredSchema object.
-        """
-        return self._schema_key_map[key]
 
     def from_reference(self, reference: Reference) -> RegisteredSchema:
         """Get a registered schema by its reference.
@@ -114,9 +100,6 @@ class SchemaRegistry:
             Returns:
                 The longest common prefix of the tuples.
             """
-            if not tuples_:
-                return ()
-
             prefix_ = tuples_[0]
             for t in tuples_:
                 # Compare the current prefix with each tuple and shorten it

--- a/litestar/_openapi/datastructures.py
+++ b/litestar/_openapi/datastructures.py
@@ -1,39 +1,99 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import TYPE_CHECKING, Sequence
 
 from litestar.exceptions import ImproperlyConfiguredException
 
 if TYPE_CHECKING:
     from litestar.openapi import OpenAPIConfig
-    from litestar.openapi.spec import Schema
+    from litestar.openapi.spec import Reference, Schema
     from litestar.plugins import OpenAPISchemaPluginProtocol
 
 
-class OpenAPIContext:
-    """OpenAPI Context.
+class RegisteredSchema:
+    def __init__(self, key: tuple[str, ...], schema: Schema, references: list[Reference]) -> None:
+        self.key = key
+        self.schema = schema
+        self.references = references
 
-    Context object used to support OpenAPI schema generation.
-    """
+    def __repr__(self) -> str:
+        return f"<RegisteredSchema key={self.key}>"
 
-    __slots__ = ("openapi_config", "plugins", "schemas", "operation_ids")
 
-    def __init__(
-        self, openapi_config: OpenAPIConfig, plugins: Sequence[OpenAPISchemaPluginProtocol], schemas: dict[str, Schema]
+class SchemaRegistry:
+    def __init__(self) -> None:
+        self._schema_map: dict = {}
+        self._model_name_groups: defaultdict[str, list[RegisteredSchema]] = defaultdict(list)
+
+    def register(
+        self,
+        key: tuple[str, ...],
+        schema: Schema,
+        reference: Reference,
     ) -> None:
-        """Initialize OpenAPIContext.
+        if (registered_schema := self._schema_map.get(key)) is not None:
+            registered_schema.references.append(reference)
+            return
 
-        Args:
-            openapi_config: OpenAPIConfig instance.
-            plugins: OpenAPI plugins.
-            schemas: Mapping of schema names to schema objects that will become the components.schemas section of the
-                OpenAPI schema.
-        """
+        self._schema_map[key] = registered_schema = RegisteredSchema(key, schema, [reference])
+        self._model_name_groups[key[-1]].append(registered_schema)
+
+    @staticmethod
+    def set_reference_paths(name: str, registered_schema: RegisteredSchema) -> None:
+        for reference in registered_schema.references:
+            reference.ref = f"#/components/schemas/{name}"
+
+    @staticmethod
+    def remove_common_prefix(tuples: list[tuple[str, ...]]) -> list[tuple[str, ...]]:
+        def longest_common_prefix(tuples_: list[tuple[str, ...]]) -> tuple[str, ...]:
+            if not tuples_:
+                return ()
+
+            prefix_ = tuples_[0]
+            for t in tuples_:
+                # Compare the current prefix with each tuple and shorten it
+                prefix_ = prefix_[: min(len(prefix_), len(t))]
+                for i in range(len(prefix_)):
+                    if prefix_[i] != t[i]:
+                        prefix_ = prefix_[:i]
+                        break
+            return prefix_
+
+        prefix = longest_common_prefix(tuples)
+        prefix_length = len(prefix)
+        return [t[prefix_length:] for t in tuples]
+
+    def generate_components_schemas(self) -> dict[str, Schema]:
+        components_schemas: dict[str, Schema] = {}
+
+        for name, name_group in self._model_name_groups.items():
+            if len(name_group) == 1:
+                self.set_reference_paths(name, name_group[0])
+                components_schemas[name] = name_group[0].schema
+                continue
+
+            full_keys = [registered_schema.key for registered_schema in name_group]
+            names = ["_".join(k) for k in self.remove_common_prefix(full_keys)]
+            for name_, registered_schema in zip(names, name_group):
+                self.set_reference_paths(name_, registered_schema)
+                components_schemas[name_] = registered_schema.schema
+
+        return components_schemas
+
+
+class OpenAPIContext:
+    def __init__(
+        self,
+        openapi_config: OpenAPIConfig,
+        plugins: Sequence[OpenAPISchemaPluginProtocol],
+        schemas: dict[str, Schema],
+    ) -> None:
         self.openapi_config = openapi_config
         self.plugins = plugins
         self.schemas = schemas
-        # used to track that operation ids are globally unique across the OpenAPI document
         self.operation_ids: set[str] = set()
+        self.schema_registry = SchemaRegistry()
 
     def add_operation_id(self, operation_id: str) -> None:
         """Add an operation ID to the context.

--- a/litestar/_openapi/parameters.py
+++ b/litestar/_openapi/parameters.py
@@ -131,7 +131,7 @@ class ParameterFactory:
         if not result:
             result = self.schema_creator.for_field_definition(field_definition)
 
-        schema = result if isinstance(result, Schema) else self.context.schemas[result.value]
+        schema = result if isinstance(result, Schema) else self.context.schema_registry.from_reference(result).schema
 
         examples_list = kwarg_definition.examples or [] if kwarg_definition else []
         examples = get_formatted_examples(field_definition, examples_list)

--- a/litestar/_openapi/plugin.py
+++ b/litestar/_openapi/plugin.py
@@ -41,6 +41,7 @@ class OpenAPIPlugin(InitPluginProtocol, ReceiveRoutePlugin):
         openapi.paths = {
             route.path_format or "/": create_path_item_for_route(context, route) for route in self.included_routes
         }
+        openapi.components.schemas = context.schema_registry.generate_components_schemas()
         return openapi
 
     def provide_openapi(self) -> OpenAPI:

--- a/litestar/_openapi/plugin.py
+++ b/litestar/_openapi/plugin.py
@@ -33,11 +33,7 @@ class OpenAPIPlugin(InitPluginProtocol, ReceiveRoutePlugin):
 
     def _build_openapi_schema(self) -> OpenAPI:
         openapi = self.openapi_config.to_openapi_schema()
-        context = OpenAPIContext(
-            openapi_config=self.openapi_config,
-            plugins=self.app.plugins.openapi,
-            schemas=openapi.components.schemas,
-        )
+        context = OpenAPIContext(openapi_config=self.openapi_config, plugins=self.app.plugins.openapi)
         openapi.paths = {
             route.path_format or "/": create_path_item_for_route(context, route) for route in self.included_routes
         }

--- a/litestar/_openapi/responses.py
+++ b/litestar/_openapi/responses.py
@@ -148,7 +148,9 @@ class ResponseFactory:
 
                 result = self.schema_creator.for_field_definition(field_def)
 
-            schema = result if isinstance(result, Schema) else self.context.schemas[result.value]
+            schema = (
+                result if isinstance(result, Schema) else self.context.schema_registry.from_reference(result).schema
+            )
             schema.content_encoding = self.route_handler.content_encoding
             schema.content_media_type = self.route_handler.content_media_type
             response = OpenAPIResponse(

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -261,7 +261,7 @@ def create_schema_for_annotation(annotation: Any) -> Schema:
 
 
 class SchemaCreator:
-    __slots__ = ("generate_examples", "plugins", "schemas", "prefer_alias", "dto_for", "schema_registry")
+    __slots__ = ("generate_examples", "plugins", "prefer_alias", "schema_registry")
 
     def __init__(
         self,

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -690,7 +690,7 @@ class SchemaCreator:
 
             schema.examples = get_formatted_examples(field, create_examples_for_field(field))
 
-        if schema.title and schema.type in (OpenAPIType.OBJECT, OpenAPIType.ARRAY):
+        if schema.title and schema.type == OpenAPIType.OBJECT:
             class_key = _get_normalized_schema_key(field.annotation)
             # the "ref" attribute set here is arbitrary, since it will be overwritten by the SchemaRegistry
             # when the "components/schemas" section of the OpenAPI document is generated and the paths are

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -691,11 +691,11 @@ class SchemaCreator:
             schema.examples = get_formatted_examples(field, create_examples_for_field(field))
 
         if schema.title and schema.type in (OpenAPIType.OBJECT, OpenAPIType.ARRAY):
-            class_name = _get_normalized_schema_key(str(field.annotation))
-            class_key = tuple(class_name.split("_"))
-            ref = Reference(ref=f"#/components/schemas/{class_name}", description=schema.description)
-
+            class_key = _get_normalized_schema_key(field.annotation)
+            # the "ref" attribute set here is arbitrary, since it will be overwritten by the SchemaRegistry
+            # when the "components/schemas" section of the OpenAPI document is generated and the paths are
+            # known.
+            ref = Reference(ref="", description=schema.description)
             self.schema_registry.register(class_key, schema, ref)
-
             return ref
         return schema

--- a/litestar/_openapi/schema_generation/utils.py
+++ b/litestar/_openapi/schema_generation/utils.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import re
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any, Mapping, _GenericAlias  # type: ignore[attr-defined]
 
 from litestar.utils.helpers import get_name
 
@@ -84,33 +83,21 @@ def _should_create_literal_schema(field_definition: FieldDefinition) -> bool:
     )
 
 
-TYPE_NAME_NORMALIZATION_SUB_REGEX = re.compile(r"[^a-zA-Z0-9\[\]]+")
-TYPE_NAME_EXTRACTION_REGEX = re.compile(r"<\w+ '(.+)'")
+def _get_normalized_schema_key(annotation: Any) -> tuple[str, ...]:
+    """Create a key for a type annotation.
 
-
-def _replace_non_alphanumeric_match(match: re.Match) -> str:
-    # we don't want to introduce leading or trailing underscores, so we only replace a
-    # char with an underscore if we're not at the beginning or at the end of the
-    # matchable string
-    return "" if match.start() == 0 or match.end() == match.endpos else "_"
-
-
-def _get_normalized_schema_key(type_annotation_str: str) -> str:
-    """Normalize a type annotation, replacing all non-alphanumeric with underscores.
-    Existing underscores will be left as-is
+    The key should be a tuple such as ``("path", "to", "type", "TypeName")``.
 
     Args:
-        type_annotation_str: A string representing a type annotation
-            (i.e. 'typing.Dict[str, typing.Any]' or '<class 'model.Foo'>')
+        annotation: a type annotation
 
     Returns:
-        A normalized version of the input string
+        A tuple of strings.
     """
-    # extract names from repr() style annotations like <class 'foo.bar.Baz'>
-    normalized_name = TYPE_NAME_EXTRACTION_REGEX.sub(r"\g<1>", type_annotation_str)
-    # replace all non-alphanumeric characters with underscores, ensuring no leading or
-    # trailing underscores
-    return TYPE_NAME_NORMALIZATION_SUB_REGEX.sub(_replace_non_alphanumeric_match, normalized_name)
+    module = getattr(annotation, "__module__", "")
+    name = str(annotation)[len(module) + 1 :] if isinstance(annotation, _GenericAlias) else annotation.__qualname__
+    name = name.replace(".<locals>.", ".")
+    return *module.split("."), name
 
 
 def get_formatted_examples(field_definition: FieldDefinition, examples: Sequence[Example]) -> Mapping[str, Example]:

--- a/litestar/_openapi/schema_generation/utils.py
+++ b/litestar/_openapi/schema_generation/utils.py
@@ -84,7 +84,7 @@ def _should_create_literal_schema(field_definition: FieldDefinition) -> bool:
     )
 
 
-TYPE_NAME_NORMALIZATION_SUB_REGEX = re.compile(r"[^a-zA-Z0-9]+")
+TYPE_NAME_NORMALIZATION_SUB_REGEX = re.compile(r"[^a-zA-Z0-9\[\]]+")
 TYPE_NAME_EXTRACTION_REGEX = re.compile(r"<\w+ '(.+)'")
 
 

--- a/tests/examples/test_openapi.py
+++ b/tests/examples/test_openapi.py
@@ -18,13 +18,7 @@ def test_schema_generation() -> None:
                             "200": {
                                 "description": "Request fulfilled, document follows",
                                 "headers": {},
-                                "content": {
-                                    "application/json": {
-                                        "schema": {
-                                            "$ref": "#/components/schemas/docs_examples_openapi_customize_pydantic_model_name_IdModel"
-                                        }
-                                    }
-                                },
+                                "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IdModel"}}},
                             }
                         },
                         "deprecated": False,
@@ -33,7 +27,7 @@ def test_schema_generation() -> None:
             },
             "components": {
                 "schemas": {
-                    "docs_examples_openapi_customize_pydantic_model_name_IdModel": {
+                    "IdModel": {
                         "properties": {"id": {"type": "string", "format": "uuid", "description": "Any UUID string"}},
                         "type": "object",
                         "required": ["id"],

--- a/tests/unit/test_contrib/test_attrs/test_schema_plugin.py
+++ b/tests/unit/test_contrib/test_attrs/test_schema_plugin.py
@@ -1,4 +1,4 @@
-from typing import Dict, Generic, Optional
+from typing import Generic, Optional
 
 from attrs import define
 from typing_extensions import Annotated, TypeVar
@@ -6,7 +6,6 @@ from typing_extensions import Annotated, TypeVar
 from litestar._openapi.schema_generation.schema import (
     SchemaCreator,
 )
-from litestar._openapi.schema_generation.utils import _get_normalized_schema_key
 from litestar.contrib.attrs.attrs_schema_plugin import AttrsSchemaPlugin
 from litestar.openapi.spec import OpenAPIType
 from litestar.openapi.spec.schema import Schema
@@ -27,11 +26,10 @@ def test_schema_generation_with_generic_classes() -> None:
     cls = AttrsGeneric[int]
     field_definition = FieldDefinition.from_kwarg(name=get_name(cls), annotation=cls)
 
-    schemas: Dict[str, Schema] = {}
-    SchemaCreator(schemas=schemas, plugins=[AttrsSchemaPlugin()]).for_field_definition(field_definition)
-
-    name = _get_normalized_schema_key(str(field_definition.annotation))
-    properties = schemas[name].properties
+    creator = SchemaCreator(plugins=[AttrsSchemaPlugin()])
+    creator.for_field_definition(field_definition)
+    schemas = creator.schema_registry.generate_components_schemas()
+    properties = schemas["AttrsGeneric[int]"].properties
     expected_foo_schema = Schema(type=OpenAPIType.INTEGER)
     expected_optional_foo_schema = Schema(one_of=[Schema(type=OpenAPIType.NULL), Schema(type=OpenAPIType.INTEGER)])
 

--- a/tests/unit/test_contrib/test_attrs/test_schema_plugin.py
+++ b/tests/unit/test_contrib/test_attrs/test_schema_plugin.py
@@ -1,16 +1,14 @@
-from typing import Generic, Optional
+from typing import Generic, Optional, TypeVar
 
 from attrs import define
-from typing_extensions import Annotated, TypeVar
+from typing_extensions import Annotated
 
-from litestar._openapi.schema_generation.schema import (
-    SchemaCreator,
-)
 from litestar.contrib.attrs.attrs_schema_plugin import AttrsSchemaPlugin
 from litestar.openapi.spec import OpenAPIType
 from litestar.openapi.spec.schema import Schema
 from litestar.typing import FieldDefinition
 from litestar.utils.helpers import get_name
+from tests.helpers import get_schema_for_field_definition
 
 T = TypeVar("T")
 
@@ -24,14 +22,11 @@ class AttrsGeneric(Generic[T]):
 
 def test_schema_generation_with_generic_classes() -> None:
     cls = AttrsGeneric[int]
-    field_definition = FieldDefinition.from_kwarg(name=get_name(cls), annotation=cls)
-
-    creator = SchemaCreator(plugins=[AttrsSchemaPlugin()])
-    creator.for_field_definition(field_definition)
-    schemas = creator.schema_registry.generate_components_schemas()
-    properties = schemas["AttrsGeneric[int]"].properties
     expected_foo_schema = Schema(type=OpenAPIType.INTEGER)
     expected_optional_foo_schema = Schema(one_of=[Schema(type=OpenAPIType.NULL), Schema(type=OpenAPIType.INTEGER)])
+
+    field_definition = FieldDefinition.from_kwarg(name=get_name(cls), annotation=cls)
+    properties = get_schema_for_field_definition(field_definition, plugins=[AttrsSchemaPlugin()]).properties
 
     assert properties
     assert properties["foo"] == expected_foo_schema

--- a/tests/unit/test_contrib/test_attrs/test_schema_spec_generation.py
+++ b/tests/unit/test_contrib/test_attrs/test_schema_spec_generation.py
@@ -24,8 +24,7 @@ def test_spec_generation() -> None:
     with create_test_client(handler) as client:
         schema = client.app.openapi_schema
         assert schema
-        key_name = "tests_unit_test_contrib_test_attrs_test_schema_spec_generation_test_spec_generation_locals_Person"
-        assert schema.to_schema()["components"]["schemas"][key_name] == {
+        assert schema.to_schema()["components"]["schemas"]["Person"] == {
             "properties": {
                 "first_name": {"type": "string"},
                 "last_name": {"type": "string"},
@@ -42,7 +41,7 @@ def test_spec_generation() -> None:
                     "oneOf": [
                         {"type": "null"},
                         {
-                            "items": {"$ref": "#/components/schemas/tests_models_DataclassPet"},
+                            "items": {"$ref": "#/components/schemas/DataclassPet"},
                             "type": "array",
                         },
                     ]

--- a/tests/unit/test_contrib/test_attrs/test_schema_spec_generation.py
+++ b/tests/unit/test_contrib/test_attrs/test_schema_spec_generation.py
@@ -24,7 +24,7 @@ def test_spec_generation() -> None:
     with create_test_client(handler) as client:
         schema = client.app.openapi_schema
         assert schema
-        assert schema.to_schema()["components"]["schemas"]["Person"] == {
+        assert schema.to_schema()["components"]["schemas"]["test_spec_generation.Person"] == {
             "properties": {
                 "first_name": {"type": "string"},
                 "last_name": {"type": "string"},

--- a/tests/unit/test_contrib/test_piccolo_orm/test_piccolo_orm_dto.py
+++ b/tests/unit/test_contrib/test_piccolo_orm/test_piccolo_orm_dto.py
@@ -108,22 +108,22 @@ def test_piccolo_dto_openapi_spec_generation() -> None:
     post_operation = concert_path.post
     assert (
         post_operation.request_body.content["application/json"].schema.ref  # type: ignore
-        == "#/components/schemas/litestar_dto_backend_CreateConcertConcertRequestBody"
+        == "#/components/schemas/CreateConcertConcertRequestBody"
     )
 
     studio_path_get_operation = studio_path.get
     assert (
         studio_path_get_operation.responses["200"].content["application/json"].schema.ref  # type: ignore
-        == "#/components/schemas/litestar_dto_backend_RetrieveStudioRecordingStudioResponseBody"
+        == "#/components/schemas/RetrieveStudioRecordingStudioResponseBody"
     )
 
     venues_path_get_operation = venues_path.get
     assert (
         venues_path_get_operation.responses["200"].content["application/json"].schema.items.ref  # type: ignore
-        == "#/components/schemas/litestar_dto_backend_RetrieveVenuesVenueResponseBody"
+        == "#/components/schemas/RetrieveVenuesVenueResponseBody"
     )
 
-    concert_schema = schema.components.schemas["litestar_dto_backend_CreateConcertConcertRequestBody"]
+    concert_schema = schema.components.schemas["CreateConcertConcertRequestBody"]
     assert concert_schema
     assert concert_schema.to_schema() == {
         "properties": {
@@ -136,7 +136,7 @@ def test_piccolo_dto_openapi_spec_generation() -> None:
         "type": "object",
     }
 
-    record_studio_schema = schema.components.schemas["litestar_dto_backend_RetrieveStudioRecordingStudioResponseBody"]
+    record_studio_schema = schema.components.schemas["RetrieveStudioRecordingStudioResponseBody"]
     assert record_studio_schema
     assert record_studio_schema.to_schema() == {
         "properties": {
@@ -150,7 +150,7 @@ def test_piccolo_dto_openapi_spec_generation() -> None:
         "type": "object",
     }
 
-    venue_schema = schema.components.schemas["litestar_dto_backend_RetrieveVenuesVenueResponseBody"]
+    venue_schema = schema.components.schemas["RetrieveVenuesVenueResponseBody"]
     assert venue_schema
     assert venue_schema.to_schema() == {
         "properties": {

--- a/tests/unit/test_contrib/test_pydantic/test_openapi.py
+++ b/tests/unit/test_contrib/test_pydantic/test_openapi.py
@@ -320,9 +320,8 @@ def test_spec_generation(cls: Any) -> None:
     with create_test_client(handler) as client:
         schema = client.app.openapi_schema
         assert schema
-        key_name = _get_normalized_schema_key(str(cls))
 
-        assert schema.to_schema()["components"]["schemas"][key_name] == {
+        assert schema.to_schema()["components"]["schemas"][cls.__name__] == {
             "properties": {
                 "first_name": {"type": "string"},
                 "last_name": {"type": "string"},
@@ -339,7 +338,7 @@ def test_spec_generation(cls: Any) -> None:
                     "oneOf": [
                         {"type": "null"},
                         {
-                            "items": {"$ref": "#/components/schemas/tests_models_DataclassPet"},
+                            "items": {"$ref": "#/components/schemas/DataclassPet"},
                             "type": "array",
                         },
                     ]
@@ -378,9 +377,8 @@ def test_schema_generation_v1(create_examples: bool) -> None:
         signature_namespace={"Lookup": Lookup},
     ) as client:
         response = client.get("/schema/openapi.json")
-        key_name = "tests_unit_test_contrib_test_pydantic_test_openapi_test_schema_generation_v1_locals_Lookup"
         assert response.status_code == HTTP_200_OK
-        assert response.json()["components"]["schemas"][key_name]["properties"]["id"] == {
+        assert response.json()["components"]["schemas"]["Lookup"]["properties"]["id"] == {
             "description": "A unique identifier",
             "examples": {"id-example-1": {"value": "e4eaaaf2-d142-11e1-b3e4-080027620cdd"}},
             "maxLength": 16,
@@ -417,8 +415,7 @@ def test_schema_generation_v2(create_examples: bool) -> None:
     ) as client:
         response = client.get("/schema/openapi.json")
         assert response.status_code == HTTP_200_OK
-        key_name = "tests_unit_test_contrib_test_pydantic_test_openapi_test_schema_generation_v2_locals_Lookup"
-        assert response.json()["components"]["schemas"][key_name]["properties"]["id"] == {
+        assert response.json()["components"]["schemas"]["Lookup"]["properties"]["id"] == {
             "description": "A unique identifier",
             "examples": {"id-example-1": {"value": "e4eaaaf2-d142-11e1-b3e4-080027620cdd"}},
             "maxLength": 16,
@@ -443,18 +440,14 @@ def test_schema_by_alias(base_model: AnyBaseModelType, pydantic_version: Pydanti
     assert app.openapi_schema
     schemas = app.openapi_schema.to_schema()["components"]["schemas"]
     request_key = "second"
-    assert schemas[
-        "tests_unit_test_contrib_test_pydantic_test_openapi_test_schema_by_alias_locals_RequestWithAlias"
-    ] == {
+    assert schemas["RequestWithAlias"] == {
         "properties": {request_key: {"type": "string"}},
         "type": "object",
         "required": [request_key],
         "title": "RequestWithAlias",
     }
     response_key = "first"
-    assert schemas[
-        "tests_unit_test_contrib_test_pydantic_test_openapi_test_schema_by_alias_locals_ResponseWithAlias"
-    ] == {
+    assert schemas["ResponseWithAlias"] == {
         "properties": {response_key: {"type": "string"}},
         "type": "object",
         "required": [response_key],
@@ -485,18 +478,14 @@ def test_schema_by_alias_plugin_override(base_model: AnyBaseModelType, pydantic_
     assert app.openapi_schema
     schemas = app.openapi_schema.to_schema()["components"]["schemas"]
     request_key = "second"
-    assert schemas[
-        "tests_unit_test_contrib_test_pydantic_test_openapi_test_schema_by_alias_plugin_override_locals_RequestWithAlias"
-    ] == {
+    assert schemas["RequestWithAlias"] == {
         "properties": {request_key: {"type": "string"}},
         "type": "object",
         "required": [request_key],
         "title": "RequestWithAlias",
     }
     response_key = "second"
-    assert schemas[
-        "tests_unit_test_contrib_test_pydantic_test_openapi_test_schema_by_alias_plugin_override_locals_ResponseWithAlias"
-    ] == {
+    assert schemas["ResponseWithAlias"] == {
         "properties": {response_key: {"type": "string"}},
         "type": "object",
         "required": [response_key],

--- a/tests/unit/test_contrib/test_pydantic/test_schema_plugin.py
+++ b/tests/unit/test_contrib/test_pydantic/test_schema_plugin.py
@@ -1,6 +1,6 @@
 import datetime
 from decimal import Decimal
-from typing import Any, Dict, Generic, Optional, Type, TypeVar, Union
+from typing import Any, Generic, Optional, Type, TypeVar, Union
 
 import pydantic as pydantic_v2
 import pytest
@@ -38,11 +38,11 @@ def test_schema_generation_with_generic_classes(model: Type[Union[PydanticV1Gene
     cls = model[int]  # type: ignore[index]
     field_definition = FieldDefinition.from_kwarg(name=get_name(cls), annotation=cls)
 
-    schemas: Dict[str, Schema] = {}
-    SchemaCreator(schemas=schemas, plugins=[PydanticSchemaPlugin()]).for_field_definition(field_definition)
+    creator = SchemaCreator(plugins=[PydanticSchemaPlugin()])
+    creator.for_field_definition(field_definition)
 
     name = _get_normalized_schema_key(str(field_definition.annotation))
-    properties = schemas[name].properties
+    properties = creator.schema_registry.get(tuple(name.split("_"))).schema.properties
     expected_foo_schema = Schema(type=OpenAPIType.INTEGER)
     expected_optional_foo_schema = Schema(one_of=[Schema(type=OpenAPIType.NULL), Schema(type=OpenAPIType.INTEGER)])
 

--- a/tests/unit/test_contrib/test_pydantic/test_schema_plugin.py
+++ b/tests/unit/test_contrib/test_pydantic/test_schema_plugin.py
@@ -8,15 +8,12 @@ from pydantic import v1 as pydantic_v1
 from pydantic.v1.generics import GenericModel
 from typing_extensions import Annotated
 
-from litestar._openapi.schema_generation.schema import (
-    SchemaCreator,
-)
-from litestar._openapi.schema_generation.utils import _get_normalized_schema_key
 from litestar.contrib.pydantic.pydantic_schema_plugin import PydanticSchemaPlugin
 from litestar.openapi.spec import OpenAPIType
 from litestar.openapi.spec.schema import Schema
 from litestar.typing import FieldDefinition
 from litestar.utils.helpers import get_name
+from tests.helpers import get_schema_for_field_definition
 
 T = TypeVar("T")
 
@@ -37,12 +34,7 @@ class PydanticV2Generic(pydantic_v2.BaseModel, Generic[T]):
 def test_schema_generation_with_generic_classes(model: Type[Union[PydanticV1Generic, PydanticV2Generic]]) -> None:
     cls = model[int]  # type: ignore[index]
     field_definition = FieldDefinition.from_kwarg(name=get_name(cls), annotation=cls)
-
-    creator = SchemaCreator(plugins=[PydanticSchemaPlugin()])
-    creator.for_field_definition(field_definition)
-
-    name = _get_normalized_schema_key(str(field_definition.annotation))
-    properties = creator.schema_registry.get(tuple(name.split("_"))).schema.properties
+    properties = get_schema_for_field_definition(field_definition, plugins=[PydanticSchemaPlugin()]).properties
     expected_foo_schema = Schema(type=OpenAPIType.INTEGER)
     expected_optional_foo_schema = Schema(one_of=[Schema(type=OpenAPIType.NULL), Schema(type=OpenAPIType.INTEGER)])
 

--- a/tests/unit/test_contrib/test_repository.py
+++ b/tests/unit/test_contrib/test_repository.py
@@ -16,7 +16,7 @@ from litestar.repository.filters import (
 
 
 def test_app_repository_signature_namespace() -> None:
-    app = Litestar([], on_app_init=[handlers.on_app_init])
+    app = Litestar([], on_app_init=[handlers.on_app_init], openapi_config=None)
 
     assert app.signature_namespace == {
         "BeforeAfter": BeforeAfter,

--- a/tests/unit/test_contrib/test_repository.py
+++ b/tests/unit/test_contrib/test_repository.py
@@ -16,7 +16,7 @@ from litestar.repository.filters import (
 
 
 def test_app_repository_signature_namespace() -> None:
-    app = Litestar([], on_app_init=[handlers.on_app_init], openapi_config=None)
+    app = Litestar([], on_app_init=[handlers.on_app_init])
 
     assert app.signature_namespace == {
         "BeforeAfter": BeforeAfter,

--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -173,7 +173,9 @@ def test_msgspec_schema_generation(create_examples: bool) -> None:
     ) as client:
         response = client.get("/schema/openapi.json")
         assert response.status_code == HTTP_200_OK
-        assert response.json()["components"]["schemas"]["Lookup"]["properties"]["id"] == {
+        assert response.json()["components"]["schemas"]["test_msgspec_schema_generation.Lookup"]["properties"][
+            "id"
+        ] == {
             "description": "A unique identifier",
             "examples": {"id-example-1": {"value": "e4eaaaf2-d142-11e1-b3e4-080027620cdd"}},
             "maxLength": 16,

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -27,9 +27,7 @@ if TYPE_CHECKING:
 def create_factory(route: BaseRoute, handler: HTTPRouteHandler) -> ParameterFactory:
     return ParameterFactory(
         OpenAPIContext(
-            openapi_config=OpenAPIConfig(title="Test API", version="1.0.0", create_examples=True),
-            plugins=[],
-            schemas={},
+            openapi_config=OpenAPIConfig(title="Test API", version="1.0.0", create_examples=True), plugins=[]
         ),
         route_handler=handler,
         path_parameters=route.path_parameters,

--- a/tests/unit/test_openapi/test_path_item.py
+++ b/tests/unit/test_openapi/test_path_item.py
@@ -50,7 +50,6 @@ def create_factory() -> CreateFactoryFixture:
             OpenAPIContext(
                 openapi_config=OpenAPIConfig(title="Test", version="1.0.0", description="Test", create_examples=True),
                 plugins=[],
-                schemas={},
             ),
             route,
         )

--- a/tests/unit/test_openapi/test_request_body.py
+++ b/tests/unit/test_openapi/test_request_body.py
@@ -91,7 +91,7 @@ def test_upload_file_request_body_generation() -> None:
 
     assert components == {
         "schemas": {
-            "tests_unit_test_openapi_test_request_body_FormData": {
+            "FormData": {
                 "properties": {
                     "cv": {
                         "type": "string",

--- a/tests/unit/test_openapi/test_request_body.py
+++ b/tests/unit/test_openapi/test_request_body.py
@@ -31,7 +31,6 @@ def openapi_context() -> OpenAPIContext:
     return OpenAPIContext(
         openapi_config=OpenAPIConfig(title="test", version="1.0.0", create_examples=True),
         plugins=[],
-        schemas={},
     )
 
 

--- a/tests/unit/test_openapi/test_responses.py
+++ b/tests/unit/test_openapi/test_responses.py
@@ -231,17 +231,13 @@ def test_create_success_response_with_response_class(create_factory: CreateFacto
 
     handler = get_registered_route_handler(handler, "test")
     factory = create_factory(handler, True)
-    schemas = factory.context.schemas
     response = factory.create_success_response()
 
     assert response.content
     reference = response.content["application/json"].schema
 
     assert isinstance(reference, Reference)
-    key = reference.ref.split("/")[-1]
-    assert isinstance(schemas[key], Schema)
-
-    assert key == "tests_models_DataclassPerson"
+    assert isinstance(factory.context.schema_registry.from_reference(reference).schema, Schema)
 
 
 def test_create_success_response_with_stream(create_factory: CreateFactoryFixture) -> None:
@@ -347,7 +343,6 @@ def test_create_additional_responses(create_factory: CreateFactoryFixture) -> No
         return DataclassPersonFactory.build()
 
     factory = create_factory(handler)
-    schemas = factory.context.schemas
     responses = factory.create_additional_responses()
 
     first_response = next(responses)
@@ -358,7 +353,7 @@ def test_create_additional_responses(create_factory: CreateFactoryFixture) -> No
     assert isinstance(first_response[1].content["application/json"], OpenAPIMediaType)
     reference = first_response[1].content["application/json"].schema
     assert isinstance(reference, Reference)
-    schema = schemas[reference.ref.split("/")[-1]]
+    schema = factory.context.schema_registry.from_reference(reference).schema
     assert isinstance(schema, Schema)
     assert schema.title == "AuthenticationError"
 
@@ -370,7 +365,7 @@ def test_create_additional_responses(create_factory: CreateFactoryFixture) -> No
     assert isinstance(second_response[1].content["text/plain"], OpenAPIMediaType)
     reference = second_response[1].content["text/plain"].schema
     assert isinstance(reference, Reference)
-    schema = schemas[reference.ref.split("/")[-1]]
+    schema = factory.context.schema_registry.from_reference(reference).schema
     assert isinstance(schema, Schema)
     assert schema.title == "ServerError"
     assert not schema.examples
@@ -431,14 +426,13 @@ def test_create_response_for_response_subclass(create_factory: CreateFactoryFixt
 
     handler = get_registered_route_handler(handler, "test")
     factory = create_factory(handler, True)
-    schemas = factory.context.schemas
     response = factory.create_success_response()
 
     assert response.content
     assert isinstance(response.content["application/json"], OpenAPIMediaType)
     reference = response.content["application/json"].schema
     assert isinstance(reference, Reference)
-    schema = schemas[reference.value]
+    schema = factory.context.schema_registry.from_reference(reference).schema
     assert schema.title == "DataclassPerson"
 
 

--- a/tests/unit/test_openapi/test_responses.py
+++ b/tests/unit/test_openapi/test_responses.py
@@ -52,7 +52,6 @@ def create_factory() -> CreateFactoryFixture:
             context=OpenAPIContext(
                 openapi_config=OpenAPIConfig(title="test", version="1.0.0", create_examples=generate_examples),
                 plugins=[],
-                schemas={},
             ),
             route_handler=route_handler,
         )

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -41,6 +41,7 @@ from litestar.testing import create_test_client
 from litestar.types.builtin_types import NoneType
 from litestar.typing import FieldDefinition
 from litestar.utils.helpers import get_name
+from tests.helpers import get_schema_for_field_definition
 from tests.models import DataclassPerson, DataclassPet
 
 if TYPE_CHECKING:
@@ -48,14 +49,6 @@ if TYPE_CHECKING:
     from typing import Callable
 
 T = TypeVar("T")
-
-
-def get_schema_for_field_definition(field_definition: FieldDefinition) -> Schema:
-    creator = SchemaCreator()
-    result = creator.for_field_definition(field_definition)
-    if isinstance(result, Schema):
-        return result
-    return creator.schema_registry.from_reference(result).schema
 
 
 def test_process_schema_result() -> None:
@@ -97,41 +90,54 @@ def test_get_normalized_schema_key() -> None:
     class LocalClass(msgspec.Struct):
         id: str
 
+    # replace each of the long strings with underscores with a tuple of strings split at each underscore
     assert (
-        "tests_unit_test_openapi_test_schema_test_get_normalized_schema_key_locals_LocalClass"
-        == _get_normalized_schema_key(str(LocalClass))
-    )
+        "tests",
+        "unit",
+        "test_openapi",
+        "test_schema",
+        "test_get_normalized_schema_key.LocalClass",
+    ) == _get_normalized_schema_key(LocalClass)
 
-    assert "tests_models_DataclassPerson" == _get_normalized_schema_key(str(DataclassPerson))
+    assert ("tests", "models", "DataclassPerson") == _get_normalized_schema_key(DataclassPerson)
 
     builtin_dict = Dict[str, List[int]]
-    assert "typing_Dict[str_typing_List[int]]" == _get_normalized_schema_key(str(builtin_dict))
+    assert ("typing", "Dict[str, typing.List[int]]") == _get_normalized_schema_key(builtin_dict)
 
     builtin_with_custom = Dict[str, DataclassPerson]
-    assert "typing_Dict[str_tests_models_DataclassPerson]" == _get_normalized_schema_key(str(builtin_with_custom))
+    assert ("typing", "Dict[str, tests.models.DataclassPerson]") == _get_normalized_schema_key(builtin_with_custom)
 
     class LocalGeneric(Generic[T]):
         pass
 
     assert (
-        "tests_unit_test_openapi_test_schema_test_get_normalized_schema_key_locals_LocalGeneric"
-        == _get_normalized_schema_key(str(LocalGeneric))
-    )
+        "tests",
+        "unit",
+        "test_openapi",
+        "test_schema",
+        "test_get_normalized_schema_key.LocalGeneric",
+    ) == _get_normalized_schema_key(LocalGeneric)
 
     generic_int = LocalGeneric[int]
     generic_str = LocalGeneric[str]
 
     assert (
-        "tests_unit_test_openapi_test_schema_test_get_normalized_schema_key_locals_LocalGeneric[int]"
-        == _get_normalized_schema_key(str(generic_int))
-    )
+        "tests",
+        "unit",
+        "test_openapi",
+        "test_schema",
+        "test_get_normalized_schema_key.LocalGeneric[int]",
+    ) == _get_normalized_schema_key(generic_int)
 
     assert (
-        "tests_unit_test_openapi_test_schema_test_get_normalized_schema_key_locals_LocalGeneric[str]"
-        == _get_normalized_schema_key(str(generic_str))
-    )
+        "tests",
+        "unit",
+        "test_openapi",
+        "test_schema",
+        "test_get_normalized_schema_key.LocalGeneric[str]",
+    ) == _get_normalized_schema_key(generic_str)
 
-    assert _get_normalized_schema_key(str(generic_int)) != _get_normalized_schema_key(str(generic_str))
+    assert _get_normalized_schema_key(generic_int) != _get_normalized_schema_key(generic_str)
 
 
 def test_dependency_schema_generation() -> None:

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -97,10 +97,10 @@ def test_get_normalized_schema_key() -> None:
     assert "tests_models_DataclassPerson" == _get_normalized_schema_key(str(DataclassPerson))
 
     builtin_dict = Dict[str, List[int]]
-    assert "typing_Dict_str_typing_List_int" == _get_normalized_schema_key(str(builtin_dict))
+    assert "typing_Dict[str_typing_List[int]]" == _get_normalized_schema_key(str(builtin_dict))
 
     builtin_with_custom = Dict[str, DataclassPerson]
-    assert "typing_Dict_str_tests_models_DataclassPerson" == _get_normalized_schema_key(str(builtin_with_custom))
+    assert "typing_Dict[str_tests_models_DataclassPerson]" == _get_normalized_schema_key(str(builtin_with_custom))
 
     class LocalGeneric(Generic[T]):
         pass
@@ -114,12 +114,12 @@ def test_get_normalized_schema_key() -> None:
     generic_str = LocalGeneric[str]
 
     assert (
-        "tests_unit_test_openapi_test_schema_test_get_normalized_schema_key_locals_LocalGeneric_int"
+        "tests_unit_test_openapi_test_schema_test_get_normalized_schema_key_locals_LocalGeneric[int]"
         == _get_normalized_schema_key(str(generic_int))
     )
 
     assert (
-        "tests_unit_test_openapi_test_schema_test_get_normalized_schema_key_locals_LocalGeneric_str"
+        "tests_unit_test_openapi_test_schema_test_get_normalized_schema_key_locals_LocalGeneric[str]"
         == _get_normalized_schema_key(str(generic_str))
     )
 

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -50,6 +50,14 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
+def get_schema_for_field_definition(field_definition: FieldDefinition) -> Schema:
+    creator = SchemaCreator()
+    result = creator.for_field_definition(field_definition)
+    if isinstance(result, Schema):
+        return result
+    return creator.schema_registry.from_reference(result).schema
+
+
 def test_process_schema_result() -> None:
     test_str = "abc"
     kwarg_definition = ParameterKwarg(
@@ -71,10 +79,10 @@ def test_process_schema_result() -> None:
         max_length=1,
         pattern="^[a-z]$",
     )
-    field = FieldDefinition.from_annotation(annotation=str, kwarg_definition=kwarg_definition)
-    schema = SchemaCreator().for_field_definition(field)
+    schema = get_schema_for_field_definition(
+        FieldDefinition.from_annotation(annotation=str, kwarg_definition=kwarg_definition)
+    )
 
-    assert isinstance(schema, Schema)
     assert schema.title
     assert schema.const == test_str
     assert kwarg_definition.examples
@@ -170,8 +178,7 @@ def test_get_schema_for_annotation_enum() -> None:
         opt1 = "opt1"
         opt2 = "opt2"
 
-    schema = SchemaCreator().for_field_definition(FieldDefinition.from_annotation(Opts))
-    assert isinstance(schema, Schema)
+    schema = get_schema_for_field_definition(FieldDefinition.from_annotation(Opts))
     assert schema.enum == ["opt1", "opt2"]
 
 
@@ -186,13 +193,8 @@ def test_handling_of_literals() -> None:
         const: ConstType
         composite: Literal[ValueType, ConstType]
 
-    schemas: Dict[str, Schema] = {}
-    result = SchemaCreator(schemas=schemas).for_field_definition(
-        FieldDefinition.from_kwarg(name="", annotation=DataclassWithLiteral)
-    )
-    assert isinstance(result, Reference)
+    schema = get_schema_for_field_definition(FieldDefinition.from_kwarg(name="", annotation=DataclassWithLiteral))
 
-    schema = schemas["tests_unit_test_openapi_test_schema_test_handling_of_literals_locals_DataclassWithLiteral"]
     assert isinstance(schema, Schema)
     assert schema.properties
 
@@ -222,14 +224,14 @@ def test_schema_hashing() -> None:
 
 
 def test_title_validation() -> None:
-    schemas: Dict[str, Schema] = {}
-    schema_creator = SchemaCreator(schemas=schemas)
-
-    schema_creator.for_field_definition(FieldDefinition.from_kwarg(name="Person", annotation=DataclassPerson))
-    assert schemas.get("tests_models_DataclassPerson")
-
-    schema_creator.for_field_definition(FieldDefinition.from_kwarg(name="Pet", annotation=DataclassPet))
-    assert schemas.get("tests_models_DataclassPet")
+    # TODO: what is this actually testing?
+    creator = SchemaCreator()
+    person_ref = creator.for_field_definition(FieldDefinition.from_kwarg(name="Person", annotation=DataclassPerson))
+    pet_ref = creator.for_field_definition(FieldDefinition.from_kwarg(name="Pet", annotation=DataclassPet))
+    assert isinstance(person_ref, Reference)
+    assert isinstance(pet_ref, Reference)
+    assert isinstance(creator.schema_registry.from_reference(person_ref).schema, Schema)
+    assert isinstance(creator.schema_registry.from_reference(pet_ref).schema, Schema)
 
 
 @pytest.mark.parametrize("with_future_annotations", [True, False])
@@ -248,10 +250,7 @@ class Foo:
     foo: Annotated[int, "Foo description"]
 """
     )
-    schemas: Dict[str, Schema] = {}
-    SchemaCreator(schemas=schemas).for_field_definition(FieldDefinition.from_annotation(module.Foo))
-    schema_key = _get_normalized_schema_key(str(module.Foo))
-    schema = schemas[schema_key]
+    schema = get_schema_for_field_definition(FieldDefinition.from_annotation(module.Foo))
     assert schema.properties and "foo" in schema.properties
 
 
@@ -272,10 +271,7 @@ class Foo(TypedDict):
     baz: Annotated[NotRequired[int], "Baz description"]
 """
     )
-    schemas: Dict[str, Schema] = {}
-    SchemaCreator(schemas=schemas).for_field_definition(FieldDefinition.from_annotation(module.Foo))
-    schema_key = _get_normalized_schema_key(str(module.Foo))
-    schema = schemas[schema_key]
+    schema = get_schema_for_field_definition(FieldDefinition.from_annotation(module.Foo))
     assert schema.properties and all(key in schema.properties for key in ("foo", "bar", "baz"))
 
 
@@ -283,9 +279,7 @@ def test_create_schema_from_msgspec_annotated_type() -> None:
     class Lookup(msgspec.Struct):
         id: Annotated[str, msgspec.Meta(max_length=16, examples=["example"], description="description", title="title")]
 
-    schemas: Dict[str, Schema] = {}
-    SchemaCreator(schemas=schemas).for_field_definition(FieldDefinition.from_kwarg(name="Lookup", annotation=Lookup))
-    schema = schemas["tests_unit_test_openapi_test_schema_test_create_schema_from_msgspec_annotated_type_locals_Lookup"]
+    schema = get_schema_for_field_definition(FieldDefinition.from_kwarg(name="Lookup", annotation=Lookup))
 
     assert schema.properties["id"].type == OpenAPIType.STRING  # type: ignore
     assert schema.properties["id"].examples == {"id-example-1": Example(value="example")}  # type: ignore
@@ -309,11 +303,7 @@ def test_annotated_types() -> None:
         constrainted_is_ascii: Annotated[str, annotated_types.IsAscii]
         constrainted_is_digit: Annotated[str, annotated_types.IsDigits]
 
-    schemas: Dict[str, Schema] = {}
-    SchemaCreator(schemas=schemas).for_field_definition(
-        FieldDefinition.from_kwarg(name="MyDataclass", annotation=MyDataclass)
-    )
-    schema = schemas["tests_unit_test_openapi_test_schema_test_annotated_types_locals_MyDataclass"]
+    schema = get_schema_for_field_definition(FieldDefinition.from_kwarg(name="MyDataclass", annotation=MyDataclass))
 
     assert schema.properties["constrained_int"].exclusive_minimum == 1  # type: ignore
     assert schema.properties["constrained_int"].exclusive_maximum == 10  # type: ignore
@@ -332,8 +322,7 @@ def test_literal_enums() -> None:
         A = auto()
         B = auto()
 
-    schema = SchemaCreator().for_field_definition(FieldDefinition.from_annotation(List[Literal[Foo.A]]))
-    assert isinstance(schema, Schema)
+    schema = get_schema_for_field_definition(FieldDefinition.from_annotation(List[Literal[Foo.A]]))
     assert isinstance(schema.items, Schema)
     assert schema.items.const == 1
 
@@ -366,16 +355,12 @@ if sys.version_info >= (3, 11):
 
 @pytest.mark.parametrize("cls", annotations)
 def test_schema_generation_with_generic_classes(cls: Any) -> None:
-    field_definition = FieldDefinition.from_kwarg(name=get_name(cls), annotation=cls)
-
-    schemas: Dict[str, Schema] = {}
-    SchemaCreator(schemas=schemas).for_field_definition(field_definition)
-
-    path_name = _get_normalized_schema_key(str(cls))
-    properties = schemas[path_name].properties
     expected_foo_schema = Schema(type=OpenAPIType.INTEGER)
     expected_optional_foo_schema = Schema(one_of=[Schema(type=OpenAPIType.NULL), Schema(type=OpenAPIType.INTEGER)])
 
+    properties = get_schema_for_field_definition(
+        FieldDefinition.from_kwarg(name=get_name(cls), annotation=cls)
+    ).properties
     assert properties
     assert properties["foo"] == expected_foo_schema
     assert properties["annotated_foo"] == expected_foo_schema
@@ -397,12 +382,9 @@ class ConstrainedGenericDataclass(Generic[T, B, C]):
 
 def test_schema_generation_with_generic_classes_constrained() -> None:
     cls = ConstrainedGenericDataclass
-    field_definition = FieldDefinition.from_kwarg(name=cls.__name__, annotation=cls)
-
-    schemas: Dict[str, Schema] = {}
-    SchemaCreator(schemas=schemas).for_field_definition(field_definition)
-
-    properties = schemas["tests_unit_test_openapi_test_schema_ConstrainedGenericDataclass"].properties
+    properties = get_schema_for_field_definition(
+        FieldDefinition.from_kwarg(name=cls.__name__, annotation=cls)
+    ).properties
 
     assert properties
     assert properties["bound"] == Schema(type=OpenAPIType.INTEGER)
@@ -427,14 +409,10 @@ def test_schema_generation_with_generic_classes_constrained() -> None:
     ),
 )
 def test_schema_generation_with_pagination(annotation: Any) -> None:
-    field_definition = FieldDefinition.from_annotation(annotation)
-    schemas: Dict[str, Schema] = {}
-    SchemaCreator(schemas=schemas).for_field_definition(field_definition)
-    schema_key = _get_normalized_schema_key(str(field_definition.inner_types[-1].annotation))
-    properties = schemas[str(schema_key)].properties
-
     expected_foo_schema = Schema(type=OpenAPIType.INTEGER)
     expected_optional_foo_schema = Schema(one_of=[Schema(type=OpenAPIType.NULL), Schema(type=OpenAPIType.INTEGER)])
+
+    properties = get_schema_for_field_definition(FieldDefinition.from_annotation(annotation).inner_types[-1]).properties
 
     assert properties
     assert properties["foo"] == expected_foo_schema
@@ -443,15 +421,13 @@ def test_schema_generation_with_pagination(annotation: Any) -> None:
 
 
 def test_schema_generation_with_ellipsis() -> None:
-    schema = SchemaCreator().for_field_definition(FieldDefinition.from_annotation(Tuple[int, ...]))
-    assert isinstance(schema, Schema)
+    schema = get_schema_for_field_definition(FieldDefinition.from_annotation(Tuple[int, ...]))
     assert isinstance(schema.items, Schema)
     assert schema.items.type == OpenAPIType.INTEGER
 
 
 def test_schema_tuple_with_union() -> None:
-    schema = SchemaCreator().for_field_definition(FieldDefinition.from_annotation(Tuple[int, Union[int, str]]))
-    assert isinstance(schema, Schema)
+    schema = get_schema_for_field_definition(FieldDefinition.from_annotation(Tuple[int, Union[int, str]]))
     assert isinstance(schema.items, Schema)
     assert schema.items.one_of == [
         Schema(type=OpenAPIType.INTEGER),
@@ -464,16 +440,14 @@ def test_optional_enum() -> None:
         A = 1
         B = 2
 
-    schema = SchemaCreator().for_field_definition(FieldDefinition.from_annotation(Optional[Foo]))
-    assert isinstance(schema, Schema)
+    schema = get_schema_for_field_definition(FieldDefinition.from_annotation(Optional[Foo]))
     assert schema.type is not None
     assert set(schema.type) == {OpenAPIType.INTEGER, OpenAPIType.NULL}
     assert schema.enum == [1, 2, None]
 
 
 def test_optional_literal() -> None:
-    schema = SchemaCreator().for_field_definition(FieldDefinition.from_annotation(Optional[Literal[1]]))
-    assert isinstance(schema, Schema)
+    schema = get_schema_for_field_definition(FieldDefinition.from_annotation(Optional[Literal[1]]))
     assert schema.type is not None
     assert set(schema.type) == {OpenAPIType.INTEGER, OpenAPIType.NULL}
     assert schema.enum == [1, None]

--- a/tests/unit/test_openapi/test_spec_generation.py
+++ b/tests/unit/test_openapi/test_spec_generation.py
@@ -4,7 +4,6 @@ import pytest
 from msgspec import Struct
 
 from litestar import post
-from litestar._openapi.schema_generation.utils import _get_normalized_schema_key
 from litestar.testing import create_test_client
 from tests.models import DataclassPerson, MsgSpecStructPerson, TypedDictPerson
 
@@ -18,9 +17,7 @@ def test_spec_generation(cls: Any) -> None:
     with create_test_client(handler) as client:
         schema = client.app.openapi_schema
         assert schema
-        schema_key = _get_normalized_schema_key(str(cls))
-
-        assert schema.to_schema()["components"]["schemas"][schema_key] == {
+        assert schema.to_schema()["components"]["schemas"][cls.__name__] == {
             "properties": {
                 "first_name": {"type": "string"},
                 "last_name": {"type": "string"},
@@ -37,7 +34,7 @@ def test_spec_generation(cls: Any) -> None:
                     "oneOf": [
                         {"type": "null"},
                         {
-                            "items": {"$ref": "#/components/schemas/tests_models_DataclassPet"},
+                            "items": {"$ref": "#/components/schemas/DataclassPet"},
                             "type": "array",
                         },
                     ]
@@ -62,9 +59,7 @@ def test_msgspec_schema() -> None:
         schema = client.app.openapi_schema
         assert schema
 
-        assert schema.to_schema()["components"]["schemas"][
-            "tests_unit_test_openapi_test_spec_generation_test_msgspec_schema_locals_CamelizedStruct"
-        ] == {
+        assert schema.to_schema()["components"]["schemas"]["CamelizedStruct"] == {
             "properties": {"fieldOne": {"type": "integer"}, "fieldTwo": {"type": "number"}},
             "required": ["fieldOne", "fieldTwo"],
             "title": "CamelizedStruct",

--- a/tests/unit/test_openapi/test_spec_generation.py
+++ b/tests/unit/test_openapi/test_spec_generation.py
@@ -59,7 +59,7 @@ def test_msgspec_schema() -> None:
         schema = client.app.openapi_schema
         assert schema
 
-        assert schema.to_schema()["components"]["schemas"]["CamelizedStruct"] == {
+        assert schema.to_schema()["components"]["schemas"]["test_msgspec_schema.CamelizedStruct"] == {
             "properties": {"fieldOne": {"type": "integer"}, "fieldTwo": {"type": "number"}},
             "required": ["fieldOne", "fieldTwo"],
             "title": "CamelizedStruct",

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -121,7 +121,7 @@ def test_classic_pagination_openapi_schema(paginator: Any) -> None:
             "schema": {
                 "properties": {
                     "items": {
-                        "items": {"$ref": "#/components/schemas/tests_models_DataclassPerson"},
+                        "items": {"$ref": "#/components/schemas/DataclassPerson"},
                         "type": "array",
                     },
                     "page_size": {"type": "integer", "description": "Number of items per page."},
@@ -178,7 +178,7 @@ def test_limit_offset_pagination_openapi_schema(paginator: Any) -> None:
             "schema": {
                 "properties": {
                     "items": {
-                        "items": {"$ref": "#/components/schemas/tests_models_DataclassPerson"},
+                        "items": {"$ref": "#/components/schemas/DataclassPerson"},
                         "type": "array",
                     },
                     "limit": {"type": "integer", "description": "Maximal number of items to send."},
@@ -258,7 +258,7 @@ def test_cursor_pagination_openapi_schema(paginator: Any) -> None:
             "schema": {
                 "properties": {
                     "items": {
-                        "items": {"$ref": "#/components/schemas/tests_models_DataclassPerson"},
+                        "items": {"$ref": "#/components/schemas/DataclassPerson"},
                         "type": "array",
                     },
                     "cursor": {


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->
https://github.com/litestar-org/litestar/commit/219355c0e322fab41c921c56ca97d356b7ef868b#diff-6cdcc2ab6bdeda3d72588f3b65db0c437f7ba9cad43892829e75c4d701f9e658R659-R661 introduced a change to the way that keys for the openapi components/schemas object were calculated to address name the possibility of name collisions.

This PR reverts that behavior for the case where a name has no collision, and only introduces extended keys for the case where there are multiple objects with the same name.

To do this, it replaces the pattern of carrying the `components/schemas` section of the openapi document around in the `OpenAPIContext` object, and replaces it with a `SchemaRegistry` object.

The schema registry tracks all schemas created for named objects, and any references to them. Once all schemas are known, we build the `components/schemas` object from the openapi doc, using the shortest possible paths to avoid collision.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

Closes #2804
