### PR TITLE
feat: Implement static file serving with regular route handlers

### DIFF
--- a/docs/examples/static_files/custom_router.py
+++ b/docs/examples/static_files/custom_router.py
@@ -1,0 +1,18 @@
+from litestar import Litestar
+from litestar.router import Router
+from litestar.static_files import create_static_files_router
+
+
+class MyRouter(Router):
+    pass
+
+
+app = Litestar(
+    route_handlers=[
+        create_static_files_router(
+            path="/static",
+            directories=["assets"],
+            router_class=MyRouter,
+        )
+    ]
+)

--- a/docs/examples/static_files/file_system.py
+++ b/docs/examples/static_files/file_system.py
@@ -1,0 +1,14 @@
+from fsspec.implementations.ftp import FTPFileSystem
+
+from litestar import Litestar
+from litestar.static_files import create_static_files_router
+
+app = Litestar(
+    route_handlers=[
+        create_static_files_router(
+            path="/static",
+            directories=["assets"],
+            file_system=FTPFileSystem(host="127.0.0.1"),
+        ),
+    ]
+)

--- a/docs/examples/static_files/full_example.py
+++ b/docs/examples/static_files/full_example.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from litestar import Litestar
+from litestar.static_files import create_static_files_router
+
+ASSETS_DIR = Path("assets")
+
+
+def on_startup():
+    ASSETS_DIR.mkdir(exist_ok=True)
+    ASSETS_DIR.joinpath("hello.txt").write_text("Hello, world!")
+
+
+app = Litestar(
+    route_handlers=[
+        create_static_files_router(path="/static", directories=["assets"]),
+    ],
+    on_startup=[on_startup],
+)
+
+
+#  run: /static/hello.txt

--- a/docs/examples/static_files/html_mode.py
+++ b/docs/examples/static_files/html_mode.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from litestar import Litestar
+from litestar.static_files import create_static_files_router
+
+HTML_DIR = Path("html")
+
+
+def on_startup() -> None:
+    HTML_DIR.mkdir(exist_ok=True)
+    HTML_DIR.joinpath("index.html").write_text("<strong>Hello, world!</strong>")
+    HTML_DIR.joinpath("404.html").write_text("<h1>Not found</h1>")
+
+
+app = Litestar(
+    route_handlers=[
+        create_static_files_router(
+            path="/",
+            directories=["html"],
+            html_mode=True,
+        )
+    ],
+    on_startup=[on_startup],
+)
+
+
+# run: /
+# run: /index.html
+# run: /something

--- a/docs/examples/static_files/passing_options.py
+++ b/docs/examples/static_files/passing_options.py
@@ -1,0 +1,14 @@
+from litestar import Litestar
+from litestar.static_files import create_static_files_router
+
+app = Litestar(
+    route_handlers=[
+        create_static_files_router(
+            path="/",
+            directories=["assets"],
+            opt={"some": True},
+            include_in_schema=False,
+            tags=["static"],
+        )
+    ]
+)

--- a/docs/examples/static_files/route_reverse.py
+++ b/docs/examples/static_files/route_reverse.py
@@ -1,0 +1,11 @@
+from litestar import Litestar
+from litestar.static_files import create_static_files_router
+
+app = Litestar(
+    route_handlers=[
+        create_static_files_router(path="/static", directories=["assets"]),
+    ]
+)
+
+
+print(app.route_reverse(name="static", file_path="/some_file.txt"))  # /static/some_file.txt

--- a/docs/examples/static_files/send_as_attachment.py
+++ b/docs/examples/static_files/send_as_attachment.py
@@ -1,0 +1,12 @@
+from litestar import Litestar
+from litestar.static_files import create_static_files_router
+
+app = Litestar(
+    route_handlers=[
+        create_static_files_router(
+            path="/static",
+            directories=["assets"],
+            send_as_attachment=True,
+        )
+    ]
+)

--- a/docs/examples/static_files/upgrade_from_static_1.py
+++ b/docs/examples/static_files/upgrade_from_static_1.py
@@ -1,0 +1,8 @@
+from litestar import Litestar
+from litestar.static_files.config import StaticFilesConfig
+
+app = Litestar(
+    static_files_config=[
+        StaticFilesConfig(directories=["assets"], path="/static"),
+    ],
+)

--- a/docs/examples/static_files/upgrade_from_static_2.py
+++ b/docs/examples/static_files/upgrade_from_static_2.py
@@ -1,0 +1,8 @@
+from litestar import Litestar
+from litestar.static_files import create_static_files_router
+
+app = Litestar(
+    route_handlers=[
+        create_static_files_router(directories=["assets"], path="/static"),
+    ],
+)

--- a/docs/usage/static-files.rst
+++ b/docs/usage/static-files.rst
@@ -1,89 +1,116 @@
-Static Files
+Static files
 ============
 
-Static files are served by the app from predefined locations. To configure static file serving, either pass an
-instance of :class:`StaticFilesConfig <.static_files.config.StaticFilesConfig>` or a list
-thereof to :class:`Litestar <.app.Litestar>` using the ``static_files_config`` kwarg.
+To serve static files (i.e. serve arbitrary files from a given directory), the
+:func:`~litestar.static_files.create_static_files_router` can be used to create a
+:class:`Router <litestar.router.Router>` to handle this task.
 
-For example, lets say our Litestar app is going to serve **regular files** from the ``my_app/static`` folder and **html
-documents** from the ``my_app/html`` folder, and we would like to serve the **static files** on the ``/files`` path,
-and the **html files** on the ``/html`` path:
+.. literalinclude:: /examples/static_files/full_example.py
+    :language: python
 
-.. code-block:: python
+In this example, files from the directory ``assets`` will be served on the path
+``/static``. A file ``assets/hello.txt`` would now be available on ``/static/hello.txt``
 
-   from litestar import Litestar
-   from litestar.static_files.config import StaticFilesConfig
+.. attention::
+    Directories are interpreted as relative to the working directory from which the
+    application is started
 
-   app = Litestar(
-       route_handlers=[...],
-       static_files_config=[
-           StaticFilesConfig(directories=["static"], path="/files"),
-           StaticFilesConfig(directories=["html"], path="/html", html_mode=True),
-       ],
-   )
-
-Matching is done based on filename, for example, assume we have a request that is trying to retrieve the path
-``/files/file.txt``\ , the **directory for the base path** ``/files`` **will be searched** for the file ``file.txt``. If it is
-found, the file will be sent, otherwise a **404 response** will be sent.
-
-If ``html_mode`` is enabled and no specific file is requested, the application will fall back to serving ``index.html``. If
-no file is found the application will look for a ``404.html`` file in order to render a response, otherwise a 404
-:class:`NotFoundException <.exceptions.http_exceptions.NotFoundException>` will be returned.
-
-You can provide a ``name`` parameter to ``StaticFilesConfig`` to identify the given config and generate links to files in
-folders belonging to that config. ``name`` should be a unique string across all static configs and
-:doc:`/usage/routing/handlers`.
-
-.. code-block:: python
-
-   from litestar import Litestar
-   from litestar.static_files.config import StaticFilesConfig
-
-   app = Litestar(
-       route_handlers=[...],
-       static_files_config=[
-           StaticFilesConfig(
-               directories=["static"], path="/some_folder/static/path", name="static"
-           ),
-       ],
-   )
-
-   url_path = app.url_for_static_asset("static", "file.pdf")
-   # /some_folder/static/path/file.pdf
 
 Sending files as attachments
 ----------------------------
 
-By default, files are sent "inline", meaning they will have a ``Content-Disposition: inline`` header.
-To send them as attachments, use the ``send_as_attachment=True`` flag, which will add a
-``Content-Disposition: attachment`` header:
+By default, files are sent "inline", meaning they will have a
+``Content-Disposition: inline`` header. Setting ``send_as_attachment=True`` flag will
+send them with a ``Content-Disposition: attachment`` instead:
 
-.. code-block:: python
+.. literalinclude:: /examples/static_files/send_as_attachment.py
+    :language: python
 
-   from litestar import Litestar
-   from litestar.static_files.config import StaticFilesConfig
 
-   app = Litestar(
-       route_handlers=[...],
-       static_files_config=[
-           StaticFilesConfig(
-               directories=["static"],
-               path="/some_folder/static/path",
-               name="static",
-               send_as_attachment=True,
-           ),
-       ],
-   )
+HTML mode
+---------
 
-File System support and Cloud Files
------------------------------------
+"HTML mode" can be enabled by setting ``html_mode=True``. This will:
 
-The :class:`StaticFilesConfig <.static_files.StaticFilesConfig>` class accepts a value called ``file_system``,
-which can be any class adhering to the Litestar :class:`FileSystemProtocol <litestar.types.FileSystemProtocol>`.
+- Serve and ``/index.html`` when the path ``/`` is requested
+- Attempt to serve ``/404.html`` when a requested file is not found
 
-This protocol is similar to the file systems defined by `fsspec <https://filesystem-spec.readthedocs.io/en/latest/>`_,
-which cover all major cloud providers and a wide range of other use cases (e.g. HTTP based file service, ``ftp``, etc.).
 
-In order to use any file system, simply use `fsspec <https://filesystem-spec.readthedocs.io/en/latest/>`_ or one of
-the libraries based upon it, or provide a custom implementation adhering to the
-:class:`FileSystemProtocol <litestar.types.FileSystemProtocol>`.
+.. literalinclude:: /examples/static_files/html_mode.py
+    :language: python
+
+
+Passing options to the generated router
+---------------------------------------
+
+Options available on :class:`~litestar.router.Router` can be passed to directly
+:func:`~litestar.static_files.create_static_files_router`:
+
+.. literalinclude:: /examples/static_files/passing_options.py
+    :language: python
+
+
+Using a custom router class
+---------------------------
+
+The router class used can be customized with the ``router_class`` parameter:
+
+.. literalinclude:: /examples/static_files/custom_router.py
+    :language: python
+
+
+
+Retrieving paths to static files
+--------------------------------
+
+:meth:`~litestar.app.Litestar.route_reverse` and
+:meth:`~litestar.connection.ASGIConnection.url_for` can be used to retrieve the path
+under which a specific file will be available:
+
+.. literalinclude:: /examples/static_files/route_reverse.py
+    :language: python
+
+.. tip::
+
+    The ``name`` parameter has to match the ``name`` parameter passed to
+    :func:`create_static_files_router`, which defaults to ``static``.
+
+
+(Remote) file systems
+---------------------
+
+To customize how Litestar interacts with the file system, a class implementing the
+:class:`~litestar.types.FileSystemProtocol` can be passed to ``file_system``. An example
+of this are the file systems provided by
+`fsspec <https://filesystem-spec.readthedocs.io/en/latest/>`_, which includes support
+for FTP, SFTP, Hadoop, SMB, GitHub and
+`many more <https://filesystem-spec.readthedocs.io/en/latest/api.html#implementations>`_,
+with support for popular cloud providers available via 3rd party implementations such as
+
+- S3 via `S3FS <https://s3fs.readthedocs.io/en/latest/>`_
+- Google Cloud Storage via `GCFS <https://gcsfs.readthedocs.io/en/latest/>`_
+- Azure Blob Storage via `adlfs <https://github.com/fsspec/adlfs>`_
+
+
+.. literalinclude:: /examples/static_files/file_system.py
+    :language: python
+
+
+Upgrading from legacy StaticFilesConfig
+---------------------------------------
+
+.. important:: Info
+    :class:`StaticFilesConfig` is deprecated and will be removed in Litestar 3.0
+
+
+Existing code can be upgraded to :func:`create_static_files_router` by replacing
+:class:`StaticFilesConfig` instances with this function call and passing the result to
+``route_handlers`` instead of ``static_files_config``:
+
+
+.. literalinclude:: /examples/static_files/upgrade_from_static_1.py
+    :language: python
+
+
+.. literalinclude:: /examples/static_files/upgrade_from_static_2.py
+    :language: python

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -137,6 +137,7 @@ class Litestar(Router):
         "_server_lifespan_managers",
         "_debug",
         "_openapi_schema",
+        "_static_files_config",
         "plugins",
         "after_exception",
         "allowed_hosts",
@@ -160,7 +161,6 @@ class Litestar(Router):
         "route_map",
         "signature_namespace",
         "state",
-        "static_files_config",
         "stores",
         "template_engine",
         "websocket_class",
@@ -410,7 +410,7 @@ class Litestar(Router):
         self.request_class = config.request_class or Request
         self.response_cache_config = config.response_cache_config
         self.state = config.state
-        self.static_files_config = config.static_files_config
+        self._static_files_config = config.static_files_config
         self.template_engine = config.template_config.engine_instance if config.template_config else None
         self.websocket_class = config.websocket_class or WebSocket
         self.debug = config.debug
@@ -464,6 +464,11 @@ class Litestar(Router):
         self.stores: StoreRegistry = (
             config.stores if isinstance(config.stores, StoreRegistry) else StoreRegistry(config.stores)
         )
+
+    @property
+    @deprecated(version="2.6.0", kind="property", info="Use create_static_files router instead")
+    def static_files_config(self) -> list[StaticFilesConfig]:
+        return self._static_files_config
 
     @property
     @deprecated(version="2.0", alternative="Litestar.plugins.cli", kind="property")
@@ -739,6 +744,9 @@ class Litestar(Router):
 
         return join_paths(output)
 
+    @deprecated(
+        "2.6.0", info="Use create_static_files router instead of StaticFilesConfig, which works with route_reverse"
+    )
     def url_for_static_asset(self, name: str, file_path: str) -> str:
         """Receives a static files handler name, an asset file path and returns resolved url path to the asset.
 

--- a/litestar/static_files/__init__.py
+++ b/litestar/static_files/__init__.py
@@ -1,4 +1,4 @@
 from litestar.static_files.base import StaticFiles
-from litestar.static_files.config import StaticFilesConfig, create_static_router
+from litestar.static_files.config import StaticFilesConfig, create_static_files_router
 
-__all__ = ("StaticFiles", "StaticFilesConfig", "create_static_router")
+__all__ = ("StaticFiles", "StaticFilesConfig", "create_static_files_router")

--- a/litestar/static_files/__init__.py
+++ b/litestar/static_files/__init__.py
@@ -1,4 +1,4 @@
 from litestar.static_files.base import StaticFiles
-from litestar.static_files.config import StaticFilesConfig
+from litestar.static_files.config import StaticFilesConfig, create_static_router
 
-__all__ = ("StaticFiles", "StaticFilesConfig")
+__all__ = ("StaticFiles", "StaticFilesConfig", "create_static_router")

--- a/litestar/static_files/base.py
+++ b/litestar/static_files/base.py
@@ -30,6 +30,7 @@ class StaticFiles:
         directories: Sequence[PathType],
         file_system: FileSystemProtocol,
         send_as_attachment: bool = False,
+        resolve_symlinks: bool = True,
     ) -> None:
         """Initialize the Application.
 
@@ -39,9 +40,10 @@ class StaticFiles:
             file_system: The file_system spec to use for serving files.
             send_as_attachment: Whether to send the file with a ``content-disposition`` header of
              ``attachment`` or ``inline``
+            resolve_symlinks: Resolve symlinks to the directories
         """
         self.adapter = FileSystemAdapter(file_system)
-        self.directories = tuple(Path(p).resolve() for p in directories)
+        self.directories = tuple(Path(p).resolve() if resolve_symlinks else Path(p) for p in directories)
         self.is_html_mode = is_html_mode
         self.send_as_attachment = send_as_attachment
 

--- a/litestar/static_files/config.py
+++ b/litestar/static_files/config.py
@@ -97,7 +97,7 @@ class StaticFilesConfig:
         )(static_files)
 
 
-def create_static_router(
+def create_static_files_router(
     path: str,
     directories: list[PathType],
     file_system: Any = None,

--- a/litestar/static_files/config.py
+++ b/litestar/static_files/config.py
@@ -11,7 +11,7 @@ from litestar.response.file import ASGIFileResponse  # noqa: TCH001
 from litestar.router import Router
 from litestar.static_files.base import StaticFiles
 from litestar.types import Empty
-from litestar.utils import normalize_path
+from litestar.utils import normalize_path, warn_deprecation
 
 __all__ = ("StaticFilesConfig",)
 
@@ -74,6 +74,15 @@ class StaticFilesConfig:
     def __post_init__(self) -> None:
         _validate_config(path=self.path, directories=self.directories, file_system=self.file_system)
         self.path = normalize_path(self.path)
+        warn_deprecation(
+            "2.6.0",
+            kind="class",
+            deprecated_name="StaticFilesConfig",
+            removal_in="3.0",
+            alternative="create_static_files_router",
+            info='Replace static_files_config=[StaticFilesConfig(path="/static", directories=["assets"])] with '
+            'route_handlers=[..., create_static_files_router(path="/static", directories=["assets"])]',
+        )
 
     def to_static_files_app(self) -> ASGIRouteHandler:
         """Return an ASGI app serving static files based on the config.

--- a/tests/examples/test_static_files.py
+++ b/tests/examples/test_static_files.py
@@ -1,0 +1,69 @@
+import secrets
+from pathlib import Path
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+
+from litestar.testing import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _chdir(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.fixture()
+def assets_file(tmp_path: Path) -> str:
+    content = secrets.token_hex()
+    assets_path = tmp_path / "assets"
+    assets_path.mkdir()
+    assets_path.joinpath("test.txt").write_text(content)
+    return content
+
+
+def test_custom_router() -> None:
+    from docs.examples.static_files import custom_router  # noqa: F401
+
+
+def test_full_example() -> None:
+    from docs.examples.static_files import full_example
+
+    with TestClient(full_example.app) as client:
+        assert client.get("/static/hello.txt").text == "Hello, world!"
+
+
+def test_html_mode() -> None:
+    from docs.examples.static_files import html_mode
+
+    with TestClient(html_mode.app) as client:
+        assert client.get("/").text == "<strong>Hello, world!</strong>"
+        assert client.get("/index.html").text == "<strong>Hello, world!</strong>"
+        assert client.get("/something").text == "<h1>Not found</h1>"
+
+
+def test_passing_options() -> None:
+    from docs.examples.static_files import passing_options  # noqa: F401
+
+
+def test_route_reverse(capsys) -> None:
+    from docs.examples.static_files import route_reverse  # noqa: F401
+
+    assert capsys.readouterr().out.strip() == "/static/some_file.txt"
+
+
+def test_send_as_attachment(tmp_path: Path, assets_file: str) -> None:
+    from docs.examples.static_files import send_as_attachment
+
+    with TestClient(send_as_attachment.app) as client:
+        res = client.get("/static/test.txt")
+        assert res.text == assets_file
+        assert res.headers["content-disposition"].startswith("attachment")
+
+
+def test_upgrade_from_static(tmp_path: Path, assets_file: str) -> None:
+    from docs.examples.static_files import upgrade_from_static_1, upgrade_from_static_2
+
+    for app in [upgrade_from_static_1.app, upgrade_from_static_2.app]:
+        with TestClient(app) as client:
+            res = client.get("/static/test.txt")
+            assert res.text == assets_file

--- a/tests/unit/test_static_files/conftest.py
+++ b/tests/unit/test_static_files/conftest.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Callable
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from fsspec.implementations.local import LocalFileSystem
+from typing_extensions import TypeAlias
+
+from litestar import Router
+from litestar.file_system import BaseLocalFileSystem
+from litestar.static_files import StaticFilesConfig, create_static_router
+from litestar.types import FileSystemProtocol
+
+MakeConfig: TypeAlias = "Callable[[StaticFilesConfig], tuple[list[StaticFilesConfig], list[Router]]]"
+
+
+@pytest.fixture(params=["config", "handlers"])
+def make_config(request: FixtureRequest) -> MakeConfig:
+    def make(config: StaticFilesConfig) -> tuple[list[StaticFilesConfig], list[Router]]:
+        if request.param == "config":
+            return [config], []
+        return [], [create_static_router(**asdict(config))]
+
+    return make
+
+
+@pytest.fixture(params=[BaseLocalFileSystem(), LocalFileSystem()])
+def file_system(request: FixtureRequest) -> FileSystemProtocol:
+    return request.param

--- a/tests/unit/test_static_files/conftest.py
+++ b/tests/unit/test_static_files/conftest.py
@@ -28,4 +28,4 @@ def make_config(request: FixtureRequest) -> MakeConfig:
 
 @pytest.fixture(params=[BaseLocalFileSystem(), LocalFileSystem()])
 def file_system(request: FixtureRequest) -> FileSystemProtocol:
-    return request.param
+    return request.param  # type: ignore[no-any-return]

--- a/tests/unit/test_static_files/conftest.py
+++ b/tests/unit/test_static_files/conftest.py
@@ -10,7 +10,7 @@ from typing_extensions import TypeAlias
 
 from litestar import Router
 from litestar.file_system import BaseLocalFileSystem
-from litestar.static_files import StaticFilesConfig, create_static_router
+from litestar.static_files import StaticFilesConfig, create_static_files_router
 from litestar.types import FileSystemProtocol
 
 MakeConfig: TypeAlias = "Callable[[StaticFilesConfig], tuple[list[StaticFilesConfig], list[Router]]]"
@@ -21,7 +21,7 @@ def make_config(request: FixtureRequest) -> MakeConfig:
     def make(config: StaticFilesConfig) -> tuple[list[StaticFilesConfig], list[Router]]:
         if request.param == "config":
             return [config], []
-        return [], [create_static_router(**asdict(config))]
+        return [], [create_static_files_router(**asdict(config))]
 
     return make
 

--- a/tests/unit/test_static_files/test_create_static_router.py
+++ b/tests/unit/test_static_files/test_create_static_router.py
@@ -20,11 +20,11 @@ def test_pass_options() -> None:
     def guard(connection: ASGIConnection, handler: BaseRouteHandler) -> None:
         pass
 
-    def handle(request: Request, exception: Exception) -> Response:
+    def handle(request: Request, exception: Any) -> Response:
         return Response(b"")
 
     async def after_request(response: Response) -> Response:
-        pass
+        return Response(b"")
 
     async def after_response(request: Request) -> None:
         pass
@@ -42,7 +42,7 @@ def test_pass_options() -> None:
         path="/",
         directories=["something"],
         guards=[guard],
-        exception_handlers=exception_handlers,
+        exception_handlers=exception_handlers,  # type: ignore[arg-type]
         opt=opts,
         after_request=after_request,
         after_response=after_response,

--- a/tests/unit/test_static_files/test_create_static_router.py
+++ b/tests/unit/test_static_files/test_create_static_router.py
@@ -1,0 +1,35 @@
+from litestar import Litestar
+from litestar.exceptions import ValidationException
+from litestar.static_files import create_static_router
+
+
+def test_route_reverse() -> None:
+    app = Litestar(route_handlers=[create_static_router(path="/static", directories=["something"], name="static")])
+
+    assert app.route_reverse("static", file_path="foo.py") == "/static/foo.py"
+
+
+def test_opt() -> None:
+    router = create_static_router(path="/", directories=["something"], opt={"foo": "bar"})
+
+    assert router.opt == {"foo": "bar"}
+
+
+def test_guards() -> None:
+    def guard():
+        pass
+
+    router = create_static_router(path="/", directories=["something"], guards=[guard])
+
+    assert router.guards == [guard]
+
+
+def test_exception_handlers() -> None:
+    def handle():
+        pass
+
+    exception_handlers = {ValidationException: handle}
+
+    router = create_static_router(path="/", directories=["something"], exception_handlers=exception_handlers)
+
+    assert router.exception_handlers == exception_handlers

--- a/tests/unit/test_static_files/test_create_static_router.py
+++ b/tests/unit/test_static_files/test_create_static_router.py
@@ -1,5 +1,8 @@
-from litestar import Litestar, Request, Response
+from typing import Any
+
+from litestar import Litestar, Request, Response, Router
 from litestar.connection import ASGIConnection
+from litestar.datastructures import CacheControlHeader
 from litestar.exceptions import ValidationException
 from litestar.handlers import BaseRouteHandler
 from litestar.static_files import create_static_router
@@ -11,27 +14,58 @@ def test_route_reverse() -> None:
     assert app.route_reverse("static", file_path="foo.py") == "/static/foo.py"
 
 
-def test_opt() -> None:
-    router = create_static_router(path="/", directories=["something"], opt={"foo": "bar"})
-
-    assert router.opt == {"foo": "bar"}
-
-
-def test_guards() -> None:
+def test_pass_options() -> None:
     def guard(connection: ASGIConnection, handler: BaseRouteHandler) -> None:
         pass
 
-    router = create_static_router(path="/", directories=["something"], guards=[guard])
-
-    assert router.guards == [guard]
-
-
-def test_exception_handlers() -> None:
     def handle(request: Request, exception: Exception) -> Response:
         return Response(b"")
 
+    async def after_request(response: Response) -> Response:
+        pass
+
+    async def after_response(request: Request) -> None:
+        pass
+
+    async def before_request(request: Request) -> Any:
+        pass
+
     exception_handlers = {ValidationException: handle}
+    opts = {"foo": "bar"}
+    cache_control = CacheControlHeader()
+    security = [{"foo": ["bar"]}]
+    tags = ["static", "random"]
 
-    router = create_static_router(path="/", directories=["something"], exception_handlers=exception_handlers)  # type: ignore[arg-type]
+    router = create_static_router(
+        path="/",
+        directories=["something"],
+        guards=[guard],
+        exception_handlers=exception_handlers,
+        opt=opts,
+        after_request=after_request,
+        after_response=after_response,
+        before_request=before_request,
+        cache_control=cache_control,
+        include_in_schema=False,
+        security=security,
+        tags=tags,
+    )
 
+    assert router.guards == [guard]
     assert router.exception_handlers == exception_handlers
+    assert router.opt == opts
+    assert router.after_request is after_request
+    assert router.after_response is after_response
+    assert router.before_request is before_request
+    assert router.cache_control is cache_control
+    assert router.include_in_schema is False
+    assert router.security == security
+    assert router.tags == tags
+
+
+def test_custom_router_class() -> None:
+    class MyRouter(Router):
+        pass
+
+    router = create_static_router("/", directories=["some"], router_class=MyRouter)
+    assert isinstance(router, MyRouter)

--- a/tests/unit/test_static_files/test_create_static_router.py
+++ b/tests/unit/test_static_files/test_create_static_router.py
@@ -5,11 +5,13 @@ from litestar.connection import ASGIConnection
 from litestar.datastructures import CacheControlHeader
 from litestar.exceptions import ValidationException
 from litestar.handlers import BaseRouteHandler
-from litestar.static_files import create_static_router
+from litestar.static_files import create_static_files_router
 
 
 def test_route_reverse() -> None:
-    app = Litestar(route_handlers=[create_static_router(path="/static", directories=["something"], name="static")])
+    app = Litestar(
+        route_handlers=[create_static_files_router(path="/static", directories=["something"], name="static")]
+    )
 
     assert app.route_reverse("static", file_path="foo.py") == "/static/foo.py"
 
@@ -36,7 +38,7 @@ def test_pass_options() -> None:
     security = [{"foo": ["bar"]}]
     tags = ["static", "random"]
 
-    router = create_static_router(
+    router = create_static_files_router(
         path="/",
         directories=["something"],
         guards=[guard],
@@ -67,5 +69,5 @@ def test_custom_router_class() -> None:
     class MyRouter(Router):
         pass
 
-    router = create_static_router("/", directories=["some"], router_class=MyRouter)
+    router = create_static_files_router("/", directories=["some"], router_class=MyRouter)
     assert isinstance(router, MyRouter)

--- a/tests/unit/test_static_files/test_create_static_router.py
+++ b/tests/unit/test_static_files/test_create_static_router.py
@@ -1,5 +1,7 @@
-from litestar import Litestar
+from litestar import Litestar, Request, Response
+from litestar.connection import ASGIConnection
 from litestar.exceptions import ValidationException
+from litestar.handlers import BaseRouteHandler
 from litestar.static_files import create_static_router
 
 
@@ -16,7 +18,7 @@ def test_opt() -> None:
 
 
 def test_guards() -> None:
-    def guard():
+    def guard(connection: ASGIConnection, handler: BaseRouteHandler) -> None:
         pass
 
     router = create_static_router(path="/", directories=["something"], guards=[guard])
@@ -25,11 +27,11 @@ def test_guards() -> None:
 
 
 def test_exception_handlers() -> None:
-    def handle():
-        pass
+    def handle(request: Request, exception: Exception) -> Response:
+        return Response(b"")
 
     exception_handlers = {ValidationException: handle}
 
-    router = create_static_router(path="/", directories=["something"], exception_handlers=exception_handlers)
+    router = create_static_router(path="/", directories=["something"], exception_handlers=exception_handlers)  # type: ignore[arg-type]
 
     assert router.exception_handlers == exception_handlers

--- a/tests/unit/test_static_files/test_file_serving_resolution.py
+++ b/tests/unit/test_static_files/test_file_serving_resolution.py
@@ -1,125 +1,145 @@
+from __future__ import annotations
+
 import gzip
 import mimetypes
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 import brotli
 import pytest
-from fsspec.implementations.local import LocalFileSystem
+from typing_extensions import TypeAlias
 
-from litestar import MediaType, get
-from litestar.file_system import BaseLocalFileSystem
-from litestar.static_files.config import StaticFilesConfig
+from litestar import MediaType, Router, get
+from litestar.static_files import StaticFilesConfig
 from litestar.status_codes import HTTP_200_OK
 from litestar.testing import create_test_client
+from tests.unit.test_static_files.conftest import MakeConfig
 
 if TYPE_CHECKING:
     from litestar.types import FileSystemProtocol
 
 
-def test_default_static_files_config(tmpdir: "Path") -> None:
+def test_default_static_files_config(tmpdir: Path, make_config: MakeConfig) -> None:
     path = tmpdir / "test.txt"
     path.write_text("content", "utf-8")
-    static_files_config = StaticFilesConfig(path="/static", directories=[tmpdir])
+    static_files_config, router = make_config(StaticFilesConfig(path="/static", directories=[tmpdir]))
 
-    with create_test_client([], static_files_config=[static_files_config]) as client:
+    with create_test_client(router, static_files_config=static_files_config) as client:
         response = client.get("/static/test.txt")
         assert response.status_code == HTTP_200_OK, response.text
         assert response.text == "content"
 
 
-def test_multiple_static_files_configs(tmpdir: "Path") -> None:
-    root1 = tmpdir.mkdir("1")  # type: ignore
-    root2 = tmpdir.mkdir("2")  # type: ignore
-    path1 = root1 / "test.txt"  # pyright: ignore
-    path1.write_text("content1", "utf-8")
-    path2 = root2 / "test.txt"  # pyright: ignore
-    path2.write_text("content2", "utf-8")
+@pytest.fixture()
+def setup_dirs(tmpdir: Path) -> tuple[Path, Path]:
+    paths = []
+    for i in range(1, 3):
+        root = tmpdir / str(i)
+        root.mkdir()
+        file_path = root / f"test_{i}.txt"
+        file_path.write_text(f"content{i}", "utf-8")
+        paths.append(root)
 
-    static_files_config = [
+    return paths[0], paths[1]
+
+
+MakeConfigs: TypeAlias = (
+    "Callable[[StaticFilesConfig, StaticFilesConfig], tuple[list[StaticFilesConfig], list[Router]]]"
+)
+
+
+@pytest.fixture()
+def make_configs(make_config: MakeConfig) -> MakeConfigs:
+    def make(
+        first_config: StaticFilesConfig, second_config: StaticFilesConfig
+    ) -> tuple[list[StaticFilesConfig], list[Router]]:
+        configs_1, routers_1 = make_config(first_config)
+        configs_2, routers_2 = make_config(second_config)
+        return [*configs_1, *configs_2], [*routers_1, *routers_2]
+
+    return make
+
+
+def test_multiple_static_files_configs(setup_dirs: tuple[Path, Path], make_configs: MakeConfigs) -> None:
+    root1, root2 = setup_dirs
+
+    configs, handlers = make_configs(
         StaticFilesConfig(path="/static_first", directories=[root1]),  # pyright: ignore
         StaticFilesConfig(path="/static_second", directories=[root2]),  # pyright: ignore
-    ]
-    with create_test_client([], static_files_config=static_files_config) as client:
-        response = client.get("/static_first/test.txt")
+    )
+    with create_test_client(handlers, static_files_config=configs) as client:
+        response = client.get("/static_first/test_1.txt")
         assert response.status_code == HTTP_200_OK
         assert response.text == "content1"
 
-        response = client.get("/static_second/test.txt")
+        response = client.get("/static_second/test_2.txt")
         assert response.status_code == HTTP_200_OK
         assert response.text == "content2"
 
 
-@pytest.mark.parametrize("file_system", (BaseLocalFileSystem(), LocalFileSystem()))
-def test_static_files_configs_with_mixed_file_systems(tmpdir: "Path", file_system: "FileSystemProtocol") -> None:
-    root1 = tmpdir.mkdir("1")  # type: ignore
-    root2 = tmpdir.mkdir("2")  # type: ignore
-    path1 = root1 / "test.txt"  # pyright: ignore
-    path1.write_text("content1", "utf-8")
-    path2 = root2 / "test.txt"  # pyright: ignore
-    path2.write_text("content2", "utf-8")
+def test_static_files_configs_with_mixed_file_systems(
+    file_system: FileSystemProtocol, setup_dirs: tuple[Path, Path], make_configs: MakeConfigs
+) -> None:
+    root1, root2 = setup_dirs
 
-    static_files_config = [
+    configs, handlers = make_configs(
         StaticFilesConfig(path="/static_first", directories=[root1], file_system=file_system),  # pyright: ignore
         StaticFilesConfig(path="/static_second", directories=[root2]),  # pyright: ignore
-    ]
-    with create_test_client([], static_files_config=static_files_config) as client:
-        response = client.get("/static_first/test.txt")
+    )
+
+    with create_test_client(handlers, static_files_config=configs) as client:
+        response = client.get("/static_first/test_1.txt")
         assert response.status_code == HTTP_200_OK
         assert response.text == "content1"
 
-        response = client.get("/static_second/test.txt")
+        response = client.get("/static_second/test_2.txt")
         assert response.status_code == HTTP_200_OK
         assert response.text == "content2"
 
 
-@pytest.mark.parametrize("file_system", (BaseLocalFileSystem(), LocalFileSystem()))
-def test_static_files_config_with_multiple_directories(tmpdir: "Path", file_system: "FileSystemProtocol") -> None:
-    root1 = tmpdir.mkdir("first")  # type: ignore
-    root2 = tmpdir.mkdir("second")  # type: ignore
-    path1 = root1 / "test1.txt"  # pyright: ignore
-    path1.write_text("content1", "utf-8")
-    path2 = root2 / "test2.txt"  # pyright: ignore
-    path2.write_text("content2", "utf-8")
+def test_static_files_config_with_multiple_directories(
+    file_system: FileSystemProtocol, setup_dirs: tuple[Path, Path], make_config: MakeConfig
+) -> None:
+    root1, root2 = setup_dirs
+    configs, handlers = make_config(
+        StaticFilesConfig(path="/static", directories=[root1, root2], file_system=file_system)
+    )
 
-    with create_test_client(
-        [],
-        static_files_config=[
-            StaticFilesConfig(path="/static", directories=[root1, root2], file_system=file_system)  # pyright: ignore
-        ],
-    ) as client:
-        response = client.get("/static/test1.txt")
+    with create_test_client(handlers, static_files_config=configs) as client:
+        response = client.get("/static/test_1.txt")
         assert response.status_code == HTTP_200_OK
         assert response.text == "content1"
 
-        response = client.get("/static/test2.txt")
+        response = client.get("/static/test_2.txt")
         assert response.status_code == HTTP_200_OK
         assert response.text == "content2"
 
 
-def test_staticfiles_for_slash_path_regular_mode(tmpdir: "Path") -> None:
+def test_staticfiles_for_slash_path_regular_mode(tmpdir: Path, make_config: MakeConfig) -> None:
     path = tmpdir / "text.txt"
     path.write_text("content", "utf-8")
 
-    static_files_config = StaticFilesConfig(path="/", directories=[tmpdir])
-    with create_test_client([], static_files_config=[static_files_config]) as client:
+    configs, handlers = make_config(StaticFilesConfig(path="/", directories=[tmpdir]))
+
+    with create_test_client(handlers, static_files_config=configs) as client:
         response = client.get("/text.txt")
         assert response.status_code == HTTP_200_OK
         assert response.text == "content"
 
 
-def test_staticfiles_for_slash_path_html_mode(tmpdir: "Path") -> None:
+def test_staticfiles_for_slash_path_html_mode(tmpdir: Path, make_config: MakeConfig) -> None:
     path = tmpdir / "index.html"
     path.write_text("<html></html>", "utf-8")
 
-    static_files_config = StaticFilesConfig(path="/", directories=[tmpdir], html_mode=True)
-    with create_test_client([], static_files_config=[static_files_config]) as client:
+    configs, handlers = make_config(StaticFilesConfig(path="/", directories=[tmpdir], html_mode=True))
+
+    with create_test_client(handlers, static_files_config=configs) as client:
         response = client.get("/")
         assert response.status_code == HTTP_200_OK
         assert response.text == "<html></html>"
 
 
-def test_sub_path_under_static_path(tmpdir: "Path") -> None:
+def test_sub_path_under_static_path(tmpdir: Path, make_config: MakeConfig) -> None:
     path = tmpdir / "test.txt"
     path.write_text("content", "utf-8")
 
@@ -127,9 +147,10 @@ def test_sub_path_under_static_path(tmpdir: "Path") -> None:
     def handler(f: str) -> str:
         return f
 
-    with create_test_client(
-        handler, static_files_config=[StaticFilesConfig(path="/static", directories=[tmpdir])]
-    ) as client:
+    configs, handlers = make_config(StaticFilesConfig(path="/static", directories=[tmpdir]))
+    handlers.append(handler)
+
+    with create_test_client(handlers, static_files_config=configs) as client:
         response = client.get("/static/test.txt")
         assert response.status_code == HTTP_200_OK
 
@@ -137,26 +158,26 @@ def test_sub_path_under_static_path(tmpdir: "Path") -> None:
         assert response.status_code == HTTP_200_OK
 
 
-def test_static_substring_of_self(tmpdir: "Path") -> None:
+def test_static_substring_of_self(tmpdir: Path, make_config: MakeConfig) -> None:
     path = tmpdir.mkdir("static_part").mkdir("static") / "test.txt"  # type: ignore
     path.write_text("content", "utf-8")
 
-    static_files_config = StaticFilesConfig(path="/static", directories=[tmpdir])
-    with create_test_client([], static_files_config=[static_files_config]) as client:
+    configs, handlers = make_config(StaticFilesConfig(path="/static", directories=[tmpdir]))
+    with create_test_client(handlers, static_files_config=configs) as client:
         response = client.get("/static/static_part/static/test.txt")
         assert response.status_code == HTTP_200_OK
         assert response.text == "content"
 
 
 @pytest.mark.parametrize("extension", ["css", "js", "html", "json"])
-def test_static_files_response_mimetype(tmpdir: "Path", extension: str) -> None:
+def test_static_files_response_mimetype(tmpdir: Path, extension: str, make_config: MakeConfig) -> None:
     fn = f"test.{extension}"
     path = tmpdir / fn
     path.write_text("content", "utf-8")
-    static_files_config = StaticFilesConfig(path="/static", directories=[tmpdir])
+    configs, handlers = make_config(StaticFilesConfig(path="/static", directories=[tmpdir]))
     expected_mime_type = mimetypes.guess_type(fn)[0]
 
-    with create_test_client([], static_files_config=[static_files_config]) as client:
+    with create_test_client(handlers, static_files_config=configs) as client:
         response = client.get(f"/static/{fn}")
         assert expected_mime_type
         assert response.status_code == HTTP_200_OK
@@ -164,7 +185,7 @@ def test_static_files_response_mimetype(tmpdir: "Path", extension: str) -> None:
 
 
 @pytest.mark.parametrize("extension", ["gz", "br"])
-def test_static_files_response_encoding(tmp_path: "Path", extension: str) -> None:
+def test_static_files_response_encoding(tmp_path: Path, extension: str, make_config: MakeConfig) -> None:
     fn = f"test.js.{extension}"
     path = tmp_path / fn
     compressed_data = None
@@ -173,10 +194,11 @@ def test_static_files_response_encoding(tmp_path: "Path", extension: str) -> Non
     elif extension == "gz":
         compressed_data = gzip.compress(b"content")
     path.write_bytes(compressed_data)  # type: ignore[arg-type]
-    static_files_config = StaticFilesConfig(path="/static", directories=[tmp_path])
     expected_encoding_type = mimetypes.guess_type(fn)[1]
 
-    with create_test_client([], static_files_config=[static_files_config]) as client:
+    configs, handlers = make_config(StaticFilesConfig(path="/static", directories=[tmp_path]))
+
+    with create_test_client(handlers, static_files_config=configs) as client:
         response = client.get(f"/static/{fn}")
         assert expected_encoding_type
         assert response.status_code == HTTP_200_OK
@@ -184,45 +206,51 @@ def test_static_files_response_encoding(tmp_path: "Path", extension: str) -> Non
 
 
 @pytest.mark.parametrize("send_as_attachment,disposition", [(True, "attachment"), (False, "inline")])
-def test_static_files_content_disposition(tmpdir: "Path", send_as_attachment: bool, disposition: str) -> None:
+def test_static_files_content_disposition(
+    tmpdir: Path, send_as_attachment: bool, disposition: str, make_config: MakeConfig
+) -> None:
     path = tmpdir.mkdir("static_part").mkdir("static") / "test.txt"  # type: ignore
     path.write_text("content", "utf-8")
 
-    static_files_config = StaticFilesConfig(path="/static", directories=[tmpdir], send_as_attachment=send_as_attachment)
+    configs, handlers = make_config(
+        StaticFilesConfig(path="/static", directories=[tmpdir], send_as_attachment=send_as_attachment)
+    )
 
-    with create_test_client([], static_files_config=[static_files_config]) as client:
+    with create_test_client(handlers, static_files_config=configs) as client:
         response = client.get("/static/static_part/static/test.txt")
         assert response.status_code == HTTP_200_OK
         assert response.headers["content-disposition"].startswith(disposition)
 
 
-def test_service_from_relative_path_using_string(tmpdir: "Path") -> None:
+def test_service_from_relative_path_using_string(tmpdir: Path, make_config: MakeConfig) -> None:
     sub_dir = Path(tmpdir.mkdir("low")).resolve()  # type: ignore
 
     path = tmpdir / "test.txt"
     path.write_text("content", "utf-8")
 
-    static_files_config = StaticFilesConfig(path="/static", directories=[f"{sub_dir}/.."])
-    with create_test_client([], static_files_config=[static_files_config]) as client:
+    configs, handlers = make_config(StaticFilesConfig(path="/static", directories=[f"{sub_dir}/.."]))
+
+    with create_test_client(handlers, static_files_config=configs) as client:
         response = client.get("/static/test.txt")
         assert response.status_code == HTTP_200_OK
         assert response.text == "content"
 
 
-def test_service_from_relative_path_using_path(tmpdir: "Path") -> None:
+def test_service_from_relative_path_using_path(tmpdir: Path, make_config: MakeConfig) -> None:
     sub_dir = Path(tmpdir.mkdir("low")).resolve()  # type: ignore
 
     path = tmpdir / "test.txt"
     path.write_text("content", "utf-8")
 
-    static_files_config = StaticFilesConfig(path="/static", directories=[Path(f"{sub_dir}/..")])
-    with create_test_client([], static_files_config=[static_files_config]) as client:
+    configs, handlers = make_config(StaticFilesConfig(path="/static", directories=[Path(f"{sub_dir}/..")]))
+
+    with create_test_client(handlers, static_files_config=configs) as client:
         response = client.get("/static/test.txt")
         assert response.status_code == HTTP_200_OK
         assert response.text == "content"
 
 
-def test_service_from_base_path_using_string(tmpdir: "Path") -> None:
+def test_service_from_base_path_using_string(tmpdir: Path) -> None:
     sub_dir = Path(tmpdir.mkdir("low")).resolve()  # type: ignore
 
     path = tmpdir / "test.txt"

--- a/tests/unit/test_static_files/test_file_serving_resolution.py
+++ b/tests/unit/test_static_files/test_file_serving_resolution.py
@@ -10,7 +10,7 @@ import pytest
 from typing_extensions import TypeAlias
 
 from litestar import MediaType, Router, get
-from litestar.static_files import StaticFilesConfig, create_static_router
+from litestar.static_files import StaticFilesConfig, create_static_files_router
 from litestar.status_codes import HTTP_200_OK
 from litestar.testing import create_test_client
 from tests.unit.test_static_files.conftest import MakeConfig
@@ -287,7 +287,7 @@ def test_resolve_symlinks(tmp_path: Path, resolve: bool) -> None:
     linked_dir.symlink_to(source_dir, target_is_directory=True)
     source_dir.joinpath("test.txt").write_text("hello")
 
-    router = create_static_router(path="/", directories=[linked_dir], resolve_symlinks=resolve)
+    router = create_static_files_router(path="/", directories=[linked_dir], resolve_symlinks=resolve)
 
     with create_test_client(router) as client:
         if not resolve:

--- a/tests/unit/test_static_files/test_file_serving_resolution.py
+++ b/tests/unit/test_static_files/test_file_serving_resolution.py
@@ -148,7 +148,7 @@ def test_sub_path_under_static_path(tmpdir: Path, make_config: MakeConfig) -> No
         return f
 
     configs, handlers = make_config(StaticFilesConfig(path="/static", directories=[tmpdir]))
-    handlers.append(handler)
+    handlers.append(handler)  # type: ignore[arg-type]
 
     with create_test_client(handlers, static_files_config=configs) as client:
         response = client.get("/static/test.txt")

--- a/tests/unit/test_static_files/test_html_mode.py
+++ b/tests/unit/test_static_files/test_html_mode.py
@@ -1,12 +1,11 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
-import pytest
-from fsspec.implementations.local import LocalFileSystem
-
-from litestar.file_system import BaseLocalFileSystem
-from litestar.static_files.config import StaticFilesConfig
+from litestar.static_files import StaticFilesConfig
 from litestar.status_codes import HTTP_200_OK, HTTP_404_NOT_FOUND
 from litestar.testing import create_test_client
+from tests.unit.test_static_files.conftest import MakeConfig
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -14,14 +13,14 @@ if TYPE_CHECKING:
     from litestar.types import FileSystemProtocol
 
 
-@pytest.mark.parametrize("file_system", (BaseLocalFileSystem(), LocalFileSystem()))
-def test_staticfiles_is_html_mode(tmpdir: "Path", file_system: "FileSystemProtocol") -> None:
+def test_staticfiles_is_html_mode(tmpdir: Path, file_system: FileSystemProtocol, make_config: MakeConfig) -> None:
     path = tmpdir / "index.html"
     path.write_text("content", "utf-8")
-    static_files_config = StaticFilesConfig(
-        path="/static", directories=[tmpdir], html_mode=True, file_system=file_system
+    static_files_config, handlers = make_config(
+        StaticFilesConfig(path="/static", directories=[tmpdir], html_mode=True, file_system=file_system)
     )
-    with create_test_client([], static_files_config=[static_files_config]) as client:
+
+    with create_test_client(handlers, static_files_config=static_files_config) as client:
         response = client.get("/static")
         assert response.status_code == HTTP_200_OK
         assert response.text == "content"
@@ -29,28 +28,28 @@ def test_staticfiles_is_html_mode(tmpdir: "Path", file_system: "FileSystemProtoc
         assert response.headers["content-disposition"].startswith("inline")
 
 
-@pytest.mark.parametrize("file_system", (BaseLocalFileSystem(), LocalFileSystem()))
-def test_staticfiles_is_html_mode_serves_404_when_present(tmpdir: "Path", file_system: "FileSystemProtocol") -> None:
+def test_staticfiles_is_html_mode_serves_404_when_present(
+    tmpdir: Path, file_system: FileSystemProtocol, make_config: MakeConfig
+) -> None:
     path = tmpdir / "404.html"
     path.write_text("not found", "utf-8")
-    static_files_config = StaticFilesConfig(
-        path="/static", directories=[tmpdir], html_mode=True, file_system=file_system
+    static_files_config, handlers = make_config(
+        StaticFilesConfig(path="/static", directories=[tmpdir], html_mode=True, file_system=file_system)
     )
-    with create_test_client([], static_files_config=[static_files_config]) as client:
+    with create_test_client(handlers, static_files_config=static_files_config) as client:
         response = client.get("/static")
         assert response.status_code == HTTP_404_NOT_FOUND
         assert response.text == "not found"
         assert response.headers["content-type"] == "text/html; charset=utf-8"
 
 
-@pytest.mark.parametrize("file_system", (BaseLocalFileSystem(), LocalFileSystem()))
 def test_staticfiles_is_html_mode_raises_exception_when_no_404_html_is_present(
-    tmpdir: "Path", file_system: "FileSystemProtocol"
+    tmpdir: Path, file_system: FileSystemProtocol, make_config: MakeConfig
 ) -> None:
-    static_files_config = StaticFilesConfig(
-        path="/static", directories=[tmpdir], html_mode=True, file_system=file_system
+    static_files_config, handlers = make_config(
+        StaticFilesConfig(path="/static", directories=[tmpdir], html_mode=True, file_system=file_system)
     )
-    with create_test_client([], static_files_config=[static_files_config]) as client:
+    with create_test_client(handlers, static_files_config=static_files_config) as client:
         response = client.get("/static")
         assert response.status_code == HTTP_404_NOT_FOUND
         assert response.json() == {"status_code": 404, "detail": "no file or directory match the path . was found"}

--- a/tests/unit/test_static_files/test_static_files_validation.py
+++ b/tests/unit/test_static_files/test_static_files_validation.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, List
 
 import pytest
 
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 @pytest.mark.parametrize("directories", [[], [""]])
 @pytest.mark.parametrize("func", [StaticFilesConfig, create_static_files_router])
-def test_config_validation_of_directories(func: Any, directories: "list[str]") -> None:
+def test_config_validation_of_directories(func: Any, directories: List[str]) -> None:
     with pytest.raises(ImproperlyConfiguredException):
         func(path="/static", directories=directories)
 

--- a/tests/unit/test_static_files/test_static_files_validation.py
+++ b/tests/unit/test_static_files/test_static_files_validation.py
@@ -4,7 +4,7 @@ import pytest
 
 from litestar import HttpMethod, Litestar, MediaType, get
 from litestar.exceptions import ImproperlyConfiguredException
-from litestar.static_files import StaticFilesConfig, create_static_router
+from litestar.static_files import StaticFilesConfig, create_static_files_router
 from litestar.status_codes import HTTP_200_OK, HTTP_204_NO_CONTENT, HTTP_405_METHOD_NOT_ALLOWED
 from litestar.testing import create_test_client
 
@@ -12,13 +12,13 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-@pytest.mark.parametrize("func", [StaticFilesConfig, create_static_router])
+@pytest.mark.parametrize("func", [StaticFilesConfig, create_static_files_router])
 def test_config_validation_of_directories(func: Any) -> None:
     with pytest.raises(ImproperlyConfiguredException):
         func(path="/static", directories=[])
 
 
-@pytest.mark.parametrize("func", [StaticFilesConfig, create_static_router])
+@pytest.mark.parametrize("func", [StaticFilesConfig, create_static_files_router])
 def test_config_validation_of_path(tmpdir: "Path", func: Any) -> None:
     path = tmpdir / "text.txt"
     path.write_text("content", "utf-8")
@@ -30,7 +30,7 @@ def test_config_validation_of_path(tmpdir: "Path", func: Any) -> None:
         func(path="/{param:int}", directories=[tmpdir])
 
 
-@pytest.mark.parametrize("func", [StaticFilesConfig, create_static_router])
+@pytest.mark.parametrize("func", [StaticFilesConfig, create_static_files_router])
 def test_config_validation_of_file_system(tmpdir: "Path", func: Any) -> None:
     class FSWithoutOpen:
         def info(self) -> None:
@@ -109,6 +109,6 @@ def test_runtime_validation_of_request_method_create_handler(tmpdir: "Path", met
     path = tmpdir / "test.txt"
     path.write_text("content", "utf-8")
 
-    with create_test_client(create_static_router(path="/static", directories=[tmpdir])) as client:
+    with create_test_client(create_static_files_router(path="/static", directories=[tmpdir])) as client:
         response = client.request(method, "/static/test.txt")
         assert response.status_code == expected

--- a/tests/unit/test_static_files/test_static_files_validation.py
+++ b/tests/unit/test_static_files/test_static_files_validation.py
@@ -12,10 +12,11 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+@pytest.mark.parametrize("directories", [[], [""]])
 @pytest.mark.parametrize("func", [StaticFilesConfig, create_static_files_router])
-def test_config_validation_of_directories(func: Any) -> None:
+def test_config_validation_of_directories(func: Any, directories: "list[str]") -> None:
     with pytest.raises(ImproperlyConfiguredException):
-        func(path="/static", directories=[])
+        func(path="/static", directories=directories)
 
 
 @pytest.mark.parametrize("func", [StaticFilesConfig, create_static_files_router])

--- a/tests/unit/test_static_files/test_static_files_validation.py
+++ b/tests/unit/test_static_files/test_static_files_validation.py
@@ -1,47 +1,50 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from litestar import HttpMethod, Litestar, MediaType, get
 from litestar.exceptions import ImproperlyConfiguredException
-from litestar.static_files.config import StaticFilesConfig
-from litestar.status_codes import HTTP_200_OK, HTTP_405_METHOD_NOT_ALLOWED
+from litestar.static_files import StaticFilesConfig, create_static_router
+from litestar.status_codes import HTTP_200_OK, HTTP_204_NO_CONTENT, HTTP_405_METHOD_NOT_ALLOWED
 from litestar.testing import create_test_client
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-def test_config_validation_of_directories() -> None:
+@pytest.mark.parametrize("func", [StaticFilesConfig, create_static_router])
+def test_config_validation_of_directories(func: Any) -> None:
     with pytest.raises(ImproperlyConfiguredException):
-        StaticFilesConfig(path="/static", directories=[])
+        func(path="/static", directories=[])
 
 
-def test_config_validation_of_path(tmpdir: "Path") -> None:
+@pytest.mark.parametrize("func", [StaticFilesConfig, create_static_router])
+def test_config_validation_of_path(tmpdir: "Path", func: Any) -> None:
     path = tmpdir / "text.txt"
     path.write_text("content", "utf-8")
 
     with pytest.raises(ImproperlyConfiguredException):
-        StaticFilesConfig(path="", directories=[tmpdir])
+        func(path="", directories=[tmpdir])
 
     with pytest.raises(ImproperlyConfiguredException):
-        StaticFilesConfig(path="/{param:int}", directories=[tmpdir])
+        func(path="/{param:int}", directories=[tmpdir])
 
 
-def test_config_validation_of_file_system(tmpdir: "Path") -> None:
+@pytest.mark.parametrize("func", [StaticFilesConfig, create_static_router])
+def test_config_validation_of_file_system(tmpdir: "Path", func: Any) -> None:
     class FSWithoutOpen:
         def info(self) -> None:
             return
 
     with pytest.raises(ImproperlyConfiguredException):
-        StaticFilesConfig(path="/static", directories=[tmpdir], file_system=FSWithoutOpen())
+        func(path="/static", directories=[tmpdir], file_system=FSWithoutOpen())
 
     class FSWithoutInfo:
         def open(self) -> None:
             return
 
     with pytest.raises(ImproperlyConfiguredException):
-        StaticFilesConfig(path="/static", directories=[tmpdir], file_system=FSWithoutInfo())
+        func(path="/static", directories=[tmpdir], file_system=FSWithoutInfo())
 
     class ImplementedFS:
         def info(self) -> None:
@@ -50,7 +53,7 @@ def test_config_validation_of_file_system(tmpdir: "Path") -> None:
         def open(self) -> None:
             return
 
-    assert StaticFilesConfig(path="/static", directories=[tmpdir], file_system=ImplementedFS())
+    assert func(path="/static", directories=[tmpdir], file_system=ImplementedFS())
 
 
 def test_runtime_validation_of_static_path_and_path_parameter(tmpdir: "Path") -> None:
@@ -79,12 +82,33 @@ def test_runtime_validation_of_static_path_and_path_parameter(tmpdir: "Path") ->
         (HttpMethod.OPTIONS, HTTP_405_METHOD_NOT_ALLOWED),
     ),
 )
-def test_runtime_validation_of_request_method(tmpdir: "Path", method: HttpMethod, expected: int) -> None:
+def test_runtime_validation_of_request_method_legacy_config(tmpdir: "Path", method: HttpMethod, expected: int) -> None:
     path = tmpdir / "test.txt"
     path.write_text("content", "utf-8")
 
     with create_test_client(
         [], static_files_config=[StaticFilesConfig(path="/static", directories=[tmpdir])]
     ) as client:
+        response = client.request(method, "/static/test.txt")
+        assert response.status_code == expected
+
+
+@pytest.mark.parametrize(
+    "method, expected",
+    (
+        (HttpMethod.GET, HTTP_200_OK),
+        (HttpMethod.HEAD, HTTP_200_OK),
+        (HttpMethod.OPTIONS, HTTP_204_NO_CONTENT),
+        (HttpMethod.PUT, HTTP_405_METHOD_NOT_ALLOWED),
+        (HttpMethod.PATCH, HTTP_405_METHOD_NOT_ALLOWED),
+        (HttpMethod.POST, HTTP_405_METHOD_NOT_ALLOWED),
+        (HttpMethod.DELETE, HTTP_405_METHOD_NOT_ALLOWED),
+    ),
+)
+def test_runtime_validation_of_request_method_create_handler(tmpdir: "Path", method: HttpMethod, expected: int) -> None:
+    path = tmpdir / "test.txt"
+    path.write_text("content", "utf-8")
+
+    with create_test_client(create_static_router(path="/static", directories=[tmpdir])) as client:
         response = client.request(method, "/static/test.txt")
         assert response.status_code == expected


### PR DESCRIPTION
Implement static file serving with regular route handlers instead of a specialised ASGI app. At the moment, this is complementary to the usage of `StaticFilesConfig` to keep backwards compatibility.

This achieves a few things:

- Fixes #2629
- Circumvents all of the special casing we have to do in our routing logic for the static files app
- Allows us to drop said special casing when removing the old functionality
- Removes the need for a `static_files_config` on the app
- Removes the need for a special `url_for_static_asset` method on the app since `route_reverse` can be used instead

Additionally:

- Most router options can now be passed to the `create_static_files_router`, allowing further customisation
- A new `resolve_symlinks` flag has been added, defaulting to `True` to keep backwards compatibility

## Usage

Instead of 

```python
app = Litestar(
    static_files_config=[
        StaticFilesConfig(path="/static", directories=["some_dir"])
    ]
)
``` 

You can now simply use

```python
app = Litestar(
  route_handlers=[
    create_static_files_router(path="/static", directories=["some_dir"])
  ]
)
```

This takes the same arguments as the `StaticFilesConfig`, but generates a router internally, with route handlers to serve the static files.

## Todo

- [x] Add docs
- [x] Add deprecation warnings for `StaticFilesConfig` related stuff