### PR TITLE
fix(OpenAPI): Fix OpenAPI schema generation for paths with path parameters of different types on the same path

### DIFF
--- a/tests/unit/test_openapi/test_path_item.py
+++ b/tests/unit/test_openapi/test_path_item.py
@@ -231,7 +231,15 @@ def test_merge_path_item_operations_operation_set_on_both_raises(method: HttpMet
 
 @pytest.mark.parametrize(
     "attr",
-    [f.name for f in dataclasses.fields(PathItem) if f.name.upper() not in [*HttpMethod, "TRACE"]],
+    [
+        f.name
+        for f in dataclasses.fields(PathItem)
+        if f.name.upper()
+        not in [
+            *HttpMethod,
+            "TRACE",  # remove once https://github.com/litestar-org/litestar/pull/3294 is merged
+        ]
+    ],
 )
 def test_merge_path_item_operation_differing_values_raises(attr: str) -> None:
     with pytest.raises(ImproperlyConfiguredException, match="Conflicting OpenAPI path configuration for '/'"):

--- a/tests/unit/test_openapi/test_path_item.py
+++ b/tests/unit/test_openapi/test_path_item.py
@@ -231,7 +231,7 @@ def test_merge_path_item_operations_operation_set_on_both_raises(method: HttpMet
 
 @pytest.mark.parametrize(
     "attr",
-    [f.name for f in dataclasses.fields(PathItem) if f.name.upper() not in HttpMethod],
+    [f.name for f in dataclasses.fields(PathItem) if f.name.upper() not in [*HttpMethod, "TRACE"]],
 )
 def test_merge_path_item_operation_differing_values_raises(attr: str) -> None:
     with pytest.raises(ImproperlyConfiguredException, match="Conflicting OpenAPI path configuration for '/'"):

--- a/tests/unit/test_openapi/test_path_item.py
+++ b/tests/unit/test_openapi/test_path_item.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 from typing_extensions import TypeAlias
 
-from litestar import Controller, Litestar, Request, Router, delete, get, HttpMethod
+from litestar import Controller, HttpMethod, Litestar, Request, Router, delete, get
 from litestar._openapi.datastructures import OpenAPIContext
 from litestar._openapi.path_item import PathItemFactory, merge_path_item_operations
 from litestar._openapi.utils import default_operation_id_creator

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -582,6 +582,7 @@ def test_routes_with_different_path_param_types_get_merged() -> None:
         pass
 
     app = Litestar([get_handler, post_handler])
+    assert app.openapi_schema.paths
     paths = app.openapi_schema.paths["/{param}"]
     assert paths.get is not None
     assert paths.post is not None

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -23,16 +23,17 @@ import pytest
 from msgspec import Struct
 from typing_extensions import Annotated, TypeAlias
 
-from litestar import Controller, MediaType, get
+from litestar import Controller, MediaType, get, post
 from litestar._openapi.schema_generation.plugins import openapi_schema_plugins
 from litestar._openapi.schema_generation.schema import (
     KWARG_DEFINITION_ATTRIBUTE_TO_OPENAPI_PROPERTY_MAP,
     SchemaCreator,
 )
 from litestar._openapi.schema_generation.utils import _get_normalized_schema_key, _type_or_first_not_none_inner_type
-from litestar.app import DEFAULT_OPENAPI_CONFIG
+from litestar.app import DEFAULT_OPENAPI_CONFIG, Litestar
 from litestar.di import Provide
 from litestar.enums import ParamType
+from litestar.exceptions import ImproperlyConfiguredException
 from litestar.openapi.spec import ExternalDocumentation, OpenAPIType, Reference
 from litestar.openapi.spec.example import Example
 from litestar.openapi.spec.schema import Schema
@@ -570,3 +571,18 @@ def test_default_not_provided_for_kwarg_but_for_field() -> None:
     schema = get_schema_for_field_definition(field_definition)
 
     assert schema.default == 10
+
+
+def test_routes_with_different_path_param_types_get_merged() -> None:
+    @get("/{param:int}")
+    async def get_handler(param: int) -> None:
+        pass
+
+    @post("/{param:str}")
+    async def post_handler(param: str) -> None:
+        pass
+
+    app = Litestar([get_handler, post_handler])
+    paths = app.openapi_schema.paths["/{param}"]
+    assert paths.get is not None
+    assert paths.post is not None

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -33,7 +33,6 @@ from litestar._openapi.schema_generation.utils import _get_normalized_schema_key
 from litestar.app import DEFAULT_OPENAPI_CONFIG, Litestar
 from litestar.di import Provide
 from litestar.enums import ParamType
-from litestar.exceptions import ImproperlyConfiguredException
 from litestar.openapi.spec import ExternalDocumentation, OpenAPIType, Reference
 from litestar.openapi.spec.example import Example
 from litestar.openapi.spec.schema import Schema


### PR DESCRIPTION
Fix a bug that would cause no OpenAPI schema to be generated for paths with path parameters that only differ on the path parameter type. 

Essentially, `/{param:int}` and `/{param:str}` (that is, two paths with the same path parameter name but a different path parmeter type) could not coexist in the same application. Defining them as `/{param:int}` and `/{other_param:str}` or `/{param:int}` and `/{param:int}` (i.e. different names or same type) would result in the correct behaviour. 

Closes #2700.


<hr>

This was caused by the way Litestar handles routing of these; A single route can have multiple route handlers, but requires that all path parameters, if existent, be of the same type. Litestar can also handle routing with parameters of different types, but creates separate routes for this. Since this representation is only internal (for OpenAPI, they are still the same path), one OpenAPI path generated for one such route would be overwritten by the next route for that path.


