### PR TITLE
fix: Generate correct OpenAPI response for `ResponseSpec(None)` (#3069)

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -44,7 +44,7 @@ Workflow
 5. (Optional) Run ``pre-commit run --all-files`` to run linters and formatters. This step is optional and will be executed
    automatically by git before you make a commit, but you may want to run it manually in order to apply fixes
 6. Commit your changes to git. Note - we follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/),
-   which are enforced using a `pre-commit` hook.
+   which are enforced using a ``pre-commit`` hook.
 7. Push the changes to your fork
 8. Open a `pull request <https://docs.github.com/en/pull-requests>`_. Give the pull request a descriptive title
    indicating what it changes. The style of the PR title should also follow

--- a/litestar/_openapi/responses.py
+++ b/litestar/_openapi/responses.py
@@ -240,14 +240,21 @@ class ResponseFactory:
                 prefer_alias=False,
                 generate_examples=additional_response.generate_examples,
             )
-            schema = schema_creator.for_field_definition(
-                FieldDefinition.from_annotation(additional_response.data_container)
-            )
+
+            content: dict[str, OpenAPIMediaType] | None
+            if additional_response.data_container is not None:
+                schema = schema_creator.for_field_definition(
+                    FieldDefinition.from_annotation(additional_response.data_container)
+                )
+                content = {additional_response.media_type: OpenAPIMediaType(schema=schema)}
+            else:
+                content = None
+
             yield (
                 str(status_code),
                 OpenAPIResponse(
                     description=additional_response.description,
-                    content={additional_response.media_type: OpenAPIMediaType(schema=schema)},
+                    content=content,
                 ),
             )
 

--- a/litestar/openapi/datastructures.py
+++ b/litestar/openapi/datastructures.py
@@ -16,7 +16,7 @@ __all__ = ("ResponseSpec",)
 class ResponseSpec:
     """Container type of additional responses."""
 
-    data_container: DataContainerType
+    data_container: DataContainerType | None
     """A model that describes the content of the response."""
     generate_examples: bool = field(default=True)
     """Generate examples for the response content."""


### PR DESCRIPTION
Fixes #3069

Explicitly declaring `responses={...: ResponseSpec(None)}` used to generate OpenAPI `content`, when it should be omitted.