### PR TITLE
fix(pydantic): Pydantic V1 schema generation for PrivateAttr in GenericModel

### DIFF
--- a/litestar/contrib/pydantic/utils.py
+++ b/litestar/contrib/pydantic/utils.py
@@ -132,7 +132,7 @@ def pydantic_get_type_hints_with_generics_resolved(
     model_annotations: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     if pydantic_v2 is Empty or (pydantic_v1 is not Empty and is_class_and_subclass(annotation, pydantic_v1.BaseModel)):
-        return get_type_hints_with_generics_resolved(annotation)
+        return get_type_hints_with_generics_resolved(annotation, type_hints=model_annotations)
 
     origin = pydantic_unwrap_and_get_origin(annotation)
     if origin is None:

--- a/litestar/utils/typing.py
+++ b/litestar/utils/typing.py
@@ -250,11 +250,11 @@ def get_type_hints_with_generics_resolved(
 
     if origin is None:
         # Implies the generic types have not been specified in the annotation
-        if type_hints is None:
+        if type_hints is None:   # pragma: no cover
             type_hints = get_type_hints(annotation, globalns=globalns, localns=localns, include_extras=include_extras)
         typevar_map = {p: p for p in annotation.__parameters__}
     else:
-        if type_hints is None:
+        if type_hints is None:   # pragma: no cover
             type_hints = get_type_hints(origin, globalns=globalns, localns=localns, include_extras=include_extras)
         # the __parameters__ is only available on the origin itself and not the annotation
         typevar_map = dict(zip(origin.__parameters__, get_args(annotation)))

--- a/litestar/utils/typing.py
+++ b/litestar/utils/typing.py
@@ -235,6 +235,7 @@ def get_type_hints_with_generics_resolved(
     globalns: dict[str, Any] | None = None,
     localns: dict[str, Any] | None = None,
     include_extras: bool = False,
+    type_hints: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Get the type hints for the given object after resolving the generic types as much as possible.
 
@@ -243,15 +244,18 @@ def get_type_hints_with_generics_resolved(
         globalns: The global namespace.
         localns: The local namespace.
         include_extras: A flag indicating whether to include the ``Annotated[T, ...]`` or not.
+        type_hints: Already resolved type hints
     """
     origin = get_origin(annotation)
 
     if origin is None:
         # Implies the generic types have not been specified in the annotation
-        type_hints = get_type_hints(annotation, globalns=globalns, localns=localns, include_extras=include_extras)
+        if type_hints is None:
+            type_hints = get_type_hints(annotation, globalns=globalns, localns=localns, include_extras=include_extras)
         typevar_map = {p: p for p in annotation.__parameters__}
     else:
-        type_hints = get_type_hints(origin, globalns=globalns, localns=localns, include_extras=include_extras)
+        if type_hints is None:
+            type_hints = get_type_hints(origin, globalns=globalns, localns=localns, include_extras=include_extras)
         # the __parameters__ is only available on the origin itself and not the annotation
         typevar_map = dict(zip(origin.__parameters__, get_args(annotation)))
 

--- a/litestar/utils/typing.py
+++ b/litestar/utils/typing.py
@@ -250,11 +250,11 @@ def get_type_hints_with_generics_resolved(
 
     if origin is None:
         # Implies the generic types have not been specified in the annotation
-        if type_hints is None:   # pragma: no cover
+        if type_hints is None:  # pragma: no cover
             type_hints = get_type_hints(annotation, globalns=globalns, localns=localns, include_extras=include_extras)
         typevar_map = {p: p for p in annotation.__parameters__}
     else:
-        if type_hints is None:   # pragma: no cover
+        if type_hints is None:  # pragma: no cover
             type_hints = get_type_hints(origin, globalns=globalns, localns=localns, include_extras=include_extras)
         # the __parameters__ is only available on the origin itself and not the annotation
         typevar_map = dict(zip(origin.__parameters__, get_args(annotation)))

--- a/tests/unit/test_contrib/test_pydantic/test_schema_plugin.py
+++ b/tests/unit/test_contrib/test_pydantic/test_schema_plugin.py
@@ -91,16 +91,36 @@ class V1ModelWithPrivateFields(pydantic_v1.BaseModel):
     _underscore_field: "foo"  # type: ignore[name-defined]  # noqa: F821
 
 
-class V2ModelWithPrivateFields(pydantic_v2.BaseModel):
+class V1GenericModelWithPrivateFields(pydantic_v1.generics.GenericModel, Generic[T]):
     class Config:
         underscore_fields_are_private = True
 
+    _field: str = pydantic_v1.PrivateAttr()
+    # include an invalid annotation here to ensure we never touch those fields
+    _underscore_field: "foo"  # type: ignore[name-defined]  # noqa: F821
+
+
+class V2ModelWithPrivateFields(pydantic_v2.BaseModel):
     _field: str = pydantic_v2.PrivateAttr()
     # include an invalid annotation here to ensure we never touch those fields
     _underscore_field: "foo"  # type: ignore[name-defined] # noqa: F821
 
 
-@pytest.mark.parametrize("model_class", [V1ModelWithPrivateFields, V2ModelWithPrivateFields])
+class V2GenericModelWithPrivateFields(pydantic_v2.BaseModel, Generic[T]):
+    _field: str = pydantic_v2.PrivateAttr()
+    # include an invalid annotation here to ensure we never touch those fields
+    _underscore_field: "foo"  # type: ignore[name-defined] # noqa: F821
+
+
+@pytest.mark.parametrize(
+    "model_class",
+    [
+        V1ModelWithPrivateFields,
+        V1GenericModelWithPrivateFields,
+        V2ModelWithPrivateFields,
+        V2GenericModelWithPrivateFields,
+    ],
+)
 def test_exclude_private_fields(model_class: Type[Union[pydantic_v1.BaseModel, pydantic_v2.BaseModel]]) -> None:
     # https://github.com/litestar-org/litestar/issues/3150
     schema = PydanticSchemaPlugin.for_pydantic_model(

--- a/tests/unit/test_contrib/test_pydantic/test_schema_plugin.py
+++ b/tests/unit/test_contrib/test_pydantic/test_schema_plugin.py
@@ -91,7 +91,7 @@ class V1ModelWithPrivateFields(pydantic_v1.BaseModel):
     _underscore_field: "foo"  # type: ignore[name-defined]  # noqa: F821
 
 
-class V1GenericModelWithPrivateFields(pydantic_v1.generics.GenericModel, Generic[T]):
+class V1GenericModelWithPrivateFields(pydantic_v1.generics.GenericModel, Generic[T]):  # pyright: ignore
     class Config:
         underscore_fields_are_private = True
 


### PR DESCRIPTION
A followup to #3151.

Fixes a bug that caused a `NameError` when a Pydantic V1 `GenericModel` has a private attribute of which the type annotation cannot be resolved at the time of schema generation.

Fix is the same as in #3151, just applied to `GenericModel`.

Closes #3150.