### PR TITLE
feat: sanitize Piccolo columns with secret=True from PydanticDTO output

### DIFF
--- a/litestar/contrib/piccolo.py
+++ b/litestar/contrib/piccolo.py
@@ -79,12 +79,11 @@ class PiccoloDTO(AbstractDTO[T], Generic[T]):
     @classmethod
     def generate_field_definitions(cls, model_type: type[Table]) -> Generator[DTOFieldDefinition, None, None]:
         for column in model_type._meta.columns:
-            if column._meta.secret:
-                continue
+            mark = Mark.WRITE_ONLY if column._meta.secret else Mark.READ_ONLY if column._meta.primary_key else None
             yield replace(
                 DTOFieldDefinition.from_field_definition(
                     field_definition=_parse_piccolo_type(column, _create_column_extra(column)),
-                    dto_field=DTOField(mark=Mark.READ_ONLY if column._meta.primary_key else None),
+                    dto_field=DTOField(mark=mark),
                     model_name=model_type.__name__,
                     default_factory=None,
                 ),

--- a/litestar/contrib/piccolo.py
+++ b/litestar/contrib/piccolo.py
@@ -79,6 +79,8 @@ class PiccoloDTO(AbstractDTO[T], Generic[T]):
     @classmethod
     def generate_field_definitions(cls, model_type: type[Table]) -> Generator[DTOFieldDefinition, None, None]:
         for column in model_type._meta.columns:
+            if column._meta.secret:
+                continue
             yield replace(
                 DTOFieldDefinition.from_field_definition(
                     field_definition=_parse_piccolo_type(column, _create_column_extra(column)),

--- a/tests/unit/test_contrib/test_piccolo_orm/test_piccolo_orm_dto.py
+++ b/tests/unit/test_contrib/test_piccolo_orm/test_piccolo_orm_dto.py
@@ -58,8 +58,20 @@ def test_serializing_single_piccolo_table(scaffold_piccolo: Callable) -> None:
 def test_serializing_multiple_piccolo_tables(scaffold_piccolo: Callable) -> None:
     with create_test_client(route_handlers=[retrieve_venues]) as client:
         response = client.get("/venues")
+
+        sanitized_venues = []
+        for v in venues:
+            non_secret_data = {
+                column._meta.db_column_name: v[column._meta.db_column_name]
+                for column in v.all_columns()
+                if not column._meta.secret
+            }
+            sanitized_venues.append(Venue(**non_secret_data))
+
         assert response.status_code == HTTP_200_OK
-        assert [str(Venue(**value).querystring) for value in response.json()] == [str(v.querystring) for v in venues]
+        assert [str(Venue(**value).querystring) for value in response.json()] == [
+            str(v.querystring) for v in sanitized_venues
+        ]
 
 
 @pytest.mark.parametrize(
@@ -154,7 +166,6 @@ def test_piccolo_dto_openapi_spec_generation() -> None:
     assert venue_schema
     assert venue_schema.to_schema() == {
         "properties": {
-            "capacity": {"oneOf": [{"type": "null"}, {"type": "integer"}]},
             "id": {"oneOf": [{"type": "null"}, {"type": "integer"}]},
             "name": {"oneOf": [{"type": "null"}, {"type": "string"}]},
         },


### PR DESCRIPTION
## Pull Request Checklist
- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ]  (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

## Description

For Picollo columns with `secret=True` set, mark those columns as `WRITE_ONLY` to prevent the column being included in `return_dto`.

## Close Issue(s)

Closes #2976
