### PR TITLE
docs: correct a tiny grammar mistake

### DIFF
--- a/docs/topics/sync-vs-async.rst
+++ b/docs/topics/sync-vs-async.rst
@@ -93,7 +93,7 @@ operations, such as calling synchronous functions that are I/O bound.
 It might be tempting to look at this and think a function should be async by default,
 unless it's performing blocking operations synchronously, but this is not the case.
 Async itself has an overhead attached to it which, while very small, can in some
-situations become non negligible. An synchronous function performing non-blocking
+situations become non negligible. A synchronous function performing non-blocking
 operations will outperform an asynchronous function doing the same.
 
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

### Description
fixed tiny grammar mistake on [docs](https://docs.litestar.dev/2/topics/sync-vs-async.html#when-to-use-an-asynchronous-function)