### PR TITLE
feat: Warn about ambiguous default values in parameter specifications

### DIFF
--- a/tests/unit/test_typing.py
+++ b/tests/unit/test_typing.py
@@ -9,7 +9,8 @@ import msgspec
 import pytest
 from typing_extensions import Annotated, NotRequired, Required, TypedDict, get_type_hints
 
-from litestar.params import DependencyKwarg, KwargDefinition, ParameterKwarg
+from litestar.exceptions import LitestarWarning
+from litestar.params import DependencyKwarg, KwargDefinition, Parameter, ParameterKwarg
 from litestar.typing import FieldDefinition, _unpack_predicate
 
 from .test_utils.test_signature import T, _check_field_definition, field_definition_int, test_type_hints
@@ -450,3 +451,13 @@ def test_field_definition_get_type_hints_dont_resolve_generics(
 )
 def test_unpack_predicate(predicate: Any, expected_meta: dict[str, Any]) -> None:
     assert _unpack_predicate(predicate) == expected_meta
+
+
+def test_warn_ambiguous_default_values() -> None:
+    with pytest.warns(LitestarWarning, match="Ambiguous default values"):
+        FieldDefinition.from_annotation(Annotated[int, Parameter(default=1)], default=2)
+
+
+def test_warn_defaults_inside_parameter_definition() -> None:
+    with pytest.warns(LitestarWarning, match="Deprecated default value specification"):
+        FieldDefinition.from_annotation(Annotated[int, Parameter(default=1)], default=1)

--- a/tests/unit/test_typing.py
+++ b/tests/unit/test_typing.py
@@ -459,5 +459,5 @@ def test_warn_ambiguous_default_values() -> None:
 
 
 def test_warn_defaults_inside_parameter_definition() -> None:
-    with pytest.warns(LitestarWarning, match="Deprecated default value specification"):
+    with pytest.warns(DeprecationWarning, match="Deprecated default value specification"):
         FieldDefinition.from_annotation(Annotated[int, Parameter(default=1)], default=1)


### PR DESCRIPTION
As discussed in https://github.com/litestar-org/litestar/pull/3280#issuecomment-2026878325, we want to warn about, and eventually disallow specifying parameter defaults in two places. 

To achieve this, 2 warnings are added:

- A deprecation warning if a default is specified when using `Annotated`: `param: Annotated[int, Parameter(..., default=1)]` instead of `param: Annotated[int, Parameter(...)] = 1`
- An additional warning in the above case if two default values are specified which do not match in value: `param: Annotated[int, Parameter(..., default=1)] = 2`

In a future version, the first one should result in an exception at startup, preventing both of these scenarios.