### PR TITLE
fix: Description not set for UUID based path parameters in OpenAPI

### DIFF
--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -117,7 +117,7 @@ TYPE_MAP: dict[type[Any] | None | Any, Schema] = {
     Sequence: Schema(type=OpenAPIType.ARRAY),
     Set: Schema(type=OpenAPIType.ARRAY),
     Tuple: Schema(type=OpenAPIType.ARRAY),
-    UUID: Schema(type=OpenAPIType.STRING, format=OpenAPIFormat.UUID, description="Any UUID string"),
+    UUID: Schema(type=OpenAPIType.STRING, format=OpenAPIFormat.UUID),
     bool: Schema(type=OpenAPIType.BOOLEAN),
     bytearray: Schema(type=OpenAPIType.STRING),
     bytes: Schema(type=OpenAPIType.STRING),

--- a/tests/examples/test_openapi.py
+++ b/tests/examples/test_openapi.py
@@ -28,7 +28,7 @@ def test_schema_generation() -> None:
             "components": {
                 "schemas": {
                     "IdModel": {
-                        "properties": {"id": {"type": "string", "format": "uuid", "description": "Any UUID string"}},
+                        "properties": {"id": {"type": "string", "format": "uuid"}},
                         "type": "object",
                         "required": ["id"],
                         "title": "IdContainer",

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -337,7 +337,9 @@ def test_uuid_path_description_generation() -> None:
     async def uuid_path(id: Annotated[UUID, Parameter(description="UUID ID")]) -> UUID:
         return id
 
-    with create_test_client([str_path, uuid_path]) as client:
+    with create_test_client(
+        [str_path, uuid_path], openapi_config=OpenAPIConfig(title="Test API", version="1.0.0")
+    ) as client:
         response = client.get("/schema/openapi.json")
         assert response.json()["paths"]["/str/{id}"]["get"]["parameters"][0]["description"] == "String ID"
         assert response.json()["paths"]["/uuid/{id}"]["get"]["parameters"][0]["description"] == "UUID ID"

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING, List, Optional, Type, cast
+from uuid import UUID
 
 import pytest
 from typing_extensions import Annotated
@@ -324,3 +325,19 @@ def test_parameter_examples() -> None:
         assert response.json()["paths"]["/"]["get"]["parameters"][0]["examples"] == {
             "text-example-1": {"summary": "example summary", "value": "example value"}
         }
+
+
+def test_uuid_path_description_generation() -> None:
+    # https://github.com/litestar-org/litestar/issues/2967
+    @get("str/{id:str}")
+    async def str_path(id: Annotated[str, Parameter(description="String ID")]) -> str:
+        return id
+
+    @get("uuid/{id:uuid}")
+    async def uuid_path(id: Annotated[UUID, Parameter(description="UUID ID")]) -> UUID:
+        return id
+
+    with create_test_client([str_path, uuid_path]) as client:
+        response = client.get("/schema/openapi.json")
+        assert response.json()["paths"]["/str/{id}"]["get"]["parameters"][0]["description"] == "String ID"
+        assert response.json()["paths"]["/uuid/{id}"]["get"]["parameters"][0]["description"] == "UUID ID"


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Resolved the bug where the description was not set for UUID-based path parameters in OpenAPI due to the reason mentioned in the issue.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
Closes #2967 
