### PR TITLE
docs: fix included line range from example

### DIFF
--- a/docs/tutorials/sqlalchemy/4-final-touches-and-recap.rst
+++ b/docs/tutorials/sqlalchemy/4-final-touches-and-recap.rst
@@ -13,7 +13,7 @@ Here is our final application:
 .. literalinclude:: /examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_plugin.py
     :language: python
     :linenos:
-    :emphasize-lines: 11,79
+    :emphasize-lines: 11,83
 
 Recap
 =====
@@ -59,7 +59,7 @@ engine and session lifecycle, and register our ``transaction`` dependency.
 .. literalinclude:: /examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_plugin.py
     :language: python
     :linenos:
-    :lines: 77-81
+    :lines: 80-84
 
 .. seealso::
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Similar to https://github.com/litestar-org/litestar/pull/3208 but for another page.

Fix https://docs.litestar.dev/dev/tutorials/sqlalchemy/4-final-touches-and-recap.html so the first example highlights this line:

https://github.com/litestar-org/litestar/blob/243733a004057ba86ea9c4bc94cbf51f58f3e0dc/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_plugin.py#L83

And so the last example is:

https://github.com/litestar-org/litestar/blob/243733a004057ba86ea9c4bc94cbf51f58f3e0dc/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_plugin.py#L80-L84

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
