### PR TITLE
docs: fix serialization example in SQLAlchemy tutorial

### DIFF
--- a/docs/tutorials/sqlalchemy/0-introduction.rst
+++ b/docs/tutorials/sqlalchemy/0-introduction.rst
@@ -103,7 +103,7 @@ serializable by Litestar.
     /examples/contrib/sqlalchemy/plugins/tutorial/full_app_no_plugins.py
     :language: python
     :linenos:
-    :lines: 2-3,14-16,45-48,94-101
+    :lines: 2-3,14-16,47-50,92-98 
     :emphasize-lines: 3,4,6,11
 
 Behavior

--- a/docs/tutorials/sqlalchemy/0-introduction.rst
+++ b/docs/tutorials/sqlalchemy/0-introduction.rst
@@ -103,8 +103,8 @@ serializable by Litestar.
     /examples/contrib/sqlalchemy/plugins/tutorial/full_app_no_plugins.py
     :language: python
     :linenos:
-    :lines: 2-3,14-16,47-50,92-98 
-    :emphasize-lines: 3,4,6,11
+    :lines: 2-3,14-15,47-50,92-98
+    :emphasize-lines: 3,4,6,7,10,15
 
 Behavior
 ++++++++


### PR DESCRIPTION
in Official docs: [Serialization section ](https://docs.litestar.dev/2/tutorials/sqlalchemy/0-introduction.html#serialization)in SQLAlchemy tutorial seems broken. Minor fix in this PR to pick and highlight relevant lines from code.
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
