### PR TITLE
test: xdist group cli autodiscovery tests

### DIFF
--- a/tests/examples/test_contrib/test_sqlalchemy/plugins/test_tutorial_example_apps.py
+++ b/tests/examples/test_contrib/test_sqlalchemy/plugins/test_tutorial_example_apps.py
@@ -17,6 +17,8 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from litestar import Litestar
 from litestar.testing import TestClient
 
+pytestmark = pytest.mark.xdist_group("sqlalchemy_examples")
+
 
 @pytest.fixture(
     params=[

--- a/tests/unit/test_cli/test_cli.py
+++ b/tests/unit/test_cli/test_cli.py
@@ -3,6 +3,8 @@ import sys
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
+import pytest
+
 from tests.unit.test_cli import CREATE_APP_FILE_CONTENT
 from tests.unit.test_cli.conftest import CreateAppFileFixture
 
@@ -33,6 +35,7 @@ def test_format_is_enabled() -> None:
     assert _format_is_enabled("a") == "[green]Enabled[/]"
 
 
+@pytest.mark.xdist_group("cli_autodiscovery")
 def test_info_command(mocker: "MockerFixture", runner: "CliRunner", app_file: "Path") -> None:
     mock = mocker.patch("litestar.cli.commands.core.show_app_info")
     result = runner.invoke(cli_command, ["info"])
@@ -41,6 +44,7 @@ def test_info_command(mocker: "MockerFixture", runner: "CliRunner", app_file: "P
     mock.assert_called_once()
 
 
+@pytest.mark.xdist_group("cli_autodiscovery")
 def test_info_command_with_app_dir(
     mocker: "MockerFixture", runner: "CliRunner", create_app_file: CreateAppFileFixture
 ) -> None:
@@ -60,6 +64,7 @@ def test_info_command_with_app_dir(
     mock.assert_called_once()
 
 
+@pytest.mark.xdist_group("cli_autodiscovery")
 def test_register_commands_from_entrypoint(mocker: "MockerFixture", runner: "CliRunner", app_file: "Path") -> None:
     mock_command_callback = MagicMock()
 

--- a/tests/unit/test_cli/test_env_resolution.py
+++ b/tests/unit/test_cli/test_env_resolution.py
@@ -62,6 +62,7 @@ def test_litestar_env_from_env_host(monkeypatch: MonkeyPatch, app_file: Path) ->
         pytest.param("application/another_random_name.py", id="application_module_random"),
     ],
 )
+@pytest.mark.xdist_group("test_env_autodiscover_from_files")
 def test_env_from_env_autodiscover_from_files(
     path: str, app_file_content: str, app_file_app_name: str, create_app_file: CreateAppFileFixture
 ) -> None:

--- a/tests/unit/test_cli/test_env_resolution.py
+++ b/tests/unit/test_cli/test_env_resolution.py
@@ -10,6 +10,8 @@ from litestar.cli._utils import LitestarEnv, _path_to_dotted_path
 
 from .conftest import CreateAppFileFixture
 
+pytestmark = pytest.mark.xdist_group("cli_autodiscovery")
+
 
 @pytest.mark.parametrize("env_name,attr_name", [("LITESTAR_DEBUG", "debug"), ("LITESTAR_RELOAD", "reload")])
 @pytest.mark.parametrize(
@@ -62,7 +64,6 @@ def test_litestar_env_from_env_host(monkeypatch: MonkeyPatch, app_file: Path) ->
         pytest.param("application/another_random_name.py", id="application_module_random"),
     ],
 )
-@pytest.mark.xdist_group("test_env_autodiscover_from_files")
 def test_env_from_env_autodiscover_from_files(
     path: str, app_file_content: str, app_file_app_name: str, create_app_file: CreateAppFileFixture
 ) -> None:


### PR DESCRIPTION
This test is flaky and best guess is it has to do with executing across multiple cores. This marker ensures they will run on the same node.

See https://discord.com/channels/919193495116337154/1151927578370768958/threads/1179281714653184122

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
