### PR TITLE
test(CLI): Fix xdist issue

### DIFF
--- a/tests/unit/test_cli/test_core_commands.py
+++ b/tests/unit/test_cli/test_core_commands.py
@@ -335,6 +335,7 @@ def test_run_command_with_server_lifespan_plugin(
         (APP_FILE_CONTENT_ROUTES_EXAMPLE, True, ("/foo", "/destroy/.*", "/java", "/haskell")),
     ],
 )
+@pytest.mark.xdist_group("cli_autodiscovery")
 def test_routes_command_options(
     runner: CliRunner,
     app_content: str,


### PR DESCRIPTION
Fix an issue introduced in #2894 that would cause tests to fail if they are not pinned to an xidst worker.