### PR TITLE
fix: add default encoders for `Enums` and `EnumMeta`

### DIFF
--- a/litestar/serialization/msgspec_hooks.py
+++ b/litestar/serialization/msgspec_hooks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import deque
 from datetime import date, datetime, time
 from decimal import Decimal
+from enum import Enum, EnumMeta
 from functools import partial
 from ipaddress import (
     IPv4Address,
@@ -52,6 +53,8 @@ DEFAULT_TYPE_ENCODERS: TypeEncodersMap = {
     deque: list,
     Decimal: lambda val: int(val) if val.as_tuple().exponent >= 0 else float(val),
     Pattern: lambda val: val.pattern,
+    Enum: lambda val: val.value if val else None,
+    EnumMeta: lambda val: None,
     # support subclasses of stdlib types, If no previous type matched, these will be
     # the last type in the mro, so we use this to (attempt to) convert a subclass into
     # its base class. # see https://github.com/jcrist/msgspec/issues/248
@@ -144,23 +147,19 @@ def encode_json(value: Any, serializer: Callable[[Any], Any] | None = None) -> b
 
 
 @overload
-def decode_json(value: str | bytes) -> Any:
-    ...
+def decode_json(value: str | bytes) -> Any: ...
 
 
 @overload
-def decode_json(value: str | bytes, type_decoders: TypeDecodersSequence | None) -> Any:
-    ...
+def decode_json(value: str | bytes, type_decoders: TypeDecodersSequence | None) -> Any: ...
 
 
 @overload
-def decode_json(value: str | bytes, target_type: type[T]) -> T:
-    ...
+def decode_json(value: str | bytes, target_type: type[T]) -> T: ...
 
 
 @overload
-def decode_json(value: str | bytes, target_type: type[T], type_decoders: TypeDecodersSequence | None) -> T:
-    ...
+def decode_json(value: str | bytes, target_type: type[T], type_decoders: TypeDecodersSequence | None) -> T: ...
 
 
 def decode_json(  # type: ignore[misc]
@@ -213,23 +212,19 @@ def encode_msgpack(value: Any, serializer: Callable[[Any], Any] | None = default
 
 
 @overload
-def decode_msgpack(value: bytes) -> Any:
-    ...
+def decode_msgpack(value: bytes) -> Any: ...
 
 
 @overload
-def decode_msgpack(value: bytes, type_decoders: TypeDecodersSequence | None) -> Any:
-    ...
+def decode_msgpack(value: bytes, type_decoders: TypeDecodersSequence | None) -> Any: ...
 
 
 @overload
-def decode_msgpack(value: bytes, target_type: type[T]) -> T:
-    ...
+def decode_msgpack(value: bytes, target_type: type[T]) -> T: ...
 
 
 @overload
-def decode_msgpack(value: bytes, target_type: type[T], type_decoders: TypeDecodersSequence | None) -> T:
-    ...
+def decode_msgpack(value: bytes, target_type: type[T], type_decoders: TypeDecodersSequence | None) -> T: ...
 
 
 def decode_msgpack(  # type: ignore[misc]

--- a/litestar/serialization/msgspec_hooks.py
+++ b/litestar/serialization/msgspec_hooks.py
@@ -147,19 +147,23 @@ def encode_json(value: Any, serializer: Callable[[Any], Any] | None = None) -> b
 
 
 @overload
-def decode_json(value: str | bytes) -> Any: ...
+def decode_json(value: str | bytes) -> Any:
+    ...
 
 
 @overload
-def decode_json(value: str | bytes, type_decoders: TypeDecodersSequence | None) -> Any: ...
+def decode_json(value: str | bytes, type_decoders: TypeDecodersSequence | None) -> Any:
+    ...
 
 
 @overload
-def decode_json(value: str | bytes, target_type: type[T]) -> T: ...
+def decode_json(value: str | bytes, target_type: type[T]) -> T:
+    ...
 
 
 @overload
-def decode_json(value: str | bytes, target_type: type[T], type_decoders: TypeDecodersSequence | None) -> T: ...
+def decode_json(value: str | bytes, target_type: type[T], type_decoders: TypeDecodersSequence | None) -> T:
+    ...
 
 
 def decode_json(  # type: ignore[misc]
@@ -212,19 +216,23 @@ def encode_msgpack(value: Any, serializer: Callable[[Any], Any] | None = default
 
 
 @overload
-def decode_msgpack(value: bytes) -> Any: ...
+def decode_msgpack(value: bytes) -> Any:
+    ...
 
 
 @overload
-def decode_msgpack(value: bytes, type_decoders: TypeDecodersSequence | None) -> Any: ...
+def decode_msgpack(value: bytes, type_decoders: TypeDecodersSequence | None) -> Any:
+    ...
 
 
 @overload
-def decode_msgpack(value: bytes, target_type: type[T]) -> T: ...
+def decode_msgpack(value: bytes, target_type: type[T]) -> T:
+    ...
 
 
 @overload
-def decode_msgpack(value: bytes, target_type: type[T], type_decoders: TypeDecodersSequence | None) -> T: ...
+def decode_msgpack(value: bytes, target_type: type[T], type_decoders: TypeDecodersSequence | None) -> T:
+    ...
 
 
 def decode_msgpack(  # type: ignore[misc]

--- a/tests/unit/test_response/test_base_response.py
+++ b/tests/unit/test_response/test_base_response.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from pathlib import PurePosixPath
 from typing import Any, Optional
 
@@ -187,6 +188,15 @@ def test_get_serializer() -> None:
     class Foo:
         pass
 
+    class Color(Enum):
+        RED = 1
+
+    class Size(str, Enum):
+        SMALL = "small"
+
+    class AltSize(Enum):
+        OTHER = "another"
+
     foo_encoder = {Foo: lambda f: "it's a foo"}
     path_encoder = {PurePosixPath: lambda p: "it's a path"}
 
@@ -202,6 +212,9 @@ def test_get_serializer() -> None:
     assert (
         get_serializer(FooResponse(None, type_encoders={Foo: lambda f: "foo"}).response_type_encoders)(Foo()) == "foo"
     )
+    assert get_serializer()(Color.RED) == Color.RED.value
+    assert get_serializer()(Size(Size.SMALL)) == "Size.SMALL"
+    assert get_serializer()(AltSize) is None
 
 
 def test_head_response_doesnt_support_content() -> None:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This addresses an issue when serializing `Enums` that was reported in discord.

```shell
Process SpawnProcess-10:
Traceback (most recent call last):
  File "/usr/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.10/dist-packages/uvicorn/_subprocess.py", line 78, in subprocess_started
    target(sockets=sockets)
  File "/usr/local/lib/python3.10/dist-packages/uvicorn/server.py", line 62, in run
    return asyncio.run(self.serve(sockets=sockets))
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "uvloop/loop.pyx", line 1517, in uvloop.loop.Loop.run_until_complete
  File "/usr/local/lib/python3.10/dist-packages/uvicorn/server.py", line 69, in serve
    config.load()
  File "/usr/local/lib/python3.10/dist-packages/uvicorn/config.py", line 458, in load
    self.loaded_app = import_from_string(self.app)
  File "/usr/local/lib/python3.10/dist-packages/uvicorn/importer.py", line 21, in import_from_string
    module = importlib.import_module(module_str)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/joey/server-management/app.py", line 379, in <module>
    app = Litestar(route_handlers=[...], openapi_config=OpenAPIConfig(title="API Docs", version="1.0.0"), type_decoders={EnumMeta: lambda: None})
  File "/usr/local/lib/python3.10/dist-packages/litestar/app.py", line 470, in __init__
    self.register(route_handler)
  File "/usr/local/lib/python3.10/dist-packages/litestar/app.py", line 657, in register
    route.create_handler_map()
  File "/usr/local/lib/python3.10/dist-packages/litestar/routes/http.py", line 99, in create_handler_map
    kwargs_model = self.create_handler_kwargs_model(route_handler=route_handler)
  File "/usr/local/lib/python3.10/dist-packages/litestar/routes/base.py", line 136, in create_handler_kwargs_model
    signature_model=route_handler.signature_model,
  File "/usr/local/lib/python3.10/dist-packages/litestar/handlers/base.py", line 194, in signature_model
    self._signature_model = SignatureModel.create(
  File "/usr/local/lib/python3.10/dist-packages/litestar/_signature/model.py", line 256, in create
    annotation = cls._create_annotation(
  File "/usr/local/lib/python3.10/dist-packages/litestar/_signature/model.py", line 309, in _create_annotation
    if decoder := _get_decoder_for_type(annotation, type_decoders=type_decoders):
  File "/usr/local/lib/python3.10/dist-packages/litestar/_signature/utils.py", line 55, in _get_decoder_for_type
    return next(
  File "/usr/local/lib/python3.10/dist-packages/litestar/_signature/utils.py", line 56, in <genexpr>
    (decoder for predicate, decoder in type_decoders if predicate(target_type)),
TypeError: cannot unpack non-iterable type object
```
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
