### PR TITLE
ci: Add workflow to notify issues for released fixes

### DIFF
--- a/.github/workflows/notify-released-issues.yml
+++ b/.github/workflows/notify-released-issues.yml
@@ -1,0 +1,32 @@
+name: Notify released issues
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        type: string
+        required: true
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Get released issues
+        id: get-released-issues
+        run:
+          echo "issues=$(python ./.github/workflows/notify_released_issues/get_closed_issues.py ${{ inputs.release_tag }})" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/github-script@v7
+        env:
+          CLOSED_ISSUES: ${{ steps.get-released-issues.outputs.issues }}
+        with:
+          script: |
+            const script = require('./.github/workflows/notify_released_issues/notify.js')
+            await script({github, context, core})

--- a/.github/workflows/notify_released_issues/get_closed_issues.py
+++ b/.github/workflows/notify_released_issues/get_closed_issues.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import itertools
+import json
+import pathlib
+import re
+import sys
+
+__all__ = (
+    "find_resolved_issues",
+    "main",
+)
+
+
+def find_resolved_issues(source: str, tag: str) -> list[str]:
+    version = tag.split("v", maxsplit=1)[-1]
+    changelog_line = f".. changelog:: {version}"
+    stop_line = ".. changelog::"
+    return list(
+        {
+            issue
+            for line in itertools.takewhile(
+                lambda l: stop_line not in l,  # noqa: E741
+                source.split(changelog_line, maxsplit=1)[1].splitlines(),
+            )
+            if re.match(r"\s+:issue: [\d ,]+", line)
+            for issue in re.findall(r"\d+", line)
+        }
+    )
+
+
+def main(tag: str) -> str:
+    source = pathlib.Path("docs/release-notes/changelog.rst").read_text()
+    return json.dumps(find_resolved_issues(source, tag))
+
+
+if __name__ == "__main__":
+    print(main(sys.argv[1]))  # noqa: T201

--- a/.github/workflows/notify_released_issues/notify.js
+++ b/.github/workflows/notify_released_issues/notify.js
@@ -1,0 +1,34 @@
+module.exports = async ({github, context, core}) => {
+
+    const issues = JSON.parse(process.env.CLOSED_ISSUES)
+    const releaseURL = context.payload.release.url
+    const releaseName = context.payload.release.name
+    const baseBody = "A fix for this issue has been released in"
+    const body = baseBody + ` [${releaseName}](${releaseURL})`
+
+    for (const issueNumber of issues) {
+        const opts = github.rest.issues.listComments.endpoint.merge({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: issueNumber,
+        });
+
+        const comments = await github.paginate(opts)
+        for (const comment of comments) {
+            if (comment.user.id === 41898282 && comment.body.startsWith(baseBody)) {
+                await github.rest.issues.deleteComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: comment.id
+                })
+            }
+        }
+
+        await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: issueNumber,
+            body: body,
+        })
+    }
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,3 +97,9 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  notify-issues:
+    name: Notify issues
+    uses: ./.github/workflows/notify-released-issues.yml
+    with:
+      release_tag: ${{ github.event.release.tag_name }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
     rev: v0.17.1
     hooks:
       - id: slotscheck
-        exclude: "test_*|docs"
+        exclude: "test_*|docs|.github"
   - repo: https://github.com/sphinx-contrib/sphinx-lint
     rev: "v0.9.1"
     hooks:


### PR DESCRIPTION
Add a workflow that creates a comment on issues that have been closed once their fix has been released.

### How it works

We record information about closed issues in our release notes. Once a release has been published, the workflow grabs the changes for the release from the release notes, extracts the issues that have been fixed and uses the GitHub API to create a comment on each issue with a link to the release.

![Screenshot from 2024-01-15 20-26-38](https://github.com/litestar-org/litestar/assets/25355197/31574f9c-2aac-480a-b219-f39b5aceeac2)

<hr>

I tried making this work via GitHub's API but it turns out that it's not that straightforward so ultimately I decided to simply extract the information from our release notes, which I think is more reliably anyway since we have control over what goes in there.
