### PR TITLE
feat: Pass `type_decoders` in WebsocketListenerRouteHandler

### DIFF
--- a/litestar/config/app.py
+++ b/litestar/config/app.py
@@ -198,10 +198,10 @@ class AppConfig:
     """A list of string tags that will be appended to the schema of all route handlers under the application."""
     template_config: TemplateConfigType | None = field(default=None)
     """An instance of :class:`TemplateConfig <.template.TemplateConfig>`."""
-    type_encoders: TypeEncodersMap | None = field(default=None)
-    """A mapping of types to callables that transform them into types supported for serialization."""
     type_decoders: TypeDecodersSequence | None = field(default=None)
     """A sequence of tuples, each composed of a predicate testing for type identity and a msgspec hook for deserialization."""
+    type_encoders: TypeEncodersMap | None = field(default=None)
+    """A mapping of types to callables that transform them into types supported for serialization."""
     websocket_class: type[WebSocket] | None = field(default=None)
     """An optional subclass of :class:`WebSocket <.connection.WebSocket>` to use for websocket connections."""
     multipart_form_part_limit: int = field(default=1000)

--- a/litestar/controller.py
+++ b/litestar/controller.py
@@ -157,10 +157,10 @@ class Controller:
 
     These types will be added to the signature namespace using their ``__name__`` attribute.
     """
-    type_encoders: TypeEncodersMap | None
-    """A mapping of types to callables that transform them into types supported for serialization."""
     type_decoders: TypeDecodersSequence | None
     """A sequence of tuples, each composed of a predicate testing for type identity and a msgspec hook for deserialization."""
+    type_encoders: TypeEncodersMap | None
+    """A mapping of types to callables that transform them into types supported for serialization."""
     websocket_class: type[WebSocket] | None
     """A custom subclass of :class:`WebSocket <.connection.WebSocket>` to be used as the default websocket for all route
     handlers under the controller.

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -90,8 +90,8 @@ class BaseRouteHandler:
         return_dto: type[AbstractDTO] | None | EmptyType = Empty,
         signature_namespace: Mapping[str, Any] | None = None,
         signature_types: Sequence[Any] | None = None,
-        type_encoders: TypeEncodersMap | None = None,
         type_decoders: TypeDecodersSequence | None = None,
+        type_encoders: TypeEncodersMap | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize ``HTTPRouteHandler``.
@@ -115,8 +115,8 @@ class BaseRouteHandler:
                 modelling.
             signature_types: A sequence of types for use in forward reference resolution during signature modeling.
                 These types will be added to the signature namespace using their ``__name__`` attribute.
-            type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             type_decoders: A sequence of tuples, each composed of a predicate testing for type identity and a msgspec hook for deserialization.
+            type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             **kwargs: Any additional kwarg - will be set in the opt dictionary.
         """
         self._parsed_fn_signature: ParsedSignature | EmptyType = Empty

--- a/litestar/handlers/websocket_handlers/listener.py
+++ b/litestar/handlers/websocket_handlers/listener.py
@@ -223,6 +223,8 @@ class WebsocketListenerRouteHandler(WebsocketRouteHandler):
             signature_namespace=signature_namespace,
             dto=dto,
             return_dto=return_dto,
+            type_decoders=type_decoders,
+            type_encoders=type_encoders,
             websocket_class=websocket_class,
             **kwargs,
         )
@@ -357,6 +359,11 @@ class WebsocketListener(ABC):
     """
     A mapping of names to types for use in forward reference resolution during signature modelling.
     """
+    type_decoders: TypeDecodersSequence | None = None
+    """
+    type_decoders: A sequence of tuples, each composed of a predicate testing for type identity and a msgspec
+        hook for deserialization.
+    """
     type_encoders: TypeEncodersMap | None = None
     """
     type_encoders: A mapping of types to callables that transform them into types supported for serialization.
@@ -391,6 +398,7 @@ class WebsocketListener(ABC):
             path=self.path,
             return_dto=self.return_dto,
             signature_namespace=self.signature_namespace,
+            type_decoders=self.type_decoders,
             type_encoders=self.type_encoders,
             websocket_class=self.websocket_class,
         )(self.on_receive)

--- a/tests/unit/test_request_class_resolution.py
+++ b/tests/unit/test_request_class_resolution.py
@@ -1,8 +1,9 @@
-from typing import Type, Union
+from typing import Optional, Type
 
 import pytest
 
 from litestar import Controller, HttpMethod, Litestar, Request, Router, get
+from litestar.handlers.http_handlers.base import HTTPRouteHandler
 
 RouterRequest: Type[Request] = type("RouterRequest", (Request,), {})
 ControllerRequest: Type[Request] = type("ControllerRequest", (Request,), {})
@@ -30,10 +31,10 @@ HandlerRequest: Type[Request] = type("HandlerRequest", (Request,), {})
     ),
 )
 def test_request_class_resolution_of_layers(
-    handler_request_class: Union[Type[Request], None],
-    controller_request_class: Union[Type[Request], None],
-    router_request_class: Union[Type[Request], None],
-    app_request_class: Union[Type[Request], None],
+    handler_request_class: Optional[Type[Request]],
+    controller_request_class: Optional[Type[Request]],
+    router_request_class: Optional[Type[Request]],
+    app_request_class: Optional[Type[Request]],
     has_default_app_class: bool,
     expected: Type[Request],
 ) -> None:
@@ -53,9 +54,9 @@ def test_request_class_resolution_of_layers(
     app = Litestar(route_handlers=[router])
 
     if app_request_class or not has_default_app_class:
-        app.request_class = app_request_class  # type: ignore
+        app.request_class = app_request_class  # type: ignore[assignment]
 
-    route_handler, _ = app.routes[0].route_handler_map[HttpMethod.GET]  # type: ignore
+    route_handler: HTTPRouteHandler = app.route_handler_method_map["/"][HttpMethod.GET]  # type: ignore[assignment]
 
     if handler_request_class:
         route_handler.request_class = handler_request_class

--- a/tests/unit/test_response/test_type_decoders.py
+++ b/tests/unit/test_response/test_type_decoders.py
@@ -1,24 +1,108 @@
-from typing import Any
+from typing import Any, Literal, Type, Union
 from unittest import mock
 
-from litestar import Controller, HttpMethod, Litestar, Router, get
+import pytest
+
+from litestar import Controller, Litestar, Router, get
 from litestar.datastructures.url import URL
+from litestar.enums import HttpMethod
+from litestar.handlers.http_handlers.base import HTTPRouteHandler
+from litestar.handlers.websocket_handlers.listener import (
+    WebsocketListener,
+    WebsocketListenerRouteHandler,
+    websocket_listener,
+)
+from litestar.types.composite_types import TypeDecodersSequence
 
 handler_decoder, router_decoder, controller_decoder, app_decoder = 4 * [(lambda t: t is URL, lambda t, v: URL(v))]
 
 
-@mock.patch("litestar.app.Litestar._get_default_plugins", mock.Mock(return_value=[]))
-def test_resolve_type_decoders() -> None:
+@pytest.fixture(scope="module")
+def controller() -> Type[Controller]:
     class MyController(Controller):
+        path = "/controller"
         type_decoders = [controller_decoder]
 
-        @get("/", type_decoders=[handler_decoder])
-        def handler(self) -> Any:
+        @get("/http", type_decoders=[handler_decoder])
+        def http(self) -> Any:
             ...
 
-    router = Router("/router", type_decoders=[router_decoder], route_handlers=[MyController])
-    app = Litestar([router], type_decoders=[app_decoder])
-    route_handler = app.routes[0].route_handler_map[HttpMethod.GET][0]  # type: ignore
-    decoders = route_handler.resolve_type_decoders()
+        @websocket_listener("/ws", type_decoders=[handler_decoder])
+        async def handler(self, data: str) -> None:
+            ...
 
-    assert decoders == [app_decoder, router_decoder, controller_decoder, handler_decoder]
+    return MyController
+
+
+@pytest.fixture(scope="module")
+def websocket_listener_handler() -> Type[WebsocketListener]:
+    class WebSocketHandler(WebsocketListener):
+        path = "/ws-listener"
+        type_decoders = [handler_decoder]
+
+        def on_receive(self, data: str) -> None:  # pyright: ignore [reportIncompatibleMethodOverride]
+            ...
+
+    return WebSocketHandler
+
+
+@pytest.fixture(scope="module")
+def http_handler() -> HTTPRouteHandler:
+    @get("/http", type_decoders=[handler_decoder])
+    def http() -> Any:
+        ...
+
+    return http
+
+
+@pytest.fixture(scope="module")
+def websocket_handler() -> WebsocketListenerRouteHandler:
+    @websocket_listener("/ws", type_decoders=[handler_decoder])
+    async def websocket(data: str) -> None:
+        ...
+
+    return websocket
+
+
+@pytest.fixture(scope="module")
+def router(
+    controller: Type[Controller],
+    websocket_listener_handler: Type[WebsocketListenerRouteHandler],
+    http_handler: Type[HTTPRouteHandler],
+    websocket_handler: Type[WebsocketListenerRouteHandler],
+) -> Router:
+    return Router(
+        "/router",
+        type_decoders=[router_decoder],
+        route_handlers=[controller, websocket_listener_handler, http_handler, websocket_handler],
+    )
+
+
+@pytest.fixture(scope="module")
+@mock.patch("litestar.app.Litestar._get_default_plugins", mock.Mock(return_value=[]))
+def app(router: Router) -> Litestar:
+    return Litestar([router], type_decoders=[app_decoder])
+
+
+@pytest.mark.parametrize(
+    "path, method, type_decoders",
+    (
+        ("/router/controller/http", HttpMethod.GET, [app_decoder, router_decoder, controller_decoder, handler_decoder]),
+        ("/router/controller/ws", "websocket", [app_decoder, router_decoder, controller_decoder, handler_decoder]),
+        ("/router/http", HttpMethod.GET, [app_decoder, router_decoder, handler_decoder]),
+        ("/router/ws", "websocket", [app_decoder, router_decoder, handler_decoder]),
+        ("/router/ws-listener", "websocket", [app_decoder, router_decoder, handler_decoder]),
+    ),
+    ids=(
+        "Controller http endpoint type decoders",
+        "Controller ws endpoint type decoders",
+        "Router http endpoint type decoders",
+        "Router ws endpoint type decoders",
+        "Router ws listener type decoders",
+    ),
+)
+def test_resolve_type_decoders(
+    path: str, method: Union[HttpMethod, Literal["websocket"]], type_decoders: TypeDecodersSequence, app: Litestar
+) -> None:
+    handler = app.route_handler_method_map[path][method]
+    assert handler.resolve_type_decoders() == type_decoders

--- a/tests/unit/test_response_class_resolution.py
+++ b/tests/unit/test_response_class_resolution.py
@@ -1,8 +1,9 @@
-from typing import Type, Union
+from typing import Optional, Type
 
 import pytest
 
 from litestar import Controller, HttpMethod, Litestar, Response, Router, get
+from litestar.handlers.http_handlers.base import HTTPRouteHandler
 
 RouterResponse: Type[Response] = type("RouterResponse", (Response,), {})
 ControllerResponse: Type[Response] = type("ControllerResponse", (Response,), {})
@@ -28,10 +29,10 @@ HandlerResponse: Type[Response] = type("HandlerResponse", (Response,), {})
     ),
 )
 def test_response_class_resolution_of_layers(
-    handler_response_class: Union[Type[Response], None],
-    controller_response_class: Union[Type[Response], None],
-    router_response_class: Union[Type[Response], None],
-    app_response_class: Union[Type[Response], None],
+    handler_response_class: Optional[Type[Response]],
+    controller_response_class: Optional[Type[Response]],
+    router_response_class: Optional[Type[Response]],
+    app_response_class: Optional[Type[Response]],
     expected: Type[Response],
 ) -> None:
     class MyController(Controller):
@@ -52,7 +53,7 @@ def test_response_class_resolution_of_layers(
     if app_response_class:
         app.response_class = app_response_class
 
-    route_handler, _ = app.routes[0].route_handler_map[HttpMethod.GET]  # type: ignore
+    route_handler: HTTPRouteHandler = app.route_handler_method_map["/"][HttpMethod.GET]  # type: ignore[assignment]
 
     if handler_response_class:
         route_handler.response_class = handler_response_class


### PR DESCRIPTION
## Description
- pass `type_decoders` to parent's `__init__` in `WebsocketListenerRouteHandler` init, otherwise `type_decoders` will be `None` 
- add tests and `baby` refactor request and response class resolution tests
- replace params order in docs, `__init__` (`decoders` before `encoders`)

