### PR TITLE
fix: add the redis mark to appropriate test

### DIFF
--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -368,7 +368,8 @@ async def test_file_store_handle_rename_fail(file_store: FileStore, mocker: Mock
     assert Path(mock_unlink.call_args_list[0].args[0]).with_suffix("") == file_store.path.joinpath("foo")
 
 
-async def test_redis_store_with_client_shutdown() -> None:
+@pytest.mark.xdist_group("redis")
+async def test_redis_store_with_client_shutdown(redis_service: None) -> None:
     redis_store = RedisStore.with_client(url="redis://localhost:6397")
     assert await redis_store._redis.ping()
     # remove the private shutdown and the assert below fails


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- make sure the test has the redis mark

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

hopefully closes windows and macos only fail in CI 
