### PR TITLE
chore(sphinx): Tweak `_get_available_port`

### DIFF
--- a/tools/sphinx_ext/run_examples.py
+++ b/tools/sphinx_ext/run_examples.py
@@ -50,7 +50,10 @@ def _load_app_from_path(path: Path) -> Litestar:
 def _get_available_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         # Bind to a free port provided by the host
-        sock.bind(("localhost", 0))
+        try:
+            sock.bind(("localhost", 0))
+        except OSError:
+            raise StartupError("Could not find an open port")
         return sock.getsockname()[1]
 
 

--- a/tools/sphinx_ext/run_examples.py
+++ b/tools/sphinx_ext/run_examples.py
@@ -54,7 +54,8 @@ def _get_available_port() -> int:
             sock.bind(("localhost", 0))
         except OSError:
             raise StartupError("Could not find an open port")
-        return sock.getsockname()[1]
+        else:
+            return sock.getsockname()[1]
 
 
 @contextmanager

--- a/tools/sphinx_ext/run_examples.py
+++ b/tools/sphinx_ext/run_examples.py
@@ -52,8 +52,8 @@ def _get_available_port() -> int:
         # Bind to a free port provided by the host
         try:
             sock.bind(("localhost", 0))
-        except OSError:
-            raise StartupError("Could not find an open port")
+        except OSError as e:
+            raise StartupError("Could not find an open port") from e
         else:
             return sock.getsockname()[1]
 

--- a/tools/sphinx_ext/run_examples.py
+++ b/tools/sphinx_ext/run_examples.py
@@ -50,7 +50,7 @@ def _load_app_from_path(path: Path) -> Litestar:
 def _get_available_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         # Bind to a free port provided by the host
-        sock.bind(("", 0))
+        sock.bind(("localhost", 0))
         return sock.getsockname()[1]
 
 

--- a/tools/sphinx_ext/run_examples.py
+++ b/tools/sphinx_ext/run_examples.py
@@ -91,10 +91,10 @@ def run_app(path: Path) -> Generator[int, None, None]:
         except StartupError:
             time.sleep(0.2)
             count += 1
+            port = _get_available_port()
         finally:
             proc.kill()
 
-            port = _get_available_port()
     else:
         raise StartupError(f"App {path} failed to come online")
 


### PR DESCRIPTION
This is just a PR that modifies how `_get_available_port` fetches a free port. It uses the suggestion from [this](https://stackoverflow.com/a/36331860/12502959) StackOverflow answer.

TL;DR - Delegates the responsibility to the host OS to fetch a free port rather than maintaining a list at application level.

Caveat emptor: I believe both the current and suggested implementation have the same problem with regards to *not* being thread / process safe so feel free to close if this is not needed. 🙂 

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
