### PR TITLE
docs: retry with different ports if examples don't come online

### DIFF
--- a/tools/sphinx_ext/run_examples.py
+++ b/tools/sphinx_ext/run_examples.py
@@ -49,44 +49,55 @@ def _load_app_from_path(path: Path) -> Litestar:
     raise RuntimeError(f"No Litestar app found in {path}")
 
 
+def _get_available_port() -> int:
+    while AVAILABLE_PORTS:
+        port = AVAILABLE_PORTS.pop(0)
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            if sock.connect_ex(("127.0.0.1", port)) != 0:
+                return port
+
+    raise StartupError("Could not find an open port")
+
+
 @contextmanager
 def run_app(path: Path) -> Generator[int, None, None]:
     """Run an example app from a python file.
 
     The first ``Litestar`` instance found in the file will be used as target to run.
     """
-    while AVAILABLE_PORTS:
-        port = AVAILABLE_PORTS.pop(0)
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            if sock.connect_ex(("127.0.0.1", port)) != 0:
-                break
-    else:
-        raise StartupError("Could not find an open port")
 
+    port = _get_available_port()
     app = _load_app_from_path(path)
 
     def run() -> None:
         with redirect_stderr(Path(os.devnull).open()):
             uvicorn.run(app, port=port, access_log=False)
 
-    proc = multiprocessing.Process(target=run)
-    proc.start()
+    count = 0
+    while count < 100:
+        proc = multiprocessing.Process(target=run)
+        proc.start()
+        try:
+            for _ in range(100):
+                try:
+                    httpx.get(f"http://127.0.0.1:{port}", timeout=0.1)
+                    break
+                except httpx.TransportError:
+                    time.sleep(0.1)
+            else:
+                raise StartupError(f"App {path} failed to come online")
 
-    try:
-        for _ in range(100):
-            try:
-                httpx.get(f"http://127.0.0.1:{port}", timeout=0.1)
-                break
-            except httpx.TransportError:
-                time.sleep(0.1)
-        else:
-            raise StartupError(f"App {path} failed to come online")
+            yield port
+            break
+        finally:
+            proc.kill()
+            AVAILABLE_PORTS.append(port)
 
-        yield port
-
-    finally:
-        proc.kill()
-        AVAILABLE_PORTS.append(port)
+            port = _get_available_port()
+            time.sleep(0.2)
+            count += 1
+    else:
+        raise StartupError(f"App {path} failed to come online")
 
 
 def extract_run_args(content: str) -> tuple[str, list[list[str]]]:

--- a/tools/sphinx_ext/run_examples.py
+++ b/tools/sphinx_ext/run_examples.py
@@ -89,13 +89,14 @@ def run_app(path: Path) -> Generator[int, None, None]:
 
             yield port
             break
+        except StartupError:
+            time.sleep(0.2)
+            count += 1
         finally:
             proc.kill()
             AVAILABLE_PORTS.append(port)
 
             port = _get_available_port()
-            time.sleep(0.2)
-            count += 1
     else:
         raise StartupError(f"App {path} failed to come online")
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

There are a lot of cases where the examples fail to come online resulting in the building of the docs to fail as seen [here](https://github.com/litestar-org/litestar/actions/runs/7833425435/job/21374391134?pr=3087). This is due to the port that is being used to run the application ends up being used by another example during sphinx's parallel build. While we get the available port before creating the app in `run_app`, by the time we actually create the subprocess and get uvicorn to run the application, the port might already be in use by another example.

To work around this, we simply keep on retrying with a different port until the application comes online or we exceed an upper limit on the number of retries.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
