### PR TITLE
fix: replace TestClient.__enter__ return type with Self

### DIFF
--- a/litestar/testing/client/async_client.py
+++ b/litestar/testing/client/async_client.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
         TimeoutTypes,
         URLTypes,
     )
+    from typing_extensions import Self
 
     from litestar.middleware.session.base import BaseBackendConfig
 
@@ -85,7 +86,7 @@ class AsyncTestClient(AsyncClient, BaseTestClient, Generic[T]):  # type: ignore[
             timeout=timeout,
         )
 
-    async def __aenter__(self) -> AsyncTestClient[T]:
+    async def __aenter__(self) -> Self:
         async with AsyncExitStack() as stack:
             self.blocking_portal = portal = stack.enter_context(self.portal())
             self.lifespan_handler = LifeSpanHandler(client=self)

--- a/litestar/testing/client/sync_client.py
+++ b/litestar/testing/client/sync_client.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
         TimeoutTypes,
         URLTypes,
     )
+    from typing_extensions import Self
 
     from litestar.middleware.session.base import BaseBackendConfig
     from litestar.testing.websocket_test_session import WebSocketTestSession
@@ -88,7 +89,7 @@ class TestClient(Client, BaseTestClient, Generic[T]):  # type: ignore[misc]
             timeout=timeout,
         )
 
-    def __enter__(self) -> TestClient[T]:
+    def __enter__(self) -> Self:
         with ExitStack() as stack:
             self.blocking_portal = portal = stack.enter_context(self.portal())
             self.lifespan_handler = LifeSpanHandler(client=self)


### PR DESCRIPTION
## Description
`TestClient.__enter__` and `AsyncTestClient.__enter__` return `self`. If you inherit `TestClient`, `__enter__` method should return derived class's instance unless override the method. So I think `typing_extensions.Self` could be more flexible return type.