### PR TITLE
test: Add missing `module_loader` tests

### DIFF
--- a/litestar/utils/module_loader.py
+++ b/litestar/utils/module_loader.py
@@ -39,7 +39,7 @@ def module_to_os_path(dotted_path: str = "app") -> Path:
     except ModuleNotFoundError as e:
         raise TypeError(f"Couldn't find the path for {dotted_path}") from e
 
-    return Path(str(src.origin).rsplit(os.path.sep + "__init__.py", maxsplit=1)[0])  # type: ignore[union-attr]
+    return Path(str(src.origin).rsplit(os.path.sep + "__init__.py", maxsplit=1)[0])
 
 
 def import_string(dotted_path: str) -> Any:

--- a/tests/unit/test_utils/test_module_loader.py
+++ b/tests/unit/test_utils/test_module_loader.py
@@ -1,4 +1,7 @@
+from pathlib import Path
+
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 
 from litestar.config.compression import CompressionConfig
 from litestar.utils.module_loader import import_string, module_to_os_path
@@ -21,3 +24,16 @@ def test_module_path() -> None:
     with pytest.raises(TypeError):
         _ = module_to_os_path("litestar.config.compression.Config")
         _ = module_to_os_path("litestar.config.compression.extra.module")
+
+
+def test_import_non_existing_attribute_raises() -> None:
+    with pytest.raises(ImportError):
+        import_string("litestar.app.some_random_string")
+
+
+def test_import_string_cached(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    tmp_path.joinpath("testmodule.py").write_text("x = 'foo'")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.syspath_prepend(tmp_path)
+
+    assert import_string("testmodule.x") == "foo"


### PR DESCRIPTION
Adds missing test for the `module_loader` package introduced in #3027.