### PR TITLE
feat: add TypeVar expansion for handler objects at registration 

### DIFF
--- a/litestar/_openapi/responses.py
+++ b/litestar/_openapi/responses.py
@@ -298,9 +298,7 @@ def create_error_responses(exceptions: list[type[HTTPException]]) -> Iterator[tu
                         ),
                     },
                     description=pascal_case_to_text(get_name(exc)),
-                    examples={
-                        exc.__name__: Example(value={"status_code": status_code, "detail": example_detail, "extra": {}})
-                    },
+                    examples=[{"status_code": status_code, "detail": example_detail, "extra": {}}],
                 )
             )
         if len(exceptions_schemas) > 1:  # noqa: SIM108

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -44,7 +44,7 @@ from litestar._openapi.schema_generation.utils import (
     _should_create_enum_schema,
     _should_create_literal_schema,
     _type_or_first_not_none_inner_type,
-    get_formatted_examples,
+    get_json_schema_formatted_examples,
 )
 from litestar.datastructures import UploadFile
 from litestar.exceptions import ImproperlyConfiguredException
@@ -558,7 +558,7 @@ class SchemaCreator:
                     not isinstance(value, Hashable) or not self.is_undefined(value)
                 ):
                     if schema_key == "examples":
-                        value = get_formatted_examples(field, cast("list[Example]", value))
+                        value = get_json_schema_formatted_examples(cast("list[Example]", value))
 
                     # we only want to transfer values from the `KwargDefinition` to `Schema` if the schema object
                     # doesn't already have a value for that property. For example, if a field is a constrained date,
@@ -580,7 +580,7 @@ class SchemaCreator:
         if not schema.examples and self.generate_examples:
             from litestar._openapi.schema_generation.examples import create_examples_for_field
 
-            schema.examples = get_formatted_examples(field, create_examples_for_field(field))
+            schema.examples = get_json_schema_formatted_examples(create_examples_for_field(field))
 
         if schema.title and schema.type == OpenAPIType.OBJECT:
             key = _get_normalized_schema_key(field.annotation)
@@ -595,7 +595,7 @@ class SchemaCreator:
         property_fields: Mapping[str, FieldDefinition],
         openapi_type: OpenAPIType = OpenAPIType.OBJECT,
         title: str | None = None,
-        examples: Mapping[str, Example] | None = None,
+        examples: list[Any] | None = None,
     ) -> Schema:
         """Create a schema for the components/schemas section of the OpenAPI spec.
 

--- a/litestar/_openapi/schema_generation/utils.py
+++ b/litestar/_openapi/schema_generation/utils.py
@@ -107,3 +107,8 @@ def get_formatted_examples(field_definition: FieldDefinition, examples: Sequence
     name = name.lower()
 
     return {f"{name}-example-{i}": example for i, example in enumerate(examples, 1)}
+
+
+def get_json_schema_formatted_examples(examples: Sequence[Example]) -> list[Any]:
+    """Format the examples into the JSON schema format."""
+    return [example.value for example in examples]

--- a/litestar/contrib/pydantic/pydantic_schema_plugin.py
+++ b/litestar/contrib/pydantic/pydantic_schema_plugin.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from typing_extensions import Annotated
 
-from litestar._openapi.schema_generation.utils import get_formatted_examples
 from litestar.contrib.pydantic.utils import (
     create_field_definitions_for_computed_fields,
     is_pydantic_2_model,
@@ -15,7 +14,7 @@ from litestar.contrib.pydantic.utils import (
     pydantic_unwrap_and_get_origin,
 )
 from litestar.exceptions import MissingDependencyException
-from litestar.openapi.spec import Example, OpenAPIFormat, OpenAPIType, Schema
+from litestar.openapi.spec import OpenAPIFormat, OpenAPIType, Schema
 from litestar.plugins import OpenAPISchemaPlugin
 from litestar.types import Empty
 from litestar.typing import FieldDefinition
@@ -314,11 +313,5 @@ class PydanticSchemaPlugin(OpenAPISchemaPlugin):
             required=sorted(f.name for f in property_fields.values() if f.is_required),
             property_fields=property_fields,
             title=title,
-            examples=(
-                None
-                if example is None
-                else get_formatted_examples(
-                    field_definition, [Example(description=f"Example {field_definition.name} value", value=example)]
-                )
-            ),
+            examples=None if example is None else [example],
         )

--- a/litestar/openapi/spec/schema.py
+++ b/litestar/openapi/spec/schema.py
@@ -9,7 +9,6 @@ from litestar.utils.predicates import is_non_string_sequence
 if TYPE_CHECKING:
     from litestar.openapi.spec.discriminator import Discriminator
     from litestar.openapi.spec.enums import OpenAPIFormat, OpenAPIType
-    from litestar.openapi.spec.example import Example
     from litestar.openapi.spec.external_documentation import ExternalDocumentation
     from litestar.openapi.spec.reference import Reference
     from litestar.openapi.spec.xml import XML
@@ -610,12 +609,8 @@ class Schema(BaseSchemaObject):
     Omitting these keywords has the same behavior as values of false.
     """
 
-    examples: Mapping[str, Example] | None = None
-    """The value of this must be an array containing the example values directly or a mapping of string
-    to an ``Example`` instance.
-
-    This is based on the ``examples`` keyword of JSON Schema.
-    """
+    examples: list[Any] | None = None
+    """The value of this must be an array containing the example values."""
 
     discriminator: Discriminator | None = None
     """Adds support for polymorphism.

--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -4,7 +4,19 @@ from collections import abc, deque
 from copy import deepcopy
 from dataclasses import dataclass, is_dataclass, replace
 from inspect import Parameter, Signature
-from typing import Any, AnyStr, Callable, Collection, ForwardRef, Literal, Mapping, Protocol, Sequence, TypeVar, cast
+from typing import (
+    Any,
+    AnyStr,
+    Callable,
+    Collection,
+    ForwardRef,
+    Literal,
+    Mapping,
+    Protocol,
+    Sequence,
+    TypeVar,
+    cast,
+)
 
 from msgspec import UnsetType
 from typing_extensions import NotRequired, Required, Self, get_args, get_origin, get_type_hints, is_typeddict
@@ -81,6 +93,7 @@ def _parse_metadata(value: Any, is_sequence_container: bool, extra: dict[str, An
         **cast("dict[str, Any]", extra or getattr(value, "extra", None) or {}),
         **(getattr(value, "json_schema_extra", None) or {}),
     }
+    example_list: list[Any] | None
     if example := extra.pop("example", None):
         example_list = [Example(value=example)]
     elif examples := getattr(value, "examples", None):

--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -14,7 +14,7 @@ from litestar import connection, datastructures, types
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types import Empty
 from litestar.typing import FieldDefinition
-from litestar.utils.typing import unwrap_annotation
+from litestar.utils.typing import _substitute_typevars, unwrap_annotation
 
 if TYPE_CHECKING:
     from typing import Sequence
@@ -131,6 +131,24 @@ def _unwrap_implicit_optional_hints(defaults: dict[str, Any], hints: dict[str, A
     return hints
 
 
+def expand_type_var_in_type_hint(type_hint: dict[str, Any], namespace: dict[str, Any] | None) -> dict[str, Any]:
+    """Expand TypeVar for any parameters in type_hint
+
+    Args:
+        type_hint: mapping of parameter to type obtained from calling `get_type_hints` or `get_fn_type_hints`
+        namespace: mapping of TypeVar to concrete type
+
+    Returns:
+        type_hint with any TypeVar parameter expanded
+    """
+    if namespace:
+        expanded_type_hint = {}
+        for name, hint in type_hint.items():
+            expanded_type_hint[name] = _substitute_typevars(hint, namespace)
+        return expanded_type_hint
+    return type_hint
+
+
 def get_fn_type_hints(fn: Any, namespace: dict[str, Any] | None = None) -> dict[str, Any]:
     """Resolve type hints for ``fn``.
 
@@ -212,8 +230,9 @@ class ParsedSignature:
         """
         signature = Signature.from_callable(fn)
         fn_type_hints = get_fn_type_hints(fn, namespace=signature_namespace)
+        expanded_type_hints = expand_type_var_in_type_hint(fn_type_hints, signature_namespace)
 
-        return cls.from_signature(signature, fn_type_hints)
+        return cls.from_signature(signature, expanded_type_hints)
 
     @classmethod
     def from_signature(cls, signature: Signature, fn_type_hints: dict[str, type]) -> Self:

--- a/tests/unit/test_contrib/test_pydantic/test_openapi.py
+++ b/tests/unit/test_contrib/test_pydantic/test_openapi.py
@@ -17,7 +17,7 @@ from litestar._openapi.schema_generation.constrained_fields import (
 from litestar._openapi.schema_generation.schema import SchemaCreator
 from litestar.contrib.pydantic import PydanticPlugin, PydanticSchemaPlugin
 from litestar.openapi import OpenAPIConfig
-from litestar.openapi.spec import Example, Reference, Schema
+from litestar.openapi.spec import Reference, Schema
 from litestar.openapi.spec.enums import OpenAPIFormat, OpenAPIType
 from litestar.params import KwargDefinition
 from litestar.status_codes import HTTP_200_OK
@@ -393,7 +393,7 @@ def test_schema_generation_v1(create_examples: bool) -> None:
         assert response.status_code == HTTP_200_OK
         assert response.json()["components"]["schemas"]["test_schema_generation_v1.Lookup"]["properties"]["id"] == {
             "description": "A unique identifier",
-            "examples": {"id-example-1": {"value": "e4eaaaf2-d142-11e1-b3e4-080027620cdd"}},
+            "examples": ["e4eaaaf2-d142-11e1-b3e4-080027620cdd"],
             "maxLength": 16,
             "minLength": 12,
             "type": "string",
@@ -430,7 +430,7 @@ def test_schema_generation_v2(create_examples: bool) -> None:
         assert response.status_code == HTTP_200_OK
         assert response.json()["components"]["schemas"]["test_schema_generation_v2.Lookup"]["properties"]["id"] == {
             "description": "A unique identifier",
-            "examples": {"id-example-1": {"value": "e4eaaaf2-d142-11e1-b3e4-080027620cdd"}},
+            "examples": ["e4eaaaf2-d142-11e1-b3e4-080027620cdd"],
             "maxLength": 16,
             "minLength": 12,
             "type": "string",
@@ -530,7 +530,7 @@ def test_create_schema_for_field_v1() -> None:
     assert isinstance(value, Schema)
     assert value.description == "description"
     assert value.title == "title"
-    assert value.examples == {"value-example-1": Example(value="example")}
+    assert value.examples == ["example"]
 
 
 def test_create_schema_for_field_v2() -> None:
@@ -550,7 +550,7 @@ def test_create_schema_for_field_v2() -> None:
     assert isinstance(value, Schema)
     assert value.description == "description"
     assert value.title == "title"
-    assert value.examples == {"value-example-1": Example(value="example")}
+    assert value.examples == ["example"]
 
 
 @pytest.mark.parametrize("with_future_annotations", [True, False])

--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -204,7 +204,7 @@ def test_msgspec_schema_generation(create_examples: bool, openapi_controller: ty
             "id"
         ] == {
             "description": "A unique identifier",
-            "examples": {"id-example-1": {"value": "e4eaaaf2-d142-11e1-b3e4-080027620cdd"}},
+            "examples": ["e4eaaaf2-d142-11e1-b3e4-080027620cdd"],
             "maxLength": 16,
             "minLength": 12,
             "type": "string",

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -71,8 +71,8 @@ def test_create_parameters(person_controller: Type[Controller]) -> None:
     assert page_size.schema.type == OpenAPIType.INTEGER
     assert page_size.required
     assert page_size.description == "Page Size Description"
-    assert page_size.schema.examples
-    assert next(iter(page_size.schema.examples.values())).value == 1
+    assert page_size.examples
+    assert page_size.schema.examples == [1]
 
     assert name.param_in == ParamType.QUERY
     assert name.name == "name"
@@ -107,19 +107,19 @@ def test_create_parameters(person_controller: Type[Controller]) -> None:
             Schema(
                 type=OpenAPIType.STRING,
                 enum=["M", "F", "O", "A"],
-                examples={"gender-example-1": Example(description="Example  value", value="M")},
+                examples=["M"],
             ),
             Schema(
                 type=OpenAPIType.ARRAY,
                 items=Schema(
                     type=OpenAPIType.STRING,
                     enum=["M", "F", "O", "A"],
-                    examples={"gender-example-1": Example(description="Example  value", value="F")},
+                    examples=["F"],
                 ),
-                examples={"list-example-1": Example(description="Example  value", value=["A"])},
+                examples=[["A"]],
             ),
         ],
-        examples={"gender-example-1": Example(value="M"), "gender-example-2": Example(value=["M", "O"])},
+        examples=["M", ["M", "O"]],
     )
     assert not gender.required
 

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -82,7 +82,7 @@ def test_process_schema_result() -> None:
     assert kwarg_definition.examples
     for signature_key, schema_key in KWARG_DEFINITION_ATTRIBUTE_TO_OPENAPI_PROPERTY_MAP.items():
         if schema_key == "examples":
-            assert schema.examples == {"str-example-1": kwarg_definition.examples[0]}
+            assert schema.examples == [kwarg_definition.examples[0].value]
         else:
             assert getattr(schema, schema_key) == getattr(kwarg_definition, signature_key)
 
@@ -225,7 +225,7 @@ def test_schema_hashing() -> None:
             Schema(type=OpenAPIType.NUMBER),
             Schema(type=OpenAPIType.OBJECT, properties={"key": Schema(type=OpenAPIType.STRING)}),
         ],
-        examples={"example-1": Example(value=None), "example-2": Example(value=[1, 2, 3])},
+        examples=[None, [1, 2, 3]],
     )
     assert hash(schema)
 
@@ -289,7 +289,7 @@ def test_create_schema_from_msgspec_annotated_type() -> None:
     schema = get_schema_for_field_definition(FieldDefinition.from_kwarg(name="Lookup", annotation=Lookup))
 
     assert schema.properties["id"].type == OpenAPIType.STRING  # type: ignore[index, union-attr]
-    assert schema.properties["id"].examples == {"id-example-1": Example(value="example")}  # type: ignore[index, union-attr]
+    assert schema.properties["id"].examples == ["example"]  # type: ignore[index, union-attr]
     assert schema.properties["id"].description == "description"  # type: ignore[index]
     assert schema.properties["id"].title == "title"  # type: ignore[index, union-attr]
     assert schema.properties["id"].max_length == 16  # type: ignore[index, union-attr]

--- a/tests/unit/test_utils/test_signature.py
+++ b/tests/unit/test_utils/test_signature.py
@@ -228,7 +228,7 @@ class GenericController(Controller, Generic[T]):
 
     def __init__(self, owner: Router) -> None:
         super().__init__(owner)
-        self.signature_namespace[T] = self.model_class
+        self.signature_namespace[T] = self.model_class  # type: ignore
 
 
 class BaseController(GenericController[T]):
@@ -249,7 +249,7 @@ def test_using_generics_in_controller_annotations(annotation_type: type, expecte
     class ConcreteController(BaseController[annotation_type]):
         path = "/"
 
-    controller_object = ConcreteController(owner=None)
+    controller_object = ConcreteController(owner=None)  # type: ignore
 
     signature = controller_object.get_route_handlers()[0].parsed_fn_signature
     actual = {"data": signature.parameters["data"].annotation, "return": signature.return_type.annotation}

--- a/tests/unit/test_utils/test_signature.py
+++ b/tests/unit/test_utils/test_signature.py
@@ -210,7 +210,7 @@ def test_expand_type_var_in_type_hints(
     ),
 )
 def test_using_generics_in_fn_annotations(namespace: dict[str, Any], expected: dict[str, Any]) -> None:
-    @post(signature_namespace=namespace)  # type: ignore[dict-item]
+    @post(signature_namespace=namespace)
     def create_item(data: T) -> T:
         return data
 
@@ -228,12 +228,12 @@ class GenericController(Controller, Generic[T]):
 
     def __init__(self, owner: Router) -> None:
         super().__init__(owner)
-        self.signature_namespace[T] = self.model_class  # type: ignore[misc] # mypy will nag here
+        self.signature_namespace[T] = self.model_class
 
 
 class BaseController(GenericController[T]):
     @post()
-    async def create(self, data: T) -> T:  # type: ignore[name-defined] # mypy takes issue with this
+    async def create(self, data: T) -> T:
         return data
 
 
@@ -246,10 +246,10 @@ class BaseController(GenericController[T]):
     ),
 )
 def test_using_generics_in_controller_annotations(annotation_type: type, expected: dict[str, Any]) -> None:
-    class ConcreteController(BaseController[annotation_type]):  # type: ignore[valid-type]
+    class ConcreteController(BaseController[annotation_type]):
         path = "/"
 
-    controller_object = ConcreteController(owner=None)  # type: ignore[arg-type] # For testing purpose
+    controller_object = ConcreteController(owner=None)
 
     signature = controller_object.get_route_handlers()[0].parsed_fn_signature
     actual = {"data": signature.parameters["data"].annotation, "return": signature.return_type.annotation}

--- a/tests/unit/test_utils/test_signature.py
+++ b/tests/unit/test_utils/test_signature.py
@@ -5,11 +5,19 @@ from __future__ import annotations
 import inspect
 from inspect import Parameter
 from types import ModuleType
-from typing import Any, Callable, List, Optional, TypeVar, Union
+from typing import Any, Callable, Generic, List, Optional, TypeVar, Union
 
 import pytest
-from typing_extensions import Annotated, NotRequired, Required, TypedDict, get_args, get_type_hints
+from typing_extensions import (
+    Annotated,
+    NotRequired,
+    Required,
+    TypedDict,
+    get_args,
+    get_type_hints,
+)
 
+from litestar import Controller, Router, post
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.file_system import BaseLocalFileSystem
 from litestar.static_files import StaticFiles
@@ -17,9 +25,18 @@ from litestar.types.asgi_types import Receive, Scope, Send
 from litestar.types.builtin_types import NoneType
 from litestar.types.empty import Empty
 from litestar.typing import FieldDefinition
-from litestar.utils.signature import ParsedSignature, add_types_to_signature_namespace, get_fn_type_hints
+from litestar.utils.signature import (
+    ParsedSignature,
+    add_types_to_signature_namespace,
+    expand_type_var_in_type_hint,
+    get_fn_type_hints,
+)
 
 T = TypeVar("T")
+U = TypeVar("U")
+
+
+class ConcreteT: ...
 
 
 def test_get_fn_type_hints_asgi_app() -> None:
@@ -161,3 +178,79 @@ def test_add_types_to_signature_namespace_with_existing_types_raises() -> None:
     """Test add_types_to_signature_namespace with existing types raises."""
     with pytest.raises(ImproperlyConfiguredException):
         add_types_to_signature_namespace([int], {"int": int})
+
+
+@pytest.mark.parametrize(
+    ("type_hint", "namespace", "expected"),
+    (
+        ({"arg1": T, "return": int}, {}, {"arg1": T, "return": int}),
+        ({"arg1": T, "return": int}, None, {"arg1": T, "return": int}),
+        ({"arg1": T, "return": int}, {U: ConcreteT}, {"arg1": T, "return": int}),
+        ({"arg1": T, "return": int}, {T: ConcreteT}, {"arg1": ConcreteT, "return": int}),
+        ({"arg1": T, "return": int}, {T: int}, {"arg1": int, "return": int}),
+        ({"arg1": int, "return": int}, {}, {"arg1": int, "return": int}),
+        ({"arg1": int, "return": int}, None, {"arg1": int, "return": int}),
+        ({"arg1": int, "return": int}, {T: int}, {"arg1": int, "return": int}),
+        ({"arg1": T, "return": T}, {T: ConcreteT}, {"arg1": ConcreteT, "return": ConcreteT}),
+        ({"arg1": T, "return": T}, {T: int}, {"arg1": int, "return": int}),
+    ),
+)
+def test_expand_type_var_in_type_hints(
+    type_hint: dict[str, Any], namespace: dict[str, Any] | None, expected: dict[str, Any]
+) -> None:
+    assert expand_type_var_in_type_hint(type_hint, namespace) == expected
+
+
+@pytest.mark.parametrize(
+    ("namespace", "expected"),
+    (
+        ({T: int}, {"data": int, "return": int}),
+        ({}, {"data": T, "return": T}),
+        ({T: ConcreteT}, {"data": ConcreteT, "return": ConcreteT}),
+    ),
+)
+def test_using_generics_in_fn_annotations(namespace: dict[str, Any], expected: dict[str, Any]) -> None:
+    @post(signature_namespace=namespace)  # type: ignore[dict-item]
+    def create_item(data: T) -> T:
+        return data
+
+    signature = create_item.parsed_fn_signature
+    actual = {"data": signature.parameters["data"].annotation, "return": signature.return_type.annotation}
+    assert actual == expected
+
+
+class GenericController(Controller, Generic[T]):
+    model_class: T
+
+    def __class_getitem__(cls, model_class: type) -> type:
+        cls_dict = {"model_class": model_class}
+        return type(f"GenericController[{model_class.__name__}", (cls,), cls_dict)
+
+    def __init__(self, owner: Router) -> None:
+        super().__init__(owner)
+        self.signature_namespace[T] = self.model_class  # type: ignore[misc] # mypy will nag here
+
+
+class BaseController(GenericController[T]):
+    @post()
+    async def create(self, data: T) -> T:  # type: ignore[name-defined] # mypy takes issue with this
+        return data
+
+
+@pytest.mark.parametrize(
+    ("annotation_type", "expected"),
+    (
+        (int, {"data": int, "return": int}),
+        (float, {"data": float, "return": float}),
+        (ConcreteT, {"data": ConcreteT, "return": ConcreteT}),
+    ),
+)
+def test_using_generics_in_controller_annotations(annotation_type: type, expected: dict[str, Any]) -> None:
+    class ConcreteController(BaseController[annotation_type]):  # type: ignore[valid-type]
+        path = "/"
+
+    controller_object = ConcreteController(owner=None)  # type: ignore[arg-type] # For testing purpose
+
+    signature = controller_object.get_route_handlers()[0].parsed_fn_signature
+    actual = {"data": signature.parameters["data"].annotation, "return": signature.return_type.annotation}
+    assert actual == expected

--- a/tests/unit/test_utils/test_signature.py
+++ b/tests/unit/test_utils/test_signature.py
@@ -228,7 +228,7 @@ class GenericController(Controller, Generic[T]):
 
     def __init__(self, owner: Router) -> None:
         super().__init__(owner)
-        self.signature_namespace[T] = self.model_class  # type: ignore
+        self.signature_namespace[T] = self.model_class  # type: ignore[misc]
 
 
 class BaseController(GenericController[T]):
@@ -246,10 +246,10 @@ class BaseController(GenericController[T]):
     ),
 )
 def test_using_generics_in_controller_annotations(annotation_type: type, expected: dict[str, Any]) -> None:
-    class ConcreteController(BaseController[annotation_type]):
+    class ConcreteController(BaseController[annotation_type]):  # type: ignore[valid-type]
         path = "/"
 
-    controller_object = ConcreteController(owner=None)  # type: ignore
+    controller_object = ConcreteController(owner=None)  # type: ignore[arg-type]
 
     signature = controller_object.get_route_handlers()[0].parsed_fn_signature
     actual = {"data": signature.parameters["data"].annotation, "return": signature.return_type.annotation}


### PR DESCRIPTION
### Description
Add a method for typevar expansion on registration
This allows the use of generic route handler and generic controller without relying on forward references.

### Closes https://github.com/litestar-org/litestar/issues/3206
A self-contained example - which would fail in the previous version:

```Python
from dataclasses import dataclass, field
from typing import Generic, TypeVar
from uuid import UUID, uuid4

from litestar import Controller, Litestar, Router, post


@dataclass
class BookDataClass:
    title: str
    id: UUID = field(default_factory=uuid4)


@dataclass
class AuthorDataClass:
    title: str
    id: UUID = field(default_factory=uuid4)


T = TypeVar("T")


class GenericController(Controller, Generic[T]):
    model_class: T

    def __class_getitem__(cls, model_class: type) -> type:
        cls_dict = {"model_class": model_class}
        return type(f"GenericController[{model_class.__name__}", (cls,), cls_dict)

    def __init__(self, owner: Router) -> None:
        super().__init__(owner)
        self.signature_namespace[T] = self.model_class  

class BaseController(GenericController[T]):
    @post()
    async def create(self, data: T) -> T:  
        return data


class AuthorDataClassController(BaseController[AuthorDataClass]):
    path = "/AuthorDataClass"


class BookDataClassController(BaseController[BookDataClass]):
    path = "/BookDataClass"
    signature_namespace = {"S": int, "U": float}


app = Litestar([AuthorDataClassController, BookDataClassController])
```
All failed tests were not caused by this new update. Please let me know what you think.