### PR TITLE
fix(OpenAPI): Ensure default values are always represented in schema for dataclasses and `msgspec.Struct`s

### DIFF
--- a/litestar/_openapi/schema_generation/plugins/dataclass.py
+++ b/litestar/_openapi/schema_generation/plugins/dataclass.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import MISSING, fields
 from typing import TYPE_CHECKING
 
 from litestar.plugins import OpenAPISchemaPlugin
+from litestar.types import Empty
 from litestar.typing import FieldDefinition
 from litestar.utils.predicates import is_optional_union
 
@@ -31,6 +33,11 @@ class DataclassSchemaPlugin(OpenAPISchemaPlugin):
                 )
             ),
             property_fields={
-                field.name: FieldDefinition.from_kwarg(type_hints[field.name], field.name) for field in dataclass_fields
+                field.name: FieldDefinition.from_kwarg(
+                    annotation=type_hints[field.name],
+                    name=field.name,
+                    default=field.default if field.default is not dataclasses.MISSING else Empty,
+                )
+                for field in dataclass_fields
             },
         )

--- a/litestar/_openapi/schema_generation/plugins/struct.py
+++ b/litestar/_openapi/schema_generation/plugins/struct.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import msgspec
 from msgspec import Struct
 from msgspec.structs import fields
 
@@ -38,7 +39,11 @@ class StructSchemaPlugin(OpenAPISchemaPlugin):
                 ]
             ),
             property_fields={
-                field.encode_name: FieldDefinition.from_kwarg(type_hints[field.name], field.encode_name)
+                field.encode_name: FieldDefinition.from_kwarg(
+                    type_hints[field.name],
+                    field.encode_name,
+                    default=field.default if field.default is not msgspec.NODEFAULT else Empty,
+                )
                 for field in struct_fields
             },
         )

--- a/litestar/_openapi/schema_generation/plugins/struct.py
+++ b/litestar/_openapi/schema_generation/plugins/struct.py
@@ -42,7 +42,7 @@ class StructSchemaPlugin(OpenAPISchemaPlugin):
                 field.encode_name: FieldDefinition.from_kwarg(
                     type_hints[field.name],
                     field.encode_name,
-                    default=field.default if field.default is not msgspec.NODEFAULT else Empty,
+                    default=field.default if field.default not in {msgspec.NODEFAULT, msgspec.UNSET} else Empty,
                 )
                 for field in struct_fields
             },

--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass
 from types import ModuleType
 from typing import Callable, Generic, Optional, TypeVar, cast
@@ -182,6 +183,43 @@ def test_msgspec_schema_generation(create_examples: bool) -> None:
             "minLength": 12,
             "type": "string",
         }
+
+
+def test_dataclass_field_default() -> None:
+    # https://github.com/litestar-org/litestar/issues/3201
+    @dataclass
+    class SomeModel:
+        field_a: str = "default_a"
+        field_b: str = dataclasses.field(default="default_b")
+        field_c: str = dataclasses.field(default_factory=lambda: "default_c")
+
+    @get("/")
+    async def handler() -> SomeModel:
+        pass
+
+    app = Litestar(route_handlers=[handler], signature_types=[SomeModel])
+    schema = app.openapi_schema.components.schemas["test_dataclass_field_default.SomeModel"]
+    assert schema.properties["field_a"].default == "default_a"
+    assert schema.properties["field_b"].default == "default_b"
+    assert schema.properties["field_c"].default is None
+
+
+def test_struct_field_default() -> None:
+    # https://github.com/litestar-org/litestar/issues/3201
+    class SomeModel(msgspec.Struct, kw_only=True):
+        field_a: str = "default_a"
+        field_b: str = msgspec.field(default="default_b")
+        field_c: str = msgspec.field(default_factory=lambda: "default_c")
+
+    @get("/")
+    async def handler() -> SomeModel:
+        pass
+
+    app = Litestar(route_handlers=[handler], signature_types=[SomeModel])
+    schema = app.openapi_schema.components.schemas["test_struct_field_default.SomeModel"]
+    assert schema.properties["field_a"].default == "default_a"
+    assert schema.properties["field_b"].default == "default_b"
+    assert schema.properties["field_c"].default is None
 
 
 def test_schema_for_optional_path_parameter() -> None:

--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -195,13 +195,14 @@ def test_dataclass_field_default() -> None:
 
     @get("/")
     async def handler() -> SomeModel:
-        pass
+        return SomeModel()
 
     app = Litestar(route_handlers=[handler], signature_types=[SomeModel])
     schema = app.openapi_schema.components.schemas["test_dataclass_field_default.SomeModel"]
-    assert schema.properties["field_a"].default == "default_a"
-    assert schema.properties["field_b"].default == "default_b"
-    assert schema.properties["field_c"].default is None
+    assert schema
+    assert schema.properties["field_a"].default == "default_a"  # type: ignore[union-attr, index]
+    assert schema.properties["field_b"].default == "default_b"  # type: ignore[union-attr, index]
+    assert schema.properties["field_c"].default is None  # type: ignore[union-attr, index]
 
 
 def test_struct_field_default() -> None:
@@ -213,13 +214,14 @@ def test_struct_field_default() -> None:
 
     @get("/")
     async def handler() -> SomeModel:
-        pass
+        return SomeModel()
 
     app = Litestar(route_handlers=[handler], signature_types=[SomeModel])
     schema = app.openapi_schema.components.schemas["test_struct_field_default.SomeModel"]
-    assert schema.properties["field_a"].default == "default_a"
-    assert schema.properties["field_b"].default == "default_b"
-    assert schema.properties["field_c"].default is None
+    assert schema
+    assert schema.properties["field_a"].default == "default_a"  # type: ignore[union-attr, index]
+    assert schema.properties["field_b"].default == "default_b"  # type: ignore[union-attr, index]
+    assert schema.properties["field_c"].default is None  # type: ignore[union-attr, index]
 
 
 def test_schema_for_optional_path_parameter() -> None:


### PR DESCRIPTION
Fix a bug that would prevent default values for dataclasses and msgspec.Struct`s to be included in the OpenAPI schema.

```python
@dataclass
class SomeModel:
    field_a: str = "default_a"
    field_b: str = dataclasses.field(default="default_b")
```
and 
```python
class SomeModel(msgspec.Struct, kw_only=True):
    field_a: str = "default_a"
    field_b: str = msgspec.field(default="default_b")
```
now generate correct schemas in all cases.

Fix #3201.

