### PR TITLE
docs: Add missing indentation in custom response

### DIFF
--- a/docs/usage/responses.rst
+++ b/docs/usage/responses.rst
@@ -711,11 +711,11 @@ instances.
 .. admonition:: Layered architecture
     :class: seealso
 
-   Response classes are part of Litestar's layered architecture, which means you can
-   set a response class on every layer of the application. If you have set a response
-   class on multiple layers, the layer closest to the route handler will take precedence.
+    Response classes are part of Litestar's layered architecture, which means you can
+    set a response class on every layer of the application. If you have set a response
+    class on multiple layers, the layer closest to the route handler will take precedence.
 
-   You can read more about this here: :ref:`usage/applications:layered architecture`
+    You can read more about this here: :ref:`usage/applications:layered architecture`
 
 Background Tasks
 ----------------


### PR DESCRIPTION
## Description

- added indentation in custom response documentation

Before:
![image](https://github.com/litestar-org/litestar/assets/35638715/6b391758-26e2-4d7c-8706-e7147e3a6e9b)

After:
![image](https://github.com/litestar-org/litestar/assets/35638715/fdfce6e3-7c39-44f6-8c5d-35ced1aa7f06)
