### PR TITLE
chore: Disable server integration tests by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,7 +203,7 @@ exclude_lines = [
 fail_under = 96
 
 [tool.pytest.ini_options]
-addopts = "--strict-markers --strict-config --dist=loadgroup"
+addopts = "--strict-markers --strict-config --dist=loadgroup -m 'not server_integration'"
 asyncio_mode = "auto"
 filterwarnings = [
   "ignore::trio.TrioDeprecationWarning:anyio._backends._trio*:",


### PR DESCRIPTION
Disable the ASGI server integration tests introduced in #3039 by default, as they are only meant to run as part of the extended CI workflow.
