### PR TITLE
fix: scope `state` key handling

### DIFF
--- a/litestar/app.py
+++ b/litestar/app.py
@@ -537,7 +537,7 @@ class Litestar(Router):
             return
 
         scope["app"] = self
-        scope["state"] = {}
+        scope.setdefault("state", {})
         await self.asgi_handler(scope, receive, self._wrap_send(send=send, scope=scope))  # type: ignore[arg-type]
 
     async def _call_lifespan_hook(self, hook: LifespanHook) -> None:

--- a/litestar/connection/base.py
+++ b/litestar/connection/base.py
@@ -117,7 +117,7 @@ class ASGIConnection(Generic[HandlerT, UserT, AuthT, StateT]):
         Returns:
             A State instance constructed from the scope["state"] value.
         """
-        return cast("StateT", State(self.scope["state"]))
+        return cast("StateT", State(self.scope.get("state")))
 
     @property
     def url(self) -> URL:

--- a/litestar/utils/scope/state.py
+++ b/litestar/utils/scope/state.py
@@ -97,10 +97,8 @@ class ScopeState:
             A `ConnectionState` object.
         """
         base = scope["state"] if "state" in scope else scope
-        if state := base.get(CONNECTION_STATE_KEY):
-            return state  # type: ignore[no-any-return]
-        state = base[CONNECTION_STATE_KEY] = cls()
-        base[CONNECTION_STATE_KEY] = state
+        if (state := base.get(CONNECTION_STATE_KEY)) is None:
+            state = base[CONNECTION_STATE_KEY] = cls()
         return state
 
 

--- a/litestar/utils/scope/state.py
+++ b/litestar/utils/scope/state.py
@@ -96,10 +96,11 @@ class ScopeState:
         Returns:
             A `ConnectionState` object.
         """
-        if state := scope["state"].get(CONNECTION_STATE_KEY):
+        base = scope["state"] if "state" in scope else scope
+        if state := base.get(CONNECTION_STATE_KEY):
             return state  # type: ignore[no-any-return]
-        state = scope["state"][CONNECTION_STATE_KEY] = cls()
-        scope["state"][CONNECTION_STATE_KEY] = state
+        state = base[CONNECTION_STATE_KEY] = cls()
+        base[CONNECTION_STATE_KEY] = state
         return state
 
 

--- a/tests/unit/test_utils/test_scope.py
+++ b/tests/unit/test_utils/test_scope.py
@@ -22,8 +22,8 @@ def scope(create_scope: Callable[..., Scope]) -> Scope:
 
 
 def test_from_scope_without_state() -> None:
-    scope = {}
-    state = ScopeState.from_scope(scope)
+    scope = {}  # type: ignore[var-annotated]
+    state = ScopeState.from_scope(scope)  # type: ignore[arg-type]
     assert "state" not in scope
     assert scope[CONNECTION_STATE_KEY] is state
 

--- a/tests/unit/test_utils/test_scope.py
+++ b/tests/unit/test_utils/test_scope.py
@@ -10,7 +10,7 @@ from litestar.utils import (
     get_litestar_scope_state,
     set_litestar_scope_state,
 )
-from litestar.utils.scope.state import ScopeState
+from litestar.utils.scope.state import CONNECTION_STATE_KEY, ScopeState
 
 if TYPE_CHECKING:
     from litestar.types.asgi_types import Scope
@@ -19,6 +19,13 @@ if TYPE_CHECKING:
 @pytest.fixture()
 def scope(create_scope: Callable[..., Scope]) -> Scope:
     return create_scope()
+
+
+def test_from_scope_without_state() -> None:
+    scope = {}
+    state = ScopeState.from_scope(scope)
+    assert "state" not in scope
+    assert scope[CONNECTION_STATE_KEY] is state
 
 
 @pytest.mark.parametrize(("pop",), [(True,), (False,)])


### PR DESCRIPTION
Fix a regression introduced in #2751 that would wrongfully assume the `state` key is always present within the ASGI Scope. This is *only* the case when the `Litestar` root application is invoked first, since we enforce such a key there, but the presence of that key is not actually guaranteed by the ASGI spec and some servers, such as hypercorn, do not provide it.