### PR TITLE
test: Fix structlog tty test for windows

### DIFF
--- a/tests/unit/test_logging/test_structlog_config.py
+++ b/tests/unit/test_logging/test_structlog_config.py
@@ -1,3 +1,5 @@
+import datetime
+import sys
 from typing import Callable
 
 import pytest
@@ -130,7 +132,10 @@ def test_structlog_config_tty_default(capsys: CaptureFixture, monkeypatch: pytes
         log_messages = capsys.readouterr().out.splitlines()
         assert len(log_messages) == 1
 
-        assert log_messages[0].startswith("\x1b[")
+        if sys.platform.startswith("win"):
+            assert log_messages[0].startswith(str(datetime.datetime.now().year))
+        else:
+            assert log_messages[0].startswith("\x1b[")
 
 
 def test_structlog_config_specify_processors(capsys: CaptureFixture) -> None:


### PR DESCRIPTION
Fix a [failing test](https://github.com/litestar-org/litestar/actions/runs/7906235715/job/21580621934#step:7:204) for structlog on windows with tty. 