### PR TITLE
fix(docs): fix rendering for code block in state class

### DIFF
--- a/litestar/datastructures/state.py
+++ b/litestar/datastructures/state.py
@@ -188,8 +188,8 @@ class State(ImmutableState, MutableMapping[str, Any]):
              state: An object to initialize the state from. Can be a dict, an instance of 'ImmutableState', or a tuple of key value paris.
              deep_copy: Whether to 'deepcopy' the passed in state.
 
-        Examples:
         .. code-block:: python
+            :caption: Examples
 
             from litestar.datastructures import State
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

## Description

- Fixes improperly render API reference docs (https://docs.litestar.dev/latest/reference/datastructures.html#litestar.datastructures.State) for code example.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
