### PR TITLE
docs(channels): Fix subsriber examples

### DIFF
--- a/docs/examples/channels/iter_stream.py
+++ b/docs/examples/channels/iter_stream.py
@@ -7,7 +7,7 @@ from litestar.channels.backends.memory import MemoryChannelsBackend
 async def handler(socket: WebSocket, channels: ChannelsPlugin) -> None:
     await socket.accept()
 
-    async with channels.subscribe(["some_channel"]) as subscriber:
+    async with channels.start_subscription(["some_channel"]) as subscriber:
         async for message in subscriber.iter_events():
             await socket.send_text(message)
 

--- a/docs/examples/channels/put_history.py
+++ b/docs/examples/channels/put_history.py
@@ -7,7 +7,7 @@ from litestar.channels.backends.memory import MemoryChannelsBackend
 async def handler(socket: WebSocket, channels: ChannelsPlugin) -> None:
     await socket.accept()
 
-    async with channels.subscribe(["some_channel"]) as subscriber:
+    async with channels.start_subscription(["some_channel"]) as subscriber:
         await channels.put_subscriber_history(subscriber, ["some_channel"], limit=10)
 
 

--- a/docs/examples/channels/run_in_background.py
+++ b/docs/examples/channels/run_in_background.py
@@ -7,10 +7,12 @@ from litestar.channels.backends.memory import MemoryChannelsBackend
 async def handler(socket: WebSocket, channels: ChannelsPlugin) -> None:
     await socket.accept()
 
-    async with await channels.subscribe(["some_channel"]) as subscriber, subscriber.run_in_background(socket.send_text):
+    async with channels.start_subscription(["some_channel"]) as subscriber, subscriber.run_in_background(
+        socket.send_text
+    ):
         while True:
             response = await socket.receive_text()
-            await subscriber.send(response)
+            await socket.send_text(response)
 
 
 app = Litestar(


### PR DESCRIPTION
Fix outdated usage of the `channels.subscribe` method; The `channel.start_subscription` method should be used instead.