### PR TITLE
feat: generate openapi components schemas in a deterministic order

### DIFF
--- a/litestar/_openapi/datastructures.py
+++ b/litestar/_openapi/datastructures.py
@@ -150,7 +150,8 @@ class SchemaRegistry:
                 self.set_reference_paths(name_, registered_schema)
                 components_schemas[name_] = registered_schema.schema
 
-        return components_schemas
+        # Sort them by name to ensure they're always generated in the same order.
+        return {name: components_schemas[name] for name in sorted(components_schemas.keys())}
 
 
 class OpenAPIContext:

--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -422,11 +422,11 @@ def test_components_schemas_in_alphabetical_order() -> None:
             ...
 
         @get("/", sync_to_thread=False)
-        def get_handler(self) -> A:
+        def get_handler(self) -> A:  # type: ignore[empty-body]
             ...
 
         @patch("/", sync_to_thread=False)
-        def patch_handler(self, data: C) -> A:
+        def patch_handler(self, data: C) -> A:  # type: ignore[empty-body]
             ...
 
         @delete("/", sync_to_thread=False)

--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -425,11 +425,11 @@ def test_components_schemas_in_alphabetical_order() -> None:
         def get_handler(self) -> A:
             ...
 
-        @patch("/")
+        @patch("/", sync_to_thread=False)
         def patch_handler(self, data: C) -> A:
             ...
 
-        @delete("/")
+        @delete("/", sync_to_thread=False)
         def delete_handler(self, data: B) -> None:
             ...
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- This PR ensuress that the insertion into the `Components.schemas` dictionary of the OpenAPI spec will be in alphabetical order (based on the normalized name of the `Schema`).

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Closes #3059.
