### PR TITLE
refactor: use value_or_default instead of conditional expression

### DIFF
--- a/litestar/stores/redis.py
+++ b/litestar/stores/redis.py
@@ -8,6 +8,7 @@ from redis.asyncio.connection import ConnectionPool
 
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types import Empty, EmptyType
+from litestar.utils.empty import value_or_default
 
 from .base import NamespacedStore
 
@@ -29,7 +30,7 @@ class RedisStore(NamespacedStore):
                 ``None``. This will make :meth:`.delete_all` unavailable.
         """
         self._redis = redis
-        self.namespace: str | None = "LITESTAR" if namespace is Empty else namespace
+        self.namespace: str | None = value_or_default(namespace, "LITESTAR")
 
         # script to get and renew a key in one atomic step
         self._get_and_renew_script = self._redis.register_script(


### PR DESCRIPTION
- There is a raw conditional expression to check `Empty` with default value. And I found an utility function `litestar.utils.empty.value_or_default` that does same thing. So I suggest to replace the conditional expression with the function: https://github.com/litestar-org/litestar/blob/8153d5b8b53d3a703f86dae90e765f56f5f4bac8/litestar/utils/empty.py#L14-L26