### PR TITLE
fix: handle single file in cases of multiple file uploads

### DIFF
--- a/litestar/_kwargs/extractors.py
+++ b/litestar/_kwargs/extractors.py
@@ -356,7 +356,7 @@ def create_multipart_extractor(
 
         if field_definition.is_non_string_sequence:
             values = list(form_values.values())
-            if field_definition.inner_types[0].annotation is UploadFile and isinstance(values[0], list):
+            if field_definition.has_inner_subclass_of(UploadFile) and isinstance(values[0], list):
                 return values[0]
 
             return values

--- a/litestar/_kwargs/extractors.py
+++ b/litestar/_kwargs/extractors.py
@@ -371,8 +371,8 @@ def create_multipart_extractor(
             return data_dto(connection).decode_builtins(form_values)
 
         for name, tp in field_definition.get_type_hints().items():
-            value = form_values[name]
-            if is_non_string_sequence(tp) and not isinstance(value, list):
+            value = form_values.get(name)
+            if value is not None and is_non_string_sequence(tp) and not isinstance(value, list):
                 form_values[name] = [value]
 
         return form_values

--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -410,6 +410,27 @@ def test_upload_multiple_files(file_count: int) -> None:
         assert response.status_code == HTTP_201_CREATED
 
 
+@dataclass
+class Files:
+    file_list: List[UploadFile]
+
+
+@pytest.mark.parametrize("file_count", (1, 2))
+def test_upload_multiple_files_in_model(file_count: int) -> None:
+    @post("/")
+    async def handler(data: Files = Body(media_type=RequestEncodingType.MULTI_PART)) -> None:
+        assert len(data.file_list) == file_count
+
+        for file in data.file_list:
+            assert await file.read() == b"1"
+
+    with create_test_client([handler]) as client:
+        files_to_upload = [("file_list", b"1") for _ in range(file_count)]
+        response = client.post("/", files=files_to_upload)
+
+        assert response.status_code == HTTP_201_CREATED
+
+
 def test_optional_formdata() -> None:
     @post("/", signature_types=[UploadFile])
     async def hello_world(data: Optional[UploadFile] = Body(media_type=RequestEncodingType.MULTI_PART)) -> None:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

This applies the same fix as in #2753 except that it iterates though all the fields and performs the check to see if the expected type is a list and converts the value into a list if it's not. 

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
Fixes #2939.