### PR TITLE
chore: Suppress pydantic deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,12 +204,8 @@ filterwarnings = [
   "ignore::DeprecationWarning:google",
   "ignore::DeprecationWarning:sphinxcontrib",
   "ignore::DeprecationWarning:litestar.*",
-  "ignore:The `__fields__` attribute is deprecated:DeprecationWarning:pydantic*",
-  "ignore:Support for class-based `config` is deprecated:DeprecationWarning:pydantic*",
-  "ignore:The `dict` method is deprecated:DeprecationWarning:",
-  "ignore:The `parse_obj` method is deprecated:DeprecationWarning:",
-  "ignore:The `json` method is deprecated:DeprecationWarning:",
-  "ignore:Extra keyword arguments on `Field` is deprecated:DeprecationWarning:pydantic*",
+  "ignore::pydantic.PydanticDeprecatedSince20::",
+  "ignore:`general_plain_validator_function`:DeprecationWarning::",
   "ignore: 'RichMultiCommand':DeprecationWarning::"  # this is coming from rich_click itself, nothing we can do about
                                                      # that for now
 ]


### PR DESCRIPTION
Suppress a few Pydantic deprecation warnings that have piled up, which we don't want to address until Pydantic v3 is out and we drop support for v1.
