### PR TITLE
docs: Fix incorrect argument name in OpenApi ResponseSpec example

### DIFF
--- a/docs/usage/openapi.rst
+++ b/docs/usage/openapi.rst
@@ -138,7 +138,7 @@ You can also modify the generated schema for the route handler using the followi
        path="/items/{pk:int}",
        responses={
            404: ResponseSpec(
-               model=ItemNotFound, description="Item was removed or not found"
+               data_container=ItemNotFound, description="Item was removed or not found"
            )
        },
    )


### PR DESCRIPTION
There is an incorrect argument name in the ResponseSpec example in the docs. ResponseSpec has no `model` arg, so when I tried to use this example I got `TypeError: ResponseSpec.__init__() got an unexpected keyword argument 'model'` exception.
The correct arg name seems to be `data_container`, so I've updated the docs accordingly.