### PR TITLE
fix: coverage report uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,5 @@
 name: Tests And Linting
 
-env:
-  MIN_PY: 3.8
-  MAX_PY: 3.12
-
 on:
   pull_request:
   merge_group:
@@ -13,25 +9,6 @@ on:
       - v1.51
 
 jobs:
-  env_as_outputs:
-    runs-on: ubuntu-latest
-    outputs:
-      MIN_PY: ${{ steps.blah.outputs.MIN_PY }}
-      MAX_PY: ${{ steps.blah.outputs.MAX_PY }}
-    steps:
-      - id: blah
-        run: |
-          vars="
-          MIN_PY
-          MAX_PY
-          "
-          setOutput() {
-            echo "${1}=${!1}" >> "${GITHUB_OUTPUT}"
-          }
-          for name in $vars; do
-            setOutput $name
-          done
-
   validate:
     runs-on: ubuntu-latest
     steps:
@@ -39,7 +16,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.MIN_PY }}
+          python-version: "3.8"
 
       - name: Install Pre-Commit
         run: python -m pip install pre-commit
@@ -61,13 +38,13 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.MIN_PY }}
+          python-version: "3.8"
           allow-prereleases: true
 
       - uses: pdm-project/setup-pdm@v3
         name: Set up PDM
         with:
-          python-version: ${{ env.MIN_PY }}
+          python-version: "3.8"
           allow-python-prereleases: false
           cache: true
           cache-dependency-path: |
@@ -86,13 +63,13 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.MIN_PY }}
+          python-version: "3.8"
           allow-prereleases: true
 
       - uses: pdm-project/setup-pdm@v3
         name: Set up PDM
         with:
-          python-version: ${{ env.MIN_PY }}
+          python-version: "3.8"
           allow-python-prereleases: false
           cache: true
           cache-dependency-path: |
@@ -112,7 +89,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     uses: ./.github/workflows/test.yml
     with:
-      coverage: ${{ (matrix.python-version == needs.env_as_outputs.outputs.MIN_PY || matrix.python-version == needs.env_as_outputs.outputs.MAX_PY) }}
+      coverage: ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.8') }}
       python-version: ${{ matrix.python-version }}
 
   test-platform-compat:
@@ -123,7 +100,7 @@ jobs:
         os: ["macos-latest", "windows-latest"]
     uses: ./.github/workflows/test.yml
     with:
-      python-version: ${{ needs.env_as_outputs.outputs.MAX_PY }}
+      python-version: "3.12"
       os: ${{ matrix.os }}
       timeout: 30
 
@@ -139,17 +116,17 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.MAX_PY }}
+          python-version: "3.12"
 
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: coverage-data.${{ env.MIN_PY }}
+          name: coverage-data.3.8
 
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: coverage-data.${{ env.MAX_PY }}
+          name: coverage-data.3.12
 
       - name: Combine coverage files
         run: |
@@ -197,13 +174,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.MAX_PY }}
+          python-version: "3.12"
           allow-prereleases: true
 
       - uses: pdm-project/setup-pdm@v3
         name: Set up PDM
         with:
-          python-version: ${{ env.MAX_PY }}
+          python-version: "3.12"
           allow-python-prereleases: false
           cache: true
           cache-dependency-path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Tests And Linting
 
+env:
+  MIN_PY: 3.8
+  MAX_PY: 3.12
+
 on:
   pull_request:
   merge_group:
@@ -9,6 +13,25 @@ on:
       - v1.51
 
 jobs:
+  env_as_outputs:
+    runs-on: ubuntu-latest
+    outputs:
+      MIN_PY: ${{ steps.blah.outputs.MIN_PY }}
+      MAX_PY: ${{ steps.blah.outputs.MAX_PY }}
+    steps:
+      - id: blah
+        run: |
+          vars="
+          MIN_PY
+          MAX_PY
+          "
+          setOutput() {
+            echo "${1}=${!1}" >> "${GITHUB_OUTPUT}"
+          }
+          for name in $vars; do
+            setOutput $name
+          done
+
   validate:
     runs-on: ubuntu-latest
     steps:
@@ -16,7 +39,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: ${{ env.MIN_PY }}
 
       - name: Install Pre-Commit
         run: python -m pip install pre-commit
@@ -38,13 +61,13 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: ${{ env.MIN_PY }}
           allow-prereleases: true
 
       - uses: pdm-project/setup-pdm@v3
         name: Set up PDM
         with:
-          python-version: "3.8"
+          python-version: ${{ env.MIN_PY }}
           allow-python-prereleases: false
           cache: true
           cache-dependency-path: |
@@ -63,13 +86,13 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: ${{ env.MIN_PY }}
           allow-prereleases: true
 
       - uses: pdm-project/setup-pdm@v3
         name: Set up PDM
         with:
-          python-version: "3.8"
+          python-version: ${{ env.MIN_PY }}
           allow-python-prereleases: false
           cache: true
           cache-dependency-path: |
@@ -89,7 +112,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     uses: ./.github/workflows/test.yml
     with:
-      coverage: ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.8') }}
+      coverage: ${{ (matrix.python-version == needs.env_as_outputs.outputs.MIN_PY || matrix.python-version == needs.env_as_outputs.outputs.MAX_PY) }}
       python-version: ${{ matrix.python-version }}
 
   test-platform-compat:
@@ -100,7 +123,7 @@ jobs:
         os: ["macos-latest", "windows-latest"]
     uses: ./.github/workflows/test.yml
     with:
-      python-version: "3.12"
+      python-version: ${{ needs.env_as_outputs.outputs.MAX_PY }}
       os: ${{ matrix.os }}
       timeout: 30
 
@@ -116,17 +139,17 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ env.MAX_PY }}
 
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: coverage-data.3.8
+          name: coverage-data.${{ env.MIN_PY }}
 
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: coverage-data.3.12
+          name: coverage-data.${{ env.MAX_PY }}
 
       - name: Combine coverage files
         run: |
@@ -174,13 +197,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ env.MAX_PY }}
           allow-prereleases: true
 
       - uses: pdm-project/setup-pdm@v3
         name: Set up PDM
         with:
-          python-version: "3.12"
+          python-version: ${{ env.MAX_PY }}
           allow-python-prereleases: false
           cache: true
           cache-dependency-path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,12 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: coverage-data
+          name: coverage-data.3.8
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-data.3.12
 
       - name: Combine coverage files
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,5 +65,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: inputs.coverage
         with:
-          name: coverage-data
+          name: coverage-data.${{ inputs.python-version }}
           path: .coverage.${{ inputs.python-version }}


### PR DESCRIPTION
Change in actions/upload-artifact@v4 broke our workflow by not allowing a 2nd file to be added to an existing artifact.

This PR adds each coverage report to a distinct artifact and pulls down those specific artifacts for combining coverage.

A negative of this approach is we hard code the artifact names with python version in the sonar job.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
