### PR TITLE
docs: fix included line range from example

### DIFF
--- a/docs/tutorials/sqlalchemy/2-serialization-plugin.rst
+++ b/docs/tutorials/sqlalchemy/2-serialization-plugin.rst
@@ -21,7 +21,7 @@ function, making the implementation even more concise.
 Compare handlers before and after Serialization Plugin
 ======================================================
 
-Once more, lets compare the sets of application handlers before and after our refactoring:
+Once more, let's compare the sets of application handlers before and after our refactoring:
 
 .. tab-set::
 
@@ -37,7 +37,7 @@ Once more, lets compare the sets of application handlers before and after our re
         .. literalinclude:: /examples/contrib/sqlalchemy/plugins/tutorial/full_app_no_plugins.py
             :language: python
             :linenos:
-            :lines: 79-100
+            :lines: 69-100
 
 Very nice! But, we can do better.
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description


Now, https://docs.litestar.dev/dev/tutorials/sqlalchemy/2-serialization-plugin.html#compare-handlers-before-and-after-serialization-plugin shows the "Before" as lines 79-100:

This is https://github.com/litestar-org/litestar/blob/ef9dbb7a0cc4c7031dbf9a7bff02719d8a65a008/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_no_plugins.py#L79-L100

We need 10 more lines, 69-100:

https://github.com/litestar-org/litestar/blob/ef9dbb7a0cc4c7031dbf9a7bff02719d8a65a008/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_no_plugins.py#L69-L100



<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
