### PR TITLE
fix: Handle `KeyError` when `root_path` is not present in ASGI scope

### DIFF
--- a/litestar/_asgi/asgi_router.py
+++ b/litestar/_asgi/asgi_router.py
@@ -79,7 +79,7 @@ class ASGIRouter:
         scope.setdefault("path_params", {})
 
         path = scope["path"]
-        if root_path := scope["root_path"]:
+        if root_path := scope.get("root_path", ""):
             path = path.split(root_path, maxsplit=1)[-1]
         normalized_path = normalize_path(path)
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->


Nginx Unit ASGI server does not set "root_path" in the ASGI scope, which is expected as part of the changes done in #3039. This PR fixes the assumption that the key is always present and instead tries to optionally retrieve it.


Issue originaly reported over at [Discord](https://discord.com/channels/919193495116337154/919193495690936353/1202204676003745792)
```
KeyError on GET /
'root_path'
```