### PR TITLE
refactor: removed duplicated type hints

### DIFF
--- a/litestar/handlers/http_handlers/decorators.py
+++ b/litestar/handlers/http_handlers/decorators.py
@@ -52,7 +52,7 @@ class delete(HTTPRouteHandler):
 
     def __init__(
         self,
-        path: str | None | list[str] | None = None,
+        path: str | list[str] | None = None,
         *,
         after_request: AfterRequestHookHandler | None = None,
         after_response: AfterResponseHookHandler | None = None,
@@ -216,7 +216,7 @@ class get(HTTPRouteHandler):
 
     def __init__(
         self,
-        path: str | None | list[str] | None = None,
+        path: str | list[str] | None = None,
         *,
         after_request: AfterRequestHookHandler | None = None,
         after_response: AfterResponseHookHandler | None = None,
@@ -381,7 +381,7 @@ class head(HTTPRouteHandler):
 
     def __init__(
         self,
-        path: str | None | list[str] | None = None,
+        path: str | list[str] | None = None,
         *,
         after_request: AfterRequestHookHandler | None = None,
         after_response: AfterResponseHookHandler | None = None,
@@ -563,7 +563,7 @@ class patch(HTTPRouteHandler):
 
     def __init__(
         self,
-        path: str | None | list[str] | None = None,
+        path: str | list[str] | None = None,
         *,
         after_request: AfterRequestHookHandler | None = None,
         after_response: AfterResponseHookHandler | None = None,
@@ -727,7 +727,7 @@ class post(HTTPRouteHandler):
 
     def __init__(
         self,
-        path: str | None | list[str] | None = None,
+        path: str | list[str] | None = None,
         *,
         after_request: AfterRequestHookHandler | None = None,
         after_response: AfterResponseHookHandler | None = None,
@@ -891,7 +891,7 @@ class put(HTTPRouteHandler):
 
     def __init__(
         self,
-        path: str | None | list[str] | None = None,
+        path: str | list[str] | None = None,
         *,
         after_request: AfterRequestHookHandler | None = None,
         after_response: AfterResponseHookHandler | None = None,

--- a/litestar/handlers/websocket_handlers/listener.py
+++ b/litestar/handlers/websocket_handlers/listener.py
@@ -71,7 +71,7 @@ class WebsocketListenerRouteHandler(WebsocketRouteHandler):
     @overload
     def __init__(
         self,
-        path: str | None | list[str] | None = None,
+        path: str | list[str] | None = None,
         *,
         connection_lifespan: Callable[..., AbstractAsyncContextManager[Any]] | None = None,
         dependencies: Dependencies | None = None,
@@ -93,7 +93,7 @@ class WebsocketListenerRouteHandler(WebsocketRouteHandler):
     @overload
     def __init__(
         self,
-        path: str | None | list[str] | None = None,
+        path: str | list[str] | None = None,
         *,
         connection_accept_handler: Callable[[WebSocket], Coroutine[Any, Any, None]] = WebSocket.accept,
         dependencies: Dependencies | None = None,
@@ -116,7 +116,7 @@ class WebsocketListenerRouteHandler(WebsocketRouteHandler):
 
     def __init__(
         self,
-        path: str | None | list[str] | None = None,
+        path: str | list[str] | None = None,
         *,
         connection_accept_handler: Callable[[WebSocket], Coroutine[Any, Any, None]] = WebSocket.accept,
         connection_lifespan: Callable[..., AbstractAsyncContextManager[Any]] | None = None,
@@ -309,7 +309,7 @@ websocket_listener = WebsocketListenerRouteHandler
 
 
 class WebsocketListener(ABC):
-    path: str | None | list[str] | None = None
+    path: str | list[str] | None = None
     """A path fragment for the route handler function or a sequence of path fragments. If not given defaults to ``/``"""
     dependencies: Dependencies | None = None
     """A string keyed mapping of dependency :class:`Provider <.di.Provide>` instances."""

--- a/litestar/handlers/websocket_handlers/route_handler.py
+++ b/litestar/handlers/websocket_handlers/route_handler.py
@@ -19,7 +19,7 @@ class WebsocketRouteHandler(BaseRouteHandler):
 
     def __init__(
         self,
-        path: str | None | list[str] | None = None,
+        path: str | list[str] | None = None,
         *,
         dependencies: Dependencies | None = None,
         exception_handlers: dict[int | type[Exception], ExceptionHandler] | None = None,


### PR DESCRIPTION
Removes unnecessarily repeated Nones in type unions introduced in 619cafb.