### PR TITLE
feat(core): Replace `anyio.to_thread.run_sync` with native versions

### DIFF
--- a/docs/reference/concurrency.rst
+++ b/docs/reference/concurrency.rst
@@ -1,0 +1,5 @@
+cli
+===
+
+.. automodule:: litestar.concurrency
+    :members:

--- a/litestar/concurrency.py
+++ b/litestar/concurrency.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import asyncio
+import contextvars
+from functools import partial
+from typing import TYPE_CHECKING, Callable, TypeVar
+
+import sniffio
+from typing_extensions import ParamSpec
+
+if TYPE_CHECKING:
+    from concurrent.futures import ThreadPoolExecutor
+
+    import trio
+
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+__all__ = (
+    "sync_to_thread",
+    "set_asyncio_executor",
+    "get_asyncio_executor",
+    "set_trio_capacity_limiter",
+    "get_trio_capacity_limiter",
+)
+
+
+class _State:
+    EXECUTOR: ThreadPoolExecutor | None = None
+    LIMITER: trio.CapacityLimiter | None = None
+
+
+async def _run_sync_asyncio(fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+    ctx = contextvars.copy_context()
+    bound_fn = partial(ctx.run, fn, *args, **kwargs)
+    return await asyncio.get_running_loop().run_in_executor(get_asyncio_executor(), bound_fn)  # pyright: ignore
+
+
+async def _run_sync_trio(fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+    import trio
+
+    return await trio.to_thread.run_sync(partial(fn, *args, **kwargs), limiter=get_trio_capacity_limiter())
+
+
+async def sync_to_thread(fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+    """Run the synchronous callable ``fn`` asynchronously in a worker thread.
+
+    When called from asyncio, uses :meth:`asyncio.AbstractEventLoop.run_in_executor` to
+    run the callable. No executor is specified by default so the current loop's executor
+    is used. A specific executor can be set using
+    :func:`~litestar.concurrency.set_asyncio_executor`. This does not affect the loop's
+    default executor.
+
+    When called from trio, uses :meth:`trio.to_thread.run_sync` to run the callable. No
+    capacity limiter is specified by default, but one can be set using
+    :func:`~litestar.concurrency.set_trio_capacity_limiter`. This does not affect trio's
+    default capacity limiter.
+    """
+    if (library := sniffio.current_async_library()) == "asyncio":
+        return await _run_sync_asyncio(fn, *args, **kwargs)
+
+    if library == "trio":
+        return await _run_sync_trio(fn, *args, **kwargs)
+
+    raise RuntimeError("Unsupported async library or not in async context")
+
+
+def set_asyncio_executor(executor: ThreadPoolExecutor | None) -> None:
+    """Set the executor in which synchronous callables will be run within an asyncio
+    context
+    """
+    try:
+        sniffio.current_async_library()
+    except sniffio.AsyncLibraryNotFoundError:
+        pass
+    else:
+        raise RuntimeError("Cannot set executor from running loop")
+
+    _State.EXECUTOR = executor
+
+
+def get_asyncio_executor() -> ThreadPoolExecutor | None:
+    """Get the executor in which synchronous callables will be run within an asyncio
+    context
+    """
+    return _State.EXECUTOR
+
+
+def set_trio_capacity_limiter(limiter: trio.CapacityLimiter | None) -> None:
+    """Set the capacity limiter used when running synchronous callable within a trio
+    context
+    """
+    try:
+        sniffio.current_async_library()
+    except sniffio.AsyncLibraryNotFoundError:
+        pass
+    else:
+        raise RuntimeError("Cannot set limiter while in async context")
+
+    _State.LIMITER = limiter
+
+
+def get_trio_capacity_limiter() -> trio.CapacityLimiter | None:
+    """Get the capacity limiter used when running synchronous callable within a trio
+    context
+    """
+    return _State.LIMITER

--- a/litestar/datastructures/upload_file.py
+++ b/litestar/datastructures/upload_file.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from tempfile import SpooledTemporaryFile
 
-from anyio.to_thread import run_sync
-
+from litestar.concurrency import sync_to_thread
 from litestar.constants import ONE_MEGABYTE
 
 __all__ = ("UploadFile",)
@@ -59,7 +58,7 @@ class UploadFile:
             None
         """
         if self.rolled_to_disk:
-            return await run_sync(self.file.write, data)
+            return await sync_to_thread(self.file.write, data)
         return self.file.write(data)
 
     async def read(self, size: int = -1) -> bytes:
@@ -72,7 +71,7 @@ class UploadFile:
             Byte string.
         """
         if self.rolled_to_disk:
-            return await run_sync(self.file.read, size)
+            return await sync_to_thread(self.file.read, size)
         return self.file.read(size)
 
     async def seek(self, offset: int) -> int:
@@ -85,7 +84,7 @@ class UploadFile:
             None.
         """
         if self.rolled_to_disk:
-            return await run_sync(self.file.seek, offset)
+            return await sync_to_thread(self.file.seek, offset)
         return self.file.seek(offset)
 
     async def close(self) -> None:
@@ -95,7 +94,7 @@ class UploadFile:
             None.
         """
         if self.rolled_to_disk:
-            return await run_sync(self.file.close)
+            return await sync_to_thread(self.file.close)
         return self.file.close()
 
     def __repr__(self) -> str:

--- a/litestar/file_system.py
+++ b/litestar/file_system.py
@@ -4,8 +4,8 @@ from stat import S_ISDIR
 from typing import TYPE_CHECKING, Any, AnyStr, cast
 
 from anyio import AsyncFile, Path, open_file
-from anyio.to_thread import run_sync
 
+from litestar.concurrency import sync_to_thread
 from litestar.exceptions import InternalServerException, NotAuthorizedException
 from litestar.types.file_types import FileSystemProtocol
 from litestar.utils.predicates import is_async_callable
@@ -77,7 +77,7 @@ class FileSystemAdapter:
             awaitable = (
                 self.file_system.info(str(path))
                 if is_async_callable(self.file_system.info)
-                else run_sync(self.file_system.info, str(path))
+                else sync_to_thread(self.file_system.info, str(path))
             )
             return cast("FileInfo", await awaitable)
         except FileNotFoundError as e:
@@ -113,7 +113,7 @@ class FileSystemAdapter:
                         buffering=buffering,
                     ),
                 )
-            return AsyncFile(await run_sync(self.file_system.open, file, mode, buffering))  # type: ignore
+            return AsyncFile(await sync_to_thread(self.file_system.open, file, mode, buffering))  # type: ignore[arg-type]
         except PermissionError as e:
             raise NotAuthorizedException(f"failed to open {file} due to missing permissions") from e
         except OSError as e:

--- a/litestar/response/sse.py
+++ b/litestar/response/sse.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, AsyncGenerator, AsyncIterable, AsyncIterator, Iterable, Iterator
 
-from anyio.to_thread import run_sync
-
+from litestar.concurrency import sync_to_thread
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.response.streaming import Stream
 from litestar.utils import AsyncIteratorWrapper
@@ -65,7 +64,7 @@ class _ServerSentEventIterator(AsyncIteratorWrapper[bytes]):
     async def _async_generator(self) -> AsyncGenerator[bytes, None]:
         while True:
             try:
-                yield await run_sync(self._call_next)
+                yield await sync_to_thread(self._call_next)
             except ValueError:
                 async for value in self.content_async_iterator:
                     yield f"data: {value}\r\n".encode() if isinstance(value, str) else b"data: {" + value + b"}\r\n"

--- a/litestar/stores/file.py
+++ b/litestar/stores/file.py
@@ -7,7 +7,8 @@ from tempfile import mkstemp
 from typing import TYPE_CHECKING
 
 from anyio import Path
-from anyio.to_thread import run_sync
+
+from litestar.concurrency import sync_to_thread
 
 from .base import NamespacedStore, StorageObject
 
@@ -73,7 +74,7 @@ class FileStore(NamespacedStore):
             pass
 
     async def _write(self, target_file: Path, storage_obj: StorageObject) -> None:
-        await run_sync(self._write_sync, target_file, storage_obj)
+        await sync_to_thread(self._write_sync, target_file, storage_obj)
 
     async def set(self, key: str, value: str | bytes, expires_in: int | timedelta | None = None) -> None:
         """Set a value.
@@ -140,7 +141,7 @@ class FileStore(NamespacedStore):
             This deletes and recreates :attr:`FileStore.path`
         """
 
-        await run_sync(shutil.rmtree, self.path)
+        await sync_to_thread(shutil.rmtree, self.path)
         await self.path.mkdir(exist_ok=True)
 
     async def delete_expired(self) -> None:

--- a/tests/unit/test_concurrency.py
+++ b/tests/unit/test_concurrency.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import AsyncMock
+
+import trio
+from pytest_mock import MockerFixture
+
+from litestar.concurrency import (
+    get_asyncio_executor,
+    get_trio_capacity_limiter,
+    set_asyncio_executor,
+    set_trio_capacity_limiter,
+    sync_to_thread,
+)
+
+
+def func() -> int:
+    return 1
+
+
+def test_sync_to_thread_asyncio() -> None:
+    loop = asyncio.new_event_loop()
+    assert loop.run_until_complete(sync_to_thread(func)) == 1
+
+
+def test_sync_to_thread_trio() -> None:
+    assert trio.run(sync_to_thread, func) == 1
+
+
+def test_get_set_asyncio_executor() -> None:
+    assert get_asyncio_executor() is None
+    executor = ThreadPoolExecutor()
+    set_asyncio_executor(executor)
+    assert get_asyncio_executor() is executor
+
+
+def test_get_set_trio_capacity_limiter() -> None:
+    limiter = trio.CapacityLimiter(10)
+    assert get_trio_capacity_limiter() is None
+    set_trio_capacity_limiter(limiter)
+    assert get_trio_capacity_limiter() is limiter
+
+
+def test_asyncio_uses_executor(mocker: MockerFixture) -> None:
+    executor = ThreadPoolExecutor()
+
+    mocker.patch("litestar.concurrency.get_asyncio_executor", return_value=executor)
+    mock_run_in_executor = AsyncMock()
+    mocker.patch("litestar.concurrency.asyncio.get_running_loop").return_value.run_in_executor = mock_run_in_executor
+
+    loop = asyncio.new_event_loop()
+    loop.run_until_complete(sync_to_thread(func))
+
+    assert mock_run_in_executor.call_args_list[0].args[0] is executor
+
+
+def test_trio_uses_limiter(mocker: MockerFixture) -> None:
+    limiter = trio.CapacityLimiter(10)
+    mocker.patch("litestar.concurrency.get_trio_capacity_limiter", return_value=limiter)
+    mock_run_sync = mocker.patch("trio.to_thread.run_sync", new_callable=AsyncMock)
+
+    trio.run(sync_to_thread, func)
+
+    assert mock_run_sync.call_args_list[0].kwargs["limiter"] is limiter


### PR DESCRIPTION
- Replace `anyio.to_thread.run_sync` with native versions of supported libraries, i.e. [`asyncio.loop.run_in_executor`](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.run_in_executor) and [`trio.to_thread.run_sync`](https://trio.readthedocs.io/en/stable/reference-core.html#trio.to_thread.run_sync)
- Add `set_asyncio_executor` and `get_asyncio_executor` utility functions to configure the executor used when running synchronous functions
- Add `set_trio_capacity_limiter` and `get_trio_capacity_limiter` utility functions to configure the `trio.CapacityLimiter` used when running synchronous functions

<hr>

Reasons for this change are twofold:

1. Performance improvements. Anyio has some [known performance overhead](https://github.com/agronholm/anyio/discussions/543), and its threading solution proved to be slower than both asyncio's and trio's built-in functionalities
2. Configurability of the thread pools used under the hood. Prior to this change the only way a user could influence these was to [set a global default in anyio](https://anyio.readthedocs.io/en/stable/threads.html#adjusting-the-default-maximum-worker-thread-count)

<hr>

Using this very simple benchmark we can see the stark difference in performance between anyio and native asyncio:

```python
import asyncio
import time
from concurrent.futures import ThreadPoolExecutor
from timeit import timeit

from anyio.to_thread import run_sync

from litestar.concurrency import sync_to_thread, set_asyncio_executor

set_asyncio_executor(ThreadPoolExecutor(40))


def func():
    time.sleep(0)


async def run_anyio():
    await run_sync(func)


async def run_native():
    await sync_to_thread(func)


async def run_anyio_batch():
    await asyncio.gather(*[run_sync(func) for _ in range(100)])


async def run_native_batch():
    await asyncio.gather(*[sync_to_thread(func) for _ in range(100)])


def run(fn):
    asyncio.new_event_loop().run_until_complete(fn())


print(timeit("run(run_anyio)", globals=globals(), number=1000))
print(timeit("run(run_native)", globals=globals(), number=1000))

print(timeit("run(run_anyio_batch)", globals=globals(), number=100))
print(timeit("run(run_native_batch)", globals=globals(), number=100))
```

```shell
0.6600718750014494
0.19882075799978338
2.053338443998655
0.7532648650012561
``` 

And testing this in a simple application, using `wrk`:

```python
from litestar import get, Litestar

@get(sync_to_thread=True)
def handler() -> str:
    return "Hello, world!"

app = Litestar(route_handlers=[handler])
```

*Without this PR*

```text
Thread Stats    Avg      Stdev     Max     +/- Stdev
Latency       23.83ms   14.72ms  266.88ms   98.07%
Req/Sec        2.22k    217.67    2.39k     95.00%

22114 requests in 5.01s, 3.10MB read
Requests/sec:   4415.57
Transfer/sec:   633.88KB
```

*With the changes applied*

```text
Thread Stats    Avg      Stdev     Max     +/- Stdev
Latency       17.14ms   13.38ms  254.68ms   96.68%
Req/Sec        3.14k     397.07   3.66k     83.00%

31234 requests in 5.01s, 4.38MB read
Requests/sec:   6236.19
Transfer/sec:   0.87MB
```
