### PR TITLE
fix(pydantic): OpenAPI schema generation for Pydantic private attributes (#3150)

### DIFF
--- a/litestar/contrib/pydantic/pydantic_schema_plugin.py
+++ b/litestar/contrib/pydantic/pydantic_schema_plugin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 from typing_extensions import Annotated
 
@@ -11,14 +11,15 @@ from litestar.contrib.pydantic.utils import (
     is_pydantic_constrained_field,
     is_pydantic_model_class,
     is_pydantic_undefined,
-    pydantic_get_unwrapped_annotation_and_type_hints,
+    pydantic_get_type_hints_with_generics_resolved,
+    pydantic_unwrap_and_get_origin,
 )
 from litestar.exceptions import MissingDependencyException
 from litestar.openapi.spec import Example, OpenAPIFormat, OpenAPIType, Schema
 from litestar.plugins import OpenAPISchemaPlugin
 from litestar.types import Empty
 from litestar.typing import FieldDefinition
-from litestar.utils import is_class_and_subclass
+from litestar.utils import is_class_and_subclass, is_generic
 
 try:
     # check if we have pydantic v2 installed, and try to import both versions
@@ -249,17 +250,22 @@ class PydanticSchemaPlugin(OpenAPISchemaPlugin):
         """
 
         annotation = field_definition.annotation
-        unwrapped_annotation, annotation_hints = pydantic_get_unwrapped_annotation_and_type_hints(annotation)
+        if is_generic(annotation):
+            is_generic_model = True
+            model = pydantic_unwrap_and_get_origin(annotation) or annotation
+        else:
+            is_generic_model = False
+            model = annotation
 
-        if is_pydantic_2_model(annotation):
-            model_config = annotation.model_config
-            model_field_info = unwrapped_annotation.model_fields
+        if is_pydantic_2_model(model):
+            model_config = model.model_config
+            model_field_info = model.model_fields
             title = model_config.get("title")
             example = model_config.get("example")
             is_v2_model = True
         else:
             model_config = annotation.__config__
-            model_field_info = unwrapped_annotation.__fields__
+            model_field_info = model.__fields__
             title = getattr(model_config, "title", None)
             example = getattr(model_config, "example", None)
             is_v2_model = False
@@ -268,15 +274,34 @@ class PydanticSchemaPlugin(OpenAPISchemaPlugin):
             k: getattr(f, "field_info", f) for k, f in model_field_info.items()
         }
 
-        property_fields = {
-            f.alias if f.alias and schema_creator.prefer_alias else k: FieldDefinition.from_kwarg(
-                annotation=Annotated[annotation_hints[k], f, f.metadata]  # type: ignore[union-attr]
-                if is_v2_model
-                else Annotated[annotation_hints[k], f],  # pyright: ignore
-                name=f.alias if f.alias and schema_creator.prefer_alias else k,
-                default=Empty if schema_creator.is_undefined(f.default) else f.default,
+        if is_v2_model:
+            # extract the annotations from the FieldInfo. This allows us to skip fields
+            # which have been marked as private
+            model_annotations = {k: field_info.annotation for k, field_info in model_fields.items()}  # type: ignore[union-attr]
+
+        else:
+            # pydantic v1 requires some workarounds here
+            model_annotations = {
+                k: f.outer_type_ if f.required else Optional[f.outer_type_] for k, f in model.__fields__.items()
+            }
+
+        if is_generic_model:
+            # if the model is generic, resolve the type variables. We pass in the
+            # already extracted annotations, to keep the logic of respecting private
+            # fields consistent with the above
+            model_annotations = pydantic_get_type_hints_with_generics_resolved(
+                annotation, model_annotations=model_annotations, include_extras=True
             )
-            for k, f in model_fields.items()
+
+        property_fields = {
+            field_info.alias if field_info.alias and schema_creator.prefer_alias else k: FieldDefinition.from_kwarg(
+                annotation=Annotated[model_annotations[k], field_info, field_info.metadata]  # type: ignore[union-attr]
+                if is_v2_model
+                else Annotated[model_annotations[k], field_info],  # pyright: ignore
+                name=field_info.alias if field_info.alias and schema_creator.prefer_alias else k,
+                default=Empty if schema_creator.is_undefined(field_info.default) else field_info.default,
+            )
+            for k, field_info in model_fields.items()
         }
 
         computed_field_definitions = create_field_definitions_for_computed_fields(

--- a/litestar/contrib/pydantic/utils.py
+++ b/litestar/contrib/pydantic/utils.py
@@ -136,7 +136,7 @@ def pydantic_get_type_hints_with_generics_resolved(
 
     origin = pydantic_unwrap_and_get_origin(annotation)
     if origin is None:
-        if model_annotations is None:
+        if model_annotations is None:  # pragma: no cover
             model_annotations = get_type_hints(
                 annotation, globalns=globalns, localns=localns, include_extras=include_extras
             )

--- a/litestar/contrib/pydantic/utils.py
+++ b/litestar/contrib/pydantic/utils.py
@@ -8,7 +8,7 @@ from typing_extensions import Annotated, get_type_hints
 from litestar.params import KwargDefinition
 from litestar.types import Empty
 from litestar.typing import FieldDefinition
-from litestar.utils import is_class_and_subclass
+from litestar.utils import deprecated, is_class_and_subclass
 from litestar.utils.predicates import is_generic
 from litestar.utils.typing import (
     _substitute_typevars,
@@ -153,7 +153,8 @@ def pydantic_get_type_hints_with_generics_resolved(
     return {n: _substitute_typevars(type_, typevar_map) for n, type_ in model_annotations.items()}
 
 
-def pydantic_get_unwrapped_annotation_and_type_hints(annotation: Any) -> tuple[Any, dict[str, Any]]:
+@deprecated(version="2.6.2")
+def pydantic_get_unwrapped_annotation_and_type_hints(annotation: Any) -> tuple[Any, dict[str, Any]]:  # pragma:  pver
     """Get the unwrapped annotation and the type hints after resolving generics.
 
     Args:
@@ -167,12 +168,6 @@ def pydantic_get_unwrapped_annotation_and_type_hints(annotation: Any) -> tuple[A
         origin = pydantic_unwrap_and_get_origin(annotation)
         return origin or annotation, pydantic_get_type_hints_with_generics_resolved(annotation, include_extras=True)
     return annotation, get_type_hints(annotation, include_extras=True)
-
-
-def get_unwrapped_model_from_annotation(annotation: Any) -> Any:
-    if is_generic(annotation):
-        return pydantic_unwrap_and_get_origin(annotation) or annotation
-    return annotation
 
 
 def is_pydantic_2_model(

--- a/tests/unit/test_contrib/test_pydantic/models.py
+++ b/tests/unit/test_contrib/test_pydantic/models.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel
 from pydantic.dataclasses import dataclass as pydantic_dataclass
@@ -15,6 +15,7 @@ class PydanticDataclassPerson:
     id: str
     optional: Optional[str]
     complex: Dict[str, List[Dict[str, str]]]
+    union: Union[int, List[str]]
     pets: Optional[List[DataclassPet]] = None
 
 
@@ -24,6 +25,7 @@ class PydanticPerson(BaseModel):
     id: str
     optional: Optional[str]
     complex: Dict[str, List[Dict[str, str]]]
+    union: Union[int, List[str]]
     pets: Optional[List[DataclassPet]] = None
 
 
@@ -33,6 +35,7 @@ class PydanticV1Person(BaseModelV1):
     id: str
     optional: Optional[str]
     complex: Dict[str, List[Dict[str, str]]]
+    union: Union[int, List[str]]
     pets: Optional[List[DataclassPet]] = None
 
 
@@ -43,4 +46,5 @@ class PydanticV1DataclassPerson:
     id: str
     optional: Optional[str]
     complex: Dict[str, List[Dict[str, str]]]
+    union: Union[int, List[str]]
     pets: Optional[List[DataclassPet]] = None

--- a/tests/unit/test_contrib/test_pydantic/test_integration.py
+++ b/tests/unit/test_contrib/test_pydantic/test_integration.py
@@ -98,7 +98,7 @@ def test_default_error_handling() -> None:
         response = client.post("/123", json={"first_name": "moishe"})
         extra = response.json().get("extra")
         assert extra is not None
-        assert len(extra) == 4
+        assert len(extra) == 5
 
 
 def test_default_error_handling_v1() -> None:
@@ -110,7 +110,7 @@ def test_default_error_handling_v1() -> None:
         response = client.post("/123", json={"first_name": "moishe"})
         extra = response.json().get("extra")
         assert extra is not None
-        assert len(extra) == 3
+        assert len(extra) == 4
 
 
 def test_signature_model_invalid_input(
@@ -172,3 +172,35 @@ def test_signature_model_invalid_input(
                     "key": "other_child.val.1",
                 },
             ]
+
+
+class V1ModelWithPrivateFields(pydantic_v1.BaseModel):
+    class Config:
+        underscore_fields_are_private = True
+
+    _field: str = pydantic_v1.PrivateAttr()
+    # include an invalid annotation here to ensure we never touch those fields
+    _underscore_field: "foo"  # noqa: F821
+    bar: str
+
+
+class V2ModelWithPrivateFields(pydantic_v2.BaseModel):
+    class Config:
+        underscore_fields_are_private = True
+
+    _field: str = pydantic_v2.PrivateAttr()
+    # include an invalid annotation here to ensure we never touch those fields
+    _underscore_field: "foo"  # noqa: F821
+    bar: str
+
+
+@pytest.mark.parametrize("model_type", [V1ModelWithPrivateFields, V2ModelWithPrivateFields])
+def test_private_fields(model_type: Type[Union[pydantic_v1.BaseModel, pydantic_v2.BaseModel]]) -> None:
+    @post("/")
+    async def handler(data: V2ModelWithPrivateFields) -> V2ModelWithPrivateFields:
+        return data
+
+    with create_test_client([handler]) as client:
+        res = client.post("/", json={"bar": "value"})
+        assert res.status_code == 201
+        assert res.json() == {"bar": "value"}

--- a/tests/unit/test_contrib/test_pydantic/test_integration.py
+++ b/tests/unit/test_contrib/test_pydantic/test_integration.py
@@ -180,7 +180,7 @@ class V1ModelWithPrivateFields(pydantic_v1.BaseModel):
 
     _field: str = pydantic_v1.PrivateAttr()
     # include an invalid annotation here to ensure we never touch those fields
-    _underscore_field: "foo"  # noqa: F821
+    _underscore_field: "foo"  # type: ignore[name-defined] # noqa: F821
     bar: str
 
 
@@ -190,7 +190,7 @@ class V2ModelWithPrivateFields(pydantic_v2.BaseModel):
 
     _field: str = pydantic_v2.PrivateAttr()
     # include an invalid annotation here to ensure we never touch those fields
-    _underscore_field: "foo"  # noqa: F821
+    _underscore_field: "foo"  # type: ignore[name-defined] # noqa: F821
     bar: str
 
 

--- a/tests/unit/test_contrib/test_pydantic/test_openapi.py
+++ b/tests/unit/test_contrib/test_pydantic/test_openapi.py
@@ -346,6 +346,7 @@ def test_spec_generation(cls: Any) -> None:
                         "items": {"type": "object", "additionalProperties": {"type": "string"}},
                     },
                 },
+                "union": {"oneOf": [{"type": "integer"}, {"items": {"type": "string"}, "type": "array"}]},
                 "pets": {
                     "oneOf": [
                         {"type": "null"},
@@ -357,7 +358,7 @@ def test_spec_generation(cls: Any) -> None:
                 },
             },
             "type": "object",
-            "required": ["complex", "first_name", "id", "last_name"],
+            "required": ["complex", "first_name", "id", "last_name", "union"],
             "title": f"{cls.__name__}",
         }
 
@@ -561,7 +562,7 @@ def test_create_schema_for_pydantic_model_with_annotated_model_attribute(
         f"""
 {'from __future__ import annotations' if with_future_annotations else ''}
 from typing_extensions import Annotated
-{'from pydantic import BaseModel' if pydantic_version == 'v1' else 'from pydantic.v1 import BaseModel'}
+{'from pydantic import BaseModel' if pydantic_version == 'v2' else 'from pydantic.v1 import BaseModel'}
 
 class Foo(BaseModel):
     foo: Annotated[int, "Foo description"]

--- a/tests/unit/test_contrib/test_pydantic/test_schema_plugin.py
+++ b/tests/unit/test_contrib/test_pydantic/test_schema_plugin.py
@@ -88,7 +88,7 @@ class V1ModelWithPrivateFields(pydantic_v1.BaseModel):
 
     _field: str = pydantic_v1.PrivateAttr()
     # include an invalid annotation here to ensure we never touch those fields
-    _underscore_field: "foo"  # noqa: F821
+    _underscore_field: "foo"  # type: ignore[name-defined]  # noqa: F821
 
 
 class V2ModelWithPrivateFields(pydantic_v2.BaseModel):
@@ -97,7 +97,7 @@ class V2ModelWithPrivateFields(pydantic_v2.BaseModel):
 
     _field: str = pydantic_v2.PrivateAttr()
     # include an invalid annotation here to ensure we never touch those fields
-    _underscore_field: "foo"  # noqa: F821
+    _underscore_field: "foo"  # type: ignore[name-defined] # noqa: F821
 
 
 @pytest.mark.parametrize("model_class", [V1ModelWithPrivateFields, V2ModelWithPrivateFields])


### PR DESCRIPTION
Fix a bug that caused a `NameError` when trying to resolve forward references in Pydantic private fields. 

Although we respected private fields in Pydantic and didn't include them in the schema, we still tried to extract their type annotation. This was fixed by not relying on `typing.get_type_hints` to get the type information, but instead using Pydantic's own APIs, allowing us to only extract information about the types of fields we're interested in.

Fixes #3150.
