### PR TITLE
ci: add new feature notifier

### DIFF
--- a/.github/workflows/pr-target.yml
+++ b/.github/workflows/pr-target.yml
@@ -19,7 +19,6 @@ jobs:
     steps:
       - name: Check PR target
         id: check-pr-target
-        if: ${{ startsWith(github.event.pull_request.title, 'feat') }}
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/pr-target.yml
+++ b/.github/workflows/pr-target.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 permissions:
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   main:
@@ -18,7 +18,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR target
+        id: check-pr-target
         if: ${{ startsWith(github.event.pull_request.title, 'feat') }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const isFeature = context.payload.pull_request.title.startsWith('feat');
+            core.setOutput('is-feature', isFeature ? 'true' : 'false');
+
+      - name: Comment PR
+        if: steps.check-pr-target.outputs.is-feature == 'true'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: "It looks like you are adding a new feature! :rocket: Please rebase and point your PR to the `develop` branch."
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fail if feature PR is targeted to main
+        if: steps.check-pr-target.outputs.is-feature == 'true' && github.event.pull_request.base.ref == 'main'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/pr-target.yml
+++ b/.github/workflows/pr-target.yml
@@ -6,8 +6,6 @@ on:
       - opened
       - edited
       - synchronize
-    branches:
-      - main
 
 permissions:
   pull-requests: write
@@ -23,17 +21,20 @@ jobs:
         with:
           script: |
             const isFeature = context.payload.pull_request.title.startsWith('feat');
-            core.setOutput('is-feature', isFeature ? 'true' : 'false');
+            const targetsMain = context.payload.pull_request.base.ref == 'main';
+            core.setOutput('needs-rebase', isFeature && targetsMain ? 'true' : 'false');
 
       - name: Comment PR
-        if: steps.check-pr-target.outputs.is-feature == 'true'
+        if: steps.check-pr-target.outputs.needs-rebase == 'true'
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: "It looks like you are adding a new feature! :rocket: Please rebase and point your PR to the `develop` branch."
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          comment_tag: check_pr_target
+          mode: recreate
 
       - name: Fail if feature PR is targeted to main
-        if: steps.check-pr-target.outputs.is-feature == 'true' && github.event.pull_request.base.ref == 'main'
+        if: steps.check-pr-target.outputs.needs-rebase == 'true'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Adds new CI workflow triggeredon comment to request users update their target base

e.g., if `feat:` is not found in the PR title you get this:

<img width="946" alt="image" src="https://github.com/litestar-org/litestar/assets/45884264/ab64ccf8-92f6-4fdf-95b0-45e0ef4cd428">


plus a failed CI task (that will need to be mandatory i guess)

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
