### PR TITLE
chore: Remove prettier from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,11 +39,6 @@ repos:
     rev: 1.16.0
     hooks:
       - id: blacken-docs
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.8"
-    hooks:
-      - id: prettier
-        exclude: "_templates|.git|.all-contributorsrc"
   - repo: https://github.com/python-formate/flake8-dunder-all
     rev: v0.3.1
     hooks:


### PR DESCRIPTION
Remove prettier from pre-commit. 
It doesn't add a lot of value and has been quite flaky recently, breaking CI and pre-commit in unexpected ways for contributors. 
