### PR TITLE
fix: sending empty data in sse in js client 

### DIFF
--- a/litestar/response/sse.py
+++ b/litestar/response/sse.py
@@ -91,7 +91,7 @@ class _ServerSentEventIterator(AsyncIteratorWrapper[bytes]):
 
 @dataclass
 class ServerSentEventMessage:
-    data: str | int | bytes | None = None
+    data: str | int | bytes | None = ""
     event: str | None = None
     id: int | str | None = None
     retry: int | None = None

--- a/test_apps/sse/sse.html
+++ b/test_apps/sse/sse.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<body>
+<h2>Server-Sent Events</h2>
+<div id="output"></div>
+<script>
+    if (typeof EventSource !== "undefined") {
+        var eventSource = new EventSource("http://localhost:8000/test_sse_empty");
+        eventSource.onmessage = function (event) {
+            console.log(event.data);
+            document.getElementById("output").innerHTML += event.data + "<br>";
+        };
+        eventSource.addEventListener("empty", (ev) => {
+            console.log("empty arrived");
+            document.getElementById("output").innerHTML += "endx arrived" + "<br>";
+            eventSource.close();
+        });
+
+        eventSource.addEventListener("error", (err) => {
+            console.error(err)
+            document.getElementById("output").innerHTML += "error: " + err + "<br>";
+        })
+    } else {
+        document.getElementById("output").innerHTML =
+            // If browser does not support SSE
+            "Sorry, the browser does not support SSE";
+    }
+</script>
+</body>
+</html>

--- a/test_apps/sse/sse_empty.py
+++ b/test_apps/sse/sse_empty.py
@@ -1,0 +1,23 @@
+from typing import AsyncIterator
+
+import uvicorn
+
+from litestar import Litestar, get
+from litestar.config.cors import CORSConfig
+from litestar.response import ServerSentEvent, ServerSentEventMessage
+from litestar.types import SSEData
+
+
+@get("/test_sse_empty")
+async def handler() -> ServerSentEvent:
+    async def generate() -> AsyncIterator[SSEData]:
+        event = ServerSentEventMessage(event="empty")
+        yield event
+
+    return ServerSentEvent(generate())
+
+
+app = Litestar(route_handlers=[handler], cors_config=CORSConfig(allow_origins=["*"]))
+
+if __name__ == "__main__":
+    uvicorn.run("sse_empty:app")


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- from our discussion here https://discord.com/channels/919193495116337154/1213242966592856164 it appears that javascript clients dont "see" an event that has no data, while we explicitly test for this and that httpx-sse receives the event fine in that case.
- the spec https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream is not that clear to me as to whether or not an event without data is ok.
- Considering the EventSource "client" is not ok with it, and that it's so easy DX-wise to make the mistake not explicitely sending it we fix it by defaulting to the empty-string

 
The added app is just to manually test the fix works, I dont know how we could incorporate it in our test suite given it involves running a server and checkin if the html page yields the event fine, maybe in e2e testing ?
