### PR TITLE
refactor: use OpenAPISchemaPlugin for all supported complex types

### DIFF
--- a/litestar/_openapi/schema_generation/__init__.py
+++ b/litestar/_openapi/schema_generation/__init__.py
@@ -1,3 +1,7 @@
+from .plugins import openapi_schema_plugins
 from .schema import SchemaCreator
 
-__all__ = ("SchemaCreator",)
+__all__ = (
+    "SchemaCreator",
+    "openapi_schema_plugins",
+)

--- a/litestar/_openapi/schema_generation/plugins/__init__.py
+++ b/litestar/_openapi/schema_generation/plugins/__init__.py
@@ -1,0 +1,16 @@
+from .dataclass import DataclassSchemaPlugin
+from .pagination import PaginationSchemaPlugin
+from .struct import StructSchemaPlugin
+from .typed_dict import TypedDictSchemaPlugin
+
+__all__ = ("openapi_schema_plugins",)
+
+# NOTE: The Pagination type plugin has to come before the Dataclass plugin since the Pagination
+# classes are dataclasses, but we want to handle them differently from how dataclasses are normally
+# handled.
+openapi_schema_plugins = [
+    PaginationSchemaPlugin(),
+    StructSchemaPlugin(),
+    DataclassSchemaPlugin(),
+    TypedDictSchemaPlugin(),
+]

--- a/litestar/_openapi/schema_generation/plugins/dataclass.py
+++ b/litestar/_openapi/schema_generation/plugins/dataclass.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import MISSING, fields
+from typing import TYPE_CHECKING
+
+from litestar._openapi.schema_generation.schema import _get_type_schema_name
+from litestar.openapi.spec import OpenAPIType, Schema
+from litestar.plugins import OpenAPISchemaPlugin
+from litestar.typing import FieldDefinition
+from litestar.utils.predicates import is_optional_union
+
+if TYPE_CHECKING:
+    from litestar._openapi.schema_generation import SchemaCreator
+
+
+class DataclassSchemaPlugin(OpenAPISchemaPlugin):
+    def is_plugin_supported_field(self, field_definition: FieldDefinition) -> bool:
+        return field_definition.is_dataclass_type
+
+    def to_openapi_schema(self, field_definition: FieldDefinition, schema_creator: SchemaCreator) -> Schema:
+        unwrapped_annotation = field_definition.origin or field_definition.annotation
+        type_hints = field_definition.get_type_hints(include_extras=True, resolve_generics=True)
+        return Schema(
+            required=sorted(
+                [
+                    field.name
+                    for field in fields(unwrapped_annotation)
+                    if (
+                        field.default is MISSING
+                        and field.default_factory is MISSING
+                        and not is_optional_union(type_hints[field.name])
+                    )
+                ]
+            ),
+            properties={
+                k: schema_creator.for_field_definition(FieldDefinition.from_kwarg(v, k)) for k, v in type_hints.items()
+            },
+            type=OpenAPIType.OBJECT,
+            title=_get_type_schema_name(field_definition),
+        )

--- a/litestar/_openapi/schema_generation/plugins/pagination.py
+++ b/litestar/_openapi/schema_generation/plugins/pagination.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from litestar.openapi.spec import OpenAPIType, Schema
+from litestar.pagination import ClassicPagination, CursorPagination, OffsetPagination
+from litestar.plugins import OpenAPISchemaPlugin
+
+if TYPE_CHECKING:
+    from litestar._openapi.schema_generation import SchemaCreator
+    from litestar.typing import FieldDefinition
+
+
+class PaginationSchemaPlugin(OpenAPISchemaPlugin):
+    def is_plugin_supported_field(self, field_definition: FieldDefinition) -> bool:
+        return field_definition.origin in (ClassicPagination, CursorPagination, OffsetPagination)
+
+    def to_openapi_schema(self, field_definition: FieldDefinition, schema_creator: SchemaCreator) -> Schema:
+        if field_definition.origin is ClassicPagination:
+            return Schema(
+                type=OpenAPIType.OBJECT,
+                properties={
+                    "items": Schema(
+                        type=OpenAPIType.ARRAY,
+                        items=schema_creator.for_field_definition(field_definition.inner_types[0]),
+                    ),
+                    "page_size": Schema(type=OpenAPIType.INTEGER, description="Number of items per page."),
+                    "current_page": Schema(type=OpenAPIType.INTEGER, description="Current page number."),
+                    "total_pages": Schema(type=OpenAPIType.INTEGER, description="Total number of pages."),
+                },
+            )
+
+        if field_definition.origin is OffsetPagination:
+            return Schema(
+                type=OpenAPIType.OBJECT,
+                properties={
+                    "items": Schema(
+                        type=OpenAPIType.ARRAY,
+                        items=schema_creator.for_field_definition(field_definition.inner_types[0]),
+                    ),
+                    "limit": Schema(type=OpenAPIType.INTEGER, description="Maximal number of items to send."),
+                    "offset": Schema(type=OpenAPIType.INTEGER, description="Offset from the beginning of the query."),
+                    "total": Schema(type=OpenAPIType.INTEGER, description="Total number of items."),
+                },
+            )
+
+        cursor_schema = schema_creator.not_generating_examples.for_field_definition(field_definition.inner_types[0])
+        cursor_schema.description = "Unique ID, designating the last identifier in the given data set. This value can be used to request the 'next' batch of records."
+
+        return Schema(
+            type=OpenAPIType.OBJECT,
+            properties={
+                "items": Schema(
+                    type=OpenAPIType.ARRAY,
+                    items=schema_creator.for_field_definition(field_definition=field_definition.inner_types[1]),
+                ),
+                "cursor": cursor_schema,
+                "results_per_page": Schema(type=OpenAPIType.INTEGER, description="Maximal number of items to send."),
+            },
+        )

--- a/litestar/_openapi/schema_generation/plugins/struct.py
+++ b/litestar/_openapi/schema_generation/plugins/struct.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from msgspec import Struct
+from msgspec.structs import fields
+
+from litestar._openapi.schema_generation.schema import _get_type_schema_name
+from litestar.openapi.spec import OpenAPIType, Schema
+from litestar.plugins import OpenAPISchemaPlugin
+from litestar.types.empty import Empty
+from litestar.typing import FieldDefinition
+from litestar.utils.predicates import is_optional_union
+
+if TYPE_CHECKING:
+    from msgspec.structs import FieldInfo
+
+    from litestar._openapi.schema_generation import SchemaCreator
+
+
+class StructSchemaPlugin(OpenAPISchemaPlugin):
+    def is_plugin_supported_field(self, field_definition: FieldDefinition) -> bool:
+        return field_definition.is_subclass_of(Struct)
+
+    def to_openapi_schema(self, field_definition: FieldDefinition, schema_creator: SchemaCreator) -> Schema:
+        def _is_field_required(field: FieldInfo) -> bool:
+            return field.required or field.default_factory is Empty
+
+        unwrapped_annotation = field_definition.origin or field_definition.annotation
+        type_hints = field_definition.get_type_hints(include_extras=True, resolve_generics=True)
+        struct_fields = fields(unwrapped_annotation)
+
+        return Schema(
+            required=sorted(
+                [
+                    field.encode_name
+                    for field in struct_fields
+                    if _is_field_required(field=field) and not is_optional_union(type_hints[field.name])
+                ]
+            ),
+            properties={
+                field.encode_name: schema_creator.for_field_definition(
+                    FieldDefinition.from_kwarg(type_hints[field.name], field.encode_name)
+                )
+                for field in struct_fields
+            },
+            type=OpenAPIType.OBJECT,
+            title=_get_type_schema_name(field_definition),
+        )

--- a/litestar/_openapi/schema_generation/plugins/typed_dict.py
+++ b/litestar/_openapi/schema_generation/plugins/typed_dict.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from litestar._openapi.schema_generation.schema import _get_type_schema_name
+from litestar.openapi.spec import OpenAPIType, Schema
+from litestar.plugins import OpenAPISchemaPlugin
+from litestar.typing import FieldDefinition
+
+if TYPE_CHECKING:
+    from litestar._openapi.schema_generation import SchemaCreator
+
+
+class TypedDictSchemaPlugin(OpenAPISchemaPlugin):
+    def is_plugin_supported_field(self, field_definition: FieldDefinition) -> bool:
+        return field_definition.is_typeddict_type
+
+    def to_openapi_schema(self, field_definition: FieldDefinition, schema_creator: SchemaCreator) -> Schema:
+        unwrapped_annotation = field_definition.origin or field_definition.annotation
+        type_hints = field_definition.get_type_hints(include_extras=True, resolve_generics=True)
+
+        return Schema(
+            required=sorted(getattr(unwrapped_annotation, "__required_keys__", [])),
+            properties={
+                k: schema_creator.for_field_definition(FieldDefinition.from_kwarg(v, k)) for k, v in type_hints.items()
+            },
+            type=OpenAPIType.OBJECT,
+            title=_get_type_schema_name(field_definition),
+        )

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections import deque
 from copy import copy
-from dataclasses import MISSING, fields
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum, EnumMeta
@@ -29,13 +28,10 @@ from typing import (
     Tuple,
     Union,
     cast,
-    get_origin,
 )
 from uuid import UUID
 
-from msgspec import Struct
-from msgspec.structs import fields as msgspec_struct_fields
-from typing_extensions import NotRequired, Required, Self, get_args
+from typing_extensions import Self, get_args
 
 from litestar._openapi.datastructures import SchemaRegistry
 from litestar._openapi.schema_generation.constrained_fields import (
@@ -55,7 +51,6 @@ from litestar.exceptions import ImproperlyConfiguredException
 from litestar.openapi.spec import Reference
 from litestar.openapi.spec.enums import OpenAPIFormat, OpenAPIType
 from litestar.openapi.spec.schema import Schema, SchemaDataContainer
-from litestar.pagination import ClassicPagination, CursorPagination, OffsetPagination
 from litestar.params import BodyKwarg, ParameterKwarg
 from litestar.plugins import OpenAPISchemaPlugin
 from litestar.types import Empty
@@ -64,7 +59,6 @@ from litestar.typing import FieldDefinition
 from litestar.utils.helpers import get_name
 from litestar.utils.predicates import (
     is_class_and_subclass,
-    is_optional_union,
     is_undefined_sentinel,
 )
 from litestar.utils.typing import (
@@ -73,8 +67,6 @@ from litestar.utils.typing import (
 )
 
 if TYPE_CHECKING:
-    from msgspec.structs import FieldInfo
-
     from litestar._openapi.datastructures import OpenAPIContext
     from litestar.openapi.spec import Example
     from litestar.plugins import OpenAPISchemaPluginProtocol
@@ -298,8 +290,14 @@ class SchemaCreator:
         return type(self)(generate_examples=False, plugins=self.plugins, prefer_alias=False)
 
     def get_plugin_for(self, field_definition: FieldDefinition) -> OpenAPISchemaPluginProtocol | None:
+        def plugin_supports_field(plugin: OpenAPISchemaPluginProtocol, field: FieldDefinition) -> bool:
+            if predicate := getattr(plugin, "is_plugin_supported_field", None):
+                return predicate(field)  # type: ignore[no-any-return]
+            return plugin.is_plugin_supported_type(field.annotation)
+
         return next(
-            (plugin for plugin in self.plugins if plugin.is_plugin_supported_type(field_definition.annotation)), None
+            (plugin for plugin in self.plugins if plugin_supports_field(plugin, field_definition)),
+            None,
         )
 
     def is_constrained_field(self, field_definition: FieldDefinition) -> bool:
@@ -310,7 +308,7 @@ class SchemaCreator:
         ) or any(
             p.is_constrained_field(field_definition)
             for p in self.plugins
-            if isinstance(p, OpenAPISchemaPlugin) and p.is_plugin_supported_type(field_definition.annotation)
+            if isinstance(p, OpenAPISchemaPlugin) and p.is_plugin_supported_field(field_definition)
         )
 
     def is_undefined(self, value: Any) -> bool:
@@ -347,19 +345,8 @@ class SchemaCreator:
             result = self.for_optional_field(field_definition)
         elif field_definition.is_union:
             result = self.for_union_field(field_definition)
-        elif field_definition.origin in (CursorPagination, OffsetPagination, ClassicPagination):
-            # NOTE: The check for whether the field_definition.annotation is a Pagination type
-            # has to come before the `is_dataclass_check` since the Pagination classes are dataclasses,
-            # but we want to handle them differently from how dataclasses are normally handled.
-            result = self.for_builtin_generics(field_definition)
         elif field_definition.is_type_var:
             result = self.for_typevar()
-        elif field_definition.is_subclass_of(Struct):
-            result = self.for_struct_class(field_definition)
-        elif field_definition.is_dataclass_type:
-            result = self.for_dataclass(field_definition)
-        elif field_definition.is_typeddict_type:
-            result = self.for_typed_dict(field_definition)
         elif self.is_constrained_field(field_definition):
             result = self.for_constrained_field(field_definition)
         elif field_definition.inner_types and not field_definition.is_generic:
@@ -449,58 +436,6 @@ class SchemaCreator:
             f"`{field_definition.name}: ... = Dependency(...)`."
         )
 
-    def for_builtin_generics(self, field_definition: FieldDefinition) -> Schema:
-        """Handle builtin generic types.
-
-        Args:
-            field_definition: A signature field instance.
-
-        Returns:
-            A schema instance.
-        """
-        if field_definition.origin is ClassicPagination:
-            return Schema(
-                type=OpenAPIType.OBJECT,
-                properties={
-                    "items": Schema(
-                        type=OpenAPIType.ARRAY,
-                        items=self.for_field_definition(field_definition.inner_types[0]),
-                    ),
-                    "page_size": Schema(type=OpenAPIType.INTEGER, description="Number of items per page."),
-                    "current_page": Schema(type=OpenAPIType.INTEGER, description="Current page number."),
-                    "total_pages": Schema(type=OpenAPIType.INTEGER, description="Total number of pages."),
-                },
-            )
-
-        if field_definition.origin is OffsetPagination:
-            return Schema(
-                type=OpenAPIType.OBJECT,
-                properties={
-                    "items": Schema(
-                        type=OpenAPIType.ARRAY,
-                        items=self.for_field_definition(field_definition.inner_types[0]),
-                    ),
-                    "limit": Schema(type=OpenAPIType.INTEGER, description="Maximal number of items to send."),
-                    "offset": Schema(type=OpenAPIType.INTEGER, description="Offset from the beginning of the query."),
-                    "total": Schema(type=OpenAPIType.INTEGER, description="Total number of items."),
-                },
-            )
-
-        cursor_schema = self.not_generating_examples.for_field_definition(field_definition.inner_types[0])
-        cursor_schema.description = "Unique ID, designating the last identifier in the given data set. This value can be used to request the 'next' batch of records."
-
-        return Schema(
-            type=OpenAPIType.OBJECT,
-            properties={
-                "items": Schema(
-                    type=OpenAPIType.ARRAY,
-                    items=self.for_field_definition(field_definition=field_definition.inner_types[1]),
-                ),
-                "cursor": cursor_schema,
-                "results_per_page": Schema(type=OpenAPIType.INTEGER, description="Maximal number of items to send."),
-            },
-        )
-
     def for_plugin(self, field_definition: FieldDefinition, plugin: OpenAPISchemaPluginProtocol) -> Schema | Reference:
         """Create a schema using a plugin.
 
@@ -523,97 +458,6 @@ class SchemaCreator:
                 )
             )
         return schema  # pragma: no cover
-
-    def for_struct_class(self, field_definition: FieldDefinition) -> Schema:
-        """Create a schema object for a msgspec.Struct class.
-
-        Args:
-            field_definition: A field definition instance.
-
-        Returns:
-            A schema instance.
-        """
-
-        def _is_field_required(field: FieldInfo) -> bool:
-            return field.required or field.default_factory is Empty
-
-        unwrapped_annotation = field_definition.origin or field_definition.annotation
-        type_hints = field_definition.get_type_hints(include_extras=True, resolve_generics=True)
-        fields = msgspec_struct_fields(unwrapped_annotation)
-
-        return Schema(
-            required=sorted(
-                [
-                    field.encode_name
-                    for field in fields
-                    if _is_field_required(field=field) and not is_optional_union(type_hints[field.name])
-                ]
-            ),
-            properties={
-                field.encode_name: self.for_field_definition(
-                    FieldDefinition.from_kwarg(type_hints[field.name], field.encode_name)
-                )
-                for field in fields
-            },
-            type=OpenAPIType.OBJECT,
-            title=_get_type_schema_name(field_definition),
-        )
-
-    # noinspection PyDataclass
-    def for_dataclass(self, field_definition: FieldDefinition) -> Schema:
-        """Create a schema object for a dataclass class.
-
-        Args:
-            field_definition: A field definition instance.
-
-        Returns:
-            A schema instance.
-        """
-
-        unwrapped_annotation = field_definition.origin or field_definition.annotation
-        type_hints = field_definition.get_type_hints(include_extras=True, resolve_generics=True)
-        return Schema(
-            required=sorted(
-                [
-                    field.name
-                    for field in fields(unwrapped_annotation)
-                    if (
-                        field.default is MISSING
-                        and field.default_factory is MISSING
-                        and not is_optional_union(type_hints[field.name])
-                    )
-                ]
-            ),
-            properties={k: self.for_field_definition(FieldDefinition.from_kwarg(v, k)) for k, v in type_hints.items()},
-            type=OpenAPIType.OBJECT,
-            title=_get_type_schema_name(field_definition),
-        )
-
-    # noinspection PyTypedDict
-    def for_typed_dict(self, field_definition: FieldDefinition) -> Schema:
-        """Create a schema object for a typeddict.
-
-        Args:
-            field_definition: A field definition instance.
-
-        Returns:
-            A schema instance.
-        """
-
-        unwrapped_annotation = field_definition.origin or field_definition.annotation
-        type_hints = field_definition.get_type_hints(include_extras=True, resolve_generics=True)
-
-        return Schema(
-            required=sorted(getattr(unwrapped_annotation, "__required_keys__", [])),
-            properties={
-                k: self.for_field_definition(FieldDefinition.from_kwarg(v, k))
-                for k, v in {
-                    k: get_args(v)[0] if get_origin(v) in (Required, NotRequired) else v for k, v in type_hints.items()
-                }.items()
-            },
-            type=OpenAPIType.OBJECT,
-            title=_get_type_schema_name(field_definition),
-        )
 
     def for_constrained_field(self, field: FieldDefinition) -> Schema:
         """Create Schema for Pydantic Constrained fields (created using constr(), conint() and so forth, or by subclassing

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -289,14 +289,15 @@ class SchemaCreator:
             return self
         return type(self)(generate_examples=False, plugins=self.plugins, prefer_alias=False)
 
-    def get_plugin_for(self, field_definition: FieldDefinition) -> OpenAPISchemaPluginProtocol | None:
-        def plugin_supports_field(plugin: OpenAPISchemaPluginProtocol, field: FieldDefinition) -> bool:
-            if predicate := getattr(plugin, "is_plugin_supported_field", None):
-                return predicate(field)  # type: ignore[no-any-return]
-            return plugin.is_plugin_supported_type(field.annotation)
+    @staticmethod
+    def plugin_supports_field(plugin: OpenAPISchemaPluginProtocol, field: FieldDefinition) -> bool:
+        if predicate := getattr(plugin, "is_plugin_supported_field", None):
+            return predicate(field)  # type: ignore[no-any-return]
+        return plugin.is_plugin_supported_type(field.annotation)
 
+    def get_plugin_for(self, field_definition: FieldDefinition) -> OpenAPISchemaPluginProtocol | None:
         return next(
-            (plugin for plugin in self.plugins if plugin_supports_field(plugin, field_definition)),
+            (plugin for plugin in self.plugins if self.plugin_supports_field(plugin, field_definition)),
             None,
         )
 

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Iterable, Mappi
 from litestar._asgi import ASGIRouter
 from litestar._asgi.utils import get_route_handlers, wrap_in_exception_handler
 from litestar._openapi.plugin import OpenAPIPlugin
+from litestar._openapi.schema_generation import openapi_schema_plugins
 from litestar.config.allowed_hosts import AllowedHostsConfig
 from litestar.config.app import AppConfig
 from litestar.config.response_cache import ResponseCacheConfig
@@ -375,7 +376,7 @@ class Litestar(Router):
             experimental_features=list(experimental_features or []),
         )
 
-        config.plugins.append(OpenAPIPlugin(self))
+        config.plugins.extend([OpenAPIPlugin(self), *openapi_schema_plugins])
 
         for handler in chain(
             on_app_init or [],

--- a/litestar/plugins/base.py
+++ b/litestar/plugins/base.py
@@ -190,10 +190,27 @@ class OpenAPISchemaPlugin(OpenAPISchemaPluginProtocol):
 
     @staticmethod
     def is_plugin_supported_type(value: Any) -> bool:
-        return False
+        """Given a value of indeterminate type, determine if this value is supported by the plugin.
+
+        This is called by the default implementation of :meth:`is_plugin_supported_field` for
+        backwards compatibility. User's should prefer to override that method instead.
+
+        Args:
+            value: An arbitrary value.
+
+        Returns:
+            A bool indicating whether the value is supported by the plugin.
+        """
+        raise NotImplementedError(
+            "One of either is_plugin_supported_type or is_plugin_supported_field should be defined. "
+            "The default implementation of is_plugin_supported_field calls is_plugin_supported_type "
+            "for backwards compatibility. Users should prefer to override is_plugin_supported_field "
+            "as it receives a 'FieldDefinition' instance which is more useful than a raw type."
+        )
 
     def is_plugin_supported_field(self, field_definition: FieldDefinition) -> bool:
-        """Given a value of indeterminate type, determine if this value is supported by the plugin.
+        """Given a :class:`FieldDefinition <litestar.typing.FieldDefinition>` that represents an indeterminate type,
+        determine if this value is supported by the plugin
 
         Args:
             field_definition: A parsed type.

--- a/litestar/plugins/base.py
+++ b/litestar/plugins/base.py
@@ -189,6 +189,21 @@ class OpenAPISchemaPlugin(OpenAPISchemaPluginProtocol):
     """Plugin to extend the support of OpenAPI schema generation for non-library types."""
 
     @staticmethod
+    def is_plugin_supported_type(value: Any) -> bool:
+        return False
+
+    def is_plugin_supported_field(self, field_definition: FieldDefinition) -> bool:
+        """Given a value of indeterminate type, determine if this value is supported by the plugin.
+
+        Args:
+            field_definition: A parsed type.
+
+        Returns:
+            Whether the type is supported by the plugin.
+        """
+        return self.is_plugin_supported_type(field_definition.annotation)
+
+    @staticmethod
     def is_undefined_sentinel(value: Any) -> bool:
         """Return ``True`` if ``value`` should be treated as an undefined field"""
         return False

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,6 +7,7 @@ from contextlib import AbstractContextManager
 from typing import Any, AsyncContextManager, Awaitable, ContextManager, TypeVar, cast, overload
 
 from litestar._openapi.schema_generation import SchemaCreator
+from litestar._openapi.schema_generation.plugins import openapi_schema_plugins
 from litestar.openapi.spec import Schema
 from litestar.plugins import OpenAPISchemaPluginProtocol
 from litestar.typing import FieldDefinition
@@ -61,7 +62,7 @@ def maybe_async_cm(obj: ContextManager[T] | AsyncContextManager[T]) -> AsyncCont
 def get_schema_for_field_definition(
     field_definition: FieldDefinition, *, plugins: list[OpenAPISchemaPluginProtocol] | None = None
 ) -> Schema:
-    plugins = plugins or []
+    plugins = [*openapi_schema_plugins, *(plugins or [])]
     creator = SchemaCreator(plugins=plugins)
     result = creator.for_field_definition(field_definition)
     if isinstance(result, Schema):

--- a/tests/unit/test_dto/test_factory/test_backends/test_backends.py
+++ b/tests/unit/test_dto/test_factory/test_backends/test_backends.py
@@ -188,7 +188,7 @@ def test_backend_create_openapi_schema(dto_factory: type[DataclassDTO]) -> None:
 
     app = Litestar(route_handlers=[handler])
 
-    creator = SchemaCreator()
+    creator = SchemaCreator(plugins=app.plugins.openapi)
     ref = dto_factory.create_openapi_schema(
         handler_id=app.get_handler_index_by_name("test")["handler"].handler_id,  # type: ignore[index]
         field_definition=FieldDefinition.from_annotation(DC),

--- a/tests/unit/test_openapi/test_responses.py
+++ b/tests/unit/test_openapi/test_responses.py
@@ -17,6 +17,7 @@ from litestar._openapi.responses import (
     ResponseFactory,
     create_error_responses,
 )
+from litestar._openapi.schema_generation.plugins import openapi_schema_plugins
 from litestar.datastructures import Cookie, ResponseHeader
 from litestar.dto import AbstractDTO
 from litestar.exceptions import (
@@ -51,7 +52,7 @@ def create_factory() -> CreateFactoryFixture:
         return ResponseFactory(
             context=OpenAPIContext(
                 openapi_config=OpenAPIConfig(title="test", version="1.0.0", create_examples=generate_examples),
-                plugins=[],
+                plugins=openapi_schema_plugins,
             ),
             route_handler=route_handler,
         )

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -24,6 +24,7 @@ from msgspec import Struct
 from typing_extensions import Annotated, TypeAlias
 
 from litestar import Controller, MediaType, get
+from litestar._openapi.schema_generation.plugins import openapi_schema_plugins
 from litestar._openapi.schema_generation.schema import (
     KWARG_DEFINITION_ATTRIBUTE_TO_OPENAPI_PROPERTY_MAP,
     SchemaCreator,
@@ -231,7 +232,7 @@ def test_schema_hashing() -> None:
 
 def test_title_validation() -> None:
     # TODO: what is this actually testing?
-    creator = SchemaCreator()
+    creator = SchemaCreator(plugins=openapi_schema_plugins)
     person_ref = creator.for_field_definition(FieldDefinition.from_kwarg(name="Person", annotation=DataclassPerson))
     pet_ref = creator.for_field_definition(FieldDefinition.from_kwarg(name="Pet", annotation=DataclassPet))
     assert isinstance(person_ref, Reference)


### PR DESCRIPTION
Instead of having separate methods on the `SchemaCreator` object for types like structs, dataclasses and typeddicts, this PR implements their schema generators as `OpenAPISchemaPlugin` types and adds them to the application's plugins on instantiation.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
