### PR TITLE
PR for #3206 

### DIFF
--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -14,7 +14,7 @@ from litestar import connection, datastructures, types
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types import Empty
 from litestar.typing import FieldDefinition
-from litestar.utils.typing import unwrap_annotation
+from litestar.utils.typing import _substitute_typevars, unwrap_annotation
 
 if TYPE_CHECKING:
     from typing import Sequence
@@ -131,6 +131,24 @@ def _unwrap_implicit_optional_hints(defaults: dict[str, Any], hints: dict[str, A
     return hints
 
 
+def expand_type_var_in_type_hint(type_hint: dict[str, Any], namespace: dict[str, Any] | None) -> dict[str, Any]:
+    """Expand TypeVar for any parameters in type_hint
+
+    Args:
+        type_hint: mapping of parameter to type obtained from calling `get_type_hints` or `get_fn_type_hints`
+        namespace: mapping of TypeVar to concrete type
+
+    Returns:
+        type_hint with any TypeVar parameter expanded
+    """
+    if namespace:
+        expanded_type_hint = {}
+        for name, hint in type_hint.items():
+            expanded_type_hint[name] = _substitute_typevars(hint, namespace)
+        return expanded_type_hint
+    return type_hint
+
+
 def get_fn_type_hints(fn: Any, namespace: dict[str, Any] | None = None) -> dict[str, Any]:
     """Resolve type hints for ``fn``.
 
@@ -212,8 +230,9 @@ class ParsedSignature:
         """
         signature = Signature.from_callable(fn)
         fn_type_hints = get_fn_type_hints(fn, namespace=signature_namespace)
+        expanded_type_hints = expand_type_var_in_type_hint(fn_type_hints, signature_namespace)
 
-        return cls.from_signature(signature, fn_type_hints)
+        return cls.from_signature(signature, expanded_type_hints)
 
     @classmethod
     def from_signature(cls, signature: Signature, fn_type_hints: dict[str, type]) -> Self:

--- a/tests/unit/test_utils/test_signature.py
+++ b/tests/unit/test_utils/test_signature.py
@@ -210,7 +210,7 @@ def test_expand_type_var_in_type_hints(
     ),
 )
 def test_using_generics_in_fn_annotations(namespace: dict[str, Any], expected: dict[str, Any]) -> None:
-    @post(signature_namespace=namespace)  # type: ignore[dict-item]
+    @post(signature_namespace=namespace)
     def create_item(data: T) -> T:
         return data
 
@@ -228,12 +228,12 @@ class GenericController(Controller, Generic[T]):
 
     def __init__(self, owner: Router) -> None:
         super().__init__(owner)
-        self.signature_namespace[T] = self.model_class  # type: ignore[misc] # mypy will nag here
+        self.signature_namespace[T] = self.model_class
 
 
 class BaseController(GenericController[T]):
     @post()
-    async def create(self, data: T) -> T:  # type: ignore[name-defined] # mypy takes issue with this
+    async def create(self, data: T) -> T:
         return data
 
 
@@ -246,10 +246,10 @@ class BaseController(GenericController[T]):
     ),
 )
 def test_using_generics_in_controller_annotations(annotation_type: type, expected: dict[str, Any]) -> None:
-    class ConcreteController(BaseController[annotation_type]):  # type: ignore[valid-type]
+    class ConcreteController(BaseController[annotation_type]):
         path = "/"
 
-    controller_object = ConcreteController(owner=None)  # type: ignore[arg-type] # For testing purpose
+    controller_object = ConcreteController(owner=None)
 
     signature = controller_object.get_route_handlers()[0].parsed_fn_signature
     actual = {"data": signature.parameters["data"].annotation, "return": signature.return_type.annotation}

--- a/tests/unit/test_utils/test_signature.py
+++ b/tests/unit/test_utils/test_signature.py
@@ -5,11 +5,19 @@ from __future__ import annotations
 import inspect
 from inspect import Parameter
 from types import ModuleType
-from typing import Any, Callable, List, Optional, TypeVar, Union
+from typing import Any, Callable, Generic, List, Optional, TypeVar, Union
 
 import pytest
-from typing_extensions import Annotated, NotRequired, Required, TypedDict, get_args, get_type_hints
+from typing_extensions import (
+    Annotated,
+    NotRequired,
+    Required,
+    TypedDict,
+    get_args,
+    get_type_hints,
+)
 
+from litestar import Controller, Router, post
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.file_system import BaseLocalFileSystem
 from litestar.static_files import StaticFiles
@@ -17,9 +25,18 @@ from litestar.types.asgi_types import Receive, Scope, Send
 from litestar.types.builtin_types import NoneType
 from litestar.types.empty import Empty
 from litestar.typing import FieldDefinition
-from litestar.utils.signature import ParsedSignature, add_types_to_signature_namespace, get_fn_type_hints
+from litestar.utils.signature import (
+    ParsedSignature,
+    add_types_to_signature_namespace,
+    expand_type_var_in_type_hint,
+    get_fn_type_hints,
+)
 
 T = TypeVar("T")
+U = TypeVar("U")
+
+
+class ConcreteT: ...
 
 
 def test_get_fn_type_hints_asgi_app() -> None:
@@ -161,3 +178,79 @@ def test_add_types_to_signature_namespace_with_existing_types_raises() -> None:
     """Test add_types_to_signature_namespace with existing types raises."""
     with pytest.raises(ImproperlyConfiguredException):
         add_types_to_signature_namespace([int], {"int": int})
+
+
+@pytest.mark.parametrize(
+    ("type_hint", "namespace", "expected"),
+    (
+        ({"arg1": T, "return": int}, {}, {"arg1": T, "return": int}),
+        ({"arg1": T, "return": int}, None, {"arg1": T, "return": int}),
+        ({"arg1": T, "return": int}, {U: ConcreteT}, {"arg1": T, "return": int}),
+        ({"arg1": T, "return": int}, {T: ConcreteT}, {"arg1": ConcreteT, "return": int}),
+        ({"arg1": T, "return": int}, {T: int}, {"arg1": int, "return": int}),
+        ({"arg1": int, "return": int}, {}, {"arg1": int, "return": int}),
+        ({"arg1": int, "return": int}, None, {"arg1": int, "return": int}),
+        ({"arg1": int, "return": int}, {T: int}, {"arg1": int, "return": int}),
+        ({"arg1": T, "return": T}, {T: ConcreteT}, {"arg1": ConcreteT, "return": ConcreteT}),
+        ({"arg1": T, "return": T}, {T: int}, {"arg1": int, "return": int}),
+    ),
+)
+def test_expand_type_var_in_type_hints(
+    type_hint: dict[str, Any], namespace: dict[str, Any] | None, expected: dict[str, Any]
+) -> None:
+    assert expand_type_var_in_type_hint(type_hint, namespace) == expected
+
+
+@pytest.mark.parametrize(
+    ("namespace", "expected"),
+    (
+        ({T: int}, {"data": int, "return": int}),
+        ({}, {"data": T, "return": T}),
+        ({T: ConcreteT}, {"data": ConcreteT, "return": ConcreteT}),
+    ),
+)
+def test_using_generics_in_fn_annotations(namespace: dict[str, Any], expected: dict[str, Any]) -> None:
+    @post(signature_namespace=namespace)  # type: ignore[dict-item]
+    def create_item(data: T) -> T:
+        return data
+
+    signature = create_item.parsed_fn_signature
+    actual = {"data": signature.parameters["data"].annotation, "return": signature.return_type.annotation}
+    assert actual == expected
+
+
+class GenericController(Controller, Generic[T]):
+    model_class: T
+
+    def __class_getitem__(cls, model_class: type) -> type:
+        cls_dict = {"model_class": model_class}
+        return type(f"GenericController[{model_class.__name__}", (cls,), cls_dict)
+
+    def __init__(self, owner: Router) -> None:
+        super().__init__(owner)
+        self.signature_namespace[T] = self.model_class  # type: ignore[misc] # mypy will nag here
+
+
+class BaseController(GenericController[T]):
+    @post()
+    async def create(self, data: T) -> T:  # type: ignore[name-defined] # mypy takes issue with this
+        return data
+
+
+@pytest.mark.parametrize(
+    ("annotation_type", "expected"),
+    (
+        (int, {"data": int, "return": int}),
+        (float, {"data": float, "return": float}),
+        (ConcreteT, {"data": ConcreteT, "return": ConcreteT}),
+    ),
+)
+def test_using_generics_in_controller_annotations(annotation_type: type, expected: dict[str, Any]) -> None:
+    class ConcreteController(BaseController[annotation_type]):  # type: ignore[valid-type]
+        path = "/"
+
+    controller_object = ConcreteController(owner=None)  # type: ignore[arg-type] # For testing purpose
+
+    signature = controller_object.get_route_handlers()[0].parsed_fn_signature
+    actual = {"data": signature.parameters["data"].annotation, "return": signature.return_type.annotation}
+    assert actual == expected


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Add a method for typevar expansion on registration 
- This allows the use of generic route handler and generic controller without relying on forward references. 

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes #3206 

A self-contained example - which would fail in the previous version: 

```Python
from dataclasses import dataclass, field
from typing import Generic, TypeVar
from uuid import UUID, uuid4

from litestar import Controller, Litestar, Router, post


@dataclass
class BookDataClass:
    title: str
    id: UUID = field(default_factory=uuid4)


@dataclass
class AuthorDataClass:
    title: str
    id: UUID = field(default_factory=uuid4)


T = TypeVar("T")


class GenericController(Controller, Generic[T]):
    model_class: T

    def __class_getitem__(cls, model_class: type) -> type:
        cls_dict = {"model_class": model_class}
        return type(f"GenericController[{model_class.__name__}", (cls,), cls_dict)

    def __init__(self, owner: Router) -> None:
        super().__init__(owner)
        self.signature_namespace[T] = self.model_class  

class BaseController(GenericController[T]):
    @post()
    async def create(self, data: T) -> T:  
        return data


class AuthorDataClassController(BaseController[AuthorDataClass]):
    path = "/AuthorDataClass"


class BookDataClassController(BaseController[BookDataClass]):
    path = "/BookDataClass"
    signature_namespace = {"S": int, "U": float}


app = Litestar([AuthorDataClassController, BookDataClassController])

```

All failed tests were not caused by this new update. Please let me know what you think.
