### PR TITLE
fix: unintended error message from `get_logger_placeholder()`

### DIFF
--- a/litestar/logging/config.py
+++ b/litestar/logging/config.py
@@ -62,7 +62,7 @@ default_picologging_handlers: dict[str, dict[str, Any]] = {
 }
 
 
-def get_logger_placeholder(_: str) -> NoReturn:  # pragma: no cover
+def get_logger_placeholder(_: str | None = None) -> NoReturn:  # pragma: no cover
     """Raise: An :class:`ImproperlyConfiguredException <.exceptions.ImproperlyConfiguredException>`"""
     raise ImproperlyConfiguredException(
         "cannot call '.get_logger' without passing 'logging_config' to the Litestar constructor first"

--- a/litestar/logging/config.py
+++ b/litestar/logging/config.py
@@ -62,7 +62,7 @@ default_picologging_handlers: dict[str, dict[str, Any]] = {
 }
 
 
-def get_logger_placeholder(_: str | None = None) -> NoReturn:  # pragma: no cover
+def get_logger_placeholder(_: str | None = None) -> NoReturn:
     """Raise: An :class:`ImproperlyConfiguredException <.exceptions.ImproperlyConfiguredException>`"""
     raise ImproperlyConfiguredException(
         "cannot call '.get_logger' without passing 'logging_config' to the Litestar constructor first"

--- a/tests/unit/test_logging/test_logging_config.py
+++ b/tests/unit/test_logging/test_logging_config.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from litestar import Request, get
+from litestar.exceptions import ImproperlyConfiguredException
 from litestar.logging.config import LoggingConfig, _get_default_handlers, default_handlers, default_picologging_handlers
 from litestar.logging.picologging import QueueListenerHandler as PicologgingQueueListenerHandler
 from litestar.logging.standard import QueueListenerHandler as StandardQueueListenerHandler
@@ -80,6 +81,12 @@ def test_picologging_dictconfig_when_disabled(dict_config_mock: Mock) -> None:
     test_logger = LoggingConfig(loggers={"app": {"level": "INFO", "handlers": ["console"]}}, handlers=default_handlers)
     with create_test_client([], on_startup=[test_logger.configure], logging_config=None):
         assert not dict_config_mock.called
+
+
+def test_get_logger_without_logging_config() -> None:
+    with create_test_client(logging_config=None) as client:
+        with pytest.raises(ImproperlyConfiguredException):
+            client.app.get_logger()
 
 
 def test_get_default_logger() -> None:

--- a/tests/unit/test_logging/test_logging_config.py
+++ b/tests/unit/test_logging/test_logging_config.py
@@ -85,7 +85,10 @@ def test_picologging_dictconfig_when_disabled(dict_config_mock: Mock) -> None:
 
 def test_get_logger_without_logging_config() -> None:
     with create_test_client(logging_config=None) as client:
-        with pytest.raises(ImproperlyConfiguredException):
+        with pytest.raises(
+            ImproperlyConfiguredException,
+            match="cannot call '.get_logger' without passing 'logging_config' to the Litestar constructor first",
+        ):
             client.app.get_logger()
 
 


### PR DESCRIPTION
### Background
- Currently, `Litestar.get_logger` is `get_logger_placeholder` only when the app initialized by keyword argument `logging_config=None`.
  - We using this keyword argument as workaround for an issue like #2862
- `request.logger` is a property that returns `self.app.get_logger()`. It calls `Litestar.get_logger` with no argument. In standard library or picologging, it is allowed and will return root logger.
- code: https://github.com/litestar-org/litestar/blob/d8322b7a588a0a272d8b611d7d0c6ab1d2ccc326/litestar/connection/base.py#L268-L278
- But `get_logger_placeholder` doesn't allow calling it with no argument. So, when you initialize app with no logging_config and try to use `request.logger`, the error is not as intended.
- Actual
```text
TypeError: get_logger_placeholder() missing 1 required positional argument: '_'
```
- Expected
```text
ImproperlyConfiguredException: cannot call '.get_logger' without passing 'logging_config' to the Litestar constructor first
```

### Changes suggested
- So I suggest to add default value `None`.