### PR TITLE
fix(OpenAPI): Schema generation for Pydantic v2 constrained secrets

### DIFF
--- a/litestar/contrib/pydantic/pydantic_schema_plugin.py
+++ b/litestar/contrib/pydantic/pydantic_schema_plugin.py
@@ -142,6 +142,8 @@ PYDANTIC_TYPE_MAP: dict[type[Any] | None | Any, Schema] = {
 if pydantic_v2 is not None:  # pragma: no cover
     PYDANTIC_TYPE_MAP.update(
         {
+            pydantic_v2.SecretStr: Schema(type=OpenAPIType.STRING),
+            pydantic_v2.SecretBytes: Schema(type=OpenAPIType.STRING),
             pydantic_v2.ByteSize: Schema(type=OpenAPIType.INTEGER),
             pydantic_v2.EmailStr: Schema(type=OpenAPIType.STRING, format=OpenAPIFormat.EMAIL),
             pydantic_v2.IPvAnyAddress: Schema(

--- a/tests/unit/test_contrib/test_pydantic/test_schema_plugin.py
+++ b/tests/unit/test_contrib/test_pydantic/test_schema_plugin.py
@@ -8,6 +8,7 @@ from pydantic import v1 as pydantic_v1
 from pydantic.v1.generics import GenericModel
 from typing_extensions import Annotated
 
+from litestar._openapi.schema_generation import SchemaCreator
 from litestar.contrib.pydantic.pydantic_schema_plugin import PydanticSchemaPlugin
 from litestar.openapi.spec import OpenAPIType
 from litestar.openapi.spec.schema import Schema
@@ -65,3 +66,17 @@ def test_schema_generation_with_generic_classes(model: Type[Union[PydanticV1Gene
 )
 def test_is_pydantic_constrained_field(constrained: Any) -> None:
     PydanticSchemaPlugin.is_constrained_field(FieldDefinition.from_annotation(constrained))
+
+
+def test_v2_constrained_secrets() -> None:
+    # https://github.com/litestar-org/litestar/issues/3148
+    class Model(pydantic_v2.BaseModel):
+        string: pydantic_v2.SecretStr = pydantic_v2.Field(min_length=1)
+        bytes_: pydantic_v2.SecretBytes = pydantic_v2.Field(min_length=1)
+
+    schema = PydanticSchemaPlugin.for_pydantic_model(
+        FieldDefinition.from_annotation(Model), schema_creator=SchemaCreator(plugins=[PydanticSchemaPlugin()])
+    )
+    assert schema.properties
+    assert schema.properties["string"] == Schema(min_length=1, type=OpenAPIType.STRING)
+    assert schema.properties["bytes_"] == Schema(min_length=1, type=OpenAPIType.STRING)


### PR DESCRIPTION
Fix schema generation for `pydantic.SecretStr` and `pydantic.SecretBytes` which, when constrained, would not be recognised as such with Pydantic V2 since they're not subtypes of their respective bases anymore.

Closes #3148.
