### PR TITLE
fix(openapi): set default on schema from `FieldDefinition`

### DIFF
--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -569,6 +569,9 @@ class SchemaCreator:
                     if getattr(schema, schema_key, None) is None:
                         setattr(schema, schema_key, value)
 
+        if schema.default is None and field.default is not Empty:
+            schema.default = field.default
+
         if not schema.examples and self.generate_examples:
             from litestar._openapi.schema_generation.examples import create_examples_for_field
 

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -37,7 +37,7 @@ from litestar.openapi.spec import ExternalDocumentation, OpenAPIType, Reference
 from litestar.openapi.spec.example import Example
 from litestar.openapi.spec.schema import Schema
 from litestar.pagination import ClassicPagination, CursorPagination, OffsetPagination
-from litestar.params import Parameter, ParameterKwarg
+from litestar.params import KwargDefinition, Parameter, ParameterKwarg
 from litestar.testing import create_test_client
 from litestar.types.builtin_types import NoneType
 from litestar.typing import FieldDefinition
@@ -555,3 +555,18 @@ def test_type_union_with_none(base_type: type) -> None:
         Reference(ref="#/components/schemas/tests_unit_test_openapi_test_schema_test_type_union_with_none.ModelA"),
         Reference("#/components/schemas/tests_unit_test_openapi_test_schema_test_type_union_with_none.ModelB"),
     ]
+
+
+def test_default_only_on_field_definition() -> None:
+    field_definition = FieldDefinition.from_annotation(int, default=10)
+    assert field_definition.kwarg_definition is None
+
+    schema = get_schema_for_field_definition(field_definition)
+    assert schema.default == 10
+
+
+def test_default_not_provided_for_kwarg_but_for_field() -> None:
+    field_definition = FieldDefinition.from_annotation(int, default=10, kwarg_definition=KwargDefinition())
+    schema = get_schema_for_field_definition(field_definition)
+
+    assert schema.default == 10


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Consider the following:

```python
    def get_foo(foo_id: int = 10) -> None:
        ...
```
In such cases, no `KwargDefinition` is created since there is no metadata provided via `Annotated`. The default is still parsed, and set on the generated `FieldDefinition`, however the `SchemaCreator` currently only considers defaults that are set on `KwargDefinition`.

So in such cases, we should fallback to the default set on the `FieldDefinition` if there is a valid default value.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234


Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
Fixes #3278.