### PR TITLE
fix(OpenAPI): Document unconsumed path parameters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
+        exclude: "tests/unit/test_openapi/test_typescript_converter/test_converter.py"
   - repo: https://github.com/provinzkraut/unasyncd
     rev: "v0.7.1"
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -409,6 +409,7 @@ known-first-party = ["litestar", "tests", "examples"]
 "tests/unit/test_contrib/test_sqlalchemy/**/*.*" = ["UP006"]
 "tools/**/*.*" = ["D", "ARG", "EM", "TRY", "G", "FBT"]
 "tools/prepare_release.py" = ["S603", "S607"]
+"tests/unit/test_openapi/test_typescript_converter/test_converter.py" = ["W293"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/tests/unit/test_openapi/test_typescript_converter/test_converter.py
+++ b/tests/unit/test_openapi/test_typescript_converter/test_converter.py
@@ -15,442 +15,475 @@ def test_openapi_to_typescript_converter(person_controller: Type[Controller], pe
 
     result = convert_openapi_to_typescript(openapi_schema=app.openapi_schema)
     assert (
-        result.write().replace("\t", "	") == "export namespace API {\n"
-        "\texport namespace PetOwnerOrPetGetPetsOrOwners {\n"
-        "\texport namespace Http200 {\n"
-        "\texport type ResponseBody = ({\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies?: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "} | {\n"
-        "\tcomplex: {\n"
-        "\t\n"
-        "};\n"
-        "\tfirst_name: string;\n"
-        "\tid: string;\n"
-        "\tlast_name: string;\n"
-        "\toptional?: null | string;\n"
-        "\tpets?: null | {\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies?: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "}[];\n"
-        "})[];\n"
-        "\n"
-        "\texport interface ResponseHeaders {\n"
-        '\t"x-my-tag"?: string;\n'
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport namespace Http406 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tdetail: string;\n"
-        "\textra?: Record<string, unknown> | null | unknown[];\n"
-        "\tstatus_code: number;\n"
-        "};\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport namespace PetPets {\n"
-        "\texport namespace Http200 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies?: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "}[];\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport namespace ServiceIdPersonBulkBulkCreatePerson {\n"
-        "\texport interface HeaderParameters {\n"
-        "\tsecret: string;\n"
-        "};\n"
-        "\n"
-        "\texport namespace Http201 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tcomplex: {\n"
-        "\t\n"
-        "};\n"
-        "\tfirst_name: string;\n"
-        "\tid: string;\n"
-        "\tlast_name: string;\n"
-        "\toptional: null | string;\n"
-        "\tpets: null | {\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "}[];\n"
-        "}[];\n"
-        "};\n"
-        "\n"
-        "\texport namespace Http400 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tdetail: string;\n"
-        "\textra?: Record<string, unknown> | null | unknown[];\n"
-        "\tstatus_code: number;\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport type RequestBody = {\n"
-        "\tcomplex: {\n"
-        "\t\n"
-        "};\n"
-        "\tfirst_name: string;\n"
-        "\tid: string;\n"
-        "\tlast_name: string;\n"
-        "\toptional: null | string;\n"
-        "\tpets: null | {\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "}[];\n"
-        "}[];\n"
-        "};\n"
-        "\n"
-        "\texport namespace ServiceIdPersonBulkBulkPartialUpdatePerson {\n"
-        "\texport interface HeaderParameters {\n"
-        "\tsecret: string;\n"
-        "};\n"
-        "\n"
-        "\texport namespace Http200 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tcomplex: {\n"
-        "\t\n"
-        "};\n"
-        "\tfirst_name: string;\n"
-        "\tid: string;\n"
-        "\tlast_name: string;\n"
-        "\toptional: null | string;\n"
-        "\tpets: null | {\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "}[];\n"
-        "}[];\n"
-        "};\n"
-        "\n"
-        "\texport namespace Http400 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tdetail: string;\n"
-        "\textra?: Record<string, unknown> | null | unknown[];\n"
-        "\tstatus_code: number;\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport type RequestBody = {\n"
-        "\tcomplex: {\n"
-        "\t\n"
-        "};\n"
-        "\tfirst_name: string;\n"
-        "\tid: string;\n"
-        "\tlast_name: string;\n"
-        "\toptional: null | string;\n"
-        "\tpets: null | {\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "}[];\n"
-        "}[];\n"
-        "};\n"
-        "\n"
-        "\texport namespace ServiceIdPersonBulkBulkUpdatePerson {\n"
-        "\texport interface HeaderParameters {\n"
-        "\tsecret: string;\n"
-        "};\n"
-        "\n"
-        "\texport namespace Http200 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tcomplex: {\n"
-        "\t\n"
-        "};\n"
-        "\tfirst_name: string;\n"
-        "\tid: string;\n"
-        "\tlast_name: string;\n"
-        "\toptional?: null | string;\n"
-        "\tpets?: null | {\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies?: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "}[];\n"
-        "}[];\n"
-        "};\n"
-        "\n"
-        "\texport namespace Http400 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tdetail: string;\n"
-        "\textra?: Record<string, unknown> | null | unknown[];\n"
-        "\tstatus_code: number;\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport type RequestBody = {\n"
-        "\tcomplex: {\n"
-        "\t\n"
-        "};\n"
-        "\tfirst_name: string;\n"
-        "\tid: string;\n"
-        "\tlast_name: string;\n"
-        "\toptional?: null | string;\n"
-        "\tpets?: null | {\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies?: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "}[];\n"
-        "}[];\n"
-        "};\n"
-        "\n"
-        "\texport namespace ServiceIdPersonCreatePerson {\n"
-        "\texport interface HeaderParameters {\n"
-        "\tsecret: string;\n"
-        "};\n"
-        "\n"
-        "\texport namespace Http201 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tcomplex: {\n"
-        "\t\n"
-        "};\n"
-        "\tfirst_name: string;\n"
-        "\tid: string;\n"
-        "\tlast_name: string;\n"
-        "\toptional?: null | string;\n"
-        "\tpets?: null | {\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies?: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "}[];\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport namespace Http400 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tdetail: string;\n"
-        "\textra?: Record<string, unknown> | null | unknown[];\n"
-        "\tstatus_code: number;\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport type RequestBody = {\n"
-        "\tcomplex: {\n"
-        "\t\n"
-        "};\n"
-        "\tfirst_name: string;\n"
-        "\tid: string;\n"
-        "\tlast_name: string;\n"
-        "\toptional?: null | string;\n"
-        "\tpets?: null | {\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies?: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "}[];\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport namespace ServiceIdPersonDataclassGetPersonDataclass {\n"
-        "\texport namespace Http200 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tcomplex: {\n"
-        "\t\n"
-        "};\n"
-        "\tfirst_name: string;\n"
-        "\tid: string;\n"
-        "\tlast_name: string;\n"
-        "\toptional?: null | string;\n"
-        "\tpets?: null | {\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies?: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "}[];\n"
-        "};\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport namespace ServiceIdPersonGetPersons {\n"
-        "\texport interface CookieParameters {\n"
-        "\tvalue: number;\n"
-        "};\n"
-        "\n"
-        "\texport interface HeaderParameters {\n"
-        "\tsecret: string;\n"
-        "};\n"
-        "\n"
-        "\texport namespace Http200 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tcomplex: {\n"
-        "\t\n"
-        "};\n"
-        "\tfirst_name: string;\n"
-        "\tid: string;\n"
-        "\tlast_name: string;\n"
-        "\toptional?: null | string;\n"
-        "\tpets?: null | {\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies?: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "}[];\n"
-        "}[];\n"
-        "};\n"
-        "\n"
-        "\texport namespace Http400 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tdetail: string;\n"
-        "\textra?: Record<string, unknown> | null | unknown[];\n"
-        "\tstatus_code: number;\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport interface PathParameters {\n"
-        "\tservice_id: number;\n"
-        "};\n"
-        "\n"
-        "\texport interface QueryParameters {\n"
-        "\tfrom_date?: null | number | string | string;\n"
-        '\tgender?: "A" | "F" | "M" | "O" | ("A" | "F" | "M" | "O")[] | null;\n'
-        "\tname?: null | string | string[];\n"
-        "\tpage: number;\n"
-        "\tpageSize: number;\n"
-        "\tto_date?: null | number | string | string;\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport namespace ServiceIdPersonPersonIdDeletePerson {\n"
-        "\texport namespace Http204 {\n"
-        "\texport type ResponseBody = undefined;\n"
-        "};\n"
-        "\n"
-        "\texport namespace Http400 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tdetail: string;\n"
-        "\textra?: Record<string, unknown> | null | unknown[];\n"
-        "\tstatus_code: number;\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport interface PathParameters {\n"
-        "\tperson_id: string;\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport namespace ServiceIdPersonPersonIdGetPersonById {\n"
-        "\texport namespace Http200 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tcomplex: {\n"
-        "\t\n"
-        "};\n"
-        "\tfirst_name: string;\n"
-        "\tid: string;\n"
-        "\tlast_name: string;\n"
-        "\toptional?: null | string;\n"
-        "\tpets?: null | {\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies?: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "}[];\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport namespace Http400 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tdetail: string;\n"
-        "\textra?: Record<string, unknown> | null | unknown[];\n"
-        "\tstatus_code: number;\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport interface PathParameters {\n"
-        "\tperson_id: string;\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport namespace ServiceIdPersonPersonIdPartialUpdatePerson {\n"
-        "\texport namespace Http200 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tcomplex: {\n"
-        "\t\n"
-        "};\n"
-        "\tfirst_name: string;\n"
-        "\tid: string;\n"
-        "\tlast_name: string;\n"
-        "\toptional: null | string;\n"
-        "\tpets: null | {\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "}[];\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport namespace Http400 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tdetail: string;\n"
-        "\textra?: Record<string, unknown> | null | unknown[];\n"
-        "\tstatus_code: number;\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport interface PathParameters {\n"
-        "\tperson_id: string;\n"
-        "};\n"
-        "\n"
-        "\texport type RequestBody = {\n"
-        "\tcomplex: {\n"
-        "\t\n"
-        "};\n"
-        "\tfirst_name: string;\n"
-        "\tid: string;\n"
-        "\tlast_name: string;\n"
-        "\toptional: null | string;\n"
-        "\tpets: null | {\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "}[];\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport namespace ServiceIdPersonPersonIdUpdatePerson {\n"
-        "\texport namespace Http200 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tcomplex: {\n"
-        "\t\n"
-        "};\n"
-        "\tfirst_name: string;\n"
-        "\tid: string;\n"
-        "\tlast_name: string;\n"
-        "\toptional?: null | string;\n"
-        "\tpets?: null | {\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies?: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "}[];\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport namespace Http400 {\n"
-        "\texport type ResponseBody = {\n"
-        "\tdetail: string;\n"
-        "\textra?: Record<string, unknown> | null | unknown[];\n"
-        "\tstatus_code: number;\n"
-        "};\n"
-        "};\n"
-        "\n"
-        "\texport interface PathParameters {\n"
-        "\tperson_id: string;\n"
-        "};\n"
-        "\n"
-        "\texport type RequestBody = {\n"
-        "\tcomplex: {\n"
-        "\t\n"
-        "};\n"
-        "\tfirst_name: string;\n"
-        "\tid: string;\n"
-        "\tlast_name: string;\n"
-        "\toptional?: null | string;\n"
-        "\tpets?: null | {\n"
-        "\tage: number;\n"
-        "\tname: string;\n"
-        '\tspecies?: "Cat" | "Dog" | "Monkey" | "Pig";\n'
-        "}[];\n"
-        "};\n"
-        "};\n"
-        "};"
+        result.write()
+        == """export namespace API {
+	export namespace PetOwnerOrPetGetPetsOrOwners {
+	export namespace Http200 {
+	export type ResponseBody = ({
+	age: number;
+	name: string;
+	species?: "Cat" | "Dog" | "Monkey" | "Pig";
+} | {
+	complex: {
+	
+};
+	first_name: string;
+	id: string;
+	last_name: string;
+	optional?: null | string;
+	pets?: null | {
+	age: number;
+	name: string;
+	species?: "Cat" | "Dog" | "Monkey" | "Pig";
+}[];
+})[];
+
+	export interface ResponseHeaders {
+	"x-my-tag"?: string;
+};
+};
+
+	export namespace Http406 {
+	export type ResponseBody = {
+	detail: string;
+	extra?: Record<string, unknown> | null | unknown[];
+	status_code: number;
+};
+};
+};
+
+	export namespace PetPets {
+	export namespace Http200 {
+	export type ResponseBody = {
+	age: number;
+	name: string;
+	species?: "Cat" | "Dog" | "Monkey" | "Pig";
+}[];
+};
+};
+
+	export namespace ServiceIdPersonBulkBulkCreatePerson {
+	export interface HeaderParameters {
+	secret: string;
+};
+
+	export namespace Http201 {
+	export type ResponseBody = {
+	complex: {
+	
+};
+	first_name: string;
+	id: string;
+	last_name: string;
+	optional: null | string;
+	pets: null | {
+	age: number;
+	name: string;
+	species: "Cat" | "Dog" | "Monkey" | "Pig";
+}[];
+}[];
+};
+
+	export namespace Http400 {
+	export type ResponseBody = {
+	detail: string;
+	extra?: Record<string, unknown> | null | unknown[];
+	status_code: number;
+};
+};
+
+	export interface PathParameters {
+	service_id: number;
+};
+
+	export type RequestBody = {
+	complex: {
+	
+};
+	first_name: string;
+	id: string;
+	last_name: string;
+	optional: null | string;
+	pets: null | {
+	age: number;
+	name: string;
+	species: "Cat" | "Dog" | "Monkey" | "Pig";
+}[];
+}[];
+};
+
+	export namespace ServiceIdPersonBulkBulkPartialUpdatePerson {
+	export interface HeaderParameters {
+	secret: string;
+};
+
+	export namespace Http200 {
+	export type ResponseBody = {
+	complex: {
+	
+};
+	first_name: string;
+	id: string;
+	last_name: string;
+	optional: null | string;
+	pets: null | {
+	age: number;
+	name: string;
+	species: "Cat" | "Dog" | "Monkey" | "Pig";
+}[];
+}[];
+};
+
+	export namespace Http400 {
+	export type ResponseBody = {
+	detail: string;
+	extra?: Record<string, unknown> | null | unknown[];
+	status_code: number;
+};
+};
+
+	export interface PathParameters {
+	service_id: number;
+};
+
+	export type RequestBody = {
+	complex: {
+	
+};
+	first_name: string;
+	id: string;
+	last_name: string;
+	optional: null | string;
+	pets: null | {
+	age: number;
+	name: string;
+	species: "Cat" | "Dog" | "Monkey" | "Pig";
+}[];
+}[];
+};
+
+	export namespace ServiceIdPersonBulkBulkUpdatePerson {
+	export interface HeaderParameters {
+	secret: string;
+};
+
+	export namespace Http200 {
+	export type ResponseBody = {
+	complex: {
+	
+};
+	first_name: string;
+	id: string;
+	last_name: string;
+	optional?: null | string;
+	pets?: null | {
+	age: number;
+	name: string;
+	species?: "Cat" | "Dog" | "Monkey" | "Pig";
+}[];
+}[];
+};
+
+	export namespace Http400 {
+	export type ResponseBody = {
+	detail: string;
+	extra?: Record<string, unknown> | null | unknown[];
+	status_code: number;
+};
+};
+
+	export interface PathParameters {
+	service_id: number;
+};
+
+	export type RequestBody = {
+	complex: {
+	
+};
+	first_name: string;
+	id: string;
+	last_name: string;
+	optional?: null | string;
+	pets?: null | {
+	age: number;
+	name: string;
+	species?: "Cat" | "Dog" | "Monkey" | "Pig";
+}[];
+}[];
+};
+
+	export namespace ServiceIdPersonCreatePerson {
+	export interface HeaderParameters {
+	secret: string;
+};
+
+	export namespace Http201 {
+	export type ResponseBody = {
+	complex: {
+	
+};
+	first_name: string;
+	id: string;
+	last_name: string;
+	optional?: null | string;
+	pets?: null | {
+	age: number;
+	name: string;
+	species?: "Cat" | "Dog" | "Monkey" | "Pig";
+}[];
+};
+};
+
+	export namespace Http400 {
+	export type ResponseBody = {
+	detail: string;
+	extra?: Record<string, unknown> | null | unknown[];
+	status_code: number;
+};
+};
+
+	export interface PathParameters {
+	service_id: number;
+};
+
+	export type RequestBody = {
+	complex: {
+	
+};
+	first_name: string;
+	id: string;
+	last_name: string;
+	optional?: null | string;
+	pets?: null | {
+	age: number;
+	name: string;
+	species?: "Cat" | "Dog" | "Monkey" | "Pig";
+}[];
+};
+};
+
+	export namespace ServiceIdPersonDataclassGetPersonDataclass {
+	export namespace Http200 {
+	export type ResponseBody = {
+	complex: {
+	
+};
+	first_name: string;
+	id: string;
+	last_name: string;
+	optional?: null | string;
+	pets?: null | {
+	age: number;
+	name: string;
+	species?: "Cat" | "Dog" | "Monkey" | "Pig";
+}[];
+};
+};
+
+	export namespace Http400 {
+	export type ResponseBody = {
+	detail: string;
+	extra?: Record<string, unknown> | null | unknown[];
+	status_code: number;
+};
+};
+
+	export interface PathParameters {
+	service_id: number;
+};
+};
+
+	export namespace ServiceIdPersonGetPersons {
+	export interface CookieParameters {
+	value: number;
+};
+
+	export interface HeaderParameters {
+	secret: string;
+};
+
+	export namespace Http200 {
+	export type ResponseBody = {
+	complex: {
+	
+};
+	first_name: string;
+	id: string;
+	last_name: string;
+	optional?: null | string;
+	pets?: null | {
+	age: number;
+	name: string;
+	species?: "Cat" | "Dog" | "Monkey" | "Pig";
+}[];
+}[];
+};
+
+	export namespace Http400 {
+	export type ResponseBody = {
+	detail: string;
+	extra?: Record<string, unknown> | null | unknown[];
+	status_code: number;
+};
+};
+
+	export interface PathParameters {
+	service_id: number;
+};
+
+	export interface QueryParameters {
+	from_date?: null | number | string | string;
+	gender?: "A" | "F" | "M" | "O" | ("A" | "F" | "M" | "O")[] | null;
+	name?: null | string | string[];
+	page: number;
+	pageSize: number;
+	to_date?: null | number | string | string;
+};
+};
+
+	export namespace ServiceIdPersonPersonIdDeletePerson {
+	export namespace Http204 {
+	export type ResponseBody = undefined;
+};
+
+	export namespace Http400 {
+	export type ResponseBody = {
+	detail: string;
+	extra?: Record<string, unknown> | null | unknown[];
+	status_code: number;
+};
+};
+
+	export interface PathParameters {
+	person_id: string;
+	service_id: number;
+};
+};
+
+	export namespace ServiceIdPersonPersonIdGetPersonById {
+	export namespace Http200 {
+	export type ResponseBody = {
+	complex: {
+	
+};
+	first_name: string;
+	id: string;
+	last_name: string;
+	optional?: null | string;
+	pets?: null | {
+	age: number;
+	name: string;
+	species?: "Cat" | "Dog" | "Monkey" | "Pig";
+}[];
+};
+};
+
+	export namespace Http400 {
+	export type ResponseBody = {
+	detail: string;
+	extra?: Record<string, unknown> | null | unknown[];
+	status_code: number;
+};
+};
+
+	export interface PathParameters {
+	person_id: string;
+	service_id: number;
+};
+};
+
+	export namespace ServiceIdPersonPersonIdPartialUpdatePerson {
+	export namespace Http200 {
+	export type ResponseBody = {
+	complex: {
+	
+};
+	first_name: string;
+	id: string;
+	last_name: string;
+	optional: null | string;
+	pets: null | {
+	age: number;
+	name: string;
+	species: "Cat" | "Dog" | "Monkey" | "Pig";
+}[];
+};
+};
+
+	export namespace Http400 {
+	export type ResponseBody = {
+	detail: string;
+	extra?: Record<string, unknown> | null | unknown[];
+	status_code: number;
+};
+};
+
+	export interface PathParameters {
+	person_id: string;
+	service_id: number;
+};
+
+	export type RequestBody = {
+	complex: {
+	
+};
+	first_name: string;
+	id: string;
+	last_name: string;
+	optional: null | string;
+	pets: null | {
+	age: number;
+	name: string;
+	species: "Cat" | "Dog" | "Monkey" | "Pig";
+}[];
+};
+};
+
+	export namespace ServiceIdPersonPersonIdUpdatePerson {
+	export namespace Http200 {
+	export type ResponseBody = {
+	complex: {
+	
+};
+	first_name: string;
+	id: string;
+	last_name: string;
+	optional?: null | string;
+	pets?: null | {
+	age: number;
+	name: string;
+	species?: "Cat" | "Dog" | "Monkey" | "Pig";
+}[];
+};
+};
+
+	export namespace Http400 {
+	export type ResponseBody = {
+	detail: string;
+	extra?: Record<string, unknown> | null | unknown[];
+	status_code: number;
+};
+};
+
+	export interface PathParameters {
+	person_id: string;
+	service_id: number;
+};
+
+	export type RequestBody = {
+	complex: {
+	
+};
+	first_name: string;
+	id: string;
+	last_name: string;
+	optional?: null | string;
+	pets?: null | {
+	age: number;
+	name: string;
+	species?: "Cat" | "Dog" | "Monkey" | "Pig";
+}[];
+};
+};
+};"""
     )


### PR DESCRIPTION
Fix a bug where path parameters not consumed by route handlers would not be included in the OpenAPI schema.

```python
from litestar import Litestar, get


@get("/{param:str}")
async def handler() -> None:
    pass
```

This could would not include the `{param}` in the schema, yet it is still required to be passed when calling the path. 

Fix #3290.