### PR TITLE
feat: make random seed for openapi example generation configurable

### DIFF
--- a/litestar/_openapi/plugin.py
+++ b/litestar/_openapi/plugin.py
@@ -32,8 +32,15 @@ class OpenAPIPlugin(InitPluginProtocol, ReceiveRoutePlugin):
         self._openapi_schema: OpenAPI | None = None
 
     def _build_openapi_schema(self) -> OpenAPI:
-        openapi = self.openapi_config.to_openapi_schema()
-        context = OpenAPIContext(openapi_config=self.openapi_config, plugins=self.app.plugins.openapi)
+        openapi_config = self.openapi_config
+
+        if openapi_config.create_examples:
+            from litestar._openapi.schema_generation.examples import ExampleFactory
+
+            ExampleFactory.seed_random(openapi_config.random_seed)
+
+        openapi = openapi_config.to_openapi_schema()
+        context = OpenAPIContext(openapi_config=openapi_config, plugins=self.app.plugins.openapi)
         openapi.paths = {
             route.path_format or "/": create_path_item_for_route(context, route)
             for route in self.included_routes.values()

--- a/litestar/openapi/config.py
+++ b/litestar/openapi/config.py
@@ -43,6 +43,8 @@ class OpenAPIConfig:
 
     create_examples: bool = field(default=False)
     """Generate examples using the polyfactory library."""
+    random_seed: int = 10
+    """The random seed used when creating the examples to ensure deterministic generation of examples."""
     openapi_controller: type[OpenAPIController] = field(default_factory=lambda: OpenAPIController)
     """Controller for generating OpenAPI routes.
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- This PR allows for the random seed used for generating the examples in the OpenAPI schema (when `create_examples` is set to `True`) to be configured by the user.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

This is related to #3059 however whether this PR is enough to close that issue or not is not confirmed.