### PR TITLE
fix: pydantic `json_schema_extra` examples.

### DIFF
--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -96,7 +96,7 @@ def _parse_metadata(value: Any, is_sequence_container: bool, extra: dict[str, An
     example_list: list[Any] | None
     if example := extra.pop("example", None):
         example_list = [Example(value=example)]
-    elif examples := getattr(value, "examples", None):
+    elif examples := (extra.pop("examples", None) or getattr(value, "examples", None)):
         example_list = [Example(value=example) for example in cast("list[str]", examples)]
     else:
         example_list = None

--- a/tests/unit/test_contrib/test_pydantic/test_openapi.py
+++ b/tests/unit/test_contrib/test_pydantic/test_openapi.py
@@ -553,6 +553,26 @@ def test_create_schema_for_field_v2() -> None:
     assert value.examples == ["example"]
 
 
+def test_create_schema_for_field_v2__examples() -> None:
+    class Model(pydantic_v2.BaseModel):
+        value: str = pydantic_v2.Field(
+            title="title", description="description", max_length=16, json_schema_extra={"examples": ["example"]}
+        )
+
+    schema = get_schema_for_field_definition(
+        FieldDefinition.from_kwarg(name="Model", annotation=Model), plugins=[PydanticSchemaPlugin()]
+    )
+
+    assert schema.properties
+
+    value = schema.properties["value"]
+
+    assert isinstance(value, Schema)
+    assert value.description == "description"
+    assert value.title == "title"
+    assert value.examples == ["example"]
+
+
 @pytest.mark.parametrize("with_future_annotations", [True, False])
 def test_create_schema_for_pydantic_model_with_annotated_model_attribute(
     with_future_annotations: bool, create_module: "Callable[[str], ModuleType]", pydantic_version: PydanticVersion


### PR DESCRIPTION
Fixes a regression introduced in 2.7 where an example for a field provided in pydantic's `Field.json_schema_extra` would cause an error.

Closes #3277

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
