### PR TITLE
feat: add typevar expansion

### DIFF
--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -14,7 +14,7 @@ from litestar import connection, datastructures, types
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types import Empty
 from litestar.typing import FieldDefinition
-from litestar.utils.typing import unwrap_annotation
+from litestar.utils.typing import _substitute_typevars, unwrap_annotation
 
 if TYPE_CHECKING:
     from typing import Sequence
@@ -131,6 +131,24 @@ def _unwrap_implicit_optional_hints(defaults: dict[str, Any], hints: dict[str, A
     return hints
 
 
+def expand_type_var_in_type_hint(type_hint: dict[str, Any], namespace: dict[str, Any] | None) -> dict[str, Any]:
+    """Expand TypeVar for any parameters in type_hint
+
+    Args:
+        type_hint: mapping of parameter to type obtained from calling `get_type_hints` or `get_fn_type_hints`
+        namespace: mapping of TypeVar to concrete type
+
+    Returns:
+        type_hint with any TypeVar parameter expanded
+    """
+    if namespace:
+        expanded_type_hint = {}
+        for name, hint in type_hint.items():
+            expanded_type_hint[name] = _substitute_typevars(hint, namespace)
+        return expanded_type_hint
+    return type_hint
+
+
 def get_fn_type_hints(fn: Any, namespace: dict[str, Any] | None = None) -> dict[str, Any]:
     """Resolve type hints for ``fn``.
 
@@ -212,8 +230,9 @@ class ParsedSignature:
         """
         signature = Signature.from_callable(fn)
         fn_type_hints = get_fn_type_hints(fn, namespace=signature_namespace)
+        expanded_type_hints = expand_type_var_in_type_hint(fn_type_hints, signature_namespace)
 
-        return cls.from_signature(signature, fn_type_hints)
+        return cls.from_signature(signature, expanded_type_hints)
 
     @classmethod
     def from_signature(cls, signature: Signature, fn_type_hints: dict[str, type]) -> Self:

--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -14,7 +14,7 @@ from litestar import connection, datastructures, types
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types import Empty
 from litestar.typing import FieldDefinition
-from litestar.utils.typing import _substitute_typevars, unwrap_annotation
+from litestar.utils.typing import expand_type_var_in_type_hint, unwrap_annotation
 
 if TYPE_CHECKING:
     from typing import Sequence
@@ -129,24 +129,6 @@ def _unwrap_implicit_optional_hints(defaults: dict[str, Any], hints: dict[str, A
             # redundant outer union
             hints[name] = args[0]
     return hints
-
-
-def expand_type_var_in_type_hint(type_hint: dict[str, Any], namespace: dict[str, Any] | None) -> dict[str, Any]:
-    """Expand TypeVar for any parameters in type_hint
-
-    Args:
-        type_hint: mapping of parameter to type obtained from calling `get_type_hints` or `get_fn_type_hints`
-        namespace: mapping of TypeVar to concrete type
-
-    Returns:
-        type_hint with any TypeVar parameter expanded
-    """
-    if namespace:
-        expanded_type_hint = {}
-        for name, hint in type_hint.items():
-            expanded_type_hint[name] = _substitute_typevars(hint, namespace)
-        return expanded_type_hint
-    return type_hint
 
 
 def get_fn_type_hints(fn: Any, namespace: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/litestar/utils/typing.py
+++ b/litestar/utils/typing.py
@@ -37,14 +37,7 @@ from typing import (
     cast,
 )
 
-from typing_extensions import (
-    Annotated,
-    NotRequired,
-    Required,
-    get_args,
-    get_origin,
-    get_type_hints,
-)
+from typing_extensions import Annotated, NotRequired, Required, get_args, get_origin, get_type_hints
 
 from litestar.types.builtin_types import NoneType, UnionTypes
 

--- a/litestar/utils/typing.py
+++ b/litestar/utils/typing.py
@@ -37,7 +37,14 @@ from typing import (
     cast,
 )
 
-from typing_extensions import Annotated, NotRequired, Required, get_args, get_origin, get_type_hints
+from typing_extensions import (
+    Annotated,
+    NotRequired,
+    Required,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
 from litestar.types.builtin_types import NoneType, UnionTypes
 
@@ -260,6 +267,21 @@ def get_type_hints_with_generics_resolved(
         typevar_map = dict(zip(origin.__parameters__, get_args(annotation)))
 
     return {n: _substitute_typevars(type_, typevar_map) for n, type_ in type_hints.items()}
+
+
+def expand_type_var_in_type_hint(type_hint: dict[str, Any], namespace: dict[str, Any] | None) -> dict[str, Any]:
+    """Expand TypeVar for any parameters in type_hint
+
+    Args:
+        type_hint: mapping of parameter to type obtained from calling `get_type_hints` or `get_fn_type_hints`
+        namespace: mapping of TypeVar to concrete type
+
+    Returns:
+        type_hint with any TypeVar parameter expanded
+    """
+    if namespace:
+        return {name: _substitute_typevars(hint, namespace) for name, hint in type_hint.items()}
+    return type_hint
 
 
 def _substitute_typevars(obj: Any, typevar_map: Mapping[Any, Any]) -> Any:

--- a/tests/unit/test_utils/test_signature.py
+++ b/tests/unit/test_utils/test_signature.py
@@ -28,7 +28,6 @@ from litestar.typing import FieldDefinition
 from litestar.utils.signature import (
     ParsedSignature,
     add_types_to_signature_namespace,
-    expand_type_var_in_type_hint,
     get_fn_type_hints,
 )
 
@@ -178,27 +177,6 @@ def test_add_types_to_signature_namespace_with_existing_types_raises() -> None:
     """Test add_types_to_signature_namespace with existing types raises."""
     with pytest.raises(ImproperlyConfiguredException):
         add_types_to_signature_namespace([int], {"int": int})
-
-
-@pytest.mark.parametrize(
-    ("type_hint", "namespace", "expected"),
-    (
-        ({"arg1": T, "return": int}, {}, {"arg1": T, "return": int}),
-        ({"arg1": T, "return": int}, None, {"arg1": T, "return": int}),
-        ({"arg1": T, "return": int}, {U: ConcreteT}, {"arg1": T, "return": int}),
-        ({"arg1": T, "return": int}, {T: ConcreteT}, {"arg1": ConcreteT, "return": int}),
-        ({"arg1": T, "return": int}, {T: int}, {"arg1": int, "return": int}),
-        ({"arg1": int, "return": int}, {}, {"arg1": int, "return": int}),
-        ({"arg1": int, "return": int}, None, {"arg1": int, "return": int}),
-        ({"arg1": int, "return": int}, {T: int}, {"arg1": int, "return": int}),
-        ({"arg1": T, "return": T}, {T: ConcreteT}, {"arg1": ConcreteT, "return": ConcreteT}),
-        ({"arg1": T, "return": T}, {T: int}, {"arg1": int, "return": int}),
-    ),
-)
-def test_expand_type_var_in_type_hints(
-    type_hint: dict[str, Any], namespace: dict[str, Any] | None, expected: dict[str, Any]
-) -> None:
-    assert expand_type_var_in_type_hint(type_hint, namespace) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_utils/test_signature.py
+++ b/tests/unit/test_utils/test_signature.py
@@ -8,14 +8,7 @@ from types import ModuleType
 from typing import Any, Callable, Generic, List, Optional, TypeVar, Union
 
 import pytest
-from typing_extensions import (
-    Annotated,
-    NotRequired,
-    Required,
-    TypedDict,
-    get_args,
-    get_type_hints,
-)
+from typing_extensions import Annotated, NotRequired, Required, TypedDict, get_args, get_type_hints
 
 from litestar import Controller, Router, post
 from litestar.exceptions import ImproperlyConfiguredException
@@ -25,11 +18,7 @@ from litestar.types.asgi_types import Receive, Scope, Send
 from litestar.types.builtin_types import NoneType
 from litestar.types.empty import Empty
 from litestar.typing import FieldDefinition
-from litestar.utils.signature import (
-    ParsedSignature,
-    add_types_to_signature_namespace,
-    get_fn_type_hints,
-)
+from litestar.utils.signature import ParsedSignature, add_types_to_signature_namespace, get_fn_type_hints
 
 T = TypeVar("T")
 U = TypeVar("U")

--- a/tests/unit/test_utils/test_signature.py
+++ b/tests/unit/test_utils/test_signature.py
@@ -5,11 +5,19 @@ from __future__ import annotations
 import inspect
 from inspect import Parameter
 from types import ModuleType
-from typing import Any, Callable, List, Optional, TypeVar, Union
+from typing import Any, Callable, Generic, List, Optional, TypeVar, Union
 
 import pytest
-from typing_extensions import Annotated, NotRequired, Required, TypedDict, get_args, get_type_hints
+from typing_extensions import (
+    Annotated,
+    NotRequired,
+    Required,
+    TypedDict,
+    get_args,
+    get_type_hints,
+)
 
+from litestar import Controller, Router, post
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.file_system import BaseLocalFileSystem
 from litestar.static_files import StaticFiles
@@ -17,9 +25,18 @@ from litestar.types.asgi_types import Receive, Scope, Send
 from litestar.types.builtin_types import NoneType
 from litestar.types.empty import Empty
 from litestar.typing import FieldDefinition
-from litestar.utils.signature import ParsedSignature, add_types_to_signature_namespace, get_fn_type_hints
+from litestar.utils.signature import (
+    ParsedSignature,
+    add_types_to_signature_namespace,
+    expand_type_var_in_type_hint,
+    get_fn_type_hints,
+)
 
 T = TypeVar("T")
+U = TypeVar("U")
+
+
+class ConcreteT: ...
 
 
 def test_get_fn_type_hints_asgi_app() -> None:
@@ -161,3 +178,79 @@ def test_add_types_to_signature_namespace_with_existing_types_raises() -> None:
     """Test add_types_to_signature_namespace with existing types raises."""
     with pytest.raises(ImproperlyConfiguredException):
         add_types_to_signature_namespace([int], {"int": int})
+
+
+@pytest.mark.parametrize(
+    ("type_hint", "namespace", "expected"),
+    (
+        ({"arg1": T, "return": int}, {}, {"arg1": T, "return": int}),
+        ({"arg1": T, "return": int}, None, {"arg1": T, "return": int}),
+        ({"arg1": T, "return": int}, {U: ConcreteT}, {"arg1": T, "return": int}),
+        ({"arg1": T, "return": int}, {T: ConcreteT}, {"arg1": ConcreteT, "return": int}),
+        ({"arg1": T, "return": int}, {T: int}, {"arg1": int, "return": int}),
+        ({"arg1": int, "return": int}, {}, {"arg1": int, "return": int}),
+        ({"arg1": int, "return": int}, None, {"arg1": int, "return": int}),
+        ({"arg1": int, "return": int}, {T: int}, {"arg1": int, "return": int}),
+        ({"arg1": T, "return": T}, {T: ConcreteT}, {"arg1": ConcreteT, "return": ConcreteT}),
+        ({"arg1": T, "return": T}, {T: int}, {"arg1": int, "return": int}),
+    ),
+)
+def test_expand_type_var_in_type_hints(
+    type_hint: dict[str, Any], namespace: dict[str, Any] | None, expected: dict[str, Any]
+) -> None:
+    assert expand_type_var_in_type_hint(type_hint, namespace) == expected
+
+
+@pytest.mark.parametrize(
+    ("namespace", "expected"),
+    (
+        ({T: int}, {"data": int, "return": int}),
+        ({}, {"data": T, "return": T}),
+        ({T: ConcreteT}, {"data": ConcreteT, "return": ConcreteT}),
+    ),
+)
+def test_using_generics_in_fn_annotations(namespace: dict[str, Any], expected: dict[str, Any]) -> None:
+    @post(signature_namespace=namespace)
+    def create_item(data: T) -> T:
+        return data
+
+    signature = create_item.parsed_fn_signature
+    actual = {"data": signature.parameters["data"].annotation, "return": signature.return_type.annotation}
+    assert actual == expected
+
+
+class GenericController(Controller, Generic[T]):
+    model_class: T
+
+    def __class_getitem__(cls, model_class: type) -> type:
+        cls_dict = {"model_class": model_class}
+        return type(f"GenericController[{model_class.__name__}", (cls,), cls_dict)
+
+    def __init__(self, owner: Router) -> None:
+        super().__init__(owner)
+        self.signature_namespace[T] = self.model_class  # type: ignore[misc]
+
+
+class BaseController(GenericController[T]):
+    @post()
+    async def create(self, data: T) -> T:
+        return data
+
+
+@pytest.mark.parametrize(
+    ("annotation_type", "expected"),
+    (
+        (int, {"data": int, "return": int}),
+        (float, {"data": float, "return": float}),
+        (ConcreteT, {"data": ConcreteT, "return": ConcreteT}),
+    ),
+)
+def test_using_generics_in_controller_annotations(annotation_type: type, expected: dict[str, Any]) -> None:
+    class ConcreteController(BaseController[annotation_type]):  # type: ignore[valid-type]
+        path = "/"
+
+    controller_object = ConcreteController(owner=None)  # type: ignore[arg-type]
+
+    signature = controller_object.get_route_handlers()[0].parsed_fn_signature
+    actual = {"data": signature.parameters["data"].annotation, "return": signature.return_type.annotation}
+    assert actual == expected

--- a/tests/unit/test_utils/test_typing.py
+++ b/tests/unit/test_utils/test_typing.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from sys import version_info
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
-from typing_extensions import Annotated
 
 import pytest
+from typing_extensions import Annotated
 
 from litestar.utils.typing import (
     expand_type_var_in_type_hint,
@@ -35,8 +35,7 @@ else:
 
 
 @pytest.mark.parametrize(
-    ("annotation", "expected"), [(Union[None, str, int], Union[str, int]),
-                                 (Optional[Union[str, int]], Union[str, int])]
+    ("annotation", "expected"), [(Union[None, str, int], Union[str, int]), (Optional[Union[str, int]], Union[str, int])]
 )
 def test_make_non_optional_union(annotation: Any, expected: Any) -> None:
     assert make_non_optional_union(annotation) == expected
@@ -45,9 +44,7 @@ def test_make_non_optional_union(annotation: Any, expected: Any) -> None:
 def test_get_origin_or_inner_type() -> None:
     assert get_origin_or_inner_type(List[DataclassPerson]) == list
     assert get_origin_or_inner_type(Annotated[List[DataclassPerson], "foo"]) == list
-    assert get_origin_or_inner_type(
-        Annotated[Dict[str, List[DataclassPerson]], "foo"]
-    ) == dict
+    assert get_origin_or_inner_type(Annotated[Dict[str, List[DataclassPerson]], "foo"]) == dict
 
 
 T = TypeVar("T")
@@ -95,56 +92,49 @@ class NestedFoo(Generic[T]):
 @pytest.mark.parametrize(
     ("annotation", "expected_type_hints"),
     (
-            (Foo[int], {"foo": int}),
-            (BoundFoo, {"bound_foo": int}),
-            (BoundFoo[int], {"bound_foo": int}),
-            (ConstrainedFoo[int], {"constrained_foo": int}),
-            (ConstrainedFoo, {"constrained_foo": Union[int, str]}),
-            (AnnotatedFoo[int], {"annotated_foo": Annotated[int, ANNOTATION]}),
-            (
-                    UnionFoo[T, V, U],  # type: ignore[valid-type]
-                    {
-                        "union_foo": Union[T, bool],
-                        # pyright: ignore[reportGeneralTypeIssues]
-                        "constrained_union_foo": Union[int, str, bool],
-                        "bound_union_foo": Union[int, bool],
-                    },
-            ),
-            (
-                    UnionFoo,
-                    {
-                        "union_foo": Union[T, bool],
-                        # pyright: ignore[reportGeneralTypeIssues]
-                        "constrained_union_foo": Union[int, str, bool],
-                        "bound_union_foo": Union[int, bool],
-                    },
-            ),
-            (
-                    MixedFoo[int],
-                    {
-                        "foo": int,
-                        "list_foo": List[int],
-                        "normal_foo": str,
-                        "normal_list_foo": List[str],
-                    },
-            ),
-            (
-                    NestedFoo[int],
-                    {
-                        "bound_foo": BoundFoo[int],
-                        "constrained_foo": ConstrainedFoo[Union[int, str]],
-                        # type: ignore[type-var]
-                        "constrained_foo_with_t": ConstrainedFoo[int],
-                    },
-            ),
+        (Foo[int], {"foo": int}),
+        (BoundFoo, {"bound_foo": int}),
+        (BoundFoo[int], {"bound_foo": int}),
+        (ConstrainedFoo[int], {"constrained_foo": int}),
+        (ConstrainedFoo, {"constrained_foo": Union[int, str]}),
+        (AnnotatedFoo[int], {"annotated_foo": Annotated[int, ANNOTATION]}),
+        (
+            UnionFoo[T, V, U],  # type: ignore[valid-type]
+            {
+                "union_foo": Union[T, bool],  # pyright: ignore[reportGeneralTypeIssues]
+                "constrained_union_foo": Union[int, str, bool],
+                "bound_union_foo": Union[int, bool],
+            },
+        ),
+        (
+            UnionFoo,
+            {
+                "union_foo": Union[T, bool],  # pyright: ignore[reportGeneralTypeIssues]
+                "constrained_union_foo": Union[int, str, bool],
+                "bound_union_foo": Union[int, bool],
+            },
+        ),
+        (
+            MixedFoo[int],
+            {
+                "foo": int,
+                "list_foo": List[int],
+                "normal_foo": str,
+                "normal_list_foo": List[str],
+            },
+        ),
+        (
+            NestedFoo[int],
+            {
+                "bound_foo": BoundFoo[int],
+                "constrained_foo": ConstrainedFoo[Union[int, str]],  # type: ignore[type-var]
+                "constrained_foo_with_t": ConstrainedFoo[int],
+            },
+        ),
     ),
 )
-def test_get_type_hints_with_generics(
-        annotation: Any, expected_type_hints: dict[str, Any]
-) -> None:
-    assert get_type_hints_with_generics_resolved(
-        annotation, include_extras=True
-    ) == expected_type_hints
+def test_get_type_hints_with_generics(annotation: Any, expected_type_hints: dict[str, Any]) -> None:
+    assert get_type_hints_with_generics_resolved(annotation, include_extras=True) == expected_type_hints
 
 
 class ConcreteT: ...
@@ -153,22 +143,19 @@ class ConcreteT: ...
 @pytest.mark.parametrize(
     ("type_hint", "namespace", "expected"),
     (
-            ({"arg1": T, "return": int}, {}, {"arg1": T, "return": int}),
-            ({"arg1": T, "return": int}, None, {"arg1": T, "return": int}),
-            ({"arg1": T, "return": int}, {U: ConcreteT}, {"arg1": T, "return": int}),
-            ({"arg1": T, "return": int}, {T: ConcreteT},
-             {"arg1": ConcreteT, "return": int}),
-            ({"arg1": T, "return": int}, {T: int}, {"arg1": int, "return": int}),
-            ({"arg1": int, "return": int}, {}, {"arg1": int, "return": int}),
-            ({"arg1": int, "return": int}, None, {"arg1": int, "return": int}),
-            ({"arg1": int, "return": int}, {T: int}, {"arg1": int, "return": int}),
-            ({"arg1": T, "return": T}, {T: ConcreteT},
-             {"arg1": ConcreteT, "return": ConcreteT}),
-            ({"arg1": T, "return": T}, {T: int}, {"arg1": int, "return": int}),
+        ({"arg1": T, "return": int}, {}, {"arg1": T, "return": int}),
+        ({"arg1": T, "return": int}, None, {"arg1": T, "return": int}),
+        ({"arg1": T, "return": int}, {U: ConcreteT}, {"arg1": T, "return": int}),
+        ({"arg1": T, "return": int}, {T: ConcreteT}, {"arg1": ConcreteT, "return": int}),
+        ({"arg1": T, "return": int}, {T: int}, {"arg1": int, "return": int}),
+        ({"arg1": int, "return": int}, {}, {"arg1": int, "return": int}),
+        ({"arg1": int, "return": int}, None, {"arg1": int, "return": int}),
+        ({"arg1": int, "return": int}, {T: int}, {"arg1": int, "return": int}),
+        ({"arg1": T, "return": T}, {T: ConcreteT}, {"arg1": ConcreteT, "return": ConcreteT}),
+        ({"arg1": T, "return": T}, {T: int}, {"arg1": int, "return": int}),
     ),
 )
 def test_expand_type_var_in_type_hints(
-        type_hint: dict[str, Any], namespace: dict[str, Any] | None,
-        expected: dict[str, Any]
+    type_hint: dict[str, Any], namespace: dict[str, Any] | None, expected: dict[str, Any]
 ) -> None:
     assert expand_type_var_in_type_hint(type_hint, namespace) == expected

--- a/tests/unit/test_utils/test_typing.py
+++ b/tests/unit/test_utils/test_typing.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from sys import version_info
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
+from typing_extensions import Annotated
 
 import pytest
-from typing_extensions import Annotated
 
 from litestar.utils.typing import (
     expand_type_var_in_type_hint,
@@ -35,7 +35,8 @@ else:
 
 
 @pytest.mark.parametrize(
-    ("annotation", "expected"), [(Union[None, str, int], Union[str, int]), (Optional[Union[str, int]], Union[str, int])]
+    ("annotation", "expected"), [(Union[None, str, int], Union[str, int]),
+                                 (Optional[Union[str, int]], Union[str, int])]
 )
 def test_make_non_optional_union(annotation: Any, expected: Any) -> None:
     assert make_non_optional_union(annotation) == expected
@@ -44,7 +45,9 @@ def test_make_non_optional_union(annotation: Any, expected: Any) -> None:
 def test_get_origin_or_inner_type() -> None:
     assert get_origin_or_inner_type(List[DataclassPerson]) == list
     assert get_origin_or_inner_type(Annotated[List[DataclassPerson], "foo"]) == list
-    assert get_origin_or_inner_type(Annotated[Dict[str, List[DataclassPerson]], "foo"]) == dict
+    assert get_origin_or_inner_type(
+        Annotated[Dict[str, List[DataclassPerson]], "foo"]
+    ) == dict
 
 
 T = TypeVar("T")
@@ -92,49 +95,56 @@ class NestedFoo(Generic[T]):
 @pytest.mark.parametrize(
     ("annotation", "expected_type_hints"),
     (
-        (Foo[int], {"foo": int}),
-        (BoundFoo, {"bound_foo": int}),
-        (BoundFoo[int], {"bound_foo": int}),
-        (ConstrainedFoo[int], {"constrained_foo": int}),
-        (ConstrainedFoo, {"constrained_foo": Union[int, str]}),
-        (AnnotatedFoo[int], {"annotated_foo": Annotated[int, ANNOTATION]}),
-        (
-            UnionFoo[T, V, U],  # type: ignore[valid-type]
-            {
-                "union_foo": Union[T, bool],  # pyright: ignore[reportGeneralTypeIssues]
-                "constrained_union_foo": Union[int, str, bool],
-                "bound_union_foo": Union[int, bool],
-            },
-        ),
-        (
-            UnionFoo,
-            {
-                "union_foo": Union[T, bool],  # pyright: ignore[reportGeneralTypeIssues]
-                "constrained_union_foo": Union[int, str, bool],
-                "bound_union_foo": Union[int, bool],
-            },
-        ),
-        (
-            MixedFoo[int],
-            {
-                "foo": int,
-                "list_foo": List[int],
-                "normal_foo": str,
-                "normal_list_foo": List[str],
-            },
-        ),
-        (
-            NestedFoo[int],
-            {
-                "bound_foo": BoundFoo[int],
-                "constrained_foo": ConstrainedFoo[Union[int, str]],  # type: ignore[type-var]
-                "constrained_foo_with_t": ConstrainedFoo[int],
-            },
-        ),
+            (Foo[int], {"foo": int}),
+            (BoundFoo, {"bound_foo": int}),
+            (BoundFoo[int], {"bound_foo": int}),
+            (ConstrainedFoo[int], {"constrained_foo": int}),
+            (ConstrainedFoo, {"constrained_foo": Union[int, str]}),
+            (AnnotatedFoo[int], {"annotated_foo": Annotated[int, ANNOTATION]}),
+            (
+                    UnionFoo[T, V, U],  # type: ignore[valid-type]
+                    {
+                        "union_foo": Union[T, bool],
+                        # pyright: ignore[reportGeneralTypeIssues]
+                        "constrained_union_foo": Union[int, str, bool],
+                        "bound_union_foo": Union[int, bool],
+                    },
+            ),
+            (
+                    UnionFoo,
+                    {
+                        "union_foo": Union[T, bool],
+                        # pyright: ignore[reportGeneralTypeIssues]
+                        "constrained_union_foo": Union[int, str, bool],
+                        "bound_union_foo": Union[int, bool],
+                    },
+            ),
+            (
+                    MixedFoo[int],
+                    {
+                        "foo": int,
+                        "list_foo": List[int],
+                        "normal_foo": str,
+                        "normal_list_foo": List[str],
+                    },
+            ),
+            (
+                    NestedFoo[int],
+                    {
+                        "bound_foo": BoundFoo[int],
+                        "constrained_foo": ConstrainedFoo[Union[int, str]],
+                        # type: ignore[type-var]
+                        "constrained_foo_with_t": ConstrainedFoo[int],
+                    },
+            ),
     ),
 )
-def test_get_type_hints_with_generics(annotation: Any, expected_type_hints: dict[str, Any]) -> None:
-    assert get_type_hints_with_generics_resolved(annotation, include_extras=True) == expected_type_hints
+def test_get_type_hints_with_generics(
+        annotation: Any, expected_type_hints: dict[str, Any]
+) -> None:
+    assert get_type_hints_with_generics_resolved(
+        annotation, include_extras=True
+    ) == expected_type_hints
 
 
 class ConcreteT: ...
@@ -143,19 +153,22 @@ class ConcreteT: ...
 @pytest.mark.parametrize(
     ("type_hint", "namespace", "expected"),
     (
-        ({"arg1": T, "return": int}, {}, {"arg1": T, "return": int}),
-        ({"arg1": T, "return": int}, None, {"arg1": T, "return": int}),
-        ({"arg1": T, "return": int}, {U: ConcreteT}, {"arg1": T, "return": int}),
-        ({"arg1": T, "return": int}, {T: ConcreteT}, {"arg1": ConcreteT, "return": int}),
-        ({"arg1": T, "return": int}, {T: int}, {"arg1": int, "return": int}),
-        ({"arg1": int, "return": int}, {}, {"arg1": int, "return": int}),
-        ({"arg1": int, "return": int}, None, {"arg1": int, "return": int}),
-        ({"arg1": int, "return": int}, {T: int}, {"arg1": int, "return": int}),
-        ({"arg1": T, "return": T}, {T: ConcreteT}, {"arg1": ConcreteT, "return": ConcreteT}),
-        ({"arg1": T, "return": T}, {T: int}, {"arg1": int, "return": int}),
+            ({"arg1": T, "return": int}, {}, {"arg1": T, "return": int}),
+            ({"arg1": T, "return": int}, None, {"arg1": T, "return": int}),
+            ({"arg1": T, "return": int}, {U: ConcreteT}, {"arg1": T, "return": int}),
+            ({"arg1": T, "return": int}, {T: ConcreteT},
+             {"arg1": ConcreteT, "return": int}),
+            ({"arg1": T, "return": int}, {T: int}, {"arg1": int, "return": int}),
+            ({"arg1": int, "return": int}, {}, {"arg1": int, "return": int}),
+            ({"arg1": int, "return": int}, None, {"arg1": int, "return": int}),
+            ({"arg1": int, "return": int}, {T: int}, {"arg1": int, "return": int}),
+            ({"arg1": T, "return": T}, {T: ConcreteT},
+             {"arg1": ConcreteT, "return": ConcreteT}),
+            ({"arg1": T, "return": T}, {T: int}, {"arg1": int, "return": int}),
     ),
 )
 def test_expand_type_var_in_type_hints(
-    type_hint: dict[str, Any], namespace: dict[str, Any] | None, expected: dict[str, Any]
+        type_hint: dict[str, Any], namespace: dict[str, Any] | None,
+        expected: dict[str, Any]
 ) -> None:
     assert expand_type_var_in_type_hint(type_hint, namespace) == expected


### PR DESCRIPTION
### Description
Add a method for typevar expansion on registration
This allows the use of generic route handler and generic controller without relying on forward references.

### Closes https://github.com/litestar-org/litestar/issues/3206
A self-contained example - which would fail in the previous version:

```Python
from dataclasses import dataclass, field
from typing import Generic, TypeVar
from uuid import UUID, uuid4

from litestar import Controller, Litestar, Router, post


@dataclass
class BookDataClass:
    title: str
    id: UUID = field(default_factory=uuid4)


@dataclass
class AuthorDataClass:
    title: str
    id: UUID = field(default_factory=uuid4)


T = TypeVar("T")


class GenericController(Controller, Generic[T]):
    model_class: T

    def __class_getitem__(cls, model_class: type) -> type:
        cls_dict = {"model_class": model_class}
        return type(f"GenericController[{model_class.__name__}", (cls,), cls_dict)

    def __init__(self, owner: Router) -> None:
        super().__init__(owner)
        self.signature_namespace[T] = self.model_class  

class BaseController(GenericController[T]):
    @post()
    async def create(self, data: T) -> T:  
        return data


class AuthorDataClassController(BaseController[AuthorDataClass]):
    path = "/AuthorDataClass"


class BookDataClassController(BaseController[BookDataClass]):
    path = "/BookDataClass"
    signature_namespace = {"S": int, "U": float}


app = Litestar([AuthorDataClassController, BookDataClassController])
```
All failed tests were not caused by this new update. Please let me know what you think.