### PR TITLE
fix: change `rich-click` to `rich_click` for `find_spec`

### DIFF
--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from litestar.types import AnyCallable
 
 
-RICH_CLICK_INSTALLED = find_spec("rich-click") is not None
+RICH_CLICK_INSTALLED = find_spec("rich_click") is not None
 UVICORN_INSTALLED = find_spec("uvicorn") is not None
 JSBEAUTIFIER_INSTALLED = find_spec("jsbeautifier") is not None
 


### PR DESCRIPTION
The `find_spec` function fails to find `rich-click`.  It should be `rich_click`

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
