### PR TITLE
fix: ensure importing of all click related stuff after running `rich_click_path`

### DIFF
--- a/litestar/cli/__init__.py
+++ b/litestar/cli/__init__.py
@@ -1,6 +1,28 @@
 """Litestar CLI."""
 from __future__ import annotations
 
+from importlib.util import find_spec
+
+# Ensure `rich_click` patching occurs before we do any imports from `click`.
+if find_spec("rich_click") is not None:
+    import rich_click as click
+    from rich_click.cli import patch as rich_click_patch
+
+    rich_click_patch()
+    click.rich_click.USE_RICH_MARKUP = True
+    click.rich_click.USE_MARKDOWN = False
+    click.rich_click.SHOW_ARGUMENTS = True
+    click.rich_click.GROUP_ARGUMENTS_OPTIONS = True
+    click.rich_click.SHOW_ARGUMENTS = True
+    click.rich_click.GROUP_ARGUMENTS_OPTIONS = True
+    click.rich_click.STYLE_ERRORS_SUGGESTION = "magenta italic"
+    click.rich_click.ERRORS_SUGGESTION = ""
+    click.rich_click.ERRORS_EPILOGUE = ""
+    click.rich_click.MAX_WIDTH = 80
+    click.rich_click.SHOW_METAVARS_COLUMN = True
+    click.rich_click.APPEND_METAVARS_HELP = True
+
+
 from .main import litestar_group
 
 __all__ = ["litestar_group"]

--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -36,13 +36,11 @@ if TYPE_CHECKING:
     from litestar.types import AnyCallable
 
 
-RICH_CLICK_INSTALLED = find_spec("rich_click") is not None
 UVICORN_INSTALLED = find_spec("uvicorn") is not None
 JSBEAUTIFIER_INSTALLED = find_spec("jsbeautifier") is not None
 
 
 __all__ = (
-    "RICH_CLICK_INSTALLED",
     "UVICORN_INSTALLED",
     "JSBEAUTIFIER_INSTALLED",
     "LoadedApp",

--- a/litestar/cli/main.py
+++ b/litestar/cli/main.py
@@ -1,35 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-from ._utils import RICH_CLICK_INSTALLED, LitestarEnv, LitestarExtensionGroup
+from click import Context, group, option, pass_context
+from click import Path as ClickPath
+
+from ._utils import LitestarEnv, LitestarExtensionGroup
 from .commands import core, schema, sessions
-
-if TYPE_CHECKING or not RICH_CLICK_INSTALLED:  # pragma: no cover
-    import click
-    from click import Context, group, option, pass_context
-    from click import Path as ClickPath
-else:  # pragma: no cover
-    import rich_click as click
-    from rich_click import Context, group, option, pass_context
-    from rich_click import Path as ClickPath
-    from rich_click.cli import patch as rich_click_patch
-
-    rich_click_patch()
-    click.rich_click.USE_RICH_MARKUP = True
-    click.rich_click.USE_MARKDOWN = False
-    click.rich_click.SHOW_ARGUMENTS = True
-    click.rich_click.GROUP_ARGUMENTS_OPTIONS = True
-    click.rich_click.SHOW_ARGUMENTS = True
-    click.rich_click.GROUP_ARGUMENTS_OPTIONS = True
-    click.rich_click.STYLE_ERRORS_SUGGESTION = "magenta italic"
-    click.rich_click.ERRORS_SUGGESTION = ""
-    click.rich_click.ERRORS_EPILOGUE = ""
-    click.rich_click.MAX_WIDTH = 80
-    click.rich_click.SHOW_METAVARS_COLUMN = True
-    click.rich_click.APPEND_METAVARS_HELP = True
-
 
 __all__ = ("litestar_group",)
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

Currently, the importing of `LitestarExtensionGroup` occurs before running `rich_click_patch`. This causes an issue due to `rich_click_patch` monkeypatching `click.Group`, `click.Command` etc. For example, consider the following code:

```python
from click import Command, Group
from click.core import Command as CCommand
from click.core import Group as CGroup

from litestar.cli import litestar_group

print(isinstance(litestar_group, (Group, Command)))  # False
print(isinstance(litestar_group, (CGroup, CCommand)))  # True

# These fail.
assert Group is CGroup
assert Command is CCommand
```
The reason for this behavior is that `LitestarExtensionGroup` is not a subclass of `RichGroup`, but a subclass of `click.Group` if it gets imported before `rich_click` gets a chance to do its patching. Then by the time we do the `isinstance` check, `click.Group` is patched to become `rich_click.RichGroup` and so the `isinstance(litestar_group, click.Group` fails.

This causes issues in the documentation generation using `sphinx-click` which does a `isinstance` which is why [this CI](https://github.com/litestar-org/litestar/actions/runs/7824742530/job/21347805990?pr=3087#step:6:48) is failing in #3087.

To fix this, we simply ensure that we run the `rich_click` patching before we any imports from `click`.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
