### PR TITLE
feat: Allow re-usable `Router` instances

### DIFF
--- a/litestar/router.py
+++ b/litestar/router.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from copy import copy
+from copy import copy, deepcopy
 from typing import TYPE_CHECKING, Any, Mapping, Sequence, cast
 
 from litestar._layers.utils import narrow_response_cookies, narrow_response_headers
@@ -309,14 +309,12 @@ class Router:
             return value(owner=self).to_handler()  # pyright: ignore
 
         if isinstance(value, Router):
-            if value.owner:
-                raise ImproperlyConfiguredException(f"Router with path {value.path} has already been registered")
-
             if value is self:
                 raise ImproperlyConfiguredException("Cannot register a router on itself")
 
-            value.owner = self
-            return value
+            router_copy = deepcopy(value)
+            router_copy.owner = self
+            return router_copy
 
         if isinstance(value, (ASGIRouteHandler, HTTPRouteHandler, WebsocketRouteHandler)):
             value.owner = self

--- a/tests/e2e/test_router_registration.py
+++ b/tests/e2e/test_router_registration.py
@@ -132,9 +132,7 @@ def test_register_validation_wrong_class() -> None:
 def test_register_already_registered_router() -> None:
     first_router = Router(path="/first", route_handlers=[])
     Router(path="/second", route_handlers=[first_router])
-
-    with pytest.raises(ImproperlyConfiguredException):
-        Router(path="/third", route_handlers=[first_router])
+    Router(path="/third", route_handlers=[first_router])
 
 
 def test_register_router_on_itself() -> None:


### PR DESCRIPTION
Fixes #3012

It was not possible to re-attach a router instance once it was attached. This
makes that possible.

The router instance now gets deecopied when it's registered to another router.

The application startup performance gets a hit here, but the same approach is
already used for controllers and handlers, so this only harmonizes the
implementation.