### PR TITLE
fix: re-add `structlog` tests

### DIFF
--- a/litestar/app.py
+++ b/litestar/app.py
@@ -514,8 +514,8 @@ class Litestar(Router):
         """
         if self.logger and self.logging_config:
             self.logging_config.set_level(self.logger, logging.DEBUG if value else logging.INFO)
-        elif self.logger and hasattr(self.logger, "setLevel"):
-            self.logger.setLevel(logging.DEBUG if value else logging.INFO)
+        elif self.logger and hasattr(self.logger, "setLevel"):  # pragma: no cover
+            self.logger.setLevel(logging.DEBUG if value else logging.INFO)  # pragma: no cover
         if isinstance(self.logging_config, LoggingConfig):
             self.logging_config.loggers["litestar"]["level"] = "DEBUG" if value else "INFO"
         self._debug = value

--- a/tests/unit/test_logging/test_structlog_config.py
+++ b/tests/unit/test_logging/test_structlog_config.py
@@ -1,186 +1,152 @@
-import logging
-import sys
-from typing import TYPE_CHECKING, Any, Dict
-from unittest.mock import Mock, patch
+from typing import Callable
 
 import pytest
+import structlog
+from pytest import CaptureFixture
+from structlog import BytesLoggerFactory, get_logger
+from structlog.processors import JSONRenderer
+from structlog.types import BindableLogger, WrappedLogger
 
-from litestar import Request, get
-from litestar.exceptions import ImproperlyConfiguredException
-from litestar.logging.config import LoggingConfig, _get_default_handlers, default_handlers, default_picologging_handlers
-from litestar.logging.picologging import QueueListenerHandler as PicologgingQueueListenerHandler
-from litestar.logging.standard import QueueListenerHandler as StandardQueueListenerHandler
-from litestar.status_codes import HTTP_200_OK
+from litestar.logging.config import LoggingConfig, StructlogEventFilter, StructLoggingConfig, default_json_serializer
+from litestar.plugins.structlog import StructlogConfig, StructlogPlugin
+from litestar.serialization import decode_json
 from litestar.testing import create_test_client
 
-if TYPE_CHECKING:
-    from _pytest.logging import LogCaptureFixture
+# structlog.testing.capture_logs changes the processors
+# Because we want to test processors, use capsys instead
 
 
-@pytest.mark.parametrize(
-    "dict_config_class, handlers, expected_called",
-    [
-        ["logging.config.dictConfig", default_handlers, True],
-        ["logging.config.dictConfig", default_picologging_handlers, False],
-        ["picologging.config.dictConfig", default_handlers, False],
-        ["picologging.config.dictConfig", default_picologging_handlers, True],
-    ],
-)
-def test_correct_dict_config_called(
-    dict_config_class: str, handlers: Dict[str, Dict[str, Any]], expected_called: bool
-) -> None:
-    with patch(dict_config_class) as dict_config_mock:
-        log_config = LoggingConfig(handlers=handlers)
-        log_config.configure()
-        if expected_called:
-            assert dict_config_mock.called
-        else:
-            assert not dict_config_mock.called
+def test_event_filter() -> None:
+    """Functionality test for the event filter processor."""
+    event_filter = StructlogEventFilter(["a_key"])
+    log_event = {"a_key": "a_val", "b_key": "b_val"}
+    log_event = event_filter(..., "", log_event)  # type:ignore[assignment]
+    assert log_event == {"b_key": "b_val"}
 
 
-@pytest.mark.parametrize("picologging_exists", [True, False])
-def test_correct_default_handlers_set(picologging_exists: bool) -> None:
-    with patch("litestar.logging.config.find_spec") as find_spec_mock:
-        find_spec_mock.return_value = picologging_exists
-        log_config = LoggingConfig()
+def test_set_level_custom_logger_factory() -> None:
+    """Functionality test for the event filter processor."""
 
-        if picologging_exists:
-            assert log_config.handlers == default_picologging_handlers
-        else:
-            assert log_config.handlers == default_handlers
+    def custom_logger_factory() -> Callable[..., WrappedLogger]:
+        """Set the default logger factory for structlog.
+
+        Returns:
+            An optional logger factory.
+        """
+        return BytesLoggerFactory()
+
+    log_config = StructLoggingConfig(logger_factory=custom_logger_factory, wrapper_class=structlog.stdlib.BoundLogger)
+    logger = get_logger()
+    assert logger.bind().__class__.__name__ != "BoundLoggerFilteringAtDebug"
+    log_config.set_level(logger, 10)
+    logger.info("a message")
+    assert logger.bind().__class__.__name__ == "BoundLoggerFilteringAtDebug"
 
 
-@pytest.mark.parametrize(
-    "dict_config_class, handlers",
-    [
-        ["logging.config.dictConfig", default_handlers],
-        ["picologging.config.dictConfig", default_picologging_handlers],
-    ],
-)
-def test_dictconfig_startup(dict_config_class: str, handlers: Any) -> None:
-    with patch(dict_config_class) as dict_config_mock:
-        test_logger = LoggingConfig(
-            handlers=handlers,
+def test_structlog_plugin(capsys: CaptureFixture) -> None:
+    with create_test_client([], plugins=[StructlogPlugin()]) as client:
+        assert client.app.logger
+        assert isinstance(client.app.logger.bind(), BindableLogger)
+        client.app.logger.info("message", key="value")
+
+        log_messages = [decode_json(value=x) for x in capsys.readouterr().out.splitlines()]
+        assert len(log_messages) == 1
+
+        # Format should be: {event: message, key: value, level: info, timestamp: isoformat}
+        log_messages[0].pop("timestamp")  # Assume structlog formats timestamp correctly
+        assert log_messages[0] == {"event": "message", "key": "value", "level": "info"}
+
+
+def test_structlog_plugin_config(capsys: CaptureFixture) -> None:
+    config = StructlogConfig()
+    with create_test_client([], plugins=[StructlogPlugin(config=config)]) as client:
+        assert client.app.logger
+        assert isinstance(client.app.logger.bind(), BindableLogger)
+        client.app.logger.info("message", key="value")
+
+        log_messages = [decode_json(value=x) for x in capsys.readouterr().out.splitlines()]
+        assert len(log_messages) == 1
+        assert client.app.plugins.get(StructlogPlugin)._config == config
+
+
+def test_structlog_plugin_config_custom_standard_logger() -> None:
+    standard_logging_config = LoggingConfig()
+    structlog_logging_config = StructLoggingConfig(standard_lib_logging_config=standard_logging_config)
+    config = StructlogConfig(structlog_logging_config=structlog_logging_config)
+    with create_test_client([], plugins=[StructlogPlugin(config=config)]) as client:
+        assert client.app.plugins.get(StructlogPlugin)._config == config
+        assert (
+            client.app.plugins.get(StructlogPlugin)._config.structlog_logging_config.standard_lib_logging_config
+            == standard_logging_config
         )
-        with create_test_client([], on_startup=[test_logger.configure]):
-            assert dict_config_mock.called
 
 
-def test_standard_queue_listener_logger(caplog: "LogCaptureFixture") -> None:
-    with caplog.at_level("INFO", logger="test_logger"):
-        logger = logging.getLogger("test_logger")
-        logger.info("Testing now!")
-        assert "Testing now!" in caplog.text
-        var = "test_var"
-        logger.info("%s", var)
-        assert var in caplog.text
+def test_structlog_plugin_config_custom() -> None:
+    structlog_logging_config = StructLoggingConfig(standard_lib_logging_config=None)
+    config = StructlogConfig(structlog_logging_config=structlog_logging_config)
+    with create_test_client([], plugins=[StructlogPlugin(config=config)]) as client:
+        assert client.app.plugins.get(StructlogPlugin)._config == config
+        assert client.app.plugins.get(StructlogPlugin)._config.structlog_logging_config == structlog_logging_config
+        assert (
+            client.app.plugins.get(StructlogPlugin)._config.structlog_logging_config.standard_lib_logging_config
+            is not None
+        )
 
 
-@patch("picologging.config.dictConfig")
-def test_picologging_dictconfig_when_disabled(dict_config_mock: Mock) -> None:
-    test_logger = LoggingConfig(loggers={"app": {"level": "INFO", "handlers": ["console"]}}, handlers=default_handlers)
-    with create_test_client([], on_startup=[test_logger.configure], logging_config=None):
-        assert not dict_config_mock.called
+def test_structlog_plugin_config_with_existing_logging_config(capsys: CaptureFixture) -> None:
+    existing_log_config = StructLoggingConfig()
+    standard_logging_config = LoggingConfig()
+    structlog_logging_config = StructLoggingConfig(standard_lib_logging_config=standard_logging_config)
+    config = StructlogConfig(structlog_logging_config=structlog_logging_config)
+    with create_test_client([], logging_config=existing_log_config, plugins=[StructlogPlugin(config=config)]) as client:
+        assert client.app.plugins.get(StructlogPlugin)._config == config
+        assert "Found pre-configured" in capsys.readouterr().out
 
 
-def test_get_logger_without_logging_config() -> None:
-    with create_test_client(logging_config=None) as client:
-        with pytest.raises(
-            ImproperlyConfiguredException,
-            match="cannot call '.get_logger' without passing 'logging_config' to the Litestar constructor first",
-        ):
-            client.app.get_logger()
+def test_structlog_config_no_tty_default(capsys: CaptureFixture) -> None:
+    with create_test_client([], logging_config=StructLoggingConfig()) as client:
+        assert client.app.logger
+        assert isinstance(client.app.logger.bind(), BindableLogger)
+        client.app.logger.info("message", key="value")
+
+        log_messages = [decode_json(value=x) for x in capsys.readouterr().out.splitlines()]
+        assert len(log_messages) == 1
+
+        # Format should be: {event: message, key: value, level: info, timestamp: isoformat}
+        log_messages[0].pop("timestamp")  # Assume structlog formats timestamp correctly
+        assert log_messages[0] == {"event": "message", "key": "value", "level": "info"}
 
 
-def test_get_default_logger() -> None:
-    with create_test_client(logging_config=LoggingConfig(handlers=default_handlers)) as client:
-        assert isinstance(client.app.logger.handlers[0], StandardQueueListenerHandler)
-        new_logger = client.app.get_logger()
-        assert isinstance(new_logger.handlers[0], StandardQueueListenerHandler)
+def test_structlog_config_tty_default(capsys: CaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    from sys import stderr
+
+    monkeypatch.setattr(stderr, "isatty", lambda: True)
+
+    with create_test_client([], logging_config=StructLoggingConfig()) as client:
+        assert client.app.logger
+        assert isinstance(client.app.logger.bind(), BindableLogger)
+        client.app.logger.info("message", key="value")
+
+        log_messages = capsys.readouterr().out.splitlines()
+        assert len(log_messages) == 1
+
+        assert log_messages[0].startswith("\x1b[")
 
 
-def test_get_picologging_logger() -> None:
-    with create_test_client(logging_config=LoggingConfig(handlers=default_picologging_handlers)) as client:
-        assert isinstance(client.app.logger.handlers[0], PicologgingQueueListenerHandler)
-        new_logger = client.app.get_logger()
-        assert isinstance(new_logger.handlers[0], PicologgingQueueListenerHandler)
+def test_structlog_config_specify_processors(capsys: CaptureFixture) -> None:
+    logging_config = StructLoggingConfig(processors=[JSONRenderer(serializer=default_json_serializer)])
 
+    with create_test_client([], logging_config=logging_config) as client:
+        assert client.app.logger
+        assert isinstance(client.app.logger.bind(), BindableLogger)
 
-@pytest.mark.parametrize(
-    "handlers, listener",
-    [
-        [default_handlers, StandardQueueListenerHandler],
-        [default_picologging_handlers, PicologgingQueueListenerHandler],
-    ],
-)
-def test_connection_logger(handlers: Any, listener: Any) -> None:
-    @get("/")
-    def handler(request: Request) -> Dict[str, bool]:
-        return {"isinstance": isinstance(request.logger.handlers[0], listener)}  # type: ignore
+        client.app.logger.info("message1", key="value1")
+        # Log twice to make sure issue #882 doesn't appear again
+        client.app.logger.info("message2", key="value2")
 
-    with create_test_client(route_handlers=[handler], logging_config=LoggingConfig(handlers=handlers)) as client:
-        response = client.get("/")
-        assert response.status_code == HTTP_200_OK
-        assert response.json()["isinstance"]
+        log_messages = [decode_json(value=x) for x in capsys.readouterr().out.splitlines()]
 
-
-def test_validation() -> None:
-    logging_config = LoggingConfig(handlers={}, loggers={})
-    assert logging_config.handlers["queue_listener"] == _get_default_handlers()["queue_listener"]
-    assert logging_config.loggers["litestar"]
-
-
-@pytest.mark.parametrize(
-    "handlers, listener",
-    [
-        [default_handlers, StandardQueueListenerHandler],
-        [default_picologging_handlers, PicologgingQueueListenerHandler],
-    ],
-)
-def test_root_logger(handlers: Any, listener: Any) -> None:
-    logging_config = LoggingConfig(handlers=handlers)
-    get_logger = logging_config.configure()
-    root_logger = get_logger()
-    assert isinstance(root_logger.handlers[0], listener)  # type: ignore
-
-
-@pytest.mark.parametrize(
-    "handlers, listener",
-    [
-        [default_handlers, StandardQueueListenerHandler],
-        [default_picologging_handlers, PicologgingQueueListenerHandler],
-    ],
-)
-def test_root_logger_no_config(handlers: Any, listener: Any) -> None:
-    logging_config = LoggingConfig(handlers=handlers, configure_root_logger=False)
-    get_logger = logging_config.configure()
-    root_logger = get_logger()
-    for handler in root_logger.handlers:  # type: ignore[attr-defined]
-        root_logger.removeHandler(handler)  # type: ignore[attr-defined]
-    get_logger = logging_config.configure()
-    root_logger = get_logger()
-    if handlers["console"]["class"] == "logging.StreamHandler":
-        assert not isinstance(root_logger.handlers[0], listener)  # type: ignore[attr-defined]
-    else:
-        assert len(root_logger.handlers) < 1  # type: ignore[attr-defined]
-
-
-@pytest.mark.parametrize(
-    "handlers, listener",
-    [
-        pytest.param(
-            default_handlers,
-            StandardQueueListenerHandler,
-            marks=pytest.mark.xfail(
-                condition=sys.version_info >= (3, 12), reason="change to QueueHandler/QueueListener config in 3.12"
-            ),
-        ),
-        [default_picologging_handlers, PicologgingQueueListenerHandler],
-    ],
-)
-def test_customizing_handler(handlers: Any, listener: Any, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setitem(handlers["queue_listener"], "handlers", ["cfg://handlers.console"])
-    logging_config = LoggingConfig(handlers=handlers)
-    get_logger = logging_config.configure()
-    root_logger = get_logger()
-    assert isinstance(root_logger.handlers[0], listener)  # type: ignore
+        assert log_messages == [
+            {"key": "value1", "event": "message1"},
+            {"key": "value2", "event": "message2"},
+        ]


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

The last commit auto-merged even though the sonar scan failed.  It looks like I accidentally merged in the previous tests on top of the updates.

This PR re-adds those tests.