### PR TITLE
fix: use `IntegrityError` instead of deprecated `ConflictError`

### DIFF
--- a/litestar/repository/exceptions.py
+++ b/litestar/repository/exceptions.py
@@ -1,5 +1,6 @@
 try:
-    from advanced_alchemy.exceptions import ConflictError, NotFoundError, RepositoryError
+    from advanced_alchemy.exceptions import IntegrityError as ConflictError
+    from advanced_alchemy.exceptions import NotFoundError, RepositoryError
 except ImportError:  # pragma: no cover
     from ._exceptions import ConflictError, NotFoundError, RepositoryError  # type: ignore[assignment]
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

This PR updates the repository to return `IntegrityError` instead of the now deprecated `ConflictError`

Separately, I think we should consider deprecating this module for version 3.0.  