### PR TITLE
chore: Replace blacken-docs with ruff

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "litestar-org/litestar",
   "build": {
     "dockerfile": "./Dockerfile",
-    "context": "."
+    "context": ".",
   },
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {
@@ -10,19 +10,19 @@
       "username": "vscode",
       "userUid": "1000",
       "userGid": "1000",
-      "upgradePackages": "true"
+      "upgradePackages": "true",
     },
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers-contrib/features/pre-commit:2": {},
     "ghcr.io/devcontainers/features/python:1": "none",
     "ghcr.io/devcontainers/features/git:1": {
       "version": "latest",
-      "ppa": "false"
-    }
+      "ppa": "false",
+    },
   },
   "customizations": {
     "codespaces": {
-      "openFiles": ["CONTRIBUTING.rst"]
+      "openFiles": ["CONTRIBUTING.rst"],
     },
     "vscode": {
       "extensions": [
@@ -31,7 +31,7 @@
         "github.vscode-github-actions",
         "ms-python.black-formatter",
         "ms-python.mypy-type-checker",
-        "charliermarsh.ruff"
+        "charliermarsh.ruff",
       ],
       "settings": {
         "python.editor.defaultFormatter": "charliermarsh.ruff",
@@ -45,17 +45,17 @@
         "terminal.integrated.profiles.linux": {
           "bash": {
             "path": "bash",
-            "icon": "terminal-bash"
+            "icon": "terminal-bash",
           },
           "zsh": {
-            "path": "zsh"
+            "path": "zsh",
           },
           "fish": {
-            "path": "fish"
-          }
-        }
-      }
-    }
+            "path": "fish",
+          },
+        },
+      },
+    },
   },
   "forwardPorts": [8000],
   "postCreateCommand": [
@@ -64,7 +64,7 @@
     "--extras",
     "full",
     "--with",
-    "docs,lint"
+    "docs,lint",
   ],
-  "remoteUser": "vscode"
+  "remoteUser": "vscode",
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,10 +35,6 @@ repos:
         exclude: "tests/openapi/typescript_converter/test_converter|README.md"
         additional_dependencies:
           - tomli
-  - repo: https://github.com/asottile/blacken-docs
-    rev: 1.16.0
-    hooks:
-      - id: blacken-docs
   - repo: https://github.com/python-formate/flake8-dunder-all
     rev: v0.3.1
     hooks:

--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -344,9 +344,11 @@ class LoggingMiddlewareConfig:
 
                 logging_middleware_config = LoggingMiddlewareConfig()
 
+
                 @get("/")
                 def my_handler(request: Request) -> None:
                     ...
+
 
                 app = Litestar(
                     route_handlers=[my_handler],

--- a/litestar/middleware/rate_limit.py
+++ b/litestar/middleware/rate_limit.py
@@ -257,9 +257,11 @@ class RateLimitConfig:
                 # limit to 10 requests per minute, excluding the schema path
                 throttle_config = RateLimitConfig(rate_limit=("minute", 10), exclude=["/schema"])
 
+
                 @get("/")
                 def my_handler(request: Request) -> None:
                     ...
+
 
                 app = Litestar(route_handlers=[my_handler], middleware=[throttle_config.middleware])
 

--- a/litestar/middleware/session/base.py
+++ b/litestar/middleware/session/base.py
@@ -85,7 +85,8 @@ class BaseBackendConfig(ABC, Generic[BaseSessionBackendT]):  # pyright: ignore
 
 
                 @get("/")
-                def my_handler(request: Request) -> None: ...
+                def my_handler(request: Request) -> None:
+                    ...
 
 
                 app = Litestar(route_handlers=[my_handler], middleware=[session_config.middleware])

--- a/litestar/security/session_auth/auth.py
+++ b/litestar/security/session_auth/auth.py
@@ -86,7 +86,8 @@ class SessionAuth(Generic[UserType, BaseSessionBackendT], AbstractSecurityConfig
 
 
                 @get("/")
-                def my_handler(request: Request) -> None: ...
+                def my_handler(request: Request) -> None:
+                    ...
 
 
                 app = Litestar(route_handlers=[my_handler], middleware=[session_auth_config.middleware])

--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -58,7 +58,8 @@ def _unwrap_implicit_optional_hints(defaults: dict[str, Any], hints: dict[str, A
 
     .. code-block:: python
 
-        def foo(a: Optional[Union[str, int]] = None): ...
+        def foo(a: Optional[Union[str, int]] = None):
+            ...
 
     ...will become `Union[str, int, NoneType]`.
 
@@ -66,7 +67,8 @@ def _unwrap_implicit_optional_hints(defaults: dict[str, Any], hints: dict[str, A
 
     .. code-block:: python
 
-        def foo(a: Annotated[Optional[Union[str, int]], ...] = None): ...
+        def foo(a: Annotated[Optional[Union[str, int]], ...] = None):
+            ...
 
     ... becomes `Union[Annotated[Union[str, int, NoneType], ...], NoneType]`
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "standard", "jwt", "pydantic", "cli", "picologging", "dev-contrib", "piccolo", "prometheus", "dev", "mako", "test", "brotli", "cryptography", "linting", "attrs", "opentelemetry", "docs", "redis", "sqlalchemy", "full", "annotated-types", "jinja", "structlog", "minijinja"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:8786dff11cddc6910aa28f92dfaf1a7b6e29389dc6929435406231abb21679c8"
+content_hash = "sha256:d15ae45eac6b6d77a630838b16d3e06192941b526fb6c53b46cf78bd7400d394"
 
 [[package]]
 name = "accessible-pygments"
@@ -394,19 +394,6 @@ files = [
     {file = "black-24.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:ecba2a15dfb2d97105be74bbfe5128bc5e9fa8477d8c46766505c1dda5883aac"},
     {file = "black-24.1.1-py3-none-any.whl", hash = "sha256:5cdc2e2195212208fbcae579b931407c1fa9997584f0a415421748aeafff1168"},
     {file = "black-24.1.1.tar.gz", hash = "sha256:48b5760dcbfe5cf97fd4fba23946681f3a81514c6ab8a45b50da67ac8fbc6c7b"},
-]
-
-[[package]]
-name = "blacken-docs"
-version = "1.16.0"
-requires_python = ">=3.8"
-summary = "Run Black on Python code blocks in documentation files."
-dependencies = [
-    "black>=22.1.0",
-]
-files = [
-    {file = "blacken_docs-1.16.0-py3-none-any.whl", hash = "sha256:b0dcb84b28ebfb352a2539202d396f50e15a54211e204a8005798f1d1edb7df8"},
-    {file = "blacken_docs-1.16.0.tar.gz", hash = "sha256:b4bdc3f3d73898dfbf0166f292c6ccfe343e65fc22ddef5319c95d1a8dcc6c1c"},
 ]
 
 [[package]]
@@ -1444,7 +1431,7 @@ files = [
 
 [[package]]
 name = "hypothesis"
-version = "6.98.3"
+version = "6.98.4"
 requires_python = ">=3.8"
 summary = "A library for property-based testing"
 dependencies = [
@@ -1453,8 +1440,8 @@ dependencies = [
     "sortedcontainers<3.0.0,>=2.1.0",
 ]
 files = [
-    {file = "hypothesis-6.98.3-py3-none-any.whl", hash = "sha256:13fd80af383508f5a4707e0148120437d962d6a3ed8f5554b4daea5777a34fc6"},
-    {file = "hypothesis-6.98.3.tar.gz", hash = "sha256:1844d92ca65a42185e1d78956400455e644f88264e1611ebdc8d6aa71b402773"},
+    {file = "hypothesis-6.98.4-py3-none-any.whl", hash = "sha256:8417d1df13e7ba0eb6cba0917e0aa6c8b0b6b35a4e7fb78db6ab84dfbeb8c8fe"},
+    {file = "hypothesis-6.98.4.tar.gz", hash = "sha256:785f47ddac183c7ffef9463b5ab7f2e4433ca9b2b1171e52eeb3f8c5b1f09fa2"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,6 @@ docs = [
   "sphinx-autobuild>=2021.3.14",
   "sphinx-copybutton>=0.5.2",
   "sphinx-toolbox>=3.5.0",
-  "blacken-docs>=1.16.0",
   "sphinx-design>=0.5.0",
   "sphinx-click>=4.4.0",
   "sphinxcontrib-mermaid>=0.9.2",
@@ -143,12 +142,11 @@ docs = [
   "litestar-sphinx-theme @ git+https://github.com/litestar-org/litestar-sphinx-theme.git",
 ]
 linting = [
-  "ruff",
+  "ruff>=0.2.1",
   "mypy",
   "pre-commit",
   "slotscheck",
   "pyright==1.1.344",
-  "blacken-docs",
   "asyncpg-stubs",
   "types-beautifulsoup4",
   "types-pytest-lazy-fixture",
@@ -339,7 +337,7 @@ lint.ignore = [
   "D202", # pydocstyle - no blank lines allowed after function docstring
   "D205", # pydocstyle - 1 blank line required between summary line and description
   "D415", # pydocstyle - first line should end with a period, question mark, or exclamation point
-  "E501", # pycodestyle line too long, handled by black
+  "E501", # pycodestyle line too long, handled by ruff format
   "PLW2901", # pylint - for loop variable overwritten by assignment target
   "RUF012", # Ruff-specific rule - annotated with classvar
   "ISC001", # Ruff formatter incompatible
@@ -404,6 +402,10 @@ known-first-party = ["litestar", "tests", "examples"]
 "tests/unit/test_contrib/test_sqlalchemy/**/*.*" = ["UP006"]
 "tools/**/*.*" = ["D", "ARG", "EM", "TRY", "G", "FBT"]
 "tools/prepare_release.py" = ["S603", "S607"]
+
+[tool.ruff.format]
+docstring-code-format = true
+docstring-code-line-length = 88
 
 [tool.unasyncd]
 add_editors_note = true


### PR DESCRIPTION
Replace `blacken-docs` with `ruff format`.