### PR TITLE
feat: Support `schema_extra` in `Parameter` and `Body`

### DIFF
--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -50,7 +50,7 @@ from litestar.datastructures import UploadFile
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.openapi.spec.enums import OpenAPIFormat, OpenAPIType
 from litestar.openapi.spec.schema import Schema, SchemaDataContainer
-from litestar.params import BodyKwarg, ParameterKwarg
+from litestar.params import BodyKwarg, KwargDefinition, ParameterKwarg
 from litestar.plugins import OpenAPISchemaPlugin
 from litestar.types import Empty
 from litestar.types.builtin_types import NoneType
@@ -568,6 +568,14 @@ class SchemaCreator:
                     # overwrite them here.
                     if getattr(schema, schema_key, None) is None:
                         setattr(schema, schema_key, value)
+
+            if isinstance(field.kwarg_definition, KwargDefinition) and (extra := field.kwarg_definition.schema_extra):
+                for schema_key, value in extra.items():
+                    if not hasattr(schema, schema_key):
+                        raise ValueError(
+                            f"`schema_extra` declares key `{schema_key}` which does not exist in `Schema` object"
+                        )
+                    setattr(schema, schema_key, value)
 
         if not schema.examples and self.generate_examples:
             from litestar._openapi.schema_generation.examples import create_examples_for_field

--- a/litestar/params.py
+++ b/litestar/params.py
@@ -116,7 +116,7 @@ class KwargDefinition:
     """Extensions to the generated schema.
 
     If set, will overwrite the matching fields in the generated schema.
-    
+
     .. versionadded:: 2.8.0
     """
 
@@ -237,6 +237,8 @@ def Parameter(
         title: String value used in the title section of the OpenAPI schema for the given parameter.
         schema_extra: Extensions to the generated schema. If set, will overwrite the matching fields in the generated
             schema.
+
+            .. versionadded:: 2.8.0
     """
     return ParameterKwarg(
         annotation=annotation,

--- a/litestar/params.py
+++ b/litestar/params.py
@@ -116,6 +116,8 @@ class KwargDefinition:
     """Extensions to the generated schema.
 
     If set, will overwrite the matching fields in the generated schema.
+    
+    .. versionadded:: 2.8.0
     """
 
     @property

--- a/litestar/params.py
+++ b/litestar/params.py
@@ -345,6 +345,8 @@ def Body(
         title: String value used in the title section of the OpenAPI schema for the given parameter.
         schema_extra: Extensions to the generated schema. If set, will overwrite the matching fields in the generated
             schema.
+
+            .. versionadded:: 2.8.0
     """
     return BodyKwarg(
         media_type=media_type,

--- a/litestar/params.py
+++ b/litestar/params.py
@@ -112,6 +112,11 @@ class KwargDefinition:
     """A sequence of valid values."""
     read_only: bool | None = field(default=None)
     """A boolean flag dictating whether this parameter is read only."""
+    schema_extra: dict[str, Any] | None = field(default=None)
+    """Extensions to the generated schema.
+
+    If set, will overwrite the matching fields in the generated schema.
+    """
 
     @property
     def is_constrained(self) -> bool:
@@ -187,6 +192,7 @@ def Parameter(
     query: str | None = None,
     required: bool | None = None,
     title: str | None = None,
+    schema_extra: dict[str, Any] | None = None,
 ) -> Any:
     """Create an extended parameter kwarg definition.
 
@@ -227,6 +233,8 @@ def Parameter(
         required: A boolean flag dictating whether this parameter is required.
             If set to False, None values will be allowed. Defaults to True.
         title: String value used in the title section of the OpenAPI schema for the given parameter.
+        schema_extra: Extensions to the generated schema. If set, will overwrite the matching fields in the generated
+            schema.
     """
     return ParameterKwarg(
         annotation=annotation,
@@ -251,6 +259,7 @@ def Parameter(
         min_length=min_length,
         max_length=max_length,
         pattern=pattern,
+        schema_extra=schema_extra,
     )
 
 
@@ -294,6 +303,7 @@ def Body(
     multiple_of: float | None = None,
     pattern: str | None = None,
     title: str | None = None,
+    schema_extra: dict[str, Any] | None = None,
 ) -> Any:
     """Create an extended request body kwarg definition.
 
@@ -331,6 +341,8 @@ def Body(
         pattern: A string representing a regex against which the given string will be matched.
             Equivalent to pattern in the OpenAPI specification.
         title: String value used in the title section of the OpenAPI schema for the given parameter.
+        schema_extra: Extensions to the generated schema. If set, will overwrite the matching fields in the generated
+            schema.
     """
     return BodyKwarg(
         media_type=media_type,
@@ -352,6 +364,7 @@ def Body(
         max_length=max_length,
         pattern=pattern,
         multipart_form_part_limit=multipart_form_part_limit,
+        schema_extra=schema_extra,
     )
 
 


### PR DESCRIPTION
## Description

This adds sort of a backdoor for modifying the generated OpenAPI spec.

The value is given as `dict[str, Any]` where the key must match with the
keyword parameter name in `Schema`. The values are used to override items in
the generated `Schema` object, so they must be in correct types (ie. not in
dictionary/json format).

The values are added at main level, without recursive merging (because we're
adjusting `Schema` object and not a dictionary). Recursive merge would be much
more work.

Chose not to implement the same for `ResponseSpec` because response models are
generated as schema components, while `ResponseSpec` can be locally different.
Handling the logic of creating new components when `schema_extra` is passed in
`ResponseSpec` would be extra effort, and isn't probably as important as being
able to adjust the inbound parameters, which are actually validated (and for
which the documentation is even more important, than for the response).

## Closes

#3022