### PR TITLE
fix: Handle move of `wrap_sqlalchemy_exception()` (#3238)

### DIFF
--- a/litestar/contrib/sqlalchemy/repository/_util.py
+++ b/litestar/contrib/sqlalchemy/repository/_util.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from advanced_alchemy.repository._util import get_instrumented_attr, wrap_sqlalchemy_exception
+from advanced_alchemy.repository._util import get_instrumented_attr
+
+try:
+    from advanced_alchemy.exceptions import wrap_sqlalchemy_exception
+except ImportError:
+    from advanced_alchemy.repository._util import wrap_sqlalchemy_exception
+
 
 __all__ = (
     "wrap_sqlalchemy_exception",


### PR DESCRIPTION
In advanced-alchemy prior to 0.8.0, this function is found in `advanced_alchemy.repository._util`, but as of 0.8.0 it moves to `advanced_alchemy.exceptions`.

## Description

Fixes #3238 by handling both the new (preferred) and old (fallback) locations for importing `wrap_sqlalchemy_exception()` from advanced-alchemy.

I'm unsure what your preferred approach is for how to test something like this, but if you let me know I'm happy to adjust the PR as needed.