### PR TITLE
fix: openapi generation with pydantic examples

### DIFF
--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -67,7 +67,7 @@ from litestar.utils.typing import (
 
 if TYPE_CHECKING:
     from litestar._openapi.datastructures import OpenAPIContext
-    from litestar.openapi.spec import Example, Reference
+    from litestar.openapi.spec import Reference
     from litestar.plugins import OpenAPISchemaPluginProtocol
 
 KWARG_DEFINITION_ATTRIBUTE_TO_OPENAPI_PROPERTY_MAP: dict[str, str] = {
@@ -558,7 +558,7 @@ class SchemaCreator:
                     not isinstance(value, Hashable) or not self.is_undefined(value)
                 ):
                     if schema_key == "examples":
-                        value = get_json_schema_formatted_examples(cast("list[Example]", value))
+                        value = get_json_schema_formatted_examples(cast("list[Any]", value))
 
                     # we only want to transfer values from the `KwargDefinition` to `Schema` if the schema object
                     # doesn't already have a value for that property. For example, if a field is a constrained date,

--- a/litestar/_openapi/schema_generation/utils.py
+++ b/litestar/_openapi/schema_generation/utils.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Mapping, _GenericAlias  # type: ignore[attr-defined]
 
+from litestar.openapi.spec import Example
 from litestar.utils.helpers import get_name
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from litestar.openapi.spec import Example
     from litestar.typing import FieldDefinition
 
 __all__ = (
@@ -109,6 +109,6 @@ def get_formatted_examples(field_definition: FieldDefinition, examples: Sequence
     return {f"{name}-example-{i}": example for i, example in enumerate(examples, 1)}
 
 
-def get_json_schema_formatted_examples(examples: Sequence[Example]) -> list[Any]:
+def get_json_schema_formatted_examples(examples: Sequence[Any]) -> list[Any]:
     """Format the examples into the JSON schema format."""
-    return [example.value for example in examples]
+    return [example.value if isinstance(example, Example) else example for example in examples]

--- a/tests/unit/test_contrib/test_pydantic/test_openapi.py
+++ b/tests/unit/test_contrib/test_pydantic/test_openapi.py
@@ -553,6 +553,26 @@ def test_create_schema_for_field_v2() -> None:
     assert value.examples == ["example"]
 
 
+def test_create_schema_for_field_v2__examples() -> None:
+    class Model(pydantic_v2.BaseModel):
+        value: str = pydantic_v2.Field(
+            title="title", description="description", max_length=16, json_schema_extra={"examples": ["example"]}
+        )
+
+    schema = get_schema_for_field_definition(
+        FieldDefinition.from_kwarg(name="Model", annotation=Model), plugins=[PydanticSchemaPlugin()]
+    )
+
+    assert schema.properties
+
+    value = schema.properties["value"]
+
+    assert isinstance(value, Schema)
+    assert value.description == "description"
+    assert value.title == "title"
+    assert value.examples == ["example"]
+
+
 @pytest.mark.parametrize("with_future_annotations", [True, False])
 def test_create_schema_for_pydantic_model_with_annotated_model_attribute(
     with_future_annotations: bool, create_module: "Callable[[str], ModuleType]", pydantic_version: PydanticVersion


### PR DESCRIPTION
## Description

Resolves an issue with OpenAPI schema generation when using ``Pydantic`` examples

## Closes
- Closes #3277
