### PR TITLE
fix: pass cache control header for static files

### DIFF
--- a/litestar/static_files/base.py
+++ b/litestar/static_files/base.py
@@ -14,7 +14,6 @@ __all__ = ("StaticFiles",)
 
 
 if TYPE_CHECKING:
-    from litestar.datastructures.headers import CacheControlHeader
     from litestar.types import Receive, Scope, Send
     from litestar.types.composite_types import PathType
     from litestar.types.file_types import FileInfo, FileSystemProtocol
@@ -32,7 +31,7 @@ class StaticFiles:
         file_system: FileSystemProtocol,
         send_as_attachment: bool = False,
         resolve_symlinks: bool = True,
-        cache_control: CacheControlHeader | None = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         """Initialize the Application.
 
@@ -43,16 +42,13 @@ class StaticFiles:
             send_as_attachment: Whether to send the file with a ``content-disposition`` header of
              ``attachment`` or ``inline``
             resolve_symlinks: Resolve symlinks to the directories
-            cache_control: ``cache_control`` header set on the response
+            headers: Headers that will be sent with every response.
         """
         self.adapter = FileSystemAdapter(file_system)
         self.directories = tuple(Path(p).resolve() if resolve_symlinks else Path(p) for p in directories)
         self.is_html_mode = is_html_mode
         self.send_as_attachment = send_as_attachment
-        self.headers: dict[str, str] | None = None
-
-        if cache_control:
-            self.headers = {"cache-control": cache_control.to_header()}
+        self.headers = headers
 
     async def get_fs_info(
         self, directories: Sequence[PathType], file_path: PathType

--- a/litestar/static_files/config.py
+++ b/litestar/static_files/config.py
@@ -168,6 +168,7 @@ def create_static_files_router(
         file_system=file_system,
         send_as_attachment=send_as_attachment,
         resolve_symlinks=resolve_symlinks,
+        cache_control=cache_control,
     )
 
     @get("{file_path:path}", name=name)

--- a/litestar/static_files/config.py
+++ b/litestar/static_files/config.py
@@ -162,13 +162,17 @@ def create_static_files_router(
     _validate_config(path=path, directories=directories, file_system=file_system)
     path = normalize_path(path)
 
+    headers = None
+    if cache_control:
+        headers = {cache_control.HEADER_NAME: cache_control.to_header()}
+
     static_files = StaticFiles(
         is_html_mode=html_mode,
         directories=directories,
         file_system=file_system,
         send_as_attachment=send_as_attachment,
         resolve_symlinks=resolve_symlinks,
-        cache_control=cache_control,
+        headers=headers,
     )
 
     @get("{file_path:path}", name=name)


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

The `cache_control` that is set on a router created by `create_static_files_router` isn't considered because the return type of the handler function is an async callable so the resolved headers are ignored [here](https://github.com/litestar-org/litestar/blob/3e5c179e714bb074bae13e02d10e2f3f51e24d5c/litestar/handlers/http_handlers/base.py#L489-L492). As a workaround, the cache control header is resolved and passed directly to the `ASGIFileResponse`.

It may have been better for the `StaticFiles.handle` to return a `File` response so that this would be handled as per our normal flow and there would be no need for special casing here. This would also allow the users to provide any headers/cookies they might want to attach to the router. However, this would be a breaking change and this could be a change considered for the next major version.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
Fixes #3129