### PR TITLE
refactor: replace unnecessary use of `default_factory` with `default`

### DIFF
--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -271,7 +271,7 @@ class LoggingMiddlewareConfig:
     response_log_message: str = field(default="HTTP Response")
     """Log message to prepend when logging a response."""
     request_log_fields: Iterable[RequestExtractorField] = field(
-        default_factory=lambda: (
+        default=(
             "path",
             "method",
             "content_type",
@@ -290,7 +290,7 @@ class LoggingMiddlewareConfig:
         -  To turn off logging of requests, use and empty iterable.
     """
     response_log_fields: Iterable[ResponseExtractorField] = field(
-        default_factory=lambda: (
+        default=(
             "status_code",
             "cookies",
             "headers",
@@ -305,7 +305,7 @@ class LoggingMiddlewareConfig:
             Thus, re-arranging the log-message is as simple as changing the iterable.
         -  To turn off logging of responses, use and empty iterable.
     """
-    middleware_class: type[LoggingMiddleware] = field(default_factory=lambda: LoggingMiddleware)
+    middleware_class: type[LoggingMiddleware] = LoggingMiddleware
     """Middleware class to use.
 
     Should be a subclass of [litestar.middleware.LoggingMiddleware].

--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -305,7 +305,7 @@ class LoggingMiddlewareConfig:
             Thus, re-arranging the log-message is as simple as changing the iterable.
         -  To turn off logging of responses, use and empty iterable.
     """
-    middleware_class: type[LoggingMiddleware] = LoggingMiddleware
+    middleware_class: type[LoggingMiddleware] = field(default=LoggingMiddleware)
     """Middleware class to use.
 
     Should be a subclass of [litestar.middleware.LoggingMiddleware].


### PR DESCRIPTION
PR replaces unnecessary use of `default_factory` with `default` for dataclass fields on the `LoggingMiddlewareConfig` where the default value returned by the factory requires no computation and is immutable.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

### Description
As far as I understand, By specifying a factory function for a mutable default value, each instance gets its own independent copy of the default value, `preventing unintended sharing of mutable state between instances`. This helps in maintaining encapsulation and avoiding potential side effects that could arise from shared mutable state.

However, in the code, `default_factory was not used for such a purpose`. Therefore, I suggest `using default to avoid misinterpretation of usage`.
