### PR TITLE
docs: name the static files handler

### DIFF
--- a/litestar/app.py
+++ b/litestar/app.py
@@ -742,7 +742,9 @@ class Litestar(Router):
                 from litestar.static_files.config import StaticFilesConfig
 
                 app = Litestar(
-                    static_files_config=[StaticFilesConfig(directories=["css"], path="/static/css")]
+                    static_files_config=[
+                        StaticFilesConfig(directories=["css"], path="/static/css", name="css")
+                    ]
                 )
 
                 path = app.url_for_static_asset("css", "main.css")


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
This PR gives the static files handler a name in the `app.url_for_static_asset` example. A named handler is required for this method to work as expected.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
