### PR TITLE
fix: support for empty payload data

### DIFF
--- a/litestar/_kwargs/extractors.py
+++ b/litestar/_kwargs/extractors.py
@@ -295,6 +295,8 @@ async def json_extractor(connection: Request[Any, Any, Any]) -> Any:
     Returns:
         The JSON value.
     """
+    if not await connection.body():
+        return Empty
     return await connection.json()
 
 
@@ -310,6 +312,8 @@ async def msgpack_extractor(connection: Request[Any, Any, Any]) -> Any:
     Returns:
         The MessagePack value.
     """
+    if not await connection.body():
+        return Empty
     return await connection.msgpack()
 
 
@@ -454,7 +458,8 @@ def create_dto_extractor(
     """
 
     async def dto_extractor(connection: Request[Any, Any, Any]) -> Any:
-        body = await connection.body()
+        if not (body := await connection.body()):
+            return Empty
         return data_dto(connection).decode_bytes(body)
 
     return dto_extractor  # type:ignore[return-value]

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -14,6 +14,7 @@ from litestar.handlers.http_handlers import HTTPRouteHandler
 from litestar.response import Response
 from litestar.routes.base import BaseRoute
 from litestar.status_codes import HTTP_204_NO_CONTENT, HTTP_400_BAD_REQUEST
+from litestar.types.empty import Empty
 from litestar.utils.scope.state import ScopeState
 
 if TYPE_CHECKING:
@@ -174,9 +175,14 @@ class HTTPRoute(BaseRoute):
 
             if "data" in kwargs:
                 try:
-                    kwargs["data"] = await kwargs["data"]
+                    data = await kwargs["data"]
                 except SerializationException as e:
                     raise ClientException(str(e)) from e
+                else:
+                    if data is Empty:
+                        del kwargs["data"]
+                    else:
+                        kwargs["data"] = data
 
             if "body" in kwargs:
                 kwargs["body"] = await kwargs["body"]

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -178,11 +178,11 @@ class HTTPRoute(BaseRoute):
                     data = await kwargs["data"]
                 except SerializationException as e:
                     raise ClientException(str(e)) from e
+
+                if data is Empty:
+                    del kwargs["data"]
                 else:
-                    if data is Empty:
-                        del kwargs["data"]
-                    else:
-                        kwargs["data"] = data
+                    kwargs["data"] = data
 
             if "body" in kwargs:
                 kwargs["body"] = await kwargs["body"]

--- a/tests/unit/test_dto/test_factory/test_integration.py
+++ b/tests/unit/test_dto/test_factory/test_integration.py
@@ -829,3 +829,22 @@ def test_dto_returning_mapping(use_experimental_dto_backend: bool) -> None:
     with create_test_client(route_handlers=[get_definition]) as client:
         response = client.get("/")
         assert response.json() == {"hello": {"name": "hello"}, "world": {"name": "world"}}
+
+
+def test_data_dto_with_default() -> None:
+    """A POST request without Body should inject the default value.
+
+    https://github.com/litestar-org/litestar/issues/2902
+    """
+
+    @dataclass
+    class Foo:
+        foo: str
+
+    @post(path="/", dto=DataclassDTO[Foo], signature_types=[Foo])
+    def test(data: Optional[Foo] = None) -> dict:
+        return {"foo": data}
+
+    with create_test_client([test]) as client:
+        response = client.post("/")
+        assert response.json() == {"foo": None}

--- a/tests/unit/test_kwargs/test_json_data.py
+++ b/tests/unit/test_kwargs/test_json_data.py
@@ -26,3 +26,14 @@ def test_empty_dict_allowed() -> None:
     with create_test_client(test_method) as client:
         response = client.post("/test", json={})
         assert response.status_code == HTTP_201_CREATED
+
+
+def test_no_body_with_default() -> None:
+    @post(path="/test")
+    def test_method(data: str = "abc") -> dict:
+        return {"data": data}
+
+    with create_test_client(test_method) as client:
+        response = client.post("/test")
+        assert response.status_code == HTTP_201_CREATED
+        assert response.json() == {"data": "abc"}

--- a/tests/unit/test_kwargs/test_msgpack_data.py
+++ b/tests/unit/test_kwargs/test_msgpack_data.py
@@ -1,3 +1,5 @@
+from typing_extensions import Annotated
+
 from litestar import post
 from litestar.enums import RequestEncodingType
 from litestar.params import Body
@@ -22,3 +24,14 @@ def test_request_body_msgpack() -> None:
     with create_test_client([test_header, test_annotated]) as client:
         response = client.post("/annotated", content=encode_msgpack(test_data))
         assert response.status_code == HTTP_201_CREATED
+
+
+def test_no_body_with_default() -> None:
+    @post(path="/test")
+    def test_method(data: Annotated[str, Body(media_type=RequestEncodingType.MESSAGEPACK)] = "abc") -> dict:
+        return {"data": data}
+
+    with create_test_client(test_method) as client:
+        response = client.post("/test")
+        assert response.status_code == HTTP_201_CREATED
+        assert response.json() == {"data": "abc"}


### PR DESCRIPTION
This PR allows the kwarg model data extractors to return `Empty` in the case where there is no payload data.

This allows us to remove the `"data"` key from the connection kwargs that are validated per the handler signature, so that default values can be properly applied.

Prior to this fix, a handler like:

```py
@post(path="/", sync_to_thread=False)
def test(data: str = "abc") -> dict:
    return {"foo": data}
```
And a request like:

```
$ curl localhost:8000 -X POST
```

would return a client error like:

```json
{"status_code":400,"detail":"Validation failed for POST http://localhost:8000/","extra":[{"message":"Expected `str`, got `null`","key":"data","source":"body"}]}
```

This PR also also allows us to divert from invoking the DTO for deserialization when there is no payload data which would result in an error like `litestar.exceptions.base_exceptions.SerializationException: Input data was truncated` from msgspec.

Closes #2902

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
