### PR TITLE
refactor: replace Any with object in get_name helper func

### DIFF
--- a/litestar/utils/helpers.py
+++ b/litestar/utils/helpers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from enum import Enum
 from functools import partial
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, TypeVar, cast
 from urllib.parse import quote
 
 from litestar.utils.typing import get_origin_or_inner_type
@@ -23,7 +23,7 @@ __all__ = (
 T = TypeVar("T")
 
 
-def get_name(value: Any) -> str:
+def get_name(value: object) -> str:
     """Get the ``__name__`` of an object.
 
     Args:


### PR DESCRIPTION
- In `get_name` helper function, the `value` argument is not necessary to be `Any`. `object`(Top type in Python) is sufficient and safer type annotation.
- And `object` annotation matches with the function's docstring: `value: An arbitrary object.`
---
Reference: https://docs.python.org/3/library/typing.html#the-any-type
> Use [object](https://docs.python.org/3/library/functions.html#object) to indicate that a value could be any type in a typesafe manner. Use [Any](https://docs.python.org/3/library/typing.html#typing.Any) to indicate that a value is dynamically typed.