### PR TITLE
fix(DTO): DTO msgspec meta constraints not being included in transfer model

### DIFF
--- a/docs/examples/contrib/piccolo/app.py
+++ b/docs/examples/contrib/piccolo/app.py
@@ -77,7 +77,4 @@ async def on_startup():
     await create_db_tables(Task, if_not_exists=True)
 
 
-app = Litestar(
-    route_handlers=[tasks, create_task, delete_task, update_task],
-    on_startup=[on_startup],
-)
+app = Litestar(route_handlers=[tasks, create_task, delete_task, update_task], on_startup=[on_startup], debug=True)


### PR DESCRIPTION
Fix an issue where msgspec constraints set in `msgspec.Meta` would not be honoured by the DTO.

In the given example, the `min_length=3` constraint would be ignored by the model generated by `MsgspecDTO`.

```python
from typing import Annotated

import msgspec
from litestar import post, Litestar
from litestar.dto import MsgspecDTO

class Request(msgspec.Struct):
    foo: Annotated[str, msgspec.Meta(min_length=3)]

@post("/example/", dto=MsgspecDTO[Request])
async def example(data: Request) -> Request:
    return data
```

Constraints like these are now transferred.

Two things to note are:

- For DTOs with `DTOConfig(partial=True)` we cannot transfer the length constraints as they are only supported on fields that as subtypes of `str`, `bytes` or a collection type, but `partial=True` sets all fields as `T | UNSET`
- For the PiccoloDTO, fields which are not required will also drop the length constraints. A warning about this will be raised here.

<hr>


**Closes #3026**
