### PR TITLE
chore: Re-introduce treating `sphinx-build` warnings as errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ docs-serve: docs-clean 								## Serve the docs locally
 
 docs: docs-clean 									## Dump the existing built docs and rebuild them
 	@echo "=> Building documentation"
-	@$(PDM) run sphinx-build -M html docs docs/_build/ -E -a -j auto --keep-going
+	@$(PDM) run sphinx-build -M html docs docs/_build/ -E -a -j auto -W --keep-going
 
 .PHONY: docs-linkcheck
 docs-linkcheck: 									## Run the link check on the docs


### PR DESCRIPTION
Reintroduce the `-W` flag for `sphinx-build` to treat warnings as errors so we don't accidentally merge PRs that later fail on docs build.