### PR TITLE
feat: Add `type_decoders` Router and route handlers

### DIFF
--- a/litestar/app.py
+++ b/litestar/app.py
@@ -216,8 +216,8 @@ class Litestar(Router):
         stores: StoreRegistry | dict[str, Store] | None = None,
         tags: Sequence[str] | None = None,
         template_config: TemplateConfigType | None = None,
-        type_encoders: TypeEncodersMap | None = None,
         type_decoders: TypeDecodersSequence | None = None,
+        type_encoders: TypeEncodersMap | None = None,
         websocket_class: type[WebSocket] | None = None,
         lifespan: Sequence[Callable[[Litestar], AbstractAsyncContextManager] | AbstractAsyncContextManager]
         | None = None,
@@ -308,9 +308,9 @@ class Litestar(Router):
             tags: A sequence of string tags that will be appended to the schema of all route handlers under the
                 application.
             template_config: An instance of :class:`TemplateConfig <.template.TemplateConfig>`
-            type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             type_decoders: A sequence of tuples, each composed of a predicate testing for type identity and a msgspec
                 hook for deserialization.
+            type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             websocket_class: An optional subclass of :class:`WebSocket <.connection.WebSocket>` to use for websocket
                 connections.
             experimental_features: An iterable of experimental features to enable

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
     from litestar.openapi.datastructures import ResponseSpec
     from litestar.openapi.spec import SecurityRequirement
     from litestar.types.callable_types import AsyncAnyCallable, OperationIDCreator
+    from litestar.types.composite_types import TypeDecodersSequence
 
 __all__ = ("HTTPRouteHandler", "route")
 
@@ -157,6 +158,7 @@ class HTTPRouteHandler(BaseRouteHandler):
         security: Sequence[SecurityRequirement] | None = None,
         summary: str | None = None,
         tags: Sequence[str] | None = None,
+        type_decoders: TypeDecodersSequence | None = None,
         type_encoders: TypeEncodersMap | None = None,
         **kwargs: Any,
     ) -> None:
@@ -228,6 +230,7 @@ class HTTPRouteHandler(BaseRouteHandler):
             security: A sequence of dictionaries that contain information about which security scheme can be used on the endpoint.
             summary: Text used for the route's schema summary section.
             tags: A sequence of string tags that will be appended to the OpenAPI schema.
+            type_decoders: A sequence of tuples, each composed of a predicate testing for type identity and a msgspec hook for deserialization.
             type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             **kwargs: Any additional kwarg - will be set in the opt dictionary.
         """
@@ -248,6 +251,7 @@ class HTTPRouteHandler(BaseRouteHandler):
             opt=opt,
             return_dto=return_dto,
             signature_namespace=signature_namespace,
+            type_decoders=type_decoders,
             type_encoders=type_encoders,
             **kwargs,
         )

--- a/litestar/handlers/http_handlers/decorators.py
+++ b/litestar/handlers/http_handlers/decorators.py
@@ -6,8 +6,8 @@ from litestar.enums import HttpMethod, MediaType
 from litestar.exceptions import HTTPException, ImproperlyConfiguredException
 from litestar.openapi.spec import Operation
 from litestar.response.file import ASGIFileResponse, File
+from litestar.types import Empty, TypeDecodersSequence
 from litestar.types.builtin_types import NoneType
-from litestar.types.empty import Empty
 from litestar.utils import is_class_and_subclass
 
 from .base import HTTPRouteHandler
@@ -93,6 +93,7 @@ class delete(HTTPRouteHandler):
         security: Sequence[SecurityRequirement] | None = None,
         summary: str | None = None,
         tags: Sequence[str] | None = None,
+        type_decoders: TypeDecodersSequence | None = None,
         type_encoders: TypeEncodersMap | None = None,
         **kwargs: Any,
     ) -> None:
@@ -163,6 +164,8 @@ class delete(HTTPRouteHandler):
             security: A sequence of dictionaries that contain information about which security scheme can be used on the endpoint.
             summary: Text used for the route's schema summary section.
             tags: A sequence of string tags that will be appended to the OpenAPI schema.
+            type_decoders: A sequence of tuples, each composed of a predicate testing for type identity and a msgspec
+                hook for deserialization.
             type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             **kwargs: Any additional kwarg - will be set in the opt dictionary.
         """
@@ -208,6 +211,7 @@ class delete(HTTPRouteHandler):
             summary=summary,
             sync_to_thread=sync_to_thread,
             tags=tags,
+            type_decoders=type_decoders,
             type_encoders=type_encoders,
             **kwargs,
         )
@@ -261,6 +265,7 @@ class get(HTTPRouteHandler):
         security: Sequence[SecurityRequirement] | None = None,
         summary: str | None = None,
         tags: Sequence[str] | None = None,
+        type_decoders: TypeDecodersSequence | None = None,
         type_encoders: TypeEncodersMap | None = None,
         **kwargs: Any,
     ) -> None:
@@ -331,6 +336,8 @@ class get(HTTPRouteHandler):
             security: A sequence of dictionaries that contain information about which security scheme can be used on the endpoint.
             summary: Text used for the route's schema summary section.
             tags: A sequence of string tags that will be appended to the OpenAPI schema.
+            type_decoders: A sequence of tuples, each composed of a predicate testing for type identity and a msgspec
+                hook for deserialization.
             type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             **kwargs: Any additional kwarg - will be set in the opt dictionary.
         """
@@ -377,6 +384,7 @@ class get(HTTPRouteHandler):
             summary=summary,
             sync_to_thread=sync_to_thread,
             tags=tags,
+            type_decoders=type_decoders,
             type_encoders=type_encoders,
             **kwargs,
         )
@@ -430,6 +438,7 @@ class head(HTTPRouteHandler):
         security: Sequence[SecurityRequirement] | None = None,
         summary: str | None = None,
         tags: Sequence[str] | None = None,
+        type_decoders: TypeDecodersSequence | None = None,
         type_encoders: TypeEncodersMap | None = None,
         **kwargs: Any,
     ) -> None:
@@ -504,6 +513,8 @@ class head(HTTPRouteHandler):
             security: A sequence of dictionaries that contain information about which security scheme can be used on the endpoint.
             summary: Text used for the route's schema summary section.
             tags: A sequence of string tags that will be appended to the OpenAPI schema.
+            type_decoders: A sequence of tuples, each composed of a predicate testing for type identity and a msgspec
+                hook for deserialization.
             type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             **kwargs: Any additional kwarg - will be set in the opt dictionary.
         """
@@ -550,6 +561,7 @@ class head(HTTPRouteHandler):
             summary=summary,
             sync_to_thread=sync_to_thread,
             tags=tags,
+            type_decoders=type_decoders,
             type_encoders=type_encoders,
             **kwargs,
         )
@@ -616,6 +628,7 @@ class patch(HTTPRouteHandler):
         security: Sequence[SecurityRequirement] | None = None,
         summary: str | None = None,
         tags: Sequence[str] | None = None,
+        type_decoders: TypeDecodersSequence | None = None,
         type_encoders: TypeEncodersMap | None = None,
         **kwargs: Any,
     ) -> None:
@@ -686,6 +699,8 @@ class patch(HTTPRouteHandler):
             security: A sequence of dictionaries that contain information about which security scheme can be used on the endpoint.
             summary: Text used for the route's schema summary section.
             tags: A sequence of string tags that will be appended to the OpenAPI schema.
+            type_decoders: A sequence of tuples, each composed of a predicate testing for type identity and a msgspec
+                hook for deserialization.
             type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             **kwargs: Any additional kwarg - will be set in the opt dictionary.
         """
@@ -731,6 +746,7 @@ class patch(HTTPRouteHandler):
             summary=summary,
             sync_to_thread=sync_to_thread,
             tags=tags,
+            type_decoders=type_decoders,
             type_encoders=type_encoders,
             **kwargs,
         )
@@ -784,6 +800,7 @@ class post(HTTPRouteHandler):
         security: Sequence[SecurityRequirement] | None = None,
         summary: str | None = None,
         tags: Sequence[str] | None = None,
+        type_decoders: TypeDecodersSequence | None = None,
         type_encoders: TypeEncodersMap | None = None,
         **kwargs: Any,
     ) -> None:
@@ -854,6 +871,8 @@ class post(HTTPRouteHandler):
             security: A sequence of dictionaries that contain information about which security scheme can be used on the endpoint.
             summary: Text used for the route's schema summary section.
             tags: A sequence of string tags that will be appended to the OpenAPI schema.
+            type_decoders: A sequence of tuples, each composed of a predicate testing for type identity and a msgspec
+                hook for deserialization.
             type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             **kwargs: Any additional kwarg - will be set in the opt dictionary.
         """
@@ -899,6 +918,7 @@ class post(HTTPRouteHandler):
             summary=summary,
             sync_to_thread=sync_to_thread,
             tags=tags,
+            type_decoders=type_decoders,
             type_encoders=type_encoders,
             **kwargs,
         )
@@ -952,6 +972,7 @@ class put(HTTPRouteHandler):
         security: Sequence[SecurityRequirement] | None = None,
         summary: str | None = None,
         tags: Sequence[str] | None = None,
+        type_decoders: TypeDecodersSequence | None = None,
         type_encoders: TypeEncodersMap | None = None,
         **kwargs: Any,
     ) -> None:
@@ -1022,6 +1043,8 @@ class put(HTTPRouteHandler):
             security: A sequence of dictionaries that contain information about which security scheme can be used on the endpoint.
             summary: Text used for the route's schema summary section.
             tags: A sequence of string tags that will be appended to the OpenAPI schema.
+            type_decoders: A sequence of tuples, each composed of a predicate testing for type identity and a msgspec
+                hook for deserialization.
             type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             **kwargs: Any additional kwarg - will be set in the opt dictionary.
         """
@@ -1067,6 +1090,7 @@ class put(HTTPRouteHandler):
             summary=summary,
             sync_to_thread=sync_to_thread,
             tags=tags,
+            type_decoders=type_decoders,
             type_encoders=type_encoders,
             **kwargs,
         )

--- a/litestar/handlers/websocket_handlers/listener.py
+++ b/litestar/handlers/websocket_handlers/listener.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from litestar import Router
     from litestar.dto import AbstractDTO
     from litestar.types.asgi_types import WebSocketMode
+    from litestar.types.composite_types import TypeDecodersSequence
 
 __all__ = ("WebsocketListener", "WebsocketListenerRouteHandler", "websocket_listener")
 
@@ -86,6 +87,7 @@ class WebsocketListenerRouteHandler(WebsocketRouteHandler):
         opt: dict[str, Any] | None = None,
         return_dto: type[AbstractDTO] | None | EmptyType = Empty,
         signature_namespace: Mapping[str, Any] | None = None,
+        type_decoders: TypeDecodersSequence | None = None,
         type_encoders: TypeEncodersMap | None = None,
         websocket_class: type[WebSocket] | None = None,
         **kwargs: Any,
@@ -111,6 +113,7 @@ class WebsocketListenerRouteHandler(WebsocketRouteHandler):
         opt: dict[str, Any] | None = None,
         return_dto: type[AbstractDTO] | None | EmptyType = Empty,
         signature_namespace: Mapping[str, Any] | None = None,
+        type_decoders: TypeDecodersSequence | None = None,
         type_encoders: TypeEncodersMap | None = None,
         websocket_class: type[WebSocket] | None = None,
         **kwargs: Any,
@@ -136,6 +139,7 @@ class WebsocketListenerRouteHandler(WebsocketRouteHandler):
         opt: dict[str, Any] | None = None,
         return_dto: type[AbstractDTO] | None | EmptyType = Empty,
         signature_namespace: Mapping[str, Any] | None = None,
+        type_decoders: TypeDecodersSequence | None = None,
         type_encoders: TypeEncodersMap | None = None,
         websocket_class: type[WebSocket] | None = None,
         **kwargs: Any,
@@ -170,6 +174,8 @@ class WebsocketListenerRouteHandler(WebsocketRouteHandler):
                 outbound response data.
             signature_namespace: A mapping of names to types for use in forward reference resolution during signature
                 modelling.
+            type_decoders: A sequence of tuples, each composed of a predicate testing for type identity and a msgspec
+                hook for deserialization.
             type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             **kwargs: Any additional kwarg - will be set in the opt dictionary.
             websocket_class: A custom subclass of :class:`WebSocket <.connection.WebSocket>` to be used as route handler's
@@ -190,6 +196,7 @@ class WebsocketListenerRouteHandler(WebsocketRouteHandler):
         self.connection_accept_handler = connection_accept_handler
         self.on_accept = ensure_async_callable(on_accept) if on_accept else None
         self.on_disconnect = ensure_async_callable(on_disconnect) if on_disconnect else None
+        self.type_decoders = type_decoders
         self.type_encoders = type_encoders
         self.websocket_class = websocket_class
 

--- a/litestar/router.py
+++ b/litestar/router.py
@@ -76,8 +76,8 @@ class Router:
         "security",
         "signature_namespace",
         "tags",
-        "type_encoders",
         "type_decoders",
+        "type_encoders",
     )
 
     def __init__(
@@ -107,8 +107,8 @@ class Router:
         signature_namespace: Mapping[str, Any] | None = None,
         signature_types: Sequence[Any] | None = None,
         tags: Sequence[str] | None = None,
-        type_encoders: TypeEncodersMap | None = None,
         type_decoders: TypeDecodersSequence | None = None,
+        type_encoders: TypeEncodersMap | None = None,
     ) -> None:
         """Initialize a ``Router``.
 
@@ -159,8 +159,8 @@ class Router:
                 These types will be added to the signature namespace using their ``__name__`` attribute.
             tags: A sequence of string tags that will be appended to the schema of all route handlers under the
                 application.
-            type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             type_decoders: A sequence of tuples, each composed of a predicate testing for type identity and a msgspec hook for deserialization.
+            type_encoders: A mapping of types to callables that transform them into types supported for serialization.
         """
 
         self.after_request = ensure_async_callable(after_request) if after_request else None  # pyright: ignore

--- a/tests/unit/test_response/test_type_decoders.py
+++ b/tests/unit/test_response/test_type_decoders.py
@@ -1,0 +1,24 @@
+from typing import Any
+from unittest import mock
+
+from litestar import Controller, HttpMethod, Litestar, Router, get
+from litestar.datastructures.url import URL
+
+handler_decoder, router_decoder, controller_decoder, app_decoder = 4 * [(lambda t: t is URL, lambda t, v: URL(v))]
+
+
+@mock.patch("litestar.app.Litestar._get_default_plugins", mock.Mock(return_value=[]))
+def test_resolve_type_decoders() -> None:
+    class MyController(Controller):
+        type_decoders = [controller_decoder]
+
+        @get("/", type_decoders=[handler_decoder])
+        def handler(self) -> Any:
+            ...
+
+    router = Router("/router", type_decoders=[router_decoder], route_handlers=[MyController])
+    app = Litestar([router], type_decoders=[app_decoder])
+    route_handler = app.routes[0].route_handler_map[HttpMethod.GET][0]  # type: ignore
+    decoders = route_handler.resolve_type_decoders()
+
+    assert decoders == [app_decoder, router_decoder, controller_decoder, handler_decoder]


### PR DESCRIPTION
## Description

- added `type_decoders` to `__init__` method for handler, routers and decorators to keep consistency with `type_encoders` parameter
- added test  for resolving type decoders

