### PR TITLE
feat: support "+json"-suffixed response media types

### DIFF
--- a/docs/examples/responses/json_suffix_responses.py
+++ b/docs/examples/responses/json_suffix_responses.py
@@ -1,26 +1,14 @@
-from typing import Optional
-
-from pydantic import BaseModel
-
 import litestar.status_codes
 from litestar import Litestar, get
 
 
-class ProblemDetails(BaseModel):
-    title: str
-    type: str
-    status: Optional[int] = None
-    detail: Optional[str] = None
-    instance: Optional[str] = None
-
-
 @get("/resources", status_code=litestar.status_codes.HTTP_418_IM_A_TEAPOT, media_type="application/problem+json")
-async def retrieve_resource() -> ProblemDetails:
-    return ProblemDetails(
-        title="Server thinks it is a teapot",
-        type="Server delusion",
-        status=litestar.status_codes.HTTP_418_IM_A_TEAPOT,
-    )
+async def retrieve_resource() -> dict:
+    return {
+        "title": "Server thinks it is a teapot",
+        "type": "Server delusion",
+        "status": litestar.status_codes.HTTP_418_IM_A_TEAPOT,
+    }
 
 
 app = Litestar(route_handlers=[retrieve_resource])

--- a/docs/examples/responses/json_suffix_responses.py
+++ b/docs/examples/responses/json_suffix_responses.py
@@ -1,11 +1,11 @@
-from typing import Any
+from typing import Any, Dict
 
 import litestar.status_codes
 from litestar import Litestar, get
 
 
 @get("/resources", status_code=litestar.status_codes.HTTP_418_IM_A_TEAPOT, media_type="application/problem+json")
-async def retrieve_resource() -> dict[str, Any]:
+async def retrieve_resource() -> Dict[str, Any]:
     return {
         "title": "Server thinks it is a teapot",
         "type": "Server delusion",

--- a/docs/examples/responses/json_suffix_responses.py
+++ b/docs/examples/responses/json_suffix_responses.py
@@ -1,9 +1,11 @@
+from typing import Any
+
 import litestar.status_codes
 from litestar import Litestar, get
 
 
 @get("/resources", status_code=litestar.status_codes.HTTP_418_IM_A_TEAPOT, media_type="application/problem+json")
-async def retrieve_resource() -> dict:
+async def retrieve_resource() -> dict[str, Any]:
     return {
         "title": "Server thinks it is a teapot",
         "type": "Server delusion",

--- a/docs/examples/responses/json_suffix_responses.py
+++ b/docs/examples/responses/json_suffix_responses.py
@@ -1,0 +1,26 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+import litestar.status_codes
+from litestar import Litestar, get
+
+
+class ProblemDetails(BaseModel):
+    title: str
+    type: str
+    status: Optional[int] = None
+    detail: Optional[str] = None
+    instance: Optional[str] = None
+
+
+@get("/resources", status_code=litestar.status_codes.HTTP_418_IM_A_TEAPOT, media_type="application/problem+json")
+async def retrieve_resource() -> ProblemDetails:
+    return ProblemDetails(
+        title="Server thinks it is a teapot",
+        type="Server delusion",
+        status=litestar.status_codes.HTTP_418_IM_A_TEAPOT,
+    )
+
+
+app = Litestar(route_handlers=[retrieve_resource])

--- a/docs/usage/responses.rst
+++ b/docs/usage/responses.rst
@@ -77,6 +77,17 @@ As previously mentioned, the default ``media_type`` is ``MediaType.JSON``. which
 If you need to return other values and would like to extend serialization you can do
 this :ref:`custom responses <usage/responses:Custom Responses>`.
 
+You can also set an application media type string with the ``+json`` suffix
+defined in `RFC 6839 <https://datatracker.ietf.org/doc/html/rfc6839#section-3.1>`_
+as the ``media_type`` and it will be recognized and serialized as json.
+For example, you can use ``application/problem+json``
+(see `RFC 7807 <https://datatracker.ietf.org/doc/html/rfc7807#section-6.1>`_)
+and it will work just like json but have the appropriate content-type header
+and show up in the generated OpenAPI schema.
+
+.. literalinclude:: /examples/responses/json_suffix_responses.py
+    :language: python
+
 MessagePack responses
 +++++++++++++++++++++
 

--- a/litestar/response/base.py
+++ b/litestar/response/base.py
@@ -385,7 +385,9 @@ class Response(Generic[T]):
             if media_type == MediaType.MESSAGEPACK:
                 return encode_msgpack(content, enc_hook)
 
-            if media_type.startswith("application/json"):
+            if media_type.startswith("application/json") or (
+                media_type.startswith("application/") and media_type.endswith("+json")
+            ):
                 return encode_json(content, enc_hook)
 
             raise ImproperlyConfiguredException(f"unsupported media_type {media_type} for content {content!r}")

--- a/litestar/response/base.py
+++ b/litestar/response/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import itertools
+import re
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Iterable, Literal, Mapping, TypeVar, overload
 
 from litestar.datastructures.cookie import Cookie
@@ -34,6 +35,8 @@ if TYPE_CHECKING:
 __all__ = ("ASGIResponse", "Response")
 
 T = TypeVar("T")
+
+MEDIA_TYPE_APPLICATION_JSON_PATTERN = re.compile(r"^application/(?:.+\+)?json")
 
 
 class ASGIResponse:
@@ -385,8 +388,8 @@ class Response(Generic[T]):
             if media_type == MediaType.MESSAGEPACK:
                 return encode_msgpack(content, enc_hook)
 
-            if media_type.startswith("application/json") or (
-                media_type.startswith("application/") and media_type.endswith("+json")
+            if MEDIA_TYPE_APPLICATION_JSON_PATTERN.match(
+                media_type,
             ):
                 return encode_json(content, enc_hook)
 

--- a/tests/examples/test_responses/test_json_suffix_responses.py
+++ b/tests/examples/test_responses/test_json_suffix_responses.py
@@ -11,7 +11,5 @@ def test_json_suffix_responses() -> None:
             "title": "Server thinks it is a teapot",
             "type": "Server delusion",
             "status": 418,
-            "detail": None,
-            "instance": None,
         }
         assert res.headers["content-type"] == "application/problem+json"

--- a/tests/examples/test_responses/test_json_suffix_responses.py
+++ b/tests/examples/test_responses/test_json_suffix_responses.py
@@ -1,0 +1,17 @@
+from docs.examples.responses.json_suffix_responses import app
+
+from litestar.testing import TestClient
+
+
+def test_json_suffix_responses() -> None:
+    with TestClient(app=app) as client:
+        res = client.get("/resources")
+        assert res.status_code == 418
+        assert res.json() == {
+            "title": "Server thinks it is a teapot",
+            "type": "Server delusion",
+            "status": 418,
+            "detail": None,
+            "instance": None,
+        }
+        assert res.headers["content-type"] == "application/problem+json"

--- a/tests/unit/test_response/test_base_response.py
+++ b/tests/unit/test_response/test_base_response.py
@@ -167,9 +167,10 @@ def test_statuses_without_body(status: int, body: Optional[str], should_raise: b
         ({}, MediaType.TEXT, False),
         ({"abc": "def"}, MediaType.JSON, False),
         (Empty, MediaType.JSON, True),
+        ({"key": "value"}, "application/something+json", False),
     ),
 )
-def test_render_method(body: Any, media_type: MediaType, should_raise: bool) -> None:
+def test_render_method(body: Any, media_type: str, should_raise: bool) -> None:
     @get("/", media_type=media_type)
     def handler() -> Any:
         return body


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
Giving route handlers a response media type of the form "application/<something>+json" automatically uses json encoding for the response.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->
Closes #3088
