### PR TITLE
feat: Support `ResponseSpec(..., examples=[...])`

### DIFF
--- a/litestar/openapi/datastructures.py
+++ b/litestar/openapi/datastructures.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from litestar.enums import MediaType
 
 if TYPE_CHECKING:
+    from litestar.openapi.spec import Example
     from litestar.types import DataContainerType
 
 
@@ -24,3 +25,5 @@ class ResponseSpec:
     """A description of the response."""
     media_type: MediaType = field(default=MediaType.JSON)
     """Response media type."""
+    examples: list[Example] | None = field(default=None)
+    """A list of Example models."""

--- a/tests/unit/test_openapi/test_responses.py
+++ b/tests/unit/test_openapi/test_responses.py
@@ -28,7 +28,7 @@ from litestar.exceptions import (
 from litestar.handlers import HTTPRouteHandler
 from litestar.openapi.config import OpenAPIConfig
 from litestar.openapi.datastructures import ResponseSpec
-from litestar.openapi.spec import OpenAPIHeader, OpenAPIMediaType, Reference, Schema
+from litestar.openapi.spec import Example, OpenAPIHeader, OpenAPIMediaType, Reference, Schema
 from litestar.openapi.spec.enums import OpenAPIType
 from litestar.response import File, Redirect, Stream, Template
 from litestar.response.base import T
@@ -414,6 +414,28 @@ def test_additional_responses_overlap_with_raises(create_factory: CreateFactoryF
     assert responses is not None
     assert responses["400"] is not None
     assert responses["400"].description == "Overwritten response"
+
+
+def test_additional_responses_with_custom_examples(create_factory: CreateFactoryFixture) -> None:
+    @get(responses={200: ResponseSpec(DataclassPerson, examples=[Example(value={"string": "example", "number": 1})])})
+    def handler() -> DataclassPerson:
+        return DataclassPersonFactory.build()
+
+    factory = create_factory(handler)
+    responses = factory.create_additional_responses()
+    status_code, response = next(responses)
+    assert response.content
+    assert response.content["application/json"].examples == {
+        "dataclassperson-example-1": Example(
+            value={
+                "string": "example",
+                "number": 1,
+            }
+        ),
+    }
+
+    with pytest.raises(StopIteration):
+        next(responses)
 
 
 def test_create_response_for_response_subclass(create_factory: CreateFactoryFixture) -> None:


### PR DESCRIPTION
Fixes #3068

Allows to define custom examples for the responses via `ResponseSpec`.

The examples set this way are always generated locally, for each response:

```json
{
  "paths": {
    "/": {
      "get": {
        "responses": {
          "200": {
            "content": {
              "application/json": {
                "schema": {...},
                "examples": ...
```

Examples that go within the schema definition cannot be set by this.