### PR TITLE
chore: Enforce mypy error definition for ignored lines.

### DIFF
--- a/docs/examples/middleware/session/cookie_backend.py
+++ b/docs/examples/middleware/session/cookie_backend.py
@@ -3,6 +3,6 @@ from os import urandom
 from litestar import Litestar
 from litestar.middleware.session.client_side import CookieBackendConfig
 
-session_config = CookieBackendConfig(secret=urandom(16))  # type: ignore[arg-type]
+session_config = CookieBackendConfig(secret=urandom(16))  # type: ignore
 
 app = Litestar(middleware=[session_config.middleware])

--- a/litestar/_asgi/routing_trie/mapping.py
+++ b/litestar/_asgi/routing_trie/mapping.py
@@ -212,7 +212,7 @@ def build_route_middleware_stack(
             handler, kwargs = cast("tuple[Any, dict[str, Any]]", middleware)
             asgi_handler = handler(app=asgi_handler, **kwargs)
         else:
-            asgi_handler = middleware(app=asgi_handler)  # type: ignore
+            asgi_handler = middleware(app=asgi_handler)  # type: ignore[call-arg]
 
     # we wrap the entire stack again in ExceptionHandlerMiddleware
     return wrap_in_exception_handler(

--- a/litestar/_kwargs/extractors.py
+++ b/litestar/_kwargs/extractors.py
@@ -135,7 +135,7 @@ def create_query_default_dict(
 
     for k, v in parsed_query:
         if k in sequence_query_parameter_names:
-            output[k].append(v)  # type: ignore
+            output[k].append(v)  # type: ignore[union-attr]
         else:
             output[k] = v
 

--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -137,7 +137,7 @@ class KwargsModel:
             "headers": headers_extractor,
             "cookies": cookies_extractor,
             "query": query_extractor,
-            "body": body_extractor,  # type: ignore
+            "body": body_extractor,  # type: ignore[dict-item]
         }
 
         extractors: list[Callable[[dict[str, Any], ASGIConnection], None]] = [

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -189,7 +189,7 @@ def create_enum_schema(annotation: EnumMeta, include_null: bool = False) -> Sche
     Returns:
         A schema instance.
     """
-    enum_values: list[str | int | None] = [v.value for v in annotation]  # type: ignore
+    enum_values: list[str | int | None] = [v.value for v in annotation]  # type: ignore[var-annotated]
     if include_null and None not in enum_values:
         enum_values.append(None)
     return Schema(type=_types_in_list(enum_values), enum=enum_values)

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -577,7 +577,7 @@ class Litestar(Router):
         await self.asgi_handler(scope, receive, self._wrap_send(send=send, scope=scope))  # type: ignore[arg-type]
 
     async def _call_lifespan_hook(self, hook: LifespanHook) -> None:
-        ret = hook(self) if inspect.signature(hook).parameters else hook()  # type: ignore
+        ret = hook(self) if inspect.signature(hook).parameters else hook()  # type: ignore[call-arg]
 
         if is_async_callable(hook):  # pyright: ignore[reportGeneralTypeIssues]
             await ret

--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -441,7 +441,7 @@ def validate_ssl_file_paths(certfile_arg: str | None, keyfile_arg: str | None) -
             raise LitestarCLIException(f"File provided for {argname} was not found: {path}")
         resolved_paths.append(str(path))
 
-    return tuple(resolved_paths)  # type: ignore
+    return tuple(resolved_paths)  # type: ignore[return-value]
 
 
 def create_ssl_files(

--- a/litestar/cli/commands/schema.py
+++ b/litestar/cli/commands/schema.py
@@ -41,7 +41,7 @@ def _generate_openapi_schema(app: Litestar, output: Path) -> None:
         raise LitestarCLIException(f"failed to write schema to path {output}") from e
 
 
-@schema_group.command("openapi")  # type: ignore
+@schema_group.command("openapi")  # type: ignore[misc]
 @option(
     "--output",
     help="output file path",
@@ -54,7 +54,7 @@ def generate_openapi_schema(app: Litestar, output: Path) -> None:
     _generate_openapi_schema(app, output)
 
 
-@schema_group.command("typescript")  # type: ignore
+@schema_group.command("typescript")  # type: ignore[misc]
 @option(
     "--output",
     help="output file path",

--- a/litestar/cli/commands/sessions.py
+++ b/litestar/cli/commands/sessions.py
@@ -29,7 +29,7 @@ def sessions_group() -> None:
     """Manage server-side sessions."""
 
 
-@sessions_group.command("delete")  # type: ignore
+@sessions_group.command("delete")  # type: ignore[misc]
 @argument("session-id")
 def delete_session_command(session_id: str, app: Litestar) -> None:
     """Delete a specific session."""
@@ -43,7 +43,7 @@ def delete_session_command(session_id: str, app: Litestar) -> None:
         console.print(f"[green]Deleted session {session_id!r}")
 
 
-@sessions_group.command("clear")  # type: ignore
+@sessions_group.command("clear")  # type: ignore[misc]
 def clear_sessions_command(app: Litestar) -> None:
     """Delete all sessions."""
     import anyio

--- a/litestar/contrib/piccolo.py
+++ b/litestar/contrib/piccolo.py
@@ -56,7 +56,7 @@ def _parse_piccolo_type(column: Column, extra: dict[str, Any]) -> FieldDefinitio
         else:
             meta = Meta(max_length=column.length, extra=extra)
     elif isinstance(column, column_types.Array):
-        column_type = List[column.base_column.value_type]  # type: ignore
+        column_type = List[column.base_column.value_type]  # type: ignore[name-defined]
         meta = Meta(extra=extra)
     elif isinstance(column, (column_types.JSON, column_types.JSONB)):
         column_type = str

--- a/litestar/contrib/prometheus/controller.py
+++ b/litestar/contrib/prometheus/controller.py
@@ -43,11 +43,11 @@ class PrometheusController(Controller):
         registry = REGISTRY
         if "prometheus_multiproc_dir" in os.environ or "PROMETHEUS_MULTIPROC_DIR" in os.environ:
             registry = CollectorRegistry()
-            multiprocess.MultiProcessCollector(registry)  # type: ignore
+            multiprocess.MultiProcessCollector(registry)  # type: ignore[no-untyped-call]
 
         if self.openmetrics_format:
             headers = {"Content-Type": OPENMETRICS_CONTENT_TYPE_LATEST}
-            return Response(openmetrics_generate_latest(registry), status_code=200, headers=headers)  # type: ignore
+            return Response(openmetrics_generate_latest(registry), status_code=200, headers=headers)  # type: ignore[no-untyped-call]
 
         headers = {"Content-Type": CONTENT_TYPE_LATEST}
         return Response(generate_latest(registry), status_code=200, headers=headers)

--- a/litestar/contrib/pydantic/pydantic_schema_plugin.py
+++ b/litestar/contrib/pydantic/pydantic_schema_plugin.py
@@ -208,7 +208,7 @@ class PydanticSchemaPlugin(OpenAPISchemaPlugin):
 
     @staticmethod
     def is_plugin_supported_type(value: Any) -> bool:
-        return isinstance(value, _supported_types) or is_class_and_subclass(value, _supported_types)  # type: ignore
+        return isinstance(value, _supported_types) or is_class_and_subclass(value, _supported_types)  # type: ignore[arg-type]
 
     @staticmethod
     def is_undefined_sentinel(value: Any) -> bool:

--- a/litestar/data_extractors.py
+++ b/litestar/data_extractors.py
@@ -152,7 +152,7 @@ class ConnectionDataExtractor:
             A string keyed dictionary of extracted values.
         """
         extractors = (
-            {**self.connection_extractors, **self.request_extractors}  # type: ignore
+            {**self.connection_extractors, **self.request_extractors}  # type: ignore[misc]
             if isinstance(connection, Request)
             else self.connection_extractors
         )
@@ -162,7 +162,7 @@ class ConnectionDataExtractor:
         self, connection: ASGIConnection[Any, Any, Any, Any], fields: Iterable[str]
     ) -> ExtractedRequestData:
         extractors = (
-            {**self.connection_extractors, **self.request_extractors}  # type: ignore
+            {**self.connection_extractors, **self.request_extractors}  # type: ignore[misc]
             if isinstance(connection, Request)
             else self.connection_extractors
         )

--- a/litestar/file_system.py
+++ b/litestar/file_system.py
@@ -49,7 +49,7 @@ class BaseLocalFileSystem(FileSystemProtocol):
             mode: Mode, similar to the built ``open``.
             buffering: Buffer size.
         """
-        return await open_file(file=file, mode=mode, buffering=buffering)  # type: ignore
+        return await open_file(file=file, mode=mode, buffering=buffering)  # type: ignore[call-overload, no-any-return]
 
 
 class FileSystemAdapter:

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -149,7 +149,7 @@ class BaseRouteHandler:
         self.type_encoders = type_encoders
 
         self.paths = (
-            {normalize_path(p) for p in path} if path and isinstance(path, list) else {normalize_path(path or "/")}  # type: ignore
+            {normalize_path(p) for p in path} if path and isinstance(path, list) else {normalize_path(path or "/")}  # type: ignore[arg-type]
         )
 
     def __call__(self, fn: AsyncAnyCallable) -> Self:
@@ -523,7 +523,7 @@ class BaseRouteHandler:
     async def authorize_connection(self, connection: ASGIConnection) -> None:
         """Ensure the connection is authorized by running all the route guards in scope."""
         for guard in self.resolve_guards():
-            await guard(connection, copy(self))  # type: ignore
+            await guard(connection, copy(self))  # type: ignore[misc]
 
     @staticmethod
     def _validate_dependency_is_unique(dependencies: dict[str, Provide], key: str, provider: Provide) -> None:

--- a/litestar/handlers/http_handlers/_utils.py
+++ b/litestar/handlers/http_handlers/_utils.py
@@ -92,7 +92,7 @@ def create_generic_asgi_response_handler(after_request: AfterRequestHookHandler 
     """
 
     async def handler(data: ASGIApp, **kwargs: Any) -> ASGIApp:
-        return await after_request(data) if after_request else data  # type: ignore
+        return await after_request(data) if after_request else data  # type: ignore[arg-type, misc, no-any-return]
 
     return handler
 
@@ -149,7 +149,7 @@ def create_response_handler(
         **kwargs: Any,  # kwargs is for return dto
     ) -> ASGIApp:
         response = await after_request(data) if after_request else data  # type:ignore[arg-type,misc]
-        return response.to_asgi_response(  # type: ignore
+        return response.to_asgi_response(  # type: ignore[no-any-return]
             app=None,
             background=background,
             cookies=cookie_list,

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -543,7 +543,7 @@ class HTTPRouteHandler(BaseRouteHandler):
             data = return_dto_type(request).data_to_encodable_type(data)
 
         response_handler = self.get_response_handler(is_response_type_data=isinstance(data, Response))
-        return await response_handler(app=app, data=data, request=request)  # type: ignore
+        return await response_handler(app=app, data=data, request=request)  # type: ignore[call-arg]
 
     def on_registration(self, app: Litestar) -> None:
         super().on_registration(app)

--- a/litestar/logging/config.py
+++ b/litestar/logging/config.py
@@ -30,9 +30,9 @@ if TYPE_CHECKING:
 try:
     from structlog.types import BindableLogger, Processor, WrappedLogger
 except ImportError:
-    BindableLogger = Any  # type: ignore
-    Processor = Any  # type: ignore
-    WrappedLogger = Any  # type: ignore
+    BindableLogger = Any  # type: ignore[assignment, misc]
+    Processor = Any  # type: ignore[misc]
+    WrappedLogger = Any  # type: ignore[misc]
 
 
 default_handlers: dict[str, dict[str, Any]] = {

--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -41,7 +41,7 @@ try:
 
     structlog_installed = True
 except ImportError:
-    BindableLogger = object  # type: ignore
+    BindableLogger = object  # type: ignore[assignment, misc]
     structlog_installed = False
 
 

--- a/litestar/middleware/rate_limit.py
+++ b/litestar/middleware/rate_limit.py
@@ -242,7 +242,7 @@ class RateLimitConfig:
 
     def __post_init__(self) -> None:
         if self.check_throttle_handler:
-            self.check_throttle_handler = ensure_async_callable(self.check_throttle_handler)  # type: ignore
+            self.check_throttle_handler = ensure_async_callable(self.check_throttle_handler)  # type: ignore[arg-type]
 
     @property
     def middleware(self) -> DefineMiddleware:

--- a/litestar/security/jwt/auth.py
+++ b/litestar/security/jwt/auth.py
@@ -212,7 +212,7 @@ class BaseJWTAuth(Generic[UserType], AbstractSecurityConfig[UserType, Token]):
         Returns:
             The encoded token formatted for the HTTP headers
         """
-        security = self.openapi_components.security_schemes.get(self.openapi_security_scheme_name, None)  # type: ignore
+        security = self.openapi_components.security_schemes.get(self.openapi_security_scheme_name, None)  # type: ignore[union-attr]
         return f"{security.scheme} {encoded_token}" if isinstance(security, SecurityScheme) else encoded_token
 
 

--- a/litestar/security/session_auth/middleware.py
+++ b/litestar/security/session_auth/middleware.py
@@ -54,7 +54,7 @@ class MiddlewareWrapper:
                 exclude_http_methods=self.config.exclude_http_methods,
                 exclude_opt_key=self.config.exclude_opt_key,
                 scopes=self.config.scopes,
-                retrieve_user_handler=self.config.retrieve_user_handler,  # type: ignore
+                retrieve_user_handler=self.config.retrieve_user_handler,  # type: ignore[arg-type]
             )
             exception_middleware = ExceptionHandlerMiddleware(
                 app=auth_middleware,

--- a/litestar/serialization/msgspec_hooks.py
+++ b/litestar/serialization/msgspec_hooks.py
@@ -163,7 +163,7 @@ def decode_json(value: str | bytes, target_type: type[T], type_decoders: TypeDec
     ...
 
 
-def decode_json(  # type: ignore
+def decode_json(  # type: ignore[misc]
     value: str | bytes,
     target_type: type[T] | EmptyType = Empty,  # pyright: ignore
     type_decoders: TypeDecodersSequence | None = None,

--- a/litestar/testing/client/sync_client.py
+++ b/litestar/testing/client/sync_client.py
@@ -511,7 +511,7 @@ class TestClient(Client, BaseTestClient, Generic[T]):  # type: ignore[misc]
                 self,
                 "GET",
                 url,
-                headers={**dict(headers or {}), **default_headers},  # type: ignore
+                headers={**dict(headers or {}), **default_headers},  # type: ignore[misc]
                 params=params,
                 cookies=cookies,
                 auth=auth,

--- a/litestar/types/builtin_types.py
+++ b/litestar/types/builtin_types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Type, Union
 
-from typing_extensions import _TypedDictMeta  # type: ignore
+from typing_extensions import _TypedDictMeta  # type: ignore[attr-defined]
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias

--- a/litestar/types/serialization.py
+++ b/litestar/types/serialization.py
@@ -29,12 +29,12 @@ if TYPE_CHECKING:
     try:
         from pydantic import BaseModel
     except ImportError:
-        BaseModel = Any  # type: ignore
+        BaseModel = Any  # type: ignore[assignment, misc]
 
     try:
         from attrs import AttrsInstance
     except ImportError:
-        AttrsInstance = Any  # type: ignore
+        AttrsInstance = Any  # type: ignore[assignment, misc]
 
 __all__ = (
     "LitestarEncodableType",

--- a/litestar/utils/helpers.py
+++ b/litestar/utils/helpers.py
@@ -55,7 +55,7 @@ def get_enum_string_value(value: Enum | str) -> str:
     Returns:
         A string.
     """
-    return value.value if isinstance(value, Enum) else value  # type:ignore
+    return value.value if isinstance(value, Enum) else value  # type: ignore[no-any-return]
 
 
 def unwrap_partial(value: MaybePartial[T]) -> T:

--- a/litestar/utils/predicates.py
+++ b/litestar/utils/predicates.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
 try:
     import attrs
 except ImportError:
-    attrs = Empty  # type: ignore
+    attrs = Empty  # type: ignore[assignment]
 
 __all__ = (
     "is_annotated_type",
@@ -148,7 +148,7 @@ def is_generic(annotation: Any) -> bool:
     Returns:
         True if the annotation is a subclass of :data:`Generic <typing.Generic>` otherwise ``False``.
     """
-    return is_class_and_subclass(annotation, Generic)  # type: ignore
+    return is_class_and_subclass(annotation, Generic)  # type: ignore[arg-type]
 
 
 def is_mapping(annotation: Any) -> TypeGuard[Mapping[Any, Any]]:
@@ -200,7 +200,7 @@ def is_non_string_sequence(annotation: Any) -> TypeGuard[Sequence[Any]]:
     try:
         return not issubclass(origin or annotation, (str, bytes)) and issubclass(
             origin or annotation,
-            (  # type: ignore
+            (  # type: ignore[arg-type]
                 Tuple,
                 List,
                 Set,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,6 +227,7 @@ python_version = "3.8"
 
 disallow_any_generics = false
 disallow_untyped_decorators = true
+enable_error_code = "ignore-without-code"
 implicit_reexport = false
 show_error_codes = true
 strict = true

--- a/tests/e2e/test_routing/test_route_indexing.py
+++ b/tests/e2e/test_routing/test_route_indexing.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 @pytest.mark.parametrize("decorator", [get, post, patch, put, delete])
 def test_indexes_handlers(decorator: Type[HTTPRouteHandler]) -> None:
-    @decorator("/path-one/{param:str}", name="handler-name")  # type: ignore
+    @decorator("/path-one/{param:str}", name="handler-name")  # type: ignore[call-arg]
     def handler() -> None:
         return None
 
@@ -59,18 +59,18 @@ def test_indexes_handlers(decorator: Type[HTTPRouteHandler]) -> None:
 
 @pytest.mark.parametrize("decorator", [get, post, patch, put, delete])
 def test_default_indexes_handlers(decorator: Type[HTTPRouteHandler]) -> None:
-    @decorator("/handler")  # type: ignore
+    @decorator("/handler")  # type: ignore[call-arg]
     def handler() -> None:
         pass
 
-    @decorator("/named_handler", name="named_handler")  # type: ignore
+    @decorator("/named_handler", name="named_handler")  # type: ignore[call-arg]
     def named_handler() -> None:
         pass
 
     class MyController(Controller):
         path = "/test"
 
-        @decorator()  # type: ignore
+        @decorator()  # type: ignore[call-arg]
         def handler(self) -> None:
             pass
 
@@ -95,11 +95,11 @@ def test_default_indexes_handlers(decorator: Type[HTTPRouteHandler]) -> None:
 
 @pytest.mark.parametrize("decorator", [get, post, patch, put, delete])
 def test_indexes_handlers_with_multiple_paths(decorator: Type[HTTPRouteHandler]) -> None:
-    @decorator(["/path-one", "/path-one/{param:str}"], name="handler")  # type: ignore
+    @decorator(["/path-one", "/path-one/{param:str}"], name="handler")  # type: ignore[call-arg]
     def handler() -> None:
         return None
 
-    @decorator(["/path-two"], name="handler-two")  # type: ignore
+    @decorator(["/path-two"], name="handler-two")  # type: ignore[call-arg]
     def handler_two() -> None:
         return None
 

--- a/tests/e2e/test_routing/test_route_reverse.py
+++ b/tests/e2e/test_routing/test_route_reverse.py
@@ -10,26 +10,26 @@ from litestar.handlers.http_handlers import HTTPRouteHandler
 
 @pytest.mark.parametrize("decorator", [get, post, patch, put, delete])
 def test_route_reverse(decorator: Type[HTTPRouteHandler]) -> None:
-    @decorator("/path-one/{param:str}", name="handler-name")  # type: ignore
+    @decorator("/path-one/{param:str}", name="handler-name")  # type: ignore[call-arg]
     def handler() -> None:
         return None
 
-    @decorator("/path-two", name="handler-no-params")  # type: ignore
+    @decorator("/path-two", name="handler-no-params")  # type: ignore[call-arg]
     def handler_no_params() -> None:
         return None
 
-    @decorator("/multiple/{str_param:str}/params/{int_param:int}/", name="multiple-params-handler-name")  # type: ignore
+    @decorator("/multiple/{str_param:str}/params/{int_param:int}/", name="multiple-params-handler-name")  # type: ignore[call-arg]
     def handler2() -> None:
         return None
 
     @decorator(
         ["/handler3", "/handler3/{str_param:str}/", "/handler3/{str_param:str}/{int_param:int}/"],
         name="multiple-default-params",
-    )  # type: ignore
+    )  # type: ignore[call-arg]
     def handler3(str_param: str = "default", int_param: int = 0) -> None:
         return None
 
-    @decorator(["/handler4/int/{int_param:int}", "/handler4/str/{str_param:str}"], name="handler4")  # type: ignore
+    @decorator(["/handler4/int/{int_param:int}", "/handler4/str/{str_param:str}"], name="handler4")  # type: ignore[call-arg]
     def handler4(int_param: int = 1, str_param: str = "str") -> None:
         return None
 
@@ -62,7 +62,7 @@ def test_route_reverse(decorator: Type[HTTPRouteHandler]) -> None:
     "complex_path_param",
     [("time", time(hour=14), "14:00"), ("float", float(1 / 3), "0.33")],
 )
-def test_route_reverse_validation_complex_params(complex_path_param) -> None:  # type: ignore
+def test_route_reverse_validation_complex_params(complex_path_param) -> None:  # type: ignore[no-untyped-def]
     param_type, param_value, param_manual_str = complex_path_param
 
     @get(f"/abc/{{param:{param_type}}}", name="handler")

--- a/tests/unit/test_cli/test_core_commands.py
+++ b/tests/unit/test_cli/test_core_commands.py
@@ -425,7 +425,7 @@ def test_remove_default_schema_routes() -> None:
     api_config = MagicMock()
     api_config.openapi_controller.path = "/schema"
 
-    results = remove_default_schema_routes(http_routes, api_config)  # type: ignore
+    results = remove_default_schema_routes(http_routes, api_config)  # type: ignore[arg-type]
     assert len(results) == 3
     for result in results:
         words = re.split(r"(^\/[a-z]+)", result.path)
@@ -441,7 +441,7 @@ def test_remove_routes_with_patterns() -> None:
         http_routes.append(http_route)
 
     patterns = ("/destroy", "/pizza", "[]")
-    results = remove_routes_with_patterns(http_routes, patterns)  # type: ignore
+    results = remove_routes_with_patterns(http_routes, patterns)  # type: ignore[arg-type]
     paths = [route.path for route in results]
     assert len(paths) == 2
     for route in ["/", "/foo"]:

--- a/tests/unit/test_connection/test_request.py
+++ b/tests/unit/test_connection/test_request.py
@@ -140,7 +140,7 @@ def test_custom_request_class() -> None:
     class MyRequest(Request):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             super().__init__(*args, **kwargs)
-            self.scope["called"] = True  # type: ignore
+            self.scope["called"] = True  # type: ignore[typeddict-unknown-key]
 
     @get("/", signature_types=[MyRequest])
     def handler(request: MyRequest) -> None:
@@ -382,7 +382,7 @@ def test_request_state() -> None:
     def handler(request: Request[Any, Any, Any]) -> dict[Any, Any]:
         request.state.test = 1
         assert request.state.test == 1
-        return request.state.dict()  # type: ignore
+        return request.state.dict()  # type: ignore[no-any-return]
 
     with create_test_client(handler) as client:
         response = client.get("/")
@@ -431,7 +431,7 @@ def test_chunked_encoding() -> None:
 def test_request_send_push_promise() -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         # the server is push-enabled
-        scope["extensions"]["http.response.push"] = {}  # type: ignore
+        scope["extensions"]["http.response.push"] = {}  # type: ignore[index]
 
         request = Request[Any, Any, Any](scope, receive, send)
         await request.send_push_promise("/style.css")
@@ -490,7 +490,7 @@ def test_request_send_push_promise_without_setting_send() -> None:
 
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         # the server is push-enabled
-        scope["extensions"]["http.response.push"] = {}  # type: ignore
+        scope["extensions"]["http.response.push"] = {}  # type: ignore[index]
 
         data = "OK"
         request = Request[Any, Any, Any](scope)

--- a/tests/unit/test_connection/test_websocket.py
+++ b/tests/unit/test_connection/test_websocket.py
@@ -71,7 +71,7 @@ async def test_custom_request_class() -> None:
     class MyWebSocket(WebSocket[Any, Any, Any]):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             super().__init__(*args, **kwargs)
-            self.scope["called"] = True  # type: ignore
+            self.scope["called"] = True  # type: ignore[typeddict-unknown-key]
 
     @websocket("/", signature_types=[MyWebSocket])
     async def handler(socket: MyWebSocket) -> None:

--- a/tests/unit/test_contrib/test_htmx/test_htmx_response.py
+++ b/tests/unit/test_contrib/test_htmx/test_htmx_response.py
@@ -187,7 +187,7 @@ async def test_trigger_event_response_invalid_after() -> None:
         return TriggerEvent(
             content="Success!",
             name="alert",
-            after="invalid",  # type: ignore
+            after="invalid",  # type: ignore[arg-type]
             params={"warning": "Confirm your choice!"},
         )
 
@@ -361,7 +361,7 @@ def test_htmx_template_response_bad_trigger_params(engine: Any, template: str, e
             context={"request": {"scope": {"path": "nope"}}},
             trigger_event="showMessage",
             params={"alert": "Confirm your Choice."},
-            after="begin",  # type: ignore
+            after="begin",  # type: ignore[arg-type]
         )
 
     with create_test_client(

--- a/tests/unit/test_contrib/test_opentelemetry.py
+++ b/tests/unit/test_contrib/test_opentelemetry.py
@@ -33,7 +33,7 @@ def create_config(**kwargs: Any) -> Tuple[OpenTelemetryConfig, InMemoryMetricRea
     tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
 
     aggregation_last_value = {Counter: ExplicitBucketHistogramAggregation()}
-    reader = InMemoryMetricReader(preferred_aggregation=aggregation_last_value)  # type: ignore
+    reader = InMemoryMetricReader(preferred_aggregation=aggregation_last_value)  # type: ignore[arg-type]
     meter_provider = MeterProvider(resource=resource, metric_readers=[reader])
 
     set_meter_provider(meter_provider)
@@ -60,9 +60,9 @@ def test_open_telemetry_middleware_with_http_route() -> None:
         assert reader.get_metrics_data()
 
         first_span, second_span, third_span = cast("Tuple[Span, Span, Span]", exporter.get_finished_spans())
-        assert dict(first_span.attributes) == {"http.status_code": 200, "type": "http.response.start"}  # type: ignore
-        assert dict(second_span.attributes) == {"type": "http.response.body"}  # type: ignore
-        assert dict(third_span.attributes) == {  # type: ignore
+        assert dict(first_span.attributes) == {"http.status_code": 200, "type": "http.response.start"}  # type: ignore[arg-type]
+        assert dict(second_span.attributes) == {"type": "http.response.body"}  # type: ignore[arg-type]
+        assert dict(third_span.attributes) == {  # type: ignore[arg-type]
             "http.scheme": "http",
             "http.host": "testserver.local",
             "net.host.port": 80,
@@ -107,11 +107,11 @@ def test_open_telemetry_middleware_with_websocket_route() -> None:
         first_span, second_span, third_span, fourth_span, fifth_span = cast(
             "Tuple[Span, Span, Span, Span, Span]", exporter.get_finished_spans()
         )
-        assert dict(first_span.attributes) == {"type": "websocket.connect"}  # type: ignore
-        assert dict(second_span.attributes) == {"type": "websocket.accept"}  # type: ignore
-        assert dict(third_span.attributes) == {"http.status_code": 200, "type": "websocket.send"}  # type: ignore
-        assert dict(fourth_span.attributes) == {"type": "websocket.close"}  # type: ignore
-        assert dict(fifth_span.attributes) == {  # type: ignore
+        assert dict(first_span.attributes) == {"type": "websocket.connect"}  # type: ignore[arg-type]
+        assert dict(second_span.attributes) == {"type": "websocket.accept"}  # type: ignore[arg-type]
+        assert dict(third_span.attributes) == {"http.status_code": 200, "type": "websocket.send"}  # type: ignore[arg-type]
+        assert dict(fourth_span.attributes) == {"type": "websocket.close"}  # type: ignore[arg-type]
+        assert dict(fifth_span.attributes) == {  # type: ignore[arg-type]
             "http.scheme": "ws",
             "http.host": "testserver",
             "net.host.port": 80,

--- a/tests/unit/test_contrib/test_piccolo_orm/test_piccolo_orm_dto.py
+++ b/tests/unit/test_contrib/test_piccolo_orm/test_piccolo_orm_dto.py
@@ -119,19 +119,19 @@ def test_piccolo_dto_openapi_spec_generation() -> None:
 
     post_operation = concert_path.post
     assert (
-        post_operation.request_body.content["application/json"].schema.ref  # type: ignore
+        post_operation.request_body.content["application/json"].schema.ref  # type: ignore[union-attr]
         == "#/components/schemas/CreateConcertConcertRequestBody"
     )
 
     studio_path_get_operation = studio_path.get
     assert (
-        studio_path_get_operation.responses["200"].content["application/json"].schema.ref  # type: ignore
+        studio_path_get_operation.responses["200"].content["application/json"].schema.ref  # type: ignore[index, union-attr]
         == "#/components/schemas/RetrieveStudioRecordingStudioResponseBody"
     )
 
     venues_path_get_operation = venues_path.get
     assert (
-        venues_path_get_operation.responses["200"].content["application/json"].schema.items.ref  # type: ignore
+        venues_path_get_operation.responses["200"].content["application/json"].schema.items.ref  # type: ignore[index, union-attr]
         == "#/components/schemas/RetrieveVenuesVenueResponseBody"
     )
 

--- a/tests/unit/test_data_extractors.py
+++ b/tests/unit/test_data_extractors.py
@@ -27,7 +27,7 @@ async def test_connection_data_extractor() -> None:
     request.scope["path_params"] = {"first": "10", "second": "20", "third": "30"}
     extractor = ConnectionDataExtractor(parse_body=True, parse_query=True)
     extracted_data = extractor(request)
-    assert await extracted_data.get("body") == await request.json()  # type: ignore
+    assert await extracted_data.get("body") == await request.json()  # type: ignore[misc]
     assert extracted_data.get("content_type") == request.content_type
     assert extracted_data.get("headers") == dict(request.headers)
     assert extracted_data.get("headers") == dict(request.headers)
@@ -48,24 +48,24 @@ def test_parse_query() -> None:
     assert parsed_extracted_data.get("query") == request.query_params.dict()
     assert unparsed_extracted_data.get("query") == request.scope["query_string"]
     # Close to avoid warnings about un-awaited coroutines.
-    parsed_extracted_data.get("body").close()  # type: ignore
-    unparsed_extracted_data.get("body").close()  # type: ignore
+    parsed_extracted_data.get("body").close()  # type: ignore[union-attr]
+    unparsed_extracted_data.get("body").close()  # type: ignore[union-attr]
 
 
 async def test_parse_json_data() -> None:
     request = factory.post(path="/a/b/c", data={"hello": "world"})
-    assert await ConnectionDataExtractor(parse_body=True)(request).get("body") == await request.json()  # type: ignore
-    assert await ConnectionDataExtractor()(request).get("body") == await request.body()  # type: ignore
+    assert await ConnectionDataExtractor(parse_body=True)(request).get("body") == await request.json()  # type: ignore[misc]
+    assert await ConnectionDataExtractor()(request).get("body") == await request.body()  # type: ignore[misc]
 
 
 async def test_parse_form_data() -> None:
     request = factory.post(path="/a/b/c", data={"file": b"123"}, request_media_type=RequestEncodingType.MULTI_PART)
-    assert await ConnectionDataExtractor(parse_body=True)(request).get("body") == dict(await request.form())  # type: ignore
+    assert await ConnectionDataExtractor(parse_body=True)(request).get("body") == dict(await request.form())  # type: ignore[misc]
 
 
 async def test_parse_url_encoded() -> None:
     request = factory.post(path="/a/b/c", data={"key": "123"}, request_media_type=RequestEncodingType.URL_ENCODED)
-    assert await ConnectionDataExtractor(parse_body=True)(request).get("body") == dict(await request.form())  # type: ignore
+    assert await ConnectionDataExtractor(parse_body=True)(request).get("body") == dict(await request.form())  # type: ignore[misc]
 
 
 @pytest.mark.parametrize("req", [factory.get(headers={"Special": "123"}), factory.get(headers={"special": "123"})])
@@ -74,7 +74,7 @@ def test_request_extraction_header_obfuscation(req: Request[Any, Any, Any]) -> N
     extracted_data = extractor(req)
     assert extracted_data.get("headers") == {"special": "*****"}
     # Close to avoid warnings about un-awaited coroutines.
-    extracted_data.get("body").close()  # type: ignore
+    extracted_data.get("body").close()  # type: ignore[union-attr]
 
 
 @pytest.mark.parametrize(
@@ -89,7 +89,7 @@ def test_request_extraction_cookie_obfuscation(req: Request[Any, Any, Any], key:
     extracted_data = extractor(req)
     assert extracted_data.get("cookies") == {"Path": "/", "SameSite": "lax", key: "*****"}
     # Close to avoid warnings about un-awaited coroutines.
-    extracted_data.get("body").close()  # type: ignore
+    extracted_data.get("body").close()  # type: ignore[union-attr]
 
 
 async def test_response_data_extractor() -> None:
@@ -105,7 +105,7 @@ async def test_response_data_extractor() -> None:
     await response({}, empty_receive, send)  # type: ignore[arg-type]
 
     assert len(messages) == 2
-    extracted_data = extractor(messages)  # type: ignore
+    extracted_data = extractor(messages)  # type: ignore[arg-type]
     assert extracted_data.get("status_code") == HTTP_200_OK
     assert extracted_data.get("body") == b'{"hello":"world"}'
     assert extracted_data.get("headers") == {**headers, "content-length": "17"}

--- a/tests/unit/test_datastructures/test_headers.py
+++ b/tests/unit/test_datastructures/test_headers.py
@@ -36,7 +36,7 @@ def test_header_container_requires_header_key_being_defined() -> None:
         def _get_header_value(self) -> str:
             return ""
 
-        def from_header(self, header_value: str) -> "Header":  # type: ignore
+        def from_header(self, header_value: str) -> "Header":  # type: ignore[explicit-override, override]
             return self
 
     with pytest.raises(ImproperlyConfiguredException):

--- a/tests/unit/test_di.py
+++ b/tests/unit/test_di.py
@@ -152,7 +152,7 @@ def test_dependency_has_async_callable(dep: Any, exp: bool) -> None:
 
 def test_raises_when_dependency_is_not_callable() -> None:
     with pytest.raises(ImproperlyConfiguredException):
-        Provide(123)  # type: ignore
+        Provide(123)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -95,7 +95,7 @@ def test_multiple_event_ids(mock: MagicMock, anyio_backend: AnyIOBackend) -> Non
 
 async def test_raises_when_decorator_called_without_callable() -> None:
     with pytest.raises(ImproperlyConfiguredException):
-        listener("test_even")(True)  # type: ignore
+        listener("test_even")(True)  # type: ignore[arg-type]
 
 
 async def test_raises_when_not_initialized() -> None:

--- a/tests/unit/test_guards.py
+++ b/tests/unit/test_guards.py
@@ -96,7 +96,7 @@ def test_guards_layering_for_same_route_handler() -> None:
     assert (
         len(
             app.asgi_router.root_route_map_node.children["/http"]
-            .asgi_handlers["GET"][1]  # type: ignore
+            .asgi_handlers["GET"][1]  # type: ignore[arg-type]
             ._resolved_guards
         )
         == 2
@@ -104,7 +104,7 @@ def test_guards_layering_for_same_route_handler() -> None:
     assert (
         len(
             app.asgi_router.root_route_map_node.children["/router/http"]
-            .asgi_handlers["GET"][1]  # type: ignore
+            .asgi_handlers["GET"][1]  # type: ignore[arg-type]
             ._resolved_guards
         )
         == 3

--- a/tests/unit/test_handlers/test_asgi_handlers/test_validations.py
+++ b/tests/unit/test_handlers/test_asgi_handlers/test_validations.py
@@ -44,4 +44,4 @@ def test_asgi_handler_validation() -> None:
         return None
 
     with pytest.raises(ImproperlyConfiguredException):
-        asgi(path="/")(sync_fn).on_registration(Litestar())  # type: ignore
+        asgi(path="/")(sync_fn).on_registration(Litestar())  # type: ignore[arg-type]

--- a/tests/unit/test_handlers/test_base_handlers/test_opt.py
+++ b/tests/unit/test_handlers/test_base_handlers/test_opt.py
@@ -46,7 +46,7 @@ async def socket_handler(socket: "WebSocket") -> None:
 )
 def test_opt_settings(decorator: "RouteHandlerType", handler: Callable) -> None:
     base_opt = {"base": 1, "kwarg_value": 0}
-    result = decorator("/", opt=base_opt, kwarg_value=2)(handler)  # type: ignore
+    result = decorator("/", opt=base_opt, kwarg_value=2)(handler)  # type: ignore[arg-type, call-arg]
     assert result.opt == {"base": 1, "kwarg_value": 2}
 
 

--- a/tests/unit/test_handlers/test_http_handlers/test_validations.py
+++ b/tests/unit/test_handlers/test_http_handlers/test_validations.py
@@ -20,11 +20,11 @@ from tests.models import DataclassPerson
 def test_route_handler_validation_http_method() -> None:
     # doesn't raise for http methods
     for value in (*list(HttpMethod), *[x.upper() for x in list(HttpMethod)]):
-        assert route(http_method=value)  # type: ignore
+        assert route(http_method=value)  # type: ignore[arg-type, truthy-bool]
 
     # raises for invalid values
     with pytest.raises(ValidationException):
-        HTTPRouteHandler(http_method="deleze")  # type: ignore
+        HTTPRouteHandler(http_method="deleze")  # type: ignore[arg-type]
 
     # also when passing an empty list
     with pytest.raises(ImproperlyConfiguredException):
@@ -32,14 +32,14 @@ def test_route_handler_validation_http_method() -> None:
 
     # also when passing malformed tokens
     with pytest.raises(ValidationException):
-        route(http_method=[HttpMethod.GET, "poft"], status_code=HTTP_200_OK)  # type: ignore
+        route(http_method=[HttpMethod.GET, "poft"], status_code=HTTP_200_OK)  # type: ignore[list-item]
 
 
 async def test_function_validation() -> None:
     with pytest.raises(ImproperlyConfiguredException):
 
         @get(path="/")
-        def method_with_no_annotation():  # type: ignore
+        def method_with_no_annotation():  # type: ignore[no-untyped-def]
             pass
 
         Litestar(route_handlers=[method_with_no_annotation])
@@ -105,7 +105,7 @@ async def test_function_validation() -> None:
     with pytest.raises(ImproperlyConfiguredException):
 
         @get("/person")
-        def test_function_2(self, data: DataclassPerson) -> None:  # type: ignore
+        def test_function_2(self, data: DataclassPerson) -> None:  # type: ignore[no-untyped-def]
             return None
 
         Litestar(route_handlers=[test_function_2])

--- a/tests/unit/test_handlers/test_websocket_handlers/test_kwarg_handling.py
+++ b/tests/unit/test_handlers/test_websocket_handlers/test_kwarg_handling.py
@@ -29,7 +29,7 @@ def test_handle_websocket_params_parsing() -> None:
     client = create_test_client(route_handlers=websocket_handler)
 
     # Set cookies on the client to avoid warnings about per-request cookies.
-    client.cookies = {"cookie": "yum"}  # type: ignore
+    client.cookies = {"cookie": "yum"}  # type: ignore[assignment]
 
     with client.websocket_connect("/1?qp=1", headers={"some-header": "abc"}) as ws:
         ws.send_json({"data": "123"})

--- a/tests/unit/test_handlers/test_websocket_handlers/test_validations.py
+++ b/tests/unit/test_handlers/test_websocket_handlers/test_validations.py
@@ -12,7 +12,7 @@ def test_raises_when_socket_arg_is_missing() -> None:
         pass
 
     with pytest.raises(ImproperlyConfiguredException):
-        websocket(path="/")(fn_without_socket_arg).on_registration(Litestar())  # type: ignore
+        websocket(path="/")(fn_without_socket_arg).on_registration(Litestar())  # type: ignore[arg-type]
 
 
 def test_raises_for_return_annotation() -> None:
@@ -33,7 +33,7 @@ def test_raises_when_no_function() -> None:
 def test_raises_when_sync_handler_user() -> None:
     with pytest.raises(ImproperlyConfiguredException):
 
-        @websocket(path="/")  # type: ignore
+        @websocket(path="/")  # type: ignore[arg-type]
         def sync_websocket_handler(socket: WebSocket) -> None:
             ...
 

--- a/tests/unit/test_kwargs/test_cookie_params.py
+++ b/tests/unit/test_kwargs/test_cookie_params.py
@@ -27,12 +27,12 @@ def test_cookie_params(t_type: Type, param_dict: dict, param: ParameterKwarg, ex
     test_path = "/test"
 
     @get(path=test_path)
-    def test_method(special_cookie: t_type = param) -> None:  # type: ignore
+    def test_method(special_cookie: t_type = param) -> None:  # type: ignore[valid-type]
         if special_cookie:
-            assert special_cookie in (param_dict.get("special-cookie"), int(param_dict.get("special-cookie")))  # type: ignore
+            assert special_cookie in (param_dict.get("special-cookie"), int(param_dict.get("special-cookie")))  # type: ignore[arg-type]
 
     with create_test_client(test_method) as client:
         # Set cookies on the client to avoid warnings about per-request cookies.
-        client.cookies = param_dict  # type: ignore
+        client.cookies = param_dict  # type: ignore[assignment]
         response = client.get(test_path)
         assert response.status_code == expected_code, response.json()

--- a/tests/unit/test_kwargs/test_header_params.py
+++ b/tests/unit/test_kwargs/test_header_params.py
@@ -27,9 +27,9 @@ def test_header_params(
     test_path = "/test"
 
     @get(path=test_path)
-    def test_method(special_header: t_type = param) -> None:  # type: ignore
+    def test_method(special_header: t_type = param) -> None:  # type: ignore[valid-type]
         if special_header:
-            assert special_header in (param_dict.get("special-header"), int(param_dict.get("special-header")))  # type: ignore
+            assert special_header in (param_dict.get("special-header"), int(param_dict.get("special-header")))  # type: ignore[arg-type]
 
     with create_test_client(test_method) as client:
         response = client.get(test_path, headers=param_dict)

--- a/tests/unit/test_kwargs/test_layered_params.py
+++ b/tests/unit/test_kwargs/test_layered_params.py
@@ -51,7 +51,7 @@ def test_layered_parameters_injected_correctly() -> None:
         },
     ) as client:
         # Set cookies on the client to avoid warnings about per-request cookies.
-        client.cookies = {"app4": "jeronimo"}  # type: ignore
+        client.cookies = {"app4": "jeronimo"}  # type: ignore[assignment]
 
         query = {"controller1": "99", "controller3": "tuna", "router1": "albatross", "app2": ["x", "y"]}
         headers = {"router3": "10"}
@@ -110,7 +110,7 @@ def test_layered_parameters_validation(parameter: str, param_type: str) -> None:
             query.pop(parameter)
 
         # Set cookies on the client to avoid warnings about per-request cookies.
-        client.cookies = cookies  # type: ignore
+        client.cookies = cookies  # type: ignore[assignment]
 
         response = client.get("/router/controller/1", params=query, headers=headers)
 

--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -90,7 +90,7 @@ def test_request_body_multi_part(t_type: type) -> None:
     data = asdict(Form(name="Moishe Zuchmir", age=30, programmer=True, value="100"))
 
     @post(path=test_path, signature_namespace={"t_type": t_type})
-    def test_method(data: Annotated[t_type, Body(media_type=RequestEncodingType.MULTI_PART)]) -> None:  # type: ignore
+    def test_method(data: Annotated[t_type, Body(media_type=RequestEncodingType.MULTI_PART)]) -> None:  # type: ignore[valid-type]
         assert data
 
     with create_test_client(test_method) as client:

--- a/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
+++ b/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
@@ -49,10 +49,10 @@ def test_application_immutable_state_injection() -> None:
 @pytest.mark.parametrize("state_typing", (State, CustomState))
 def test_application_state_injection(state_typing: Type[State]) -> None:
     @get("/", media_type=MediaType.TEXT)
-    def route_handler(state: state_typing) -> str:  # type: ignore
+    def route_handler(state: state_typing) -> str:  # type: ignore[valid-type]
         assert state
-        state.called = True  # type: ignore
-        return cast("str", state.msg)  # type: ignore
+        state.called = True  # type: ignore[attr-defined]
+        return cast("str", state.msg)  # type: ignore[attr-defined]
 
     with create_test_client(route_handler, state=State({"called": False})) as client:
         client.app.state.msg = "hello"

--- a/tests/unit/test_logging/test_logging_config.py
+++ b/tests/unit/test_logging/test_logging_config.py
@@ -116,7 +116,7 @@ def test_get_picologging_logger() -> None:
 def test_connection_logger(handlers: Any, listener: Any) -> None:
     @get("/")
     def handler(request: Request) -> Dict[str, bool]:
-        return {"isinstance": isinstance(request.logger.handlers[0], listener)}  # type: ignore
+        return {"isinstance": isinstance(request.logger.handlers[0], listener)}  # type: ignore[attr-defined]
 
     with create_test_client(route_handlers=[handler], logging_config=LoggingConfig(handlers=handlers)) as client:
         response = client.get("/")
@@ -141,7 +141,7 @@ def test_root_logger(handlers: Any, listener: Any) -> None:
     logging_config = LoggingConfig(handlers=handlers)
     get_logger = logging_config.configure()
     root_logger = get_logger()
-    assert isinstance(root_logger.handlers[0], listener)  # type: ignore
+    assert isinstance(root_logger.handlers[0], listener)  # type: ignore[attr-defined]
 
 
 @pytest.mark.parametrize(
@@ -183,4 +183,4 @@ def test_customizing_handler(handlers: Any, listener: Any, monkeypatch: pytest.M
     logging_config = LoggingConfig(handlers=handlers)
     get_logger = logging_config.configure()
     root_logger = get_logger()
-    assert isinstance(root_logger.handlers[0], listener)  # type: ignore
+    assert isinstance(root_logger.handlers[0], listener)  # type: ignore[attr-defined]

--- a/tests/unit/test_middleware/test_allowed_hosts_middleware.py
+++ b/tests/unit/test_middleware/test_allowed_hosts_middleware.py
@@ -35,12 +35,12 @@ def test_allowed_hosts_middleware() -> None:
     assert len(unpacked_middleware) == 4
     allowed_hosts_middleware = cast("Any", unpacked_middleware[1])
     assert isinstance(allowed_hosts_middleware, AllowedHostsMiddleware)
-    assert allowed_hosts_middleware.allowed_hosts_regex.pattern == ".*\\.example.com$|moishe.zuchmir.com"  # type: ignore
+    assert allowed_hosts_middleware.allowed_hosts_regex.pattern == ".*\\.example.com$|moishe.zuchmir.com"  # type: ignore[union-attr]
 
 
 def test_allowed_hosts_middleware_hosts_regex() -> None:
     config = AllowedHostsConfig(allowed_hosts=["*.example.com", "moishe.zuchmir.com"])
-    middleware = AllowedHostsMiddleware(app=DummyApp(), config=config)  # type: ignore
+    middleware = AllowedHostsMiddleware(app=DummyApp(), config=config)  # type: ignore[abstract]
     assert middleware.allowed_hosts_regex is not None
     assert middleware.allowed_hosts_regex.pattern == ".*\\.example.com$|moishe.zuchmir.com"
 
@@ -59,7 +59,7 @@ def test_allowed_hosts_middleware_redirect_regex() -> None:
     config = AllowedHostsConfig(
         allowed_hosts=["*.example.com", "www.moishe.zuchmir.com", "www.yada.bada.bing.io", "example.com"]
     )
-    middleware = AllowedHostsMiddleware(app=DummyApp(), config=config)  # type: ignore
+    middleware = AllowedHostsMiddleware(app=DummyApp(), config=config)  # type: ignore[abstract]
     assert middleware.redirect_domains is not None
     assert middleware.redirect_domains.pattern == "moishe.zuchmir.com|yada.bada.bing.io"
 
@@ -75,23 +75,23 @@ def test_middleware_allowed_hosts() -> None:
     config = AllowedHostsConfig(allowed_hosts=["*.example.com", "moishe.zuchmir.com"])
 
     with create_test_client(handler, allowed_hosts=config) as client:
-        client.base_url = "http://x.example.com"  # type: ignore
+        client.base_url = "http://x.example.com"  # type: ignore[assignment]
         response = client.get("/")
         assert response.status_code == HTTP_200_OK
 
-        client.base_url = "http://x.y.example.com"  # type: ignore
+        client.base_url = "http://x.y.example.com"  # type: ignore[assignment]
         response = client.get("/")
         assert response.status_code == HTTP_200_OK
 
-        client.base_url = "http://moishe.zuchmir.com"  # type: ignore
+        client.base_url = "http://moishe.zuchmir.com"  # type: ignore[assignment]
         response = client.get("/")
         assert response.status_code == HTTP_200_OK
 
-        client.base_url = "http://x.moishe.zuchmir.com"  # type: ignore
+        client.base_url = "http://x.moishe.zuchmir.com"  # type: ignore[assignment]
         response = client.get("/")
         assert response.status_code == HTTP_400_BAD_REQUEST
 
-        client.base_url = "http://x.example.x.com"  # type: ignore
+        client.base_url = "http://x.example.x.com"  # type: ignore[assignment]
         response = client.get("/")
         assert response.status_code == HTTP_400_BAD_REQUEST
 
@@ -105,7 +105,7 @@ def test_middleware_allow_all() -> None:
     config = AllowedHostsConfig(allowed_hosts=["*", "*.example.com", "moishe.zuchmir.com"])
 
     with create_test_client(handler, allowed_hosts=config) as client:
-        client.base_url = "http://any.domain.allowed.com"  # type: ignore
+        client.base_url = "http://any.domain.allowed.com"  # type: ignore[assignment]
         response = client.get("/")
         assert response.status_code == HTTP_200_OK
 
@@ -118,7 +118,7 @@ def test_middleware_redirect_on_www_by_default() -> None:
     config = AllowedHostsConfig(allowed_hosts=["www.moishe.zuchmir.com"])
 
     with create_test_client(handler, allowed_hosts=config) as client:
-        client.base_url = "http://moishe.zuchmir.com"  # type: ignore
+        client.base_url = "http://moishe.zuchmir.com"  # type: ignore[assignment]
         response = client.get("/")
         assert response.status_code == HTTP_200_OK
         assert str(response.url) == "http://www.moishe.zuchmir.com/"
@@ -132,7 +132,7 @@ def test_middleware_does_not_redirect_when_off() -> None:
     config = AllowedHostsConfig(allowed_hosts=["www.moishe.zuchmir.com"], www_redirect=False)
 
     with create_test_client(handler, allowed_hosts=config) as client:
-        client.base_url = "http://moishe.zuchmir.com"  # type: ignore
+        client.base_url = "http://moishe.zuchmir.com"  # type: ignore[assignment]
         response = client.get("/")
         assert response.status_code == HTTP_400_BAD_REQUEST
 

--- a/tests/unit/test_middleware/test_exception_handler_middleware.py
+++ b/tests/unit/test_middleware/test_exception_handler_middleware.py
@@ -123,7 +123,7 @@ def test_exception_handler_middleware_exception_handlers_mapping() -> None:
         return Response(content={"an": "error"}, status_code=HTTP_500_INTERNAL_SERVER_ERROR)
 
     app = Litestar(route_handlers=[handler], exception_handlers={Exception: exception_handler}, openapi_config=None)
-    assert app.asgi_router.root_route_map_node.children["/"].asgi_handlers["GET"][0].exception_handlers == {  # type: ignore
+    assert app.asgi_router.root_route_map_node.children["/"].asgi_handlers["GET"][0].exception_handlers == {  # type: ignore[attr-defined]
         Exception: exception_handler,
         StarletteHTTPException: _starlette_exception_handler,
     }

--- a/tests/unit/test_middleware/test_logging_middleware.py
+++ b/tests/unit/test_middleware/test_logging_middleware.py
@@ -45,10 +45,10 @@ def handler() -> HTTPRouteHandler:
 
 def test_logging_middleware_config_validation() -> None:
     with pytest.raises(ImproperlyConfiguredException):
-        LoggingMiddlewareConfig(response_log_fields=None)  # type: ignore
+        LoggingMiddlewareConfig(response_log_fields=None)  # type: ignore[arg-type]
 
     with pytest.raises(ImproperlyConfiguredException):
-        LoggingMiddlewareConfig(request_log_fields=None)  # type: ignore
+        LoggingMiddlewareConfig(request_log_fields=None)  # type: ignore[arg-type]
 
 
 def test_logging_middleware_regular_logger(
@@ -59,7 +59,7 @@ def test_logging_middleware_regular_logger(
     ) as client, caplog.at_level(INFO):
         # Set cookies on the client to avoid warnings about per-request cookies.
         client.app.get_logger = get_logger
-        client.cookies = {"request-cookie": "abc"}  # type: ignore
+        client.cookies = {"request-cookie": "abc"}  # type: ignore[assignment]
         response = client.get("/", headers={"request-header": "1"})
         assert response.status_code == HTTP_200_OK
         assert len(caplog.messages) == 2
@@ -80,7 +80,7 @@ def test_logging_middleware_struct_logger(handler: HTTPRouteHandler) -> None:
         logging_config=StructLoggingConfig(),
     ) as client, capture_logs() as cap_logs:
         # Set cookies on the client to avoid warnings about per-request cookies.
-        client.cookies = {"request-cookie": "abc"}  # type: ignore
+        client.cookies = {"request-cookie": "abc"}  # type: ignore[assignment]
         response = client.get("/", headers={"request-header": "1"})
         assert response.status_code == HTTP_200_OK
         assert len(cap_logs) == 2
@@ -126,7 +126,7 @@ def test_logging_middleware_exclude_pattern(
         route_handlers=[handler, handler2], middleware=[config.middleware]
     ) as client, caplog.at_level(INFO):
         # Set cookies on the client to avoid warnings about per-request cookies.
-        client.cookies = {"request-cookie": "abc"}  # type: ignore
+        client.cookies = {"request-cookie": "abc"}  # type: ignore[assignment]
         client.app.get_logger = get_logger
 
         response = client.get("/exclude")
@@ -150,7 +150,7 @@ def test_logging_middleware_exclude_opt_key(
         route_handlers=[handler, handler2], middleware=[config.middleware]
     ) as client, caplog.at_level(INFO):
         # Set cookies on the client to avoid warnings about per-request cookies.
-        client.cookies = {"request-cookie": "abc"}  # type: ignore
+        client.cookies = {"request-cookie": "abc"}  # type: ignore[assignment]
         client.app.get_logger = get_logger
 
         response = client.get("/exclude")
@@ -172,7 +172,7 @@ def test_logging_middleware_compressed_response_body(
         middleware=[LoggingMiddlewareConfig(include_compressed_body=include).middleware],
     ) as client, caplog.at_level(INFO):
         # Set cookies on the client to avoid warnings about per-request cookies.
-        client.cookies = {"request-cookie": "abc"}  # type: ignore
+        client.cookies = {"request-cookie": "abc"}  # type: ignore[assignment]
         client.app.get_logger = get_logger
         response = client.get("/", headers={"request-header": "1"})
         assert response.status_code == HTTP_200_OK
@@ -249,7 +249,7 @@ def test_logging_middleware_log_fields(
     ) as client, caplog.at_level(INFO):
         # Set cookies on the client to avoid warnings about per-request cookies.
         client.app.get_logger = get_logger
-        client.cookies = {"request-cookie": "abc"}  # type: ignore
+        client.cookies = {"request-cookie": "abc"}  # type: ignore[assignment]
         response = client.get("/", headers={"request-header": "1"})
         assert response.status_code == HTTP_200_OK
         assert len(caplog.messages) == 2

--- a/tests/unit/test_middleware/test_middleware_handling.py
+++ b/tests/unit/test_middleware/test_middleware_handling.py
@@ -34,9 +34,9 @@ class MiddlewareProtocolRequestLoggingMiddleware(MiddlewareProtocol):
 
 
 class BaseMiddlewareRequestLoggingMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:  # type: ignore
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:  # type: ignore[explicit-override, override]
         logging.getLogger(__name__).info("%s - %s", request.method, request.url)
-        return await call_next(request)  # type: ignore
+        return await call_next(request)  # type: ignore[arg-type, return-value]
 
 
 class MiddlewareWithArgsAndKwargs(BaseHTTPMiddleware):
@@ -45,7 +45,7 @@ class MiddlewareWithArgsAndKwargs(BaseHTTPMiddleware):
         self.arg = arg
         self.kwarg = kwarg
 
-    async def dispatch(  # type: ignore
+    async def dispatch(  # type: ignore[empty-body, explicit-override, override]
         self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
     ) -> Response:
         ...

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -38,7 +38,7 @@ def create_factory(route: BaseRoute, handler: HTTPRouteHandler) -> ParameterFact
 def _create_parameters(app: Litestar, path: str) -> List["OpenAPIParameter"]:
     index = find_index(app.routes, lambda x: x.path_format == path)
     route = app.routes[index]
-    route_handler = route.route_handler_map["GET"][0]  # type: ignore
+    route_handler = route.route_handler_map["GET"][0]  # type: ignore[union-attr]
     handler = route_handler.fn
     assert callable(handler)
     return create_factory(route, route_handler).create_parameters_for_handler()
@@ -167,10 +167,10 @@ def test_deduplication_for_param_where_key_and_type_are_equal() -> None:
 
     app = Litestar(route_handlers=[handler])
     assert isinstance(app.openapi_schema, OpenAPI)
-    open_api_path_item = app.openapi_schema.paths["/test"]  # type: ignore
-    open_api_parameters = open_api_path_item.get.parameters  # type: ignore
-    assert len(open_api_parameters) == 2  # type: ignore
-    assert {p.name for p in open_api_parameters} == {"query_param", "other_param"}  # type: ignore
+    open_api_path_item = app.openapi_schema.paths["/test"]  # type: ignore[index]
+    open_api_parameters = open_api_path_item.get.parameters  # type: ignore[union-attr]
+    assert len(open_api_parameters) == 2  # type: ignore[arg-type]
+    assert {p.name for p in open_api_parameters} == {"query_param", "other_param"}  # type: ignore[union-attr]
 
 
 def test_raise_for_multiple_parameters_of_same_name_and_differing_types() -> None:
@@ -199,7 +199,7 @@ def test_dependency_params_in_docs_if_dependency_provided() -> None:
         return None
 
     app = Litestar(route_handlers=[handler])
-    param_name_set = {p.name for p in cast("OpenAPI", app.openapi_schema).paths["/"].get.parameters}  # type: ignore
+    param_name_set = {p.name for p in cast("OpenAPI", app.openapi_schema).paths["/"].get.parameters}  # type: ignore[index, redundant-cast, union-attr]
     assert "dep" not in param_name_set
     assert "param" in param_name_set
 
@@ -210,7 +210,7 @@ def test_dependency_not_in_doc_params_if_not_provided() -> None:
         return None
 
     app = Litestar(route_handlers=[handler])
-    assert cast("OpenAPI", app.openapi_schema).paths["/"].get.parameters is None  # type: ignore
+    assert cast("OpenAPI", app.openapi_schema).paths["/"].get.parameters is None  # type: ignore[index, redundant-cast, union-attr]
 
 
 def test_non_dependency_in_doc_params_if_not_provided() -> None:
@@ -219,7 +219,7 @@ def test_non_dependency_in_doc_params_if_not_provided() -> None:
         return None
 
     app = Litestar(route_handlers=[handler])
-    param_name_set = {p.name for p in cast("OpenAPI", app.openapi_schema).paths["/"].get.parameters}  # type: ignore
+    param_name_set = {p.name for p in cast("OpenAPI", app.openapi_schema).paths["/"].get.parameters}  # type: ignore[index, redundant-cast, union-attr]
     assert "param" in param_name_set
 
 
@@ -267,48 +267,48 @@ def test_layered_parameters() -> None:
     local, app3, controller1, router1, router3, app4, app2, controller3 = tuple(parameters)
 
     assert app4.param_in == ParamType.COOKIE
-    assert app4.schema.type == OpenAPIType.STRING  # type: ignore
+    assert app4.schema.type == OpenAPIType.STRING  # type: ignore[union-attr]
     assert app4.required
-    assert app4.schema.examples  # type: ignore
+    assert app4.schema.examples  # type: ignore[union-attr]
 
     assert app2.param_in == ParamType.QUERY
-    assert app2.schema.type == OpenAPIType.ARRAY  # type: ignore
+    assert app2.schema.type == OpenAPIType.ARRAY  # type: ignore[union-attr]
     assert app2.required
-    assert app2.schema.examples  # type: ignore
+    assert app2.schema.examples  # type: ignore[union-attr]
 
     assert app3.param_in == ParamType.QUERY
-    assert app3.schema.type == OpenAPIType.BOOLEAN  # type: ignore
+    assert app3.schema.type == OpenAPIType.BOOLEAN  # type: ignore[union-attr]
     assert not app3.required
-    assert app3.schema.examples  # type: ignore
+    assert app3.schema.examples  # type: ignore[union-attr]
 
     assert router1.param_in == ParamType.QUERY
-    assert router1.schema.type == OpenAPIType.STRING  # type: ignore
+    assert router1.schema.type == OpenAPIType.STRING  # type: ignore[union-attr]
     assert router1.required
-    assert router1.schema.pattern == "^[a-zA-Z]$"  # type: ignore
-    assert router1.schema.examples  # type: ignore
+    assert router1.schema.pattern == "^[a-zA-Z]$"  # type: ignore[union-attr]
+    assert router1.schema.examples  # type: ignore[union-attr]
 
     assert router3.param_in == ParamType.HEADER
-    assert router3.schema.type == OpenAPIType.NUMBER  # type: ignore
+    assert router3.schema.type == OpenAPIType.NUMBER  # type: ignore[union-attr]
     assert router3.required
-    assert router3.schema.multiple_of == 5.0  # type: ignore
-    assert router3.schema.examples  # type: ignore
+    assert router3.schema.multiple_of == 5.0  # type: ignore[union-attr]
+    assert router3.schema.examples  # type: ignore[union-attr]
 
     assert controller1.param_in == ParamType.QUERY
-    assert controller1.schema.type == OpenAPIType.INTEGER  # type: ignore
+    assert controller1.schema.type == OpenAPIType.INTEGER  # type: ignore[union-attr]
     assert controller1.required
-    assert controller1.schema.exclusive_maximum == 100.0  # type: ignore
-    assert controller1.schema.examples  # type: ignore
+    assert controller1.schema.exclusive_maximum == 100.0  # type: ignore[union-attr]
+    assert controller1.schema.examples  # type: ignore[union-attr]
 
     assert controller3.param_in == ParamType.QUERY
-    assert controller3.schema.type == OpenAPIType.NUMBER  # type: ignore
+    assert controller3.schema.type == OpenAPIType.NUMBER  # type: ignore[union-attr]
     assert controller3.required
-    assert controller3.schema.minimum == 5.0  # type: ignore
-    assert controller3.schema.examples  # type: ignore
+    assert controller3.schema.minimum == 5.0  # type: ignore[union-attr]
+    assert controller3.schema.examples  # type: ignore[union-attr]
 
     assert local.param_in == ParamType.PATH
-    assert local.schema.type == OpenAPIType.INTEGER  # type: ignore
+    assert local.schema.type == OpenAPIType.INTEGER  # type: ignore[union-attr]
     assert local.required
-    assert local.schema.examples  # type: ignore
+    assert local.schema.examples  # type: ignore[union-attr]
 
 
 def test_parameter_examples() -> None:

--- a/tests/unit/test_openapi/test_path_item.py
+++ b/tests/unit/test_openapi/test_path_item.py
@@ -29,7 +29,7 @@ def route(person_controller: type[Controller]) -> HTTPRoute:
 
 @pytest.fixture()
 def routes_with_router(person_controller: type[Controller]) -> tuple[HTTPRoute, HTTPRoute]:
-    class PersonControllerV2(person_controller):  # type: ignore
+    class PersonControllerV2(person_controller):  # type: ignore[misc, valid-type]
         pass
 
     router_v1 = Router(path="/v1", route_handlers=[person_controller])
@@ -106,7 +106,7 @@ def test_unique_operation_ids_for_multiple_http_methods_with_handler_level_opera
     index = find_index(app.routes, lambda x: x.path_format == "/")
     route_with_multiple_methods = cast("HTTPRoute", app.routes[index])
     factory = create_factory(route_with_multiple_methods)
-    factory.context.openapi_config.operation_id_creator = lambda x: "abc"  # type: ignore
+    factory.context.openapi_config.operation_id_creator = lambda x: "abc"  # type: ignore[assignment, misc]
     schema = create_factory(route_with_multiple_methods).create_path_item()
     assert schema.get
     assert schema.get.operation_id

--- a/tests/unit/test_openapi/test_request_body.py
+++ b/tests/unit/test_openapi/test_request_body.py
@@ -49,7 +49,7 @@ def create_request(openapi_context: OpenAPIContext) -> RequestBodyFactory:
 
 def test_create_request_body(person_controller: Type[Controller], create_request: RequestBodyFactory) -> None:
     for route in Litestar(route_handlers=[person_controller]).routes:
-        for route_handler, _ in route.route_handler_map.values():  # type: ignore
+        for route_handler, _ in route.route_handler_map.values():  # type: ignore[union-attr]
             handler_fields = route_handler.parsed_fn_signature.parameters
             if "data" in handler_fields:
                 request_body = create_request(route_handler, handler_fields["data"])

--- a/tests/unit/test_openapi/test_responses.py
+++ b/tests/unit/test_openapi/test_responses.py
@@ -527,4 +527,4 @@ def test_file_response_media_type(content_media_type: Any, expected: Any, create
         return File("test.txt")
 
     response = create_factory(handler).create_success_response()
-    assert next(iter(response.content.values())).schema.content_media_type == expected  # type: ignore
+    assert next(iter(response.content.values())).schema.content_media_type == expected  # type: ignore[union-attr]

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -288,11 +288,11 @@ def test_create_schema_from_msgspec_annotated_type() -> None:
 
     schema = get_schema_for_field_definition(FieldDefinition.from_kwarg(name="Lookup", annotation=Lookup))
 
-    assert schema.properties["id"].type == OpenAPIType.STRING  # type: ignore
-    assert schema.properties["id"].examples == {"id-example-1": Example(value="example")}  # type: ignore
-    assert schema.properties["id"].description == "description"  # type: ignore
-    assert schema.properties["id"].title == "title"  # type: ignore
-    assert schema.properties["id"].max_length == 16  # type: ignore
+    assert schema.properties["id"].type == OpenAPIType.STRING  # type: ignore[index, union-attr]
+    assert schema.properties["id"].examples == {"id-example-1": Example(value="example")}  # type: ignore[index, union-attr]
+    assert schema.properties["id"].description == "description"  # type: ignore[index]
+    assert schema.properties["id"].title == "title"  # type: ignore[index, union-attr]
+    assert schema.properties["id"].max_length == 16  # type: ignore[index, union-attr]
     assert schema.required == ["id"]
 
 
@@ -312,20 +312,20 @@ def test_annotated_types() -> None:
 
     schema = get_schema_for_field_definition(FieldDefinition.from_kwarg(name="MyDataclass", annotation=MyDataclass))
 
-    assert schema.properties["constrained_int"].exclusive_minimum == 1  # type: ignore
-    assert schema.properties["constrained_int"].exclusive_maximum == 10  # type: ignore
-    assert schema.properties["constrained_float"].minimum == 1  # type: ignore
-    assert schema.properties["constrained_float"].maximum == 10  # type: ignore
-    assert datetime.utcfromtimestamp(schema.properties["constrained_date"].exclusive_minimum) == datetime.fromordinal(  # type: ignore
+    assert schema.properties["constrained_int"].exclusive_minimum == 1  # type: ignore[index, union-attr]
+    assert schema.properties["constrained_int"].exclusive_maximum == 10  # type: ignore[index, union-attr]
+    assert schema.properties["constrained_float"].minimum == 1  # type: ignore[index, union-attr]
+    assert schema.properties["constrained_float"].maximum == 10  # type: ignore[index, union-attr]
+    assert datetime.utcfromtimestamp(schema.properties["constrained_date"].exclusive_minimum) == datetime.fromordinal(  # type: ignore[arg-type, index, union-attr]
         historical_date.toordinal()
     )
-    assert datetime.utcfromtimestamp(schema.properties["constrained_date"].exclusive_maximum) == datetime.fromordinal(  # type: ignore
+    assert datetime.utcfromtimestamp(schema.properties["constrained_date"].exclusive_maximum) == datetime.fromordinal(  # type: ignore[arg-type, index, union-attr]
         today.toordinal()
     )
-    assert schema.properties["constrained_lower_case"].description == "must be in lower case"  # type: ignore
-    assert schema.properties["constrained_upper_case"].description == "must be in upper case"  # type: ignore
-    assert schema.properties["constrained_is_ascii"].pattern == "[[:ascii:]]"  # type: ignore
-    assert schema.properties["constrained_is_digit"].pattern == "[[:digit:]]"  # type: ignore
+    assert schema.properties["constrained_lower_case"].description == "must be in lower case"  # type: ignore[index]
+    assert schema.properties["constrained_upper_case"].description == "must be in upper case"  # type: ignore[index]
+    assert schema.properties["constrained_is_ascii"].pattern == "[[:ascii:]]"  # type: ignore[index, union-attr]
+    assert schema.properties["constrained_is_digit"].pattern == "[[:digit:]]"  # type: ignore[index, union-attr]
 
 
 def test_literal_enums() -> None:

--- a/tests/unit/test_openapi/test_tags.py
+++ b/tests/unit/test_openapi/test_tags.py
@@ -47,12 +47,12 @@ def openapi_schema(app: Litestar) -> "OpenAPI":
 
 
 def test_openapi_schema_handler_tags(openapi_schema: "OpenAPI") -> None:
-    assert openapi_schema.paths["/handler"].get.tags == ["handler"]  # type: ignore
+    assert openapi_schema.paths["/handler"].get.tags == ["handler"]  # type: ignore[index, union-attr]
 
 
 def test_openapi_schema_controller_tags(openapi_schema: "OpenAPI") -> None:
-    assert openapi_schema.paths["/controller"].get.tags == ["a", "controller", "handler"]  # type: ignore
+    assert openapi_schema.paths["/controller"].get.tags == ["a", "controller", "handler"]  # type: ignore[index, union-attr]
 
 
 def test_openapi_schema_router_tags(openapi_schema: "OpenAPI") -> None:
-    assert openapi_schema.paths["/router/controller"].get.tags == ["a", "controller", "handler", "router"]  # type: ignore
+    assert openapi_schema.paths["/router/controller"].get.tags == ["a", "controller", "handler", "router"]  # type: ignore[index, union-attr]

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -80,11 +80,11 @@ data = DataclassPersonFactory.batch(50)
 def test_classic_pagination_data_shape(paginator: Any) -> None:
     @get("/async")
     async def async_handler(page_size: int, current_page: int) -> ClassicPagination[DataclassPerson]:
-        return await paginator(page_size=page_size, current_page=current_page)  # type: ignore
+        return await paginator(page_size=page_size, current_page=current_page)  # type: ignore[no-any-return]
 
     @get("/sync")
     def sync_handler(page_size: int, current_page: int) -> ClassicPagination[DataclassPerson]:
-        return paginator(page_size=page_size, current_page=current_page)  # type: ignore
+        return paginator(page_size=page_size, current_page=current_page)  # type: ignore[no-any-return]
 
     with create_test_client([async_handler, sync_handler]) as client:
         if isinstance(paginator, TestSyncClassicPaginator):
@@ -104,11 +104,11 @@ def test_classic_pagination_data_shape(paginator: Any) -> None:
 def test_classic_pagination_openapi_schema(paginator: Any) -> None:
     @get("/async")
     async def async_handler(page_size: int, current_page: int) -> ClassicPagination[DataclassPerson]:
-        return await paginator(page_size=page_size, current_page=current_page)  # type: ignore
+        return await paginator(page_size=page_size, current_page=current_page)  # type: ignore[no-any-return]
 
     @get("/sync")
     def sync_handler(page_size: int, current_page: int) -> ClassicPagination[DataclassPerson]:
-        return paginator(page_size=page_size, current_page=current_page)  # type: ignore
+        return paginator(page_size=page_size, current_page=current_page)  # type: ignore[no-any-return]
 
     with create_test_client([async_handler, sync_handler], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
         schema = client.app.openapi_schema
@@ -137,11 +137,11 @@ def test_classic_pagination_openapi_schema(paginator: Any) -> None:
 def test_limit_offset_pagination_data_shape(paginator: Any) -> None:
     @get("/async")
     async def async_handler(limit: int, offset: int) -> OffsetPagination[DataclassPerson]:
-        return await paginator(limit=limit, offset=offset)  # type: ignore
+        return await paginator(limit=limit, offset=offset)  # type: ignore[no-any-return]
 
     @get("/sync")
     def sync_handler(limit: int, offset: int) -> OffsetPagination[DataclassPerson]:
-        return paginator(limit=limit, offset=offset)  # type: ignore
+        return paginator(limit=limit, offset=offset)  # type: ignore[no-any-return]
 
     with create_test_client([async_handler, sync_handler]) as client:
         if isinstance(paginator, TestSyncOffsetPaginator):
@@ -161,11 +161,11 @@ def test_limit_offset_pagination_data_shape(paginator: Any) -> None:
 def test_limit_offset_pagination_openapi_schema(paginator: Any) -> None:
     @get("/async")
     async def async_handler(limit: int, offset: int) -> OffsetPagination[DataclassPerson]:
-        return await paginator(limit=limit, offset=offset)  # type: ignore
+        return await paginator(limit=limit, offset=offset)  # type: ignore[no-any-return]
 
     @get("/sync")
     def sync_handler(limit: int, offset: int) -> OffsetPagination[DataclassPerson]:
-        return paginator(limit=limit, offset=offset)  # type: ignore
+        return paginator(limit=limit, offset=offset)  # type: ignore[no-any-return]
 
     with create_test_client([async_handler, sync_handler], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
         schema = client.app.openapi_schema
@@ -218,11 +218,11 @@ class TestAsyncCursorPagination(AbstractAsyncCursorPaginator[str, DataclassPerso
 def test_cursor_pagination_data_shape(paginator: Any) -> None:
     @get("/async")
     async def async_handler(cursor: Optional[str] = None) -> CursorPagination[str, DataclassPerson]:
-        return await paginator(cursor=cursor, results_per_page=5)  # type: ignore
+        return await paginator(cursor=cursor, results_per_page=5)  # type: ignore[no-any-return]
 
     @get("/sync")
     def sync_handler(cursor: Optional[str] = None) -> CursorPagination[str, DataclassPerson]:
-        return paginator(cursor=cursor, results_per_page=5)  # type: ignore
+        return paginator(cursor=cursor, results_per_page=5)  # type: ignore[no-any-return]
 
     with create_test_client([async_handler, sync_handler]) as client:
         if isinstance(paginator, TestSyncCursorPagination):
@@ -241,11 +241,11 @@ def test_cursor_pagination_data_shape(paginator: Any) -> None:
 def test_cursor_pagination_openapi_schema(paginator: Any) -> None:
     @get("/async")
     async def async_handler(cursor: Optional[str] = None) -> CursorPagination[str, DataclassPerson]:
-        return await paginator(cursor=cursor, results_per_page=5)  # type: ignore
+        return await paginator(cursor=cursor, results_per_page=5)  # type: ignore[no-any-return]
 
     @get("/sync")
     def sync_handler(cursor: Optional[str] = None) -> CursorPagination[str, DataclassPerson]:
-        return paginator(cursor=cursor, results_per_page=5)  # type: ignore
+        return paginator(cursor=cursor, results_per_page=5)  # type: ignore[no-any-return]
 
     with create_test_client([async_handler, sync_handler], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
         schema = client.app.openapi_schema

--- a/tests/unit/test_response/test_response_cookies.py
+++ b/tests/unit/test_response/test_response_cookies.py
@@ -37,7 +37,7 @@ def test_response_cookies() -> None:
         response_cookies=[app_first, app_second],
         route_handlers=[first_router, second_router],
     )
-    route_handler, _ = app.routes[0].route_handler_map[HttpMethod.GET]  # type: ignore
+    route_handler, _ = app.routes[0].route_handler_map[HttpMethod.GET]  # type: ignore[union-attr]
     response_cookies = {cookie.key: cookie.value for cookie in route_handler.resolve_response_cookies()}
     assert response_cookies["first"] == local_first.value
     assert response_cookies["second"] == controller_second.value

--- a/tests/unit/test_response/test_response_headers.py
+++ b/tests/unit/test_response/test_response_headers.py
@@ -38,7 +38,7 @@ def test_response_headers() -> None:
         route_handlers=[first_router, second_router],
     )
 
-    route_handler, _ = app.routes[0].route_handler_map[HttpMethod.GET]  # type: ignore
+    route_handler, _ = app.routes[0].route_handler_map[HttpMethod.GET]  # type: ignore[union-attr]
     resolved_headers = {header.name: header for header in route_handler.resolve_response_headers()}
     assert resolved_headers["first"].value == local_first.value
     assert resolved_headers["second"].value == controller_second.value
@@ -184,6 +184,6 @@ def test_explicit_headers_override_response_headers(
 
     app = Litestar(route_handlers=[my_handler])
 
-    route_handler, _ = app.routes[0].route_handler_map[HttpMethod.GET]  # type: ignore
+    route_handler, _ = app.routes[0].route_handler_map[HttpMethod.GET]  # type: ignore[union-attr]
     resolved_headers = {header.name: header for header in route_handler.resolve_response_headers()}
     assert resolved_headers[header.HEADER_NAME].value == header.to_header()

--- a/tests/unit/test_response/test_streaming_response.py
+++ b/tests/unit/test_response/test_streaming_response.py
@@ -56,7 +56,7 @@ async def test_streaming_response_stops_if_receiving_http_disconnect_with_async_
     response = ASGIStreamingResponse(iterator=stream_indefinitely())
 
     with anyio.move_on_after(1) as cancel_scope:
-        await response({}, receive_disconnect, send)  # type: ignore
+        await response({}, receive_disconnect, send)  # type: ignore[arg-type]
     assert not cancel_scope.cancel_called, "Content streaming should stop itself."
 
 
@@ -80,7 +80,7 @@ async def test_streaming_response_stops_if_receiving_http_disconnect_with_sync_i
     response = ASGIStreamingResponse(iterator=cycle(["1", "2", "3"]))
 
     with anyio.move_on_after(1) as cancel_scope:
-        await response({}, receive_disconnect, send)  # type: ignore
+        await response({}, receive_disconnect, send)  # type: ignore[arg-type]
     assert not cancel_scope.cancel_called, "Content streaming should stop itself."
 
 

--- a/tests/unit/test_response/test_type_encoders.py
+++ b/tests/unit/test_response/test_type_encoders.py
@@ -33,7 +33,7 @@ def test_resolve_type_encoders() -> None:
     router = Router("/router", type_encoders={router_type: router_encoder}, route_handlers=[MyController])
     app = Litestar([router], type_encoders={app_type: app_encoder})
 
-    route_handler = app.routes[0].route_handler_map[HttpMethod.GET][0]  # type: ignore
+    route_handler = app.routes[0].route_handler_map[HttpMethod.GET][0]  # type: ignore[union-attr]
     encoders = route_handler.resolve_type_encoders()
     assert encoders.get(handler_type) == handler_encoder
     assert encoders.get(controller_type) == controller_encoder

--- a/tests/unit/test_security/test_jwt/test_auth.py
+++ b/tests/unit/test_security/test_jwt/test_auth.py
@@ -175,7 +175,7 @@ async def test_jwt_cookie_auth(
         key=auth_cookie,
         auth_header=auth_header,
         default_token_expiration=default_token_expiration,
-        retrieve_user_handler=retrieve_user_handler,  # type: ignore
+        retrieve_user_handler=retrieve_user_handler,  # type: ignore[var-annotated]
         token_secret=token_secret,
     )
 
@@ -298,7 +298,7 @@ async def test_path_exclusion() -> None:
 
 
 def test_jwt_auth_openapi() -> None:
-    jwt_auth = JWTAuth[Any](token_secret="abc123", retrieve_user_handler=lambda _: None)  # type: ignore
+    jwt_auth = JWTAuth[Any](token_secret="abc123", retrieve_user_handler=lambda _: None)  # type: ignore[arg-type, misc]
     assert jwt_auth.openapi_components.to_schema() == {
         "schemas": {},
         "securitySchemes": {
@@ -348,7 +348,7 @@ async def test_oauth2_password_bearer_auth_openapi(mock_db: "MemoryStore") -> No
     jwt_auth = OAuth2PasswordBearerAuth(
         token_url="/login",
         token_secret="abc123",
-        retrieve_user_handler=retrieve_user_handler,  # type: ignore
+        retrieve_user_handler=retrieve_user_handler,  # type: ignore[var-annotated]
     )
 
     @get("/login")

--- a/tests/unit/test_signature/test_validation.py
+++ b/tests/unit/test_signature/test_validation.py
@@ -33,7 +33,7 @@ def test_parses_values_from_connection_kwargs_raises() -> None:
 
 def test_create_signature_validation() -> None:
     @get()
-    def my_fn(typed: int, untyped) -> None:  # type: ignore
+    def my_fn(typed: int, untyped) -> None:  # type: ignore[no-untyped-def]
         pass
 
     with pytest.raises(ImproperlyConfiguredException):

--- a/tests/unit/test_static_files/test_file_serving_resolution.py
+++ b/tests/unit/test_static_files/test_file_serving_resolution.py
@@ -159,7 +159,7 @@ def test_sub_path_under_static_path(tmpdir: Path, make_config: MakeConfig) -> No
 
 
 def test_static_substring_of_self(tmpdir: Path, make_config: MakeConfig) -> None:
-    path = tmpdir.mkdir("static_part").mkdir("static") / "test.txt"  # type: ignore
+    path = tmpdir.mkdir("static_part").mkdir("static") / "test.txt"  # type: ignore[arg-type, func-returns-value]
     path.write_text("content", "utf-8")
 
     configs, handlers = make_config(StaticFilesConfig(path="/static", directories=[tmpdir]))
@@ -209,7 +209,7 @@ def test_static_files_response_encoding(tmp_path: Path, extension: str, make_con
 def test_static_files_content_disposition(
     tmpdir: Path, send_as_attachment: bool, disposition: str, make_config: MakeConfig
 ) -> None:
-    path = tmpdir.mkdir("static_part").mkdir("static") / "test.txt"  # type: ignore
+    path = tmpdir.mkdir("static_part").mkdir("static") / "test.txt"  # type: ignore[arg-type, func-returns-value]
     path.write_text("content", "utf-8")
 
     configs, handlers = make_config(
@@ -223,7 +223,7 @@ def test_static_files_content_disposition(
 
 
 def test_service_from_relative_path_using_string(tmpdir: Path, make_config: MakeConfig) -> None:
-    sub_dir = Path(tmpdir.mkdir("low")).resolve()  # type: ignore
+    sub_dir = Path(tmpdir.mkdir("low")).resolve()  # type: ignore[arg-type, func-returns-value]
 
     path = tmpdir / "test.txt"
     path.write_text("content", "utf-8")
@@ -237,7 +237,7 @@ def test_service_from_relative_path_using_string(tmpdir: Path, make_config: Make
 
 
 def test_service_from_relative_path_using_path(tmpdir: Path, make_config: MakeConfig) -> None:
-    sub_dir = Path(tmpdir.mkdir("low")).resolve()  # type: ignore
+    sub_dir = Path(tmpdir.mkdir("low")).resolve()  # type: ignore[arg-type, func-returns-value]
 
     path = tmpdir / "test.txt"
     path.write_text("content", "utf-8")
@@ -251,7 +251,7 @@ def test_service_from_relative_path_using_path(tmpdir: Path, make_config: MakeCo
 
 
 def test_service_from_base_path_using_string(tmpdir: Path) -> None:
-    sub_dir = Path(tmpdir.mkdir("low")).resolve()  # type: ignore
+    sub_dir = Path(tmpdir.mkdir("low")).resolve()  # type: ignore[arg-type, func-returns-value]
 
     path = tmpdir / "test.txt"
     path.write_text("content", "utf-8")

--- a/tests/unit/test_testing/test_request_factory.py
+++ b/tests/unit/test_testing/test_request_factory.py
@@ -69,7 +69,7 @@ async def test_request_factory_create_with_data(data_cls: DataContainerType) -> 
     request = RequestFactory()._create_request_with_data(
         HttpMethod.POST,
         "/",
-        data=data_cls(**person_data),  # type: ignore
+        data=data_cls(**person_data),  # type: ignore[operator]
     )
     body = await request.body()
     assert json.loads(body) == person_data

--- a/tests/unit/test_utils/test_sync.py
+++ b/tests/unit/test_utils/test_sync.py
@@ -32,10 +32,10 @@ async def test_function_wrapper_wraps_async_method_correctly() -> None:
 
     wrapped_method = ensure_async_callable(instance.my_method)
 
-    await wrapped_method(1)  # type: ignore
+    await wrapped_method(1)  # type: ignore[unused-coroutine]
     assert instance.value == 1
 
-    await wrapped_method(value=10)  # type: ignore
+    await wrapped_method(value=10)  # type: ignore[unused-coroutine]
     assert instance.value == 10
 
 
@@ -62,10 +62,10 @@ async def test_function_wrapper_wraps_async_function_correctly() -> None:
 
     wrapped_function = ensure_async_callable(my_function)
 
-    await wrapped_function(1)  # type: ignore
+    await wrapped_function(1)  # type: ignore[unused-coroutine]
     assert obj["value"] == 1
 
-    await wrapped_function(new_value=10)  # type: ignore
+    await wrapped_function(new_value=10)  # type: ignore[unused-coroutine]
     assert obj["value"] == 10
 
 
@@ -98,8 +98,8 @@ async def test_function_wrapper_wraps_async_class_correctly() -> None:
 
     wrapped_class = ensure_async_callable(instance)
 
-    await wrapped_class(1)  # type: ignore
+    await wrapped_class(1)  # type: ignore[unused-coroutine]
     assert instance.value == 1
 
-    await wrapped_class(new_value=10)  # type: ignore
+    await wrapped_class(new_value=10)  # type: ignore[unused-coroutine]
     assert instance.value == 10

--- a/tests/unit/test_websocket_class_resolution.py
+++ b/tests/unit/test_websocket_class_resolution.py
@@ -54,14 +54,14 @@ def test_websocket_class_resolution_of_layers(
     app = Litestar(route_handlers=[router])
 
     if app_websocket_class or not has_default_app_class:
-        app.websocket_class = app_websocket_class  # type: ignore
+        app.websocket_class = app_websocket_class  # type: ignore[assignment]
 
-    route_handler = app.routes[0].route_handler  # type: ignore
+    route_handler = app.routes[0].route_handler  # type: ignore[union-attr]
 
     if handler_websocket_class:
-        route_handler.websocket_class = handler_websocket_class  # type: ignore
+        route_handler.websocket_class = handler_websocket_class  # type: ignore[union-attr]
 
-    websocket_class = route_handler.resolve_websocket_class()  # type: ignore
+    websocket_class = route_handler.resolve_websocket_class()  # type: ignore[union-attr]
     assert websocket_class is expected
 
 
@@ -104,12 +104,12 @@ def test_listener_websocket_class_resolution_of_layers(
     app = Litestar(route_handlers=[router])
 
     if app_websocket_class or not has_default_app_class:
-        app.websocket_class = app_websocket_class  # type: ignore
+        app.websocket_class = app_websocket_class  # type: ignore[assignment]
 
-    route_handler = app.routes[0].route_handler  # type: ignore
+    route_handler = app.routes[0].route_handler  # type: ignore[union-attr]
 
     if handler_websocket_class:
-        route_handler.websocket_class = handler_websocket_class  # type: ignore
+        route_handler.websocket_class = handler_websocket_class  # type: ignore[union-attr]
 
-    websocket_class = route_handler.resolve_websocket_class()  # type: ignore
+    websocket_class = route_handler.resolve_websocket_class()  # type: ignore[union-attr]
     assert websocket_class is expected


### PR DESCRIPTION
## Description

- Added `enable_error_code = "ignore-without-code"` to mypy config
