### PR TITLE
fix: simplify conditional logic check for libraries

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,3 @@ coverage:
         target: auto
 comment:
   require_changes: true
-flag_management:
-  default_rules: # the rules that will be followed for any flag added, generally
-    carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,6 @@ coverage:
         target: auto
 comment:
   require_changes: true
+flag_management:
+  default_rules: # the rules that will be followed for any flag added, generally
+    carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,5 +3,9 @@ coverage:
     project:
       default:
         target: auto
+        threshold: 0.1%
+    patch:
+      default:
+        target: auto
 comment:
   require_changes: true

--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -24,7 +24,7 @@ from litestar import Litestar, __version__
 from litestar.middleware import DefineMiddleware
 from litestar.utils import get_name
 
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 10):  # pragma: no cover
     from importlib.metadata import entry_points
 else:
     from importlib_metadata import entry_points

--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -25,9 +25,9 @@ from litestar.middleware import DefineMiddleware
 from litestar.utils import get_name
 
 if sys.version_info >= (3, 10):  # pragma: no cover
-    from importlib.metadata import entry_points
-else:
-    from importlib_metadata import entry_points
+    from importlib.metadata import entry_points  # pragma: no cover
+else:  # pragma: no cover
+    from importlib_metadata import entry_points  # pragma: no cover
 
 
 if TYPE_CHECKING:

--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -24,10 +24,10 @@ from litestar import Litestar, __version__
 from litestar.middleware import DefineMiddleware
 from litestar.utils import get_name
 
-if sys.version_info >= (3, 10):  # pragma: no cover
-    from importlib.metadata import entry_points  # pragma: no cover
-else:  # pragma: no cover
-    from importlib_metadata import entry_points  # pragma: no cover
+if sys.version_info >= (3, 10):
+    from importlib.metadata import entry_points
+else:
+    from importlib_metadata import entry_points
 
 
 if TYPE_CHECKING:

--- a/litestar/cli/commands/core.py
+++ b/litestar/cli/commands/core.py
@@ -8,11 +8,12 @@ import sys
 from contextlib import AbstractContextManager, ExitStack, contextmanager
 from typing import TYPE_CHECKING, Any, Iterator
 
+import click
+from click import Context, command, option
 from rich.tree import Tree
 
 from litestar.app import DEFAULT_OPENAPI_CONFIG
 from litestar.cli._utils import (
-    RICH_CLICK_INSTALLED,
     UVICORN_INSTALLED,
     LitestarEnv,
     console,
@@ -24,16 +25,6 @@ from litestar.cli._utils import (
 )
 from litestar.routes import ASGIRoute, HTTPRoute, WebSocketRoute
 from litestar.utils.helpers import unwrap_partial
-
-if UVICORN_INSTALLED:
-    import uvicorn
-
-if TYPE_CHECKING or not RICH_CLICK_INSTALLED:  # pragma: no cover
-    import click
-    from click import Context, command, option
-else:
-    import rich_click as click
-    from rich_click import Context, command, option
 
 __all__ = ("info_command", "routes_command", "run_command")
 
@@ -226,6 +217,8 @@ def run_command(
     show_app_info(app)
     with _server_lifespan(app):
         if workers == 1 and not reload:
+            import uvicorn
+
             # A guard statement at the beginning of this function prevents uvicorn from being unbound
             # See "reportUnboundVariable in:
             # https://microsoft.github.io/pyright/#/configuration?id=type-check-diagnostics-settings

--- a/litestar/cli/commands/sessions.py
+++ b/litestar/cli/commands/sessions.py
@@ -1,19 +1,12 @@
-from typing import TYPE_CHECKING
-
+from click import argument, group
 from rich.prompt import Confirm
 
 from litestar import Litestar
-from litestar.cli._utils import RICH_CLICK_INSTALLED, LitestarCLIException, LitestarGroup, console
+from litestar.cli._utils import LitestarCLIException, LitestarGroup, console
 from litestar.middleware import DefineMiddleware
 from litestar.middleware.session import SessionMiddleware
 from litestar.middleware.session.server_side import ServerSideSessionBackend
 from litestar.utils import is_class_and_subclass
-
-if TYPE_CHECKING or not RICH_CLICK_INSTALLED:  # pragma: no cover
-    from click import argument, group
-else:
-    from rich_click import argument, group
-
 
 __all__ = ("clear_sessions_command", "delete_session_command", "get_session_backend", "sessions_group")
 

--- a/litestar/cli/main.py
+++ b/litestar/cli/main.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING or not RICH_CLICK_INSTALLED:  # pragma: no cover
     import click
     from click import Context, group, option, pass_context
     from click import Path as ClickPath
-else:
+else:  # pragma: no cover
     import rich_click as click
     from rich_click import Context, group, option, pass_context
     from rich_click import Path as ClickPath

--- a/tests/unit/test_cli/test_ssl.py
+++ b/tests/unit/test_cli/test_ssl.py
@@ -243,7 +243,7 @@ def test_without_cryptography_installed(
 
     assert isinstance(result.exception, SystemExit)
     exc = get_click_exception(result.exception)
-    assert "Cryptogpraphy must be installed when using --create-self-signed-cert" in exc.message
+    assert "Cryptography must be installed when using --create-self-signed-cert" in exc.message
 
 
 @pytest.mark.usefixtures("mock_uvicorn_run")


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

This PR does the following CLI cleanup items:
- use `find_spec` to set "library found" variables
- Rich click's CLI patcher only needs to run once.  From then on we can import the normal click types.  I've removed a few of these conditional checks.
- Only create the beautifier class when executed
- Typo fix