### PR TITLE
fix(openapi): correctly process routes with multiple route handlers

### DIFF
--- a/litestar/_openapi/plugin.py
+++ b/litestar/_openapi/plugin.py
@@ -27,7 +27,7 @@ class OpenAPIPlugin(InitPluginProtocol, ReceiveRoutePlugin):
 
     def __init__(self, app: Litestar) -> None:
         self.app = app
-        self.included_routes: list[HTTPRoute] = []
+        self.included_routes: dict[str, HTTPRoute] = {}
         self._openapi_config: OpenAPIConfig | None = None
         self._openapi_schema: OpenAPI | None = None
 
@@ -35,7 +35,8 @@ class OpenAPIPlugin(InitPluginProtocol, ReceiveRoutePlugin):
         openapi = self.openapi_config.to_openapi_schema()
         context = OpenAPIContext(openapi_config=self.openapi_config, plugins=self.app.plugins.openapi)
         openapi.paths = {
-            route.path_format or "/": create_path_item_for_route(context, route) for route in self.included_routes
+            route.path_format or "/": create_path_item_for_route(context, route)
+            for route in self.included_routes.values()
         }
         openapi.components.schemas = context.schema_registry.generate_components_schemas()
         return openapi
@@ -64,4 +65,4 @@ class OpenAPIPlugin(InitPluginProtocol, ReceiveRoutePlugin):
         if any(route_handler.resolve_include_in_schema() for route_handler, _ in route.route_handler_map.values()):
             # Force recompute the schema if a new route is added
             self._openapi_schema = None
-            self.included_routes.append(route)
+            self.included_routes[route.path] = route

--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -352,3 +352,22 @@ class Model:
         f"{module_b.__name__}_Model",
     }
     # TODO: expand this test to cover more cases
+
+
+def test_multiple_handlers_for_same_route() -> None:
+    @post("/", sync_to_thread=False)
+    def post_handler() -> None:
+        ...
+
+    @get("/", sync_to_thread=False)
+    def get_handler() -> None:
+        ...
+
+    app = Litestar([get_handler, post_handler])
+    openapi_plugin = app.plugins.get(OpenAPIPlugin)
+    openapi = openapi_plugin.provide_openapi()
+
+    assert openapi.paths is not None
+    path_item = openapi.paths["/"]
+    assert path_item.get is not None
+    assert path_item.post is not None


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
This PR fixes an issue where the OpenAPI schema generation would fail when there are multiple route handlers for a given path.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

Fixes #2863.