### PR TITLE
fix: replace deprectated property

### DIFF
--- a/litestar/app.py
+++ b/litestar/app.py
@@ -457,7 +457,7 @@ class Litestar(Router):
             self.get_logger = self.logging_config.configure()
             self.logger = self.get_logger("litestar")
 
-        for static_config in self.static_files_config:
+        for static_config in self._static_files_config:
             self.register(static_config.to_static_files_app())
 
         self.asgi_handler = self._create_asgi_handler()


### PR DESCRIPTION
- `Litestar.static_files_config` property is deprecated since 2.6.0 by #2960 
- But `Litestar.__init__` uses the property. I'm not sure that it is intended or not, I can't avoid that deprecated warning from calling `Litestar(...)`.
  ```
  DeprecationWarning: Use of deprecated property 'static_files_config'. Deprecated in litestar 2.6.0. This property will be removed in the next major version. Use create_static_files router instead
  ```
- I suggest replace the property access to internal attribute in internal code.