### PR TITLE
fix: no signature model data validation if DTO

### DIFF
--- a/litestar/_signature/model.py
+++ b/litestar/_signature/model.py
@@ -252,6 +252,7 @@ class SignatureModel(Struct):
                 field_definition=field_definition,
                 type_decoders=[*(type_decoders or []), *DEFAULT_TYPE_DECODERS],
                 meta_data=meta_data,
+                data_dto=data_dto,
             )
 
             default = field_definition.default if field_definition.has_default else NODEFAULT
@@ -277,7 +278,12 @@ class SignatureModel(Struct):
         field_definition: FieldDefinition,
         type_decoders: TypeDecodersSequence,
         meta_data: Meta | None = None,
+        data_dto: type[AbstractDTO] | None = None,
     ) -> Any:
+        # DTOs have already validated their data, so we can just use Any here
+        if field_definition.name == "data" and data_dto:
+            return Any
+
         annotation = _normalize_annotation(field_definition=field_definition)
 
         if annotation is Any:


### PR DESCRIPTION
By the time the signature model is parsed, the DTO has already validated and built the object to be injected as `data`, so we don't need the signature model to do it again.

This PR ensures that `data` fields are typed as `Any` on the signature model so that validation doesn't occur twice.

This is a regression introduced in #2088, so I've added an explicit test for it.

Closes #2149

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
