### PR TITLE
fix: adjust spacing in deprecation warning

### DIFF
--- a/litestar/utils/scope/__init__.py
+++ b/litestar/utils/scope/__init__.py
@@ -55,7 +55,8 @@ def __getattr__(name: str) -> Any:
             version="2.4",
             kind="import",
             removal_in="3.0",
-            info=f"'litestar.utils.scope.{name}' is deprecated. The Litestar scope state is private and should not be used. Plugin authors should maintain their own scope state namespace.",
+            info=f"'litestar.utils.scope.{name}' is deprecated. The Litestar scope state is private and should not be "
+            f"used. Plugin authors should maintain their own scope state namespace.",
         )
         return globals()["_deprecated_names"][name]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")  # pragma: no cover

--- a/litestar/utils/scope/__init__.py
+++ b/litestar/utils/scope/__init__.py
@@ -55,8 +55,7 @@ def __getattr__(name: str) -> Any:
             version="2.4",
             kind="import",
             removal_in="3.0",
-            info=f"'litestar.utils.scope.{name}' is deprecated. The Litestar scope state is private and should not be used."
-            "Plugin authors should maintain their own scope state namespace.",
+            info=f"'litestar.utils.scope.{name}' is deprecated. The Litestar scope state is private and should not be used. Plugin authors should maintain their own scope state namespace.",
         )
         return globals()["_deprecated_names"][name]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")  # pragma: no cover


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- When using the scope utils the messaging is missing a space

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
