### PR TITLE
fix: Unique schema names for nested models (#3134)

### DIFF
--- a/litestar/dto/_backend.py
+++ b/litestar/dto/_backend.py
@@ -406,6 +406,8 @@ class DTOBackend:
             if nested_depth == self.dto_factory.config.max_nested_depth:
                 raise RecursionError
 
+            unique_name = f"{unique_name}{field_definition.raw.__name__}"
+
             nested_field_definitions = self.parse_model(
                 model_type=field_definition.annotation,
                 exclude=exclude,

--- a/tests/unit/test_dto/test_factory/test_backends/test_backends.py
+++ b/tests/unit/test_dto/test_factory/test_backends/test_backends.py
@@ -197,6 +197,7 @@ def test_backend_create_openapi_schema(dto_factory: type[DataclassDTO]) -> None:
     schemas = creator.schema_registry.generate_components_schemas()
     assert isinstance(ref, Reference)
     schema = schemas[ref.value]
+    assert schema.title == "HandlerDCResponseBody"
     assert schema.properties is not None
     a, b, c = schema.properties["a"], schema.properties["b"], schema.properties["c"]
     assert isinstance(a, Schema)
@@ -209,6 +210,7 @@ def test_backend_create_openapi_schema(dto_factory: type[DataclassDTO]) -> None:
     assert c.items.type == "integer"
     assert isinstance(nested := schema.properties["nested"], Reference)  # noqa: RUF018
     nested_schema = schemas[nested.value]
+    assert nested_schema.title == "HandlerDCNestedDCResponseBody"
     assert nested_schema.properties is not None
     nested_a, nested_b = nested_schema.properties["a"], nested_schema.properties["b"]
     assert isinstance(nested_a, Schema)


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- After confirming its a nested model and not past the max_nested_depth, append the nested model's name to the unique_name for a name different from the parent. 

I'm unsure if this is the best place or way to handle this. It will change the schema title for all nested models. 

Before this patch, the MCVE of #3134 would give the following response schemas.
1. app.get_logsLogfileResponseBody
2. GetLogsLogfileResponseBody
3. GetUsersUserResponseBody
4. GetUsersUser_0ResponseBody

After this patch, it would give the follow.
1. GetLogsLogfileResponseBody
2. GetLogsLogfileUserResponseBody
3. GetUsersUserResponseBody
4. GetUsersUser_0LogfileResponseBody

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Closes #3134