### PR TITLE
fix(2971): OpenAPI schema generation fails for Union of Structs when including `None`

### DIFF
--- a/litestar/_openapi/schema_generation/plugins/struct.py
+++ b/litestar/_openapi/schema_generation/plugins/struct.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 class StructSchemaPlugin(OpenAPISchemaPlugin):
     def is_plugin_supported_field(self, field_definition: FieldDefinition) -> bool:
-        return field_definition.is_subclass_of(Struct)
+        return not field_definition.is_union and field_definition.is_subclass_of(Struct)
 
     def to_openapi_schema(self, field_definition: FieldDefinition, schema_creator: SchemaCreator) -> Schema:
         def is_field_required(field: FieldInfo) -> bool:

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -495,27 +495,26 @@ def test_process_schema_result_with_unregistered_object_schema() -> None:
 
 @pytest.mark.parametrize("base_type", [msgspec.Struct, TypedDict, dataclass])
 def test_type_union(base_type: type) -> None:
-    if base_type is dataclass:
+    if base_type is dataclass:  # type: ignore[comparison-overlap]
 
         @dataclass
-        class ModelA:
+        class ModelA:  # pyright: ignore
             pass
 
         @dataclass
-        class ModelB:
+        class ModelB:  # pyright: ignore
             pass
     else:
 
-        class ModelA(base_type):
+        class ModelA(base_type):  # type: ignore[no-redef, misc]
             pass
 
-        class ModelB(base_type):
+        class ModelB(base_type):  # type: ignore[no-redef, misc]
             pass
 
     schema = get_schema_for_field_definition(
         FieldDefinition.from_kwarg(name="Lookup", annotation=Union[ModelA, ModelB])
     )
-    assert len(schema.one_of) == 2
     assert schema.one_of == [
         Reference(ref="#/components/schemas/tests_unit_test_openapi_test_schema_test_type_union.ModelA"),
         Reference(ref="#/components/schemas/tests_unit_test_openapi_test_schema_test_type_union.ModelB"),
@@ -525,27 +524,26 @@ def test_type_union(base_type: type) -> None:
 @pytest.mark.parametrize("base_type", [msgspec.Struct, TypedDict, dataclass])
 def test_type_union_with_none(base_type: type) -> None:
     # https://github.com/litestar-org/litestar/issues/2971
-    if base_type is dataclass:
+    if base_type is dataclass:  # type: ignore[comparison-overlap]
 
         @dataclass
-        class ModelA:
+        class ModelA:  # pyright: ignore
             pass
 
         @dataclass
-        class ModelB:
+        class ModelB:  # pyright: ignore
             pass
     else:
 
-        class ModelA(base_type):
+        class ModelA(base_type):  # type: ignore[no-redef, misc]
             pass
 
-        class ModelB(base_type):
+        class ModelB(base_type):  # type: ignore[no-redef, misc]
             pass
 
     schema = get_schema_for_field_definition(
         FieldDefinition.from_kwarg(name="Lookup", annotation=Union[ModelA, ModelB, None])
     )
-    assert len(schema.one_of) == 3
     assert schema.one_of == [
         Schema(type=OpenAPIType.NULL),
         Reference(ref="#/components/schemas/tests_unit_test_openapi_test_schema_test_type_union_with_none.ModelA"),

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -491,3 +491,42 @@ def test_process_schema_result_with_unregistered_object_schema() -> None:
     schema = Schema(title="has title", type=OpenAPIType.OBJECT)
     field_definition = FieldDefinition.from_annotation(dict)
     assert SchemaCreator().process_schema_result(field_definition, schema) is schema
+
+
+def test_msgspec_struct_union() -> None:
+    class StructA(msgspec.Struct):
+        a: int
+
+    class StructB(msgspec.Struct):
+        a: int
+
+    schema = get_schema_for_field_definition(
+        FieldDefinition.from_kwarg(name="Lookup", annotation=Union[StructA, StructB])
+    )
+    assert len(schema.one_of) == 2
+    assert schema.one_of == [
+        Reference(ref="#/components/schemas/tests_unit_test_openapi_test_schema_test_msgspec_struct_union.StructA"),
+        Reference("#/components/schemas/tests_unit_test_openapi_test_schema_test_msgspec_struct_union.StructB"),
+    ]
+
+
+def test_msgspec_struct_union_with_none() -> None:
+    class StructA(msgspec.Struct):
+        a: int
+
+    class StructB(msgspec.Struct):
+        a: int
+
+    schema = get_schema_for_field_definition(
+        FieldDefinition.from_kwarg(name="Lookup", annotation=Union[StructA, StructB, None])
+    )
+    assert len(schema.one_of) == 3
+    assert schema.one_of == [
+        Schema(type=OpenAPIType.NULL),
+        Reference(
+            ref="#/components/schemas/tests_unit_test_openapi_test_schema_test_msgspec_struct_union_with_none.StructA"
+        ),
+        Reference(
+            "#/components/schemas/tests_unit_test_openapi_test_schema_test_msgspec_struct_union_with_none.StructB"
+        ),
+    ]

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -493,40 +493,61 @@ def test_process_schema_result_with_unregistered_object_schema() -> None:
     assert SchemaCreator().process_schema_result(field_definition, schema) is schema
 
 
-def test_msgspec_struct_union() -> None:
-    class StructA(msgspec.Struct):
-        a: int
+@pytest.mark.parametrize("base_type", [msgspec.Struct, TypedDict, dataclass])
+def test_type_union(base_type: type) -> None:
+    if base_type is dataclass:
 
-    class StructB(msgspec.Struct):
-        a: int
+        @dataclass
+        class ModelA:
+            pass
+
+        @dataclass
+        class ModelB:
+            pass
+    else:
+
+        class ModelA(base_type):
+            pass
+
+        class ModelB(base_type):
+            pass
 
     schema = get_schema_for_field_definition(
-        FieldDefinition.from_kwarg(name="Lookup", annotation=Union[StructA, StructB])
+        FieldDefinition.from_kwarg(name="Lookup", annotation=Union[ModelA, ModelB])
     )
     assert len(schema.one_of) == 2
     assert schema.one_of == [
-        Reference(ref="#/components/schemas/tests_unit_test_openapi_test_schema_test_msgspec_struct_union.StructA"),
-        Reference("#/components/schemas/tests_unit_test_openapi_test_schema_test_msgspec_struct_union.StructB"),
+        Reference(ref="#/components/schemas/tests_unit_test_openapi_test_schema_test_type_union.ModelA"),
+        Reference(ref="#/components/schemas/tests_unit_test_openapi_test_schema_test_type_union.ModelB"),
     ]
 
 
-def test_msgspec_struct_union_with_none() -> None:
-    class StructA(msgspec.Struct):
-        a: int
+@pytest.mark.parametrize("base_type", [msgspec.Struct, TypedDict, dataclass])
+def test_type_union_with_none(base_type: type) -> None:
+    # https://github.com/litestar-org/litestar/issues/2971
+    if base_type is dataclass:
 
-    class StructB(msgspec.Struct):
-        a: int
+        @dataclass
+        class ModelA:
+            pass
+
+        @dataclass
+        class ModelB:
+            pass
+    else:
+
+        class ModelA(base_type):
+            pass
+
+        class ModelB(base_type):
+            pass
 
     schema = get_schema_for_field_definition(
-        FieldDefinition.from_kwarg(name="Lookup", annotation=Union[StructA, StructB, None])
+        FieldDefinition.from_kwarg(name="Lookup", annotation=Union[ModelA, ModelB, None])
     )
     assert len(schema.one_of) == 3
     assert schema.one_of == [
         Schema(type=OpenAPIType.NULL),
-        Reference(
-            ref="#/components/schemas/tests_unit_test_openapi_test_schema_test_msgspec_struct_union_with_none.StructA"
-        ),
-        Reference(
-            "#/components/schemas/tests_unit_test_openapi_test_schema_test_msgspec_struct_union_with_none.StructB"
-        ),
+        Reference(ref="#/components/schemas/tests_unit_test_openapi_test_schema_test_type_union_with_none.ModelA"),
+        Reference("#/components/schemas/tests_unit_test_openapi_test_schema_test_type_union_with_none.ModelB"),
     ]


### PR DESCRIPTION
Fix #2971 by checking for union types in the schema plugin as suggested by @peterschutt in [this comment](https://github.com/litestar-org/litestar/issues/2971#issuecomment-1884725385).

The following code would raise an `AttributeError` 

```python
import msgspec

from litestar import get
from litestar.testing import create_test_client

class StructA(msgspec.Struct):
    pass

class StructB(msgspec.Struct):
    pass


@get("/")
async def handler() -> StructA | StructB:
    return StructA()
``` 

and when including `None` in the union of the return value

```python
import msgspec

from litestar import get
from litestar.testing import create_test_client

class StructA(msgspec.Struct):
    pass

class StructB(msgspec.Struct):
    pass


@get("/")
async def handler() -> StructA | StructB | None:
    return StructA()

with create_test_client([handler]) as client:
    client.get("/schema")
``` 

a `TypeError` would be raised. 