### PR TITLE
fix(ci): docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
             ./pdm.lock
 
       - name: Install dependencies
-        run: pdm install -G:all
+        run: pdm sync -G:all
 
       - name: Fetch gh pages
         run: git fetch origin gh-pages --depth=1


### PR DESCRIPTION
Use `pdm sync` for building docs environment so that pdm won't ever generate a new lock file which causes the subsequent checkout in the `build_docs.py` tool to fail.

Closes #2853

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
