### PR TITLE
feat: pass examples given in the `FieldDefinition` to the `OpenAPIMediaType`

### DIFF
--- a/litestar/_openapi/request_body.py
+++ b/litestar/_openapi/request_body.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Mapping
 
 from litestar._openapi.schema_generation import SchemaCreator
+from litestar._openapi.schema_generation.utils import get_formatted_examples
 from litestar.enums import RequestEncodingType
 from litestar.openapi.spec.media_type import OpenAPIMediaType
 from litestar.openapi.spec.request_body import RequestBody
@@ -13,7 +14,7 @@ __all__ = ("create_request_body",)
 if TYPE_CHECKING:
     from litestar._openapi.datastructures import OpenAPIContext
     from litestar.dto import AbstractDTO
-    from litestar.openapi.spec import Example, Reference
+    from litestar.openapi.spec import Example
     from litestar.typing import FieldDefinition
 
 
@@ -48,11 +49,8 @@ def create_request_body(
     else:
         schema = schema_creator.for_field_definition(data_field)
 
-    examples: dict[str, Example | Reference] | None = None
-    if isinstance(data_field.kwarg_definition, BodyKwarg) and data_field.kwarg_definition.examples:
-        examples = {}
-        for example in data_field.kwarg_definition.examples:
-            if isinstance(example.summary, str) and isinstance(example.value, dict):
-                examples[example.summary] = example
+    examples: Mapping[str, Example] | None = None
+    if isinstance(data_field.kwarg_definition, BodyKwarg) and isinstance(data_field.kwarg_definition.examples, list):
+        examples = get_formatted_examples(data_field, data_field.kwarg_definition.examples)
 
     return RequestBody(required=True, content={media_type: OpenAPIMediaType(schema=schema, examples=examples)})

--- a/litestar/_openapi/request_body.py
+++ b/litestar/_openapi/request_body.py
@@ -4,12 +4,12 @@ from typing import TYPE_CHECKING
 
 from litestar._openapi.schema_generation import SchemaCreator
 from litestar.enums import RequestEncodingType
+from litestar.openapi.spec import Example, Reference
 from litestar.openapi.spec.media_type import OpenAPIMediaType
 from litestar.openapi.spec.request_body import RequestBody
 from litestar.params import BodyKwarg
 
 __all__ = ("create_request_body",)
-
 
 if TYPE_CHECKING:
     from litestar._openapi.datastructures import OpenAPIContext
@@ -48,4 +48,10 @@ def create_request_body(
     else:
         schema = schema_creator.for_field_definition(data_field)
 
-    return RequestBody(required=True, content={media_type: OpenAPIMediaType(schema=schema)})
+    examples: dict[str, Example | Reference] | None = None
+    if isinstance(data_field.kwarg_definition, BodyKwarg) and data_field.kwarg_definition.examples:
+        examples = {
+            example.summary: example for example in data_field.kwarg_definition.examples if example.summary is not None
+        }
+
+    return RequestBody(required=True, content={media_type: OpenAPIMediaType(schema=schema, examples=examples)})

--- a/litestar/_openapi/request_body.py
+++ b/litestar/_openapi/request_body.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 from litestar._openapi.schema_generation import SchemaCreator
 from litestar.enums import RequestEncodingType
-from litestar.openapi.spec import Example, Reference
 from litestar.openapi.spec.media_type import OpenAPIMediaType
 from litestar.openapi.spec.request_body import RequestBody
 from litestar.params import BodyKwarg
@@ -15,6 +14,7 @@ if TYPE_CHECKING:
     from litestar._openapi.datastructures import OpenAPIContext
     from litestar.dto import AbstractDTO
     from litestar.typing import FieldDefinition
+    from litestar.openapi.spec import Example, Reference
 
 
 def create_request_body(

--- a/litestar/_openapi/request_body.py
+++ b/litestar/_openapi/request_body.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from litestar.dto import AbstractDTO
     from litestar.openapi.spec import Example
     from litestar.typing import FieldDefinition
+    from litestar.openapi.spec import Example, Reference
 
 
 def create_request_body(

--- a/litestar/_openapi/request_body.py
+++ b/litestar/_openapi/request_body.py
@@ -13,8 +13,8 @@ __all__ = ("create_request_body",)
 if TYPE_CHECKING:
     from litestar._openapi.datastructures import OpenAPIContext
     from litestar.dto import AbstractDTO
-    from litestar.typing import FieldDefinition
     from litestar.openapi.spec import Example, Reference
+    from litestar.typing import FieldDefinition
 
 
 def create_request_body(

--- a/litestar/_openapi/request_body.py
+++ b/litestar/_openapi/request_body.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Mapping
+from typing import TYPE_CHECKING
 
 from litestar._openapi.schema_generation import SchemaCreator
-from litestar._openapi.schema_generation.utils import get_formatted_examples
 from litestar.enums import RequestEncodingType
+from litestar.openapi.spec import Example, Reference
 from litestar.openapi.spec.media_type import OpenAPIMediaType
 from litestar.openapi.spec.request_body import RequestBody
 from litestar.params import BodyKwarg
@@ -14,7 +14,6 @@ __all__ = ("create_request_body",)
 if TYPE_CHECKING:
     from litestar._openapi.datastructures import OpenAPIContext
     from litestar.dto import AbstractDTO
-    from litestar.openapi.spec import Example
     from litestar.typing import FieldDefinition
 
 
@@ -49,8 +48,10 @@ def create_request_body(
     else:
         schema = schema_creator.for_field_definition(data_field)
 
-    examples: Mapping[str, Example] | None = None
-    if isinstance(data_field.kwarg_definition, BodyKwarg) and isinstance(data_field.kwarg_definition.examples, list):
-        examples = get_formatted_examples(data_field, data_field.kwarg_definition.examples)
+    examples: dict[str, Example | Reference] | None = None
+    if isinstance(data_field.kwarg_definition, BodyKwarg) and data_field.kwarg_definition.examples:
+        examples = {
+            example.summary: example for example in data_field.kwarg_definition.examples if example.summary is not None
+        }
 
     return RequestBody(required=True, content={media_type: OpenAPIMediaType(schema=schema, examples=examples)})

--- a/litestar/_openapi/request_body.py
+++ b/litestar/_openapi/request_body.py
@@ -50,8 +50,9 @@ def create_request_body(
 
     examples: dict[str, Example | Reference] | None = None
     if isinstance(data_field.kwarg_definition, BodyKwarg) and data_field.kwarg_definition.examples:
-        examples = {
-            example.summary: example for example in data_field.kwarg_definition.examples if example.summary is not None
-        }
+        examples = {}
+        for example in data_field.kwarg_definition.examples:
+            if isinstance(example.summary, str) and isinstance(example.value, dict):
+                examples[example.summary] = example
 
     return RequestBody(required=True, content={media_type: OpenAPIMediaType(schema=schema, examples=examples)})

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -78,8 +78,6 @@ class HTTPRouteHandler(BaseRouteHandler):
         "_resolved_before_request",
         "_response_handler_mapping",
         "_resolved_include_in_schema",
-        "_resolved_response_class",
-        "_resolved_request_class",
         "_resolved_tags",
         "_resolved_security",
         "after_request",
@@ -292,8 +290,6 @@ class HTTPRouteHandler(BaseRouteHandler):
         self._resolved_before_request: AsyncAnyCallable | None | EmptyType = Empty
         self._response_handler_mapping: ResponseHandlerMap = {"default_handler": Empty, "response_type_handler": Empty}
         self._resolved_include_in_schema: bool | EmptyType = Empty
-        self._resolved_response_class: type[Response] | EmptyType = Empty
-        self._resolved_request_class: type[Request] | EmptyType = Empty
         self._resolved_security: list[SecurityRequirement] | EmptyType = Empty
         self._resolved_tags: list[str] | EmptyType = Empty
 
@@ -316,14 +312,10 @@ class HTTPRouteHandler(BaseRouteHandler):
         Returns:
             The default :class:`Request <.connection.Request>` class for the route handler.
         """
-
-        if self._resolved_request_class is Empty:
-            self._resolved_request_class = next(
-                (layer.request_class for layer in reversed(self.ownership_layers) if layer.request_class is not None),
-                Request,
-            )
-
-        return cast("type[Request]", self._resolved_request_class)
+        return next(
+            (layer.request_class for layer in reversed(self.ownership_layers) if layer.request_class is not None),
+            Request,
+        )
 
     def resolve_response_class(self) -> type[Response]:
         """Return the closest custom Response class in the owner graph or the default Response class.
@@ -333,13 +325,10 @@ class HTTPRouteHandler(BaseRouteHandler):
         Returns:
             The default :class:`Response <.response.Response>` class for the route handler.
         """
-        if self._resolved_response_class is Empty:
-            self._resolved_response_class = next(
-                (layer.response_class for layer in reversed(self.ownership_layers) if layer.response_class is not None),
-                Response,
-            )
-
-        return cast("type[Response]", self._resolved_response_class)
+        return next(
+            (layer.response_class for layer in reversed(self.ownership_layers) if layer.response_class is not None),
+            Response,
+        )
 
     def resolve_response_headers(self) -> frozenset[ResponseHeader]:
         """Return all header parameters in the scope of the handler function.

--- a/litestar/openapi/spec/media_type.py
+++ b/litestar/openapi/spec/media_type.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Mapping
 
 from litestar.openapi.spec.base import BaseSchemaObject
 
@@ -32,7 +32,7 @@ class OpenAPIMediaType(BaseSchemaObject):
     example provided by the schema.
     """
 
-    examples: dict[str, Example | Reference] | None = None
+    examples: dict[str, Example | Reference] | Mapping[str, Example] | None = None
     """Examples of the media type.
 
     Each example object SHOULD match the media type and specified schema if present.

--- a/tests/unit/test_cli/test_core_commands.py
+++ b/tests/unit/test_cli/test_core_commands.py
@@ -1,19 +1,17 @@
-import io
 import os
 import re
 import sys
 from pathlib import Path
-from typing import Callable, Generator, List, Literal, Optional, Tuple, Union
+from typing import Callable, Generator, List, Optional, Tuple
 from unittest.mock import MagicMock
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from click.testing import CliRunner
 from pytest_mock import MockerFixture
-from rich.console import Console
 
 from litestar import __version__ as litestar_version
-from litestar.cli import _utils
+from litestar.cli._utils import remove_default_schema_routes, remove_routes_with_patterns
 from litestar.cli.main import litestar_group as cli_command
 from litestar.exceptions import LitestarWarning
 
@@ -117,7 +115,7 @@ def test_run_command(
     else:
         uds = None
 
-    if fd is not None:
+    if fd:
         if set_in_env:
             monkeypatch.setenv("LITESTAR_FILE_DESCRIPTOR", str(fd))
         else:
@@ -151,6 +149,7 @@ def test_run_command(
             args.extend([f"--reload-exclude={s}" for s in reload_exclude])
 
     path = create_app_file(custom_app_file or "app.py", directory=app_dir)
+
     result = runner.invoke(cli_command, args)
 
     assert result.exception is None
@@ -256,115 +255,6 @@ def test_run_command_with_app_factory(
     )
 
 
-@pytest.mark.parametrize(
-    "cli, env, expected",
-    (
-        (
-            ("--reload", True),
-            ("LITESTAR_RELOAD", False),
-            "--reload",
-        ),
-        (
-            ("--reload-dir", [".", "../somewhere_else"]),
-            ("LITESTAR_RELOAD_DIRS", ["../somewhere_else3", "../somewhere_else2"]),
-            ["--reload-dir=.", "--reload-dir=../somewhere_else"],
-        ),
-        (
-            ("--reload-include", ["*.rst", "*.yml"]),
-            ("LITESTAR_RELOAD_INCLUDES", ["*.rst2", "*.yml2"]),
-            ["--reload-include=*.rst", "--reload-include=*.yml"],
-        ),
-        (
-            ("--reload-exclude", ["*.rst", "*.yml"]),
-            ("LITESTAR_RELOAD_EXCLUDES", ["*.rst2", "*.yml2"]),
-            ["--reload-exclude=*.rst", "--reload-exclude=*.yml"],
-        ),
-        (
-            ("--wc", 2),
-            ("WEB_CONCURRENCY", 4),
-            "--workers=2",
-        ),
-        (
-            ("--fd", 0),
-            ("LITESTAR_FILE_DESCRIPTOR", 1),
-            "--fd=0",
-        ),
-        (
-            ("--uds", "/run/uvicorn/litestar_test.sock"),
-            ("LITESTAR_UNIX_DOMAIN_SOCKET", "/run/uvicorn/litestar_test2.sock"),
-            "--uds=/run/uvicorn/litestar_test.sock",
-        ),
-        (
-            ("-d", True),
-            ("LITESTAR_DEBUG", False),
-            ("LITESTAR_DEBUG", "1"),
-        ),
-        (
-            ("--pdb", True),
-            ("LITESTAR_PDB", False),
-            ("LITESTAR_PDB", "1"),
-        ),
-    ),
-)
-def test_run_command_arguments_precedence(
-    cli: Tuple[str, Union[Literal[True], List[str], str]],
-    env: Tuple[str, Union[Literal[True], List[str], str]],
-    expected: str,
-    runner: CliRunner,
-    monkeypatch: MonkeyPatch,
-    mock_subprocess_run: MagicMock,
-    tmp_project_dir: Path,
-    create_app_file: CreateAppFileFixture,
-    mock_uvicorn_run: MagicMock,
-) -> None:
-    args = []
-    args.extend(["--app", f"{Path('my_app.py').stem}:app"])
-    args.extend(["--app-dir", str(Path(tmp_project_dir / "custom_subfolder"))])
-    args.extend(["run"])
-    create_app_file("my_app.py", directory="custom_subfolder")
-
-    env_name, env_value = env
-    cli_name, cli_value = cli
-
-    if env_name:
-        if isinstance(env_value, list):
-            monkeypatch.setenv(env_name, "".join(env_value))
-        else:
-            monkeypatch.setenv(env_name, env_value)  # type: ignore[arg-type] # pyright: ignore (reportGeneralTypeIssues)
-
-    if cli_name:
-        if cli_value is True:
-            args.append(cli_name)
-        elif isinstance(cli_value, list):
-            for value in cli_value:
-                args.extend([cli_name, value])
-        else:
-            args.extend([cli_name, cli_value])
-
-    result = runner.invoke(cli_command, args)
-
-    assert result.exception is None
-    assert result.exit_code == 0
-
-    if cli_name in ["--fd", "--uds"]:
-        mock_subprocess_run.assert_not_called()
-        if isinstance(expected, list):  # type: ignore[unreachable]
-            assert all(_ in mock_uvicorn_run.call_args_list[0].args[0] for _ in expected)  # type: ignore[unreachable]
-        else:
-            assert mock_uvicorn_run.call_args_list[0].kwargs.get(cli_name.strip("--")) == cli_value
-
-    elif cli_name in ["-d", "--pdb"]:
-        assert os.environ.get(expected[0]) == expected[1]
-
-    else:
-        mock_subprocess_run.assert_called_once()
-
-        if isinstance(expected, list):  # type: ignore[unreachable]
-            assert all(_ in mock_subprocess_run.call_args_list[0].args[0] for _ in expected)  # type: ignore[unreachable]
-        else:
-            assert expected in mock_subprocess_run.call_args_list[0].args[0]
-
-
 @pytest.fixture()
 def unset_env() -> Generator[None, None, None]:
     initial_env = {**os.environ}
@@ -386,58 +276,6 @@ def test_run_command_debug(
 
     assert result.exit_code == 0
     assert os.getenv("LITESTAR_DEBUG") == "1"
-
-
-@pytest.mark.usefixtures("mock_uvicorn_run", "unset_env")
-def test_run_command_quiet_console(
-    app_file: Path, runner: CliRunner, monkeypatch: MonkeyPatch, create_app_file: CreateAppFileFixture
-) -> None:
-    console = Console(file=io.StringIO())
-    monkeypatch.setattr(_utils, "console", console)
-
-    path = create_app_file("_create_app_with_path.py", content=CREATE_APP_FILE_CONTENT)
-    app_path = f"{path.stem}:create_app"
-    monkeypatch.delenv("LITESTAR_QUIET_CONSOLE", raising=False)
-    result = runner.invoke(cli_command, ["--app", app_path, "run"])
-    assert result.exit_code == 0
-    normal_output = console.file.getvalue()  # type: ignore[attr-defined]
-    assert "Using Litestar from env:" in normal_output
-    assert "Starting server process" in result.stdout
-    del result
-    console = Console(file=io.StringIO())
-    monkeypatch.setattr(_utils, "console", console)
-    monkeypatch.setenv("LITESTAR_QUIET_CONSOLE", "1")
-    assert os.getenv("LITESTAR_QUIET_CONSOLE") == "1"
-    result = runner.invoke(cli_command, ["--app", app_path, "run"])
-    assert result.exit_code == 0
-    quiet_output = console.file.getvalue()  # type: ignore[attr-defined]
-    assert "Starting server process" not in result.stdout
-    assert "Using Litestar from env:" not in quiet_output
-    console.clear()
-
-
-@pytest.mark.usefixtures("mock_uvicorn_run", "unset_env")
-def test_run_command_custom_app_name(
-    app_file: Path, runner: CliRunner, monkeypatch: MonkeyPatch, create_app_file: CreateAppFileFixture
-) -> None:
-    console = Console(file=io.StringIO())
-    monkeypatch.setattr(_utils, "console", console)
-
-    path = create_app_file("_create_app_with_path.py", content=CREATE_APP_FILE_CONTENT)
-    app_path = f"{path.stem}:create_app"
-    monkeypatch.delenv("LITESTAR_APP_NAME", raising=False)
-    result = runner.invoke(cli_command, ["--app", app_path, "run"])
-    assert result.exit_code == 0
-    _output = console.file.getvalue()  # type: ignore[attr-defined]
-    assert "Using Litestar from env:" in _output
-    console = Console(file=io.StringIO())
-    monkeypatch.setattr(_utils, "console", console)
-    monkeypatch.setenv("LITESTAR_APP_NAME", "My Stuff")
-    assert os.getenv("LITESTAR_APP_NAME") == "My Stuff"
-    result = runner.invoke(cli_command, ["--app", app_path, "run"])
-    assert result.exit_code == 0
-    _output = console.file.getvalue()  # type: ignore[attr-defined]
-    assert "Using My Stuff from env:" in _output
 
 
 @pytest.mark.usefixtures("mock_uvicorn_run", "unset_env")
@@ -512,21 +350,21 @@ def test_run_command_with_server_lifespan_plugin(
 @pytest.mark.parametrize(
     "app_content, schema_enabled, exclude_pattern_list, expected_result_routes_count",
     [
-        pytest.param(APP_FILE_CONTENT_ROUTES_EXAMPLE, False, (), 3, id="schema-disabled_no-exclude"),
+        pytest.param(APP_FILE_CONTENT_ROUTES_EXAMPLE, False, (), 3, id="schema-enabled_no-exclude"),
         pytest.param(
             APP_FILE_CONTENT_ROUTES_EXAMPLE,
             False,
             ("/foo", "/destroy/.*", "/java", "/haskell"),
             2,
-            id="schema-disabled_exclude",
+            id="schema-enabled_exclude",
         ),
-        pytest.param(APP_FILE_CONTENT_ROUTES_EXAMPLE, True, (), 13, id="schema-enabled_no-exclude"),
+        pytest.param(APP_FILE_CONTENT_ROUTES_EXAMPLE, True, (), 12, id="schema-disabled_no-exclude"),
         pytest.param(
             APP_FILE_CONTENT_ROUTES_EXAMPLE,
             True,
             ("/foo", "/destroy/.*", "/java", "/haskell"),
-            12,
-            id="schema-enabled_exclude",
+            11,
+            id="schema-disabled_exclude",
         ),
     ],
 )
@@ -587,7 +425,7 @@ def test_remove_default_schema_routes() -> None:
     api_config = MagicMock()
     api_config.openapi_controller.path = "/schema"
 
-    results = _utils.remove_default_schema_routes(http_routes, api_config)  # type: ignore[arg-type]
+    results = remove_default_schema_routes(http_routes, api_config)  # type: ignore[arg-type]
     assert len(results) == 3
     for result in results:
         words = re.split(r"(^\/[a-z]+)", result.path)
@@ -603,7 +441,7 @@ def test_remove_routes_with_patterns() -> None:
         http_routes.append(http_route)
 
     patterns = ("/destroy", "/pizza", "[]")
-    results = _utils.remove_routes_with_patterns(http_routes, patterns)  # type: ignore[arg-type]
+    results = remove_routes_with_patterns(http_routes, patterns)  # type: ignore[arg-type]
     paths = [route.path for route in results]
     assert len(paths) == 2
     for route in ["/", "/foo"]:

--- a/tests/unit/test_handlers/test_websocket_handlers/test_validations.py
+++ b/tests/unit/test_handlers/test_websocket_handlers/test_validations.py
@@ -34,7 +34,8 @@ def test_raises_when_sync_handler_user() -> None:
     with pytest.raises(ImproperlyConfiguredException):
 
         @websocket(path="/")  # type: ignore[arg-type]
-        def sync_websocket_handler(socket: WebSocket) -> None: ...
+        def sync_websocket_handler(socket: WebSocket) -> None:
+            ...
 
         sync_websocket_handler.on_registration(Litestar())
 
@@ -43,7 +44,8 @@ def test_raises_when_data_kwarg_is_used() -> None:
     with pytest.raises(ImproperlyConfiguredException):
 
         @websocket(path="/")
-        async def websocket_handler_with_data_kwarg(socket: WebSocket, data: Any) -> None: ...
+        async def websocket_handler_with_data_kwarg(socket: WebSocket, data: Any) -> None:
+            ...
 
         websocket_handler_with_data_kwarg.on_registration(Litestar())
 
@@ -52,7 +54,8 @@ def test_raises_when_request_kwarg_is_used() -> None:
     with pytest.raises(ImproperlyConfiguredException):
 
         @websocket(path="/")
-        async def websocket_handler_with_request_kwarg(socket: WebSocket, request: Any) -> None: ...
+        async def websocket_handler_with_request_kwarg(socket: WebSocket, request: Any) -> None:
+            ...
 
         websocket_handler_with_request_kwarg.on_registration(Litestar())
 
@@ -61,6 +64,7 @@ def test_raises_when_body_kwarg_is_used() -> None:
     with pytest.raises(ImproperlyConfiguredException):
 
         @websocket(path="/")
-        async def websocket_handler_with_request_kwarg(socket: WebSocket, body: bytes) -> None: ...
+        async def websocket_handler_with_request_kwarg(socket: WebSocket, body: bytes) -> None:
+            ...
 
         websocket_handler_with_request_kwarg.on_registration(Litestar())

--- a/tests/unit/test_openapi/test_request_body.py
+++ b/tests/unit/test_openapi/test_request_body.py
@@ -157,5 +157,5 @@ def test_example_in_request_body_schema_generation() -> None:
     schema = app.openapi_schema.to_schema()
 
     assert schema["paths"]["/example"]["post"]["requestBody"]["content"]["application/json"]["examples"] == {
-        "example": {"summary": "example", "value": {"name": "John", "age": 30}}
+        "data-example-1": {"summary": "example", "value": {"name": "John", "age": 30}}
     }

--- a/tests/unit/test_openapi/test_request_body.py
+++ b/tests/unit/test_openapi/test_request_body.py
@@ -48,7 +48,7 @@ def create_request(openapi_context: OpenAPIContext) -> RequestBodyFactory:
 
 def test_create_request_body(person_controller: Type[Controller], create_request: RequestBodyFactory) -> None:
     for route in Litestar(route_handlers=[person_controller]).routes:
-        for route_handler, _ in route.route_handler_map.values():  # type: ignore
+        for route_handler, _ in route.route_handler_map.values():  # type: ignore[union-attr]
             handler_fields = route_handler.parsed_fn_signature.parameters
             if "data" in handler_fields:
                 request_body = create_request(route_handler, handler_fields["data"])

--- a/tests/unit/test_openapi/test_request_body.py
+++ b/tests/unit/test_openapi/test_request_body.py
@@ -48,7 +48,7 @@ def create_request(openapi_context: OpenAPIContext) -> RequestBodyFactory:
 
 def test_create_request_body(person_controller: Type[Controller], create_request: RequestBodyFactory) -> None:
     for route in Litestar(route_handlers=[person_controller]).routes:
-        for route_handler, _ in route.route_handler_map.values():  # type: ignore[union-attr]
+        for route_handler, _ in route.route_handler_map.values():  # type: ignore
             handler_fields = route_handler.parsed_fn_signature.parameters
             if "data" in handler_fields:
                 request_body = create_request(route_handler, handler_fields["data"])
@@ -157,5 +157,5 @@ def test_example_in_request_body_schema_generation() -> None:
     schema = app.openapi_schema.to_schema()
 
     assert schema["paths"]["/example"]["post"]["requestBody"]["content"]["application/json"]["examples"] == {
-        "data-example-1": {"summary": "example", "value": {"name": "John", "age": 30}}
+        "example": {"summary": "example", "value": {"name": "John", "age": 30}}
     }

--- a/tests/unit/test_openapi/test_request_body.py
+++ b/tests/unit/test_openapi/test_request_body.py
@@ -1,18 +1,17 @@
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Type
-from unittest.mock import ANY, MagicMock
+from typing import Callable, Dict, List, Type
 
 import pytest
+from typing_extensions import Annotated
 
 from litestar import Controller, Litestar, post
 from litestar._openapi.datastructures import OpenAPIContext
 from litestar._openapi.request_body import create_request_body
 from litestar.datastructures.upload_file import UploadFile
-from litestar.dto import AbstractDTO
 from litestar.enums import RequestEncodingType
 from litestar.handlers import BaseRouteHandler
 from litestar.openapi.config import OpenAPIConfig
-from litestar.openapi.spec import RequestBody
+from litestar.openapi.spec import Example, RequestBody
 from litestar.params import Body
 from litestar.typing import FieldDefinition
 
@@ -142,16 +141,21 @@ def test_upload_file_model_schema_generation() -> None:
     }
 
 
-def test_request_body_generation_with_dto(create_request: RequestBodyFactory) -> None:
-    mock_dto = MagicMock(spec=AbstractDTO)
+def test_example_in_request_body_schema_generation() -> None:
+    @dataclass
+    class SampleClass:
+        name: str
+        age: int
 
-    @post(path="/form-upload", dto=mock_dto)  # pyright: ignore
-    async def handler(data: Dict[str, Any]) -> None:
+    @post(path="/example")
+    async def handler(
+        data: Annotated[SampleClass, Body(examples=[Example(summary="example", value={"name": "John", "age": 30})])],
+    ) -> None:
         return None
 
-    Litestar(route_handlers=[handler])
-    field_definition = FieldDefinition.from_annotation(Dict[str, Any])
-    create_request(handler, field_definition)
-    mock_dto.create_openapi_schema.assert_called_once_with(
-        field_definition=field_definition, handler_id=handler.handler_id, schema_creator=ANY
-    )
+    app = Litestar([handler])
+    schema = app.openapi_schema.to_schema()
+
+    assert schema["paths"]["/example"]["post"]["requestBody"]["content"]["application/json"]["examples"] == {
+        "example": {"summary": "example", "value": {"name": "John", "age": 30}}
+    }

--- a/tests/unit/test_response/test_type_decoders.py
+++ b/tests/unit/test_response/test_type_decoders.py
@@ -24,10 +24,12 @@ def controller() -> Type[Controller]:
         type_decoders = [controller_decoder]
 
         @get("/http", type_decoders=[handler_decoder])
-        def http(self) -> Any: ...
+        def http(self) -> Any:
+            ...
 
         @websocket_listener("/ws", type_decoders=[handler_decoder])
-        async def handler(self, data: str) -> None: ...
+        async def handler(self, data: str) -> None:
+            ...
 
     return MyController
 
@@ -47,7 +49,8 @@ def websocket_listener_handler() -> Type[WebsocketListener]:
 @pytest.fixture(scope="module")
 def http_handler() -> HTTPRouteHandler:
     @get("/http", type_decoders=[handler_decoder])
-    def http() -> Any: ...
+    def http() -> Any:
+        ...
 
     return http
 
@@ -55,7 +58,8 @@ def http_handler() -> HTTPRouteHandler:
 @pytest.fixture(scope="module")
 def websocket_handler() -> WebsocketListenerRouteHandler:
     @websocket_listener("/ws", type_decoders=[handler_decoder])
-    async def websocket(data: str) -> None: ...
+    async def websocket(data: str) -> None:
+        ...
 
     return websocket
 


### PR DESCRIPTION
## Description

- Passes examples given within the FieldDefinition to the OpenAPIMediaType

```python
@post(media_type=MediaType.TEXT)
def create_person(
    self, data: Annotated[DataclassPerson, Body(examples=[Example(summary="this is an example", value={"key": "value"})])], secret_header: str = Parameter(header="secret")
) -> DataclassPerson:
    return data
```


![image](https://github.com/litestar-org/litestar/assets/38849824/4e808407-efc2-454e-afa0-5b1e2560838a)

## Fixes

Fixes #3076
