### PR TITLE
chore: Revert "fix: add default encoders for `Enums` and `EnumMeta`"

### DIFF
--- a/litestar/serialization/msgspec_hooks.py
+++ b/litestar/serialization/msgspec_hooks.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections import deque
 from datetime import date, datetime, time
 from decimal import Decimal
-from enum import Enum, EnumMeta
 from functools import partial
 from ipaddress import (
     IPv4Address,
@@ -53,8 +52,6 @@ DEFAULT_TYPE_ENCODERS: TypeEncodersMap = {
     deque: list,
     Decimal: lambda val: int(val) if val.as_tuple().exponent >= 0 else float(val),
     Pattern: lambda val: val.pattern,
-    Enum: lambda val: val.value if val else None,
-    EnumMeta: lambda val: None,
     # support subclasses of stdlib types, If no previous type matched, these will be
     # the last type in the mro, so we use this to (attempt to) convert a subclass into
     # its base class. # see https://github.com/jcrist/msgspec/issues/248

--- a/tests/unit/test_response/test_base_response.py
+++ b/tests/unit/test_response/test_base_response.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from pathlib import PurePosixPath
 from typing import Any, Optional
 
@@ -188,15 +187,6 @@ def test_get_serializer() -> None:
     class Foo:
         pass
 
-    class Color(Enum):
-        RED = 1
-
-    class Size(str, Enum):
-        SMALL = "small"
-
-    class AltSize(Enum):
-        OTHER = "another"
-
     foo_encoder = {Foo: lambda f: "it's a foo"}
     path_encoder = {PurePosixPath: lambda p: "it's a path"}
 
@@ -212,9 +202,6 @@ def test_get_serializer() -> None:
     assert (
         get_serializer(FooResponse(None, type_encoders={Foo: lambda f: "foo"}).response_type_encoders)(Foo()) == "foo"
     )
-    assert get_serializer()(Color.RED) == Color.RED.value
-    assert get_serializer()(Size(Size.SMALL)) == "Size.SMALL"
-    assert get_serializer()(AltSize) is None
 
 
 def test_head_response_doesnt_support_content() -> None:


### PR DESCRIPTION
Reverts litestar-org/litestar#3193

This may need more thought about why the patch was necessary in the first place.