### PR TITLE
fix: ServerSentEvent typing error

### DIFF
--- a/litestar/response/sse.py
+++ b/litestar/response/sse.py
@@ -21,7 +21,7 @@ DEFAULT_SEPARATOR = "\r\n"
 class _ServerSentEventIterator(AsyncIteratorWrapper[bytes]):
     __slots__ = ("content_async_iterator", "event_id", "event_type", "retry_duration", "comment_message")
 
-    content_async_iterator: AsyncIteratorWrapper[SSEData] | AsyncIterable[SSEData] | AsyncIterator[SSEData]
+    content_async_iterator: AsyncIterable[SSEData]
 
     def __init__(
         self,

--- a/litestar/response/sse.py
+++ b/litestar/response/sse.py
@@ -131,7 +131,7 @@ class ServerSentEventMessage:
 class ServerSentEvent(Stream):
     def __init__(
         self,
-        content: str | bytes | StreamType[str | bytes],
+        content: str | bytes | StreamType[str | bytes | ServerSentEventMessage],
         *,
         background: BackgroundTask | BackgroundTasks | None = None,
         cookies: ResponseCookies | None = None,

--- a/litestar/response/sse.py
+++ b/litestar/response/sse.py
@@ -25,7 +25,7 @@ class _ServerSentEventIterator(AsyncIteratorWrapper[bytes]):
 
     def __init__(
         self,
-        content: str | bytes | StreamType[int | str | bytes | dict[str, Any] | ServerSentEventMessage],
+        content: str | bytes | StreamType[SSEData],
         event_type: str | None = None,
         event_id: int | str | None = None,
         retry_duration: int | None = None,

--- a/litestar/response/sse.py
+++ b/litestar/response/sse.py
@@ -25,7 +25,7 @@ class _ServerSentEventIterator(AsyncIteratorWrapper[bytes]):
 
     def __init__(
         self,
-        content: str | bytes | StreamType[str | bytes],
+        content: str | bytes | StreamType[int | str | bytes | dict[str, Any], ServerSentEventMessage],
         event_type: str | None = None,
         event_id: int | str | None = None,
         retry_duration: int | None = None,
@@ -131,7 +131,7 @@ class ServerSentEventMessage:
 class ServerSentEvent(Stream):
     def __init__(
         self,
-        content: str | bytes | StreamType[str | bytes | ServerSentEventMessage],
+        content: str | bytes | StreamType[int | str | bytes | dict[str, Any] | ServerSentEventMessage],
         *,
         background: BackgroundTask | BackgroundTasks | None = None,
         cookies: ResponseCookies | None = None,

--- a/litestar/response/sse.py
+++ b/litestar/response/sse.py
@@ -21,11 +21,15 @@ DEFAULT_SEPARATOR = "\r\n"
 class _ServerSentEventIterator(AsyncIteratorWrapper[bytes]):
     __slots__ = ("content_async_iterator", "event_id", "event_type", "retry_duration", "comment_message")
 
-    content_async_iterator: AsyncIteratorWrapper[bytes | str] | AsyncIterable[str | bytes] | AsyncIterator[str | bytes]
+    content_async_iterator: AsyncIteratorWrapper[
+        int | str | bytes | dict[str, Any] | ServerSentEventMessage
+    ] | AsyncIterable[int | str | bytes | dict[str, Any] | ServerSentEventMessage] | AsyncIterator[
+        int | str | bytes | dict[str, Any] | ServerSentEventMessage
+    ]
 
     def __init__(
         self,
-        content: str | bytes | StreamType[int | str | bytes | dict[str, Any], ServerSentEventMessage],
+        content: str | bytes | StreamType[int | str | bytes | dict[str, Any] | ServerSentEventMessage],
         event_type: str | None = None,
         event_id: int | str | None = None,
         retry_duration: int | None = None,
@@ -56,7 +60,7 @@ class _ServerSentEventIterator(AsyncIteratorWrapper[bytes]):
         if isinstance(content, (str, bytes)):
             self.content_async_iterator = AsyncIteratorWrapper([content])
         elif isinstance(content, (Iterable, Iterator)):
-            self.content_async_iterator = AsyncIteratorWrapper(content)  # type: ignore[arg-type]
+            self.content_async_iterator = AsyncIteratorWrapper(content)
         elif isinstance(content, (AsyncIterable, AsyncIterator, AsyncIteratorWrapper)):
             self.content_async_iterator = content
         else:

--- a/litestar/response/sse.py
+++ b/litestar/response/sse.py
@@ -12,7 +12,7 @@ from litestar.utils import AsyncIteratorWrapper
 
 if TYPE_CHECKING:
     from litestar.background_tasks import BackgroundTask, BackgroundTasks
-    from litestar.types import ResponseCookies, ResponseHeaders, StreamType
+    from litestar.types import ResponseCookies, ResponseHeaders, SSEData, StreamType
 
 _LINE_BREAK_RE = re.compile(r"\r\n|\r|\n")
 DEFAULT_SEPARATOR = "\r\n"
@@ -21,11 +21,7 @@ DEFAULT_SEPARATOR = "\r\n"
 class _ServerSentEventIterator(AsyncIteratorWrapper[bytes]):
     __slots__ = ("content_async_iterator", "event_id", "event_type", "retry_duration", "comment_message")
 
-    content_async_iterator: AsyncIteratorWrapper[
-        int | str | bytes | dict[str, Any] | ServerSentEventMessage
-    ] | AsyncIterable[int | str | bytes | dict[str, Any] | ServerSentEventMessage] | AsyncIterator[
-        int | str | bytes | dict[str, Any] | ServerSentEventMessage
-    ]
+    content_async_iterator: AsyncIteratorWrapper[SSEData] | AsyncIterable[SSEData] | AsyncIterator[SSEData]
 
     def __init__(
         self,
@@ -135,7 +131,7 @@ class ServerSentEventMessage:
 class ServerSentEvent(Stream):
     def __init__(
         self,
-        content: str | bytes | StreamType[int | str | bytes | dict[str, Any] | ServerSentEventMessage],
+        content: str | bytes | StreamType[SSEData],
         *,
         background: BackgroundTask | BackgroundTasks | None = None,
         cookies: ResponseCookies | None = None,

--- a/litestar/types/__init__.py
+++ b/litestar/types/__init__.py
@@ -73,7 +73,7 @@ from .composite_types import (
 )
 from .empty import Empty, EmptyType
 from .file_types import FileInfo, FileSystemProtocol
-from .helper_types import AnyIOBackend, MaybePartial, OptionalSequence, StreamType, SyncOrAsyncUnion
+from .helper_types import AnyIOBackend, MaybePartial, OptionalSequence, SSEData, StreamType, SyncOrAsyncUnion
 from .internal_types import (
     ControllerRouterHandler,
     ReservedKwargs,
@@ -155,6 +155,7 @@ __all__ = (
     "Send",
     "Serializer",
     "StreamType",
+    "SSEData",
     "SyncOrAsyncUnion",
     "TypeDecodersSequence",
     "TypeEncodersMap",

--- a/litestar/types/helper_types.py
+++ b/litestar/types/helper_types.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 
-__all__ = ("OptionalSequence", "SyncOrAsyncUnion", "AnyIOBackend", "StreamType", "MaybePartial")
+__all__ = ("OptionalSequence", "SyncOrAsyncUnion", "AnyIOBackend", "StreamType", "MaybePartial", "SSEData")
 
 OptionalSequence: TypeAlias = Optional[Sequence[T]]
 """Types 'T' as union of Sequence[T] and None."""

--- a/litestar/types/helper_types.py
+++ b/litestar/types/helper_types.py
@@ -17,10 +17,10 @@ from typing import (
     Union,
 )
 
-from litestar.response.sse import ServerSentEventMessage
-
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
+
+    from litestar.response.sse import ServerSentEventMessage
 
 
 T = TypeVar("T")
@@ -43,5 +43,5 @@ StreamType: TypeAlias = Union[Iterable[T], Iterator[T], AsyncIterable[T], AsyncI
 MaybePartial: TypeAlias = Union[T, partial]
 """A potentially partial callable."""
 
-SSEData: TypeAlias = Union[int, str, bytes, Dict[str, Any], ServerSentEventMessage]
+SSEData: TypeAlias = Union[int, str, bytes, Dict[str, Any], "ServerSentEventMessage"]
 """A type alias for SSE data."""

--- a/litestar/types/helper_types.py
+++ b/litestar/types/helper_types.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from functools import partial
 from typing import (
     TYPE_CHECKING,
+    Any,
     AsyncIterable,
     AsyncIterator,
     Awaitable,
@@ -15,8 +16,11 @@ from typing import (
     Union,
 )
 
+from litestar.response.sse import ServerSentEventMessage
+
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
+
 
 T = TypeVar("T")
 
@@ -37,3 +41,6 @@ StreamType: TypeAlias = Union[Iterable[T], Iterator[T], AsyncIterable[T], AsyncI
 
 MaybePartial: TypeAlias = Union[T, partial]
 """A potentially partial callable."""
+
+SSEData: TypeAlias = int | str | bytes | dict[str, Any] | ServerSentEventMessage
+"""A type alias for SSE data."""

--- a/litestar/types/helper_types.py
+++ b/litestar/types/helper_types.py
@@ -7,6 +7,7 @@ from typing import (
     AsyncIterable,
     AsyncIterator,
     Awaitable,
+    Dict,
     Iterable,
     Iterator,
     Literal,
@@ -42,5 +43,5 @@ StreamType: TypeAlias = Union[Iterable[T], Iterator[T], AsyncIterable[T], AsyncI
 MaybePartial: TypeAlias = Union[T, partial]
 """A potentially partial callable."""
 
-SSEData: TypeAlias = Union[int, str, bytes, dict[str, Any], ServerSentEventMessage]
+SSEData: TypeAlias = Union[int, str, bytes, Dict[str, Any], ServerSentEventMessage]
 """A type alias for SSE data."""

--- a/litestar/types/helper_types.py
+++ b/litestar/types/helper_types.py
@@ -42,5 +42,5 @@ StreamType: TypeAlias = Union[Iterable[T], Iterator[T], AsyncIterable[T], AsyncI
 MaybePartial: TypeAlias = Union[T, partial]
 """A potentially partial callable."""
 
-SSEData: TypeAlias = int | str | bytes | dict[str, Any] | ServerSentEventMessage
+SSEData: TypeAlias = Union[int, str, bytes, dict[str, Any], ServerSentEventMessage]
 """A type alias for SSE data."""

--- a/tests/unit/test_response/test_sse.py
+++ b/tests/unit/test_response/test_sse.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncIterator, Dict, Iterator, List, Union
+from typing import AsyncIterator, Iterator, List
 
 import anyio
 import pytest
@@ -10,6 +10,7 @@ from litestar.exceptions import ImproperlyConfiguredException
 from litestar.response import ServerSentEvent
 from litestar.response.sse import ServerSentEventMessage
 from litestar.testing import create_async_test_client
+from litestar.types import SSEData
 
 
 async def test_sse_steaming_response() -> None:
@@ -61,7 +62,7 @@ async def test_sse_steaming_response() -> None:
 async def test_various_sse_inputs(input: str, expected_events: List[HTTPXServerSentEvent]) -> None:
     @get("/testme")
     async def handler() -> ServerSentEvent:
-        async def numbers() -> AsyncIterator[Union[int, str, bytes, Dict[str, Any], ServerSentEventMessage]]:
+        async def numbers() -> AsyncIterator[SSEData]:
             for i in range(1, 6):
                 await anyio.sleep(0.001)
                 if input == "integer":

--- a/tests/unit/test_response/test_sse.py
+++ b/tests/unit/test_response/test_sse.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncIterator, Iterator, List
+from typing import AsyncIterator, Iterator, List, Union
 
 import anyio
 import pytest
@@ -61,7 +61,7 @@ async def test_sse_steaming_response() -> None:
 async def test_various_sse_inputs(input: str, expected_events: List[HTTPXServerSentEvent]) -> None:
     @get("/testme")
     async def handler() -> ServerSentEvent:
-        async def numbers() -> AsyncIterator[Any]:
+        async def numbers() -> AsyncIterator[Union[int, str, bytes, dict, ServerSentEventMessage]]:
             for i in range(1, 6):
                 await anyio.sleep(0.001)
                 if input == "integer":

--- a/tests/unit/test_response/test_sse.py
+++ b/tests/unit/test_response/test_sse.py
@@ -1,4 +1,4 @@
-from typing import AsyncIterator, Iterator, List, Union
+from typing import Any, AsyncIterator, Dict, Iterator, List, Union
 
 import anyio
 import pytest
@@ -61,7 +61,7 @@ async def test_sse_steaming_response() -> None:
 async def test_various_sse_inputs(input: str, expected_events: List[HTTPXServerSentEvent]) -> None:
     @get("/testme")
     async def handler() -> ServerSentEvent:
-        async def numbers() -> AsyncIterator[Union[int, str, bytes, dict, ServerSentEventMessage]]:
+        async def numbers() -> AsyncIterator[Union[int, str, bytes, Dict[str, Any], ServerSentEventMessage]]:
             for i in range(1, 6):
                 await anyio.sleep(0.001)
                 if input == "integer":


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

fixes small typing error:

```
error: Argument 1 to "ServerSentEvent" has incompatible type "AsyncIterable[ServerSentEventMessage]"; expected "str | bytes | Iterable[str | bytes] | Iterator[str | bytes] | AsyncIterable[str | bytes] | AsyncIterator[str | bytes]"  [arg-type]
 ```

inside `test_sse` there was a `Any` I changed to trigger the test then solved it.

