### PR TITLE
fix: kwarg ambiguity exc msg for path params

### DIFF
--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -457,16 +457,16 @@ class KwargsModel:
             *list(layered_parameters.keys()),
         }
 
-        for intersection in (
+        intersection = (
             path_parameters.intersection(dependency_keys)
             or path_parameters.intersection(parameter_names)
             or dependency_keys.intersection(parameter_names)
-        ):
-            if intersection:
-                raise ImproperlyConfiguredException(
-                    f"Kwarg resolution ambiguity detected for the following keys: {', '.join(intersection)}. "
-                    f"Make sure to use distinct keys for your dependencies, path parameters and aliased parameters."
-                )
+        )
+        if intersection:
+            raise ImproperlyConfiguredException(
+                f"Kwarg resolution ambiguity detected for the following keys: {', '.join(intersection)}. "
+                f"Make sure to use distinct keys for your dependencies, path parameters and aliased parameters."
+            )
 
         if used_reserved_kwargs := {
             *parameter_names,

--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -465,7 +465,7 @@ class KwargsModel:
         if intersection:
             raise ImproperlyConfiguredException(
                 f"Kwarg resolution ambiguity detected for the following keys: {', '.join(intersection)}. "
-                f"Make sure to use distinct keys for your dependencies, path parameters and aliased parameters."
+                f"Make sure to use distinct keys for your dependencies, path parameters, and aliased parameters."
             )
 
         if used_reserved_kwargs := {

--- a/tests/unit/test_kwargs/test_path_params.py
+++ b/tests/unit/test_kwargs/test_path_params.py
@@ -121,6 +121,17 @@ def test_duplicate_path_param_validation() -> None:
         Litestar(route_handlers=[test_method])
 
 
+def test_path_param_defined_in_layered_params_error() -> None:
+    @get(path="/{param:int}")
+    def test_method(param: int) -> None:
+        raise AssertionError("should not be called")
+
+    with pytest.raises(ImproperlyConfiguredException) as exc_info:
+        Litestar(route_handlers=[test_method], parameters={"param": Parameter(gt=3)})
+
+    assert "Kwarg resolution ambiguity detected for the following keys: param." in str(exc_info.value)
+
+
 @pytest.mark.parametrize(
     "param_type_name, param_type_class, value, expected_value",
     [


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This PR cherry picks @guacs' commit from #3223 that fixes the way we construct the exception message when there is a kwarg ambiguity detected for path parameters.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
