### PR TITLE
docs: Add missing title for `reference/security/jwt`

### DIFF
--- a/docs/reference/security/jwt.rst
+++ b/docs/reference/security/jwt.rst
@@ -1,2 +1,5 @@
+jwt
+===
+
 .. automodule:: litestar.security.jwt
     :members:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
Added missing title for `reference/security/jwt` docs page.