### PR TITLE
docs: reference correct property for `secure` Cookie option

### DIFF
--- a/docs/examples/security/jwt/using_jwt_cookie_auth.py
+++ b/docs/examples/security/jwt/using_jwt_cookie_auth.py
@@ -40,7 +40,7 @@ jwt_cookie_auth = JWTCookieAuth[User](
     # and our openAPI docs.
     exclude=["/login", "/schema"],
     # Tip: We can optionally supply cookie options to the configuration.  Here is an example of enabling the secure cookie option
-    # auth_cookie_options=CookieOptions(secure=True),
+    # secure=True,
 )
 
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Use current method signature for the `secure` Cookies flag for `JWTCookieAuth` in the documentation
