### PR TITLE
ci: Fix release link in released fix notifier

### DIFF
--- a/.github/workflows/notify_released_issues/notify.js
+++ b/.github/workflows/notify_released_issues/notify.js
@@ -1,7 +1,7 @@
 module.exports = async ({github, context, core}) => {
 
     const issues = JSON.parse(process.env.CLOSED_ISSUES)
-    const releaseURL = context.payload.release.url
+    const releaseURL = context.payload.release.html_url
     const releaseName = context.payload.release.name
     const baseBody = "A fix for this issue has been released in"
     const body = baseBody + ` [${releaseName}](${releaseURL})`

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,6 +99,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
 
   notify-issues:
+    needs: publish-release
     name: Notify issues
     uses: ./.github/workflows/notify-released-issues.yml
     with:


### PR DESCRIPTION
- Make the comment link to the HTML version of the release instead of GitHub's API
- Only notify when a release has been successfully triggered