### PR TITLE
fix: CONTRIBUTING.rst "Automatically execute examples" bug fix

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -217,8 +217,8 @@ This is equivalent to:
 
       @get("/")
       def hello_world() -> Dict[str, str]:
-         """Handler function that returns a greeting dictionary."""
-         return {"hello": "world"}
+          """Handler function that returns a greeting dictionary."""
+          return {"hello": "world"}
 
 
       app = Litestar(route_handlers=[hello_world])

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -208,31 +208,28 @@ In practice, this looks like the following:
 
 This is equivalent to:
 
+.. code-block:: python
 
-.. raw:: rst
+      from typing import Dict
 
-   .. code-block:: python
-
-       from typing import Dict
-
-       from litestar import Litestar, get
+      from litestar import Litestar, get
 
 
-       @get("/")
-       def hello_world() -> Dict[str, str]:
-           """Handler function that returns a greeting dictionary."""
-           return {"hello": "world"}
+      @get("/")
+      def hello_world() -> Dict[str, str]:
+         """Handler function that returns a greeting dictionary."""
+         return {"hello": "world"}
 
 
-       app = Litestar(route_handlers=[hello_world])
+      app = Litestar(route_handlers=[hello_world])
 
 
-   .. admonition:: Run it
+.. admonition:: Run it
 
-       .. code-block:: bash
+      .. code-block:: bash
 
-           > curl http://127.0.0.1:8000/
-           {"hello": "world"}
+         > curl http://127.0.0.1:8000/
+         {"hello": "world"}
 
 
 Creating a new release


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

Fixes tiny bug on the CONTRIBUTING.rst

Currently, just a line above https://docs.litestar.dev/latest/contribution-guide.html#creating-a-new-release, the docs are cut-off after "This is equivalent to:"
![image](https://github.com/litestar-org/litestar/assets/10182564/ea467e25-acdc-4ee0-92d6-7c71fb9199aa)


After the fix: 
![image](https://github.com/litestar-org/litestar/assets/10182564/a6798cf3-8afa-4829-b924-fbd803748348)
