### PR TITLE
fix: #2867 - Ensure `type_encoders` are passed to exception response

### DIFF
--- a/litestar/middleware/exceptions/_debug_response.py
+++ b/litestar/middleware/exceptions/_debug_response.py
@@ -191,4 +191,9 @@ def create_debug_response(request: Request, exc: Exception) -> Response:
         content = create_plain_text_response_content(exc)
         media_type = MediaType.TEXT
 
-    return Response(content=content, media_type=media_type, status_code=HTTP_500_INTERNAL_SERVER_ERROR)
+    return Response(
+        content=content,
+        media_type=media_type,
+        status_code=HTTP_500_INTERNAL_SERVER_ERROR,
+        type_encoders=request.app.type_encoders,
+    )

--- a/litestar/middleware/exceptions/_debug_response.py
+++ b/litestar/middleware/exceptions/_debug_response.py
@@ -200,7 +200,7 @@ def create_debug_response(request: Request, exc: Exception) -> Response:
     )
 
 
-def _get_type_encoders_for_request(request: Request) -> TypeEncodersMap:
+def _get_type_encoders_for_request(request: Request) -> TypeEncodersMap | None:
     try:
         return request.route_handler.resolve_type_encoders()
     # we might be in a 404, or before we could resolve the handler, so this

--- a/litestar/middleware/exceptions/_debug_response.py
+++ b/litestar/middleware/exceptions/_debug_response.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from inspect import FrameInfo
 
     from litestar.connection import Request
+    from litestar.types import TypeEncodersMap
 
 tpl_dir = Path(__file__).parent / "templates"
 
@@ -195,5 +196,15 @@ def create_debug_response(request: Request, exc: Exception) -> Response:
         content=content,
         media_type=media_type,
         status_code=HTTP_500_INTERNAL_SERVER_ERROR,
-        type_encoders=request.route_handler.resolve_type_encoders(),
+        type_encoders=_get_type_encoders_for_request(request) if request is not None else None,
     )
+
+
+def _get_type_encoders_for_request(request: Request) -> TypeEncodersMap:
+    try:
+        return request.route_handler.resolve_type_encoders()
+    # we might be in a 404, or before we could resolve the handler, so this
+    # could potentially error out. In this case we fall back on the application
+    # type encoders
+    except (KeyError, AttributeError):
+        return request.app.type_encoders

--- a/litestar/middleware/exceptions/_debug_response.py
+++ b/litestar/middleware/exceptions/_debug_response.py
@@ -195,5 +195,5 @@ def create_debug_response(request: Request, exc: Exception) -> Response:
         content=content,
         media_type=media_type,
         status_code=HTTP_500_INTERNAL_SERVER_ERROR,
-        type_encoders=request.app.type_encoders,
+        type_encoders=request.route_handler.resolve_type_encoders(),
     )

--- a/litestar/middleware/exceptions/middleware.py
+++ b/litestar/middleware/exceptions/middleware.py
@@ -11,7 +11,7 @@ from litestar.datastructures import Headers
 from litestar.enums import MediaType, ScopeType
 from litestar.exceptions import WebSocketException
 from litestar.middleware.cors import CORSMiddleware
-from litestar.middleware.exceptions._debug_response import create_debug_response
+from litestar.middleware.exceptions._debug_response import _get_type_encoders_for_request, create_debug_response
 from litestar.serialization import encode_json
 from litestar.status_codes import HTTP_500_INTERNAL_SERVER_ERROR
 from litestar.utils.deprecation import warn_deprecation
@@ -103,7 +103,7 @@ class ExceptionResponseContent:
             headers=self.headers,
             status_code=self.status_code,
             media_type=self.media_type,
-            type_encoders=request.route_handler.resolve_type_encoders() if request else None,
+            type_encoders=_get_type_encoders_for_request(request) if request is not None else None,
         )
 
 

--- a/litestar/middleware/exceptions/middleware.py
+++ b/litestar/middleware/exceptions/middleware.py
@@ -85,7 +85,7 @@ class ExceptionResponseContent:
     extra: dict[str, Any] | list[Any] | None = field(default=None)
     """An extra mapping to attach to the exception."""
 
-    def to_response(self) -> Response:
+    def to_response(self, request: Request | None = None) -> Response:
         """Create a response from the model attributes.
 
         Returns:
@@ -103,6 +103,7 @@ class ExceptionResponseContent:
             headers=self.headers,
             status_code=self.status_code,
             media_type=self.media_type,
+            type_encoders=request.app.type_encoders if request else None,
         )
 
 
@@ -139,7 +140,7 @@ def create_exception_response(request: Request[Any, Any, Any], exc: Exception) -
         extra=getattr(exc, "extra", None),
         media_type=media_type,
     )
-    return content.to_response()
+    return content.to_response(request=request)
 
 
 class ExceptionHandlerMiddleware:

--- a/litestar/middleware/exceptions/middleware.py
+++ b/litestar/middleware/exceptions/middleware.py
@@ -103,7 +103,7 @@ class ExceptionResponseContent:
             headers=self.headers,
             status_code=self.status_code,
             media_type=self.media_type,
-            type_encoders=request.app.type_encoders if request else None,
+            type_encoders=request.route_handler.resolve_type_encoders() if request else None,
         )
 
 


### PR DESCRIPTION
Fix a bug that would cause a `SerializationException` when custom types were present within a `ValidationException`, which would be the case if a Pydantic error was passed verbatim. 

The fix is to pass along the `type_encoders` resolved from the route handler of the originating request.

Fixes #2867.