### PR TITLE
fix(scope): Revert scope state regression

### DIFF
--- a/litestar/utils/scope/state.py
+++ b/litestar/utils/scope/state.py
@@ -96,9 +96,9 @@ class ScopeState:
         Returns:
             A `ConnectionState` object.
         """
-        base = scope["state"] if "state" in scope else scope
-        if (state := base.get(CONNECTION_STATE_KEY)) is None:
-            state = base[CONNECTION_STATE_KEY] = cls()
+        base_scope_state = scope.setdefault("state", {})
+        if (state := base_scope_state.get(CONNECTION_STATE_KEY)) is None:
+            state = base_scope_state[CONNECTION_STATE_KEY] = cls()
         return state
 
 

--- a/tests/unit/test_utils/test_scope.py
+++ b/tests/unit/test_utils/test_scope.py
@@ -24,8 +24,7 @@ def scope(create_scope: Callable[..., Scope]) -> Scope:
 def test_from_scope_without_state() -> None:
     scope = {}  # type: ignore[var-annotated]
     state = ScopeState.from_scope(scope)  # type: ignore[arg-type]
-    assert "state" not in scope
-    assert scope[CONNECTION_STATE_KEY] is state
+    assert scope["state"][CONNECTION_STATE_KEY] is state
 
 
 @pytest.mark.parametrize(("pop",), [(True,), (False,)])


### PR DESCRIPTION
Fix a regression introduced in #3070 while fixing another regression.

This now leaves the `scope["state"]` handling functionally untouched, to preserve behaviour. The behaviour is still not entirely correct, but it's not something we can fix without introducing breaking changes. 