### PR TITLE
feat: Pydantic dto non instantiable types

### DIFF
--- a/tests/unit/test_contrib/test_pydantic/__init__.py
+++ b/tests/unit/test_contrib/test_pydantic/__init__.py
@@ -1,3 +1,11 @@
-from typing import Literal
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    import pydantic as pydantic_v2
+    from pydantic import v1 as pydantic_v1
+    from typing_extensions import TypeAlias
 
 PydanticVersion = Literal["v1", "v2"]
+BaseModelType: TypeAlias = "type[pydantic_v1.BaseModel| pydantic_v2.BaseModel]"

--- a/tests/unit/test_contrib/test_pydantic/test_integration.py
+++ b/tests/unit/test_contrib/test_pydantic/test_integration.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, Union
+from typing import Any, Dict, List
 
 import pydantic as pydantic_v2
 import pytest
@@ -13,7 +13,7 @@ from litestar.status_codes import HTTP_400_BAD_REQUEST
 from litestar.testing import create_test_client
 from tests.unit.test_contrib.test_pydantic.models import PydanticPerson, PydanticV1Person
 
-from . import PydanticVersion
+from . import BaseModelType, PydanticVersion
 
 
 @pytest.mark.parametrize(("meta",), [(None,), (Body(media_type=RequestEncodingType.URL_ENCODED),)])
@@ -140,9 +140,7 @@ def test_serialize_raw_errors_v2() -> None:
         ]
 
 
-def test_signature_model_invalid_input(
-    base_model: Type[Union[pydantic_v2.BaseModel, pydantic_v1.BaseModel]], pydantic_version: PydanticVersion
-) -> None:
+def test_signature_model_invalid_input(base_model: BaseModelType, pydantic_version: PydanticVersion) -> None:
     class OtherChild(base_model):  # type: ignore[misc, valid-type]
         val: List[int]
 
@@ -221,7 +219,7 @@ class V2ModelWithPrivateFields(pydantic_v2.BaseModel):
 
 
 @pytest.mark.parametrize("model_type", [V1ModelWithPrivateFields, V2ModelWithPrivateFields])
-def test_private_fields(model_type: Type[Union[pydantic_v1.BaseModel, pydantic_v2.BaseModel]]) -> None:
+def test_private_fields(model_type: BaseModelType) -> None:
     @post("/")
     async def handler(data: V2ModelWithPrivateFields) -> V2ModelWithPrivateFields:
         return data
@@ -230,3 +228,79 @@ def test_private_fields(model_type: Type[Union[pydantic_v1.BaseModel, pydantic_v
         res = client.post("/", json={"bar": "value"})
         assert res.status_code == 201
         assert res.json() == {"bar": "value"}
+
+
+@pytest.mark.parametrize(
+    ("base_model", "type_", "in_"),
+    [
+        pytest.param(pydantic_v2.BaseModel, pydantic_v2.JsonValue, {"foo": "bar"}, id="pydantic_v2.JsonValue"),
+        pytest.param(
+            pydantic_v1.BaseModel, pydantic_v1.IPvAnyAddress, "127.0.0.1", id="pydantic_v1.IPvAnyAddress (v4)"
+        ),
+        pytest.param(
+            pydantic_v2.BaseModel, pydantic_v2.IPvAnyAddress, "127.0.0.1", id="pydantic_v2.IPvAnyAddress (v4)"
+        ),
+        pytest.param(
+            pydantic_v1.BaseModel,
+            pydantic_v1.IPvAnyAddress,
+            "2001:db8::ff00:42:8329",
+            id="pydantic_v1.IPvAnyAddress (v6)",
+        ),
+        pytest.param(
+            pydantic_v2.BaseModel,
+            pydantic_v2.IPvAnyAddress,
+            "2001:db8::ff00:42:8329",
+            id="pydantic_v2.IPvAnyAddress (v6)",
+        ),
+        pytest.param(
+            pydantic_v1.BaseModel, pydantic_v1.IPvAnyInterface, "127.0.0.1/24", id="pydantic_v1.IPvAnyInterface (v4)"
+        ),
+        pytest.param(
+            pydantic_v2.BaseModel, pydantic_v2.IPvAnyInterface, "127.0.0.1/24", id="pydantic_v2.IPvAnyInterface (v4)"
+        ),
+        pytest.param(
+            pydantic_v1.BaseModel,
+            pydantic_v1.IPvAnyInterface,
+            "2001:db8::ff00:42:8329/128",
+            id="pydantic_v1.IPvAnyInterface (v6)",
+        ),
+        pytest.param(
+            pydantic_v2.BaseModel,
+            pydantic_v2.IPvAnyInterface,
+            "2001:db8::ff00:42:8329/128",
+            id="pydantic_v2.IPvAnyInterface (v6)",
+        ),
+        pytest.param(
+            pydantic_v1.BaseModel, pydantic_v1.IPvAnyNetwork, "127.0.0.1/32", id="pydantic_v1.IPvAnyNetwork (v4)"
+        ),
+        pytest.param(
+            pydantic_v2.BaseModel, pydantic_v2.IPvAnyNetwork, "127.0.0.1/32", id="pydantic_v2.IPvAnyNetwork (v4)"
+        ),
+        pytest.param(
+            pydantic_v1.BaseModel,
+            pydantic_v1.IPvAnyNetwork,
+            "2001:db8::ff00:42:8329/128",
+            id="pydantic_v1.IPvAnyNetwork (v6)",
+        ),
+        pytest.param(
+            pydantic_v2.BaseModel,
+            pydantic_v2.IPvAnyNetwork,
+            "2001:db8::ff00:42:8329/128",
+            id="pydantic_v2.IPvAnyNetwork (v6)",
+        ),
+        pytest.param(pydantic_v1.BaseModel, pydantic_v1.EmailStr, "test@example.com", id="pydantic_v1.EmailStr"),
+        pytest.param(pydantic_v2.BaseModel, pydantic_v2.EmailStr, "test@example.com", id="pydantic_v2.EmailStr"),
+    ],
+)
+def test_dto_with_non_instantiable_types(base_model: BaseModelType, type_: Any, in_: Any) -> None:
+    class Model(base_model):  # type: ignore[misc, valid-type]
+        foo: type_
+
+    @post("/", dto=PydanticDTO[Model])
+    async def handler(data: Model) -> Model:
+        return data
+
+    with create_test_client(handler) as client:
+        res = client.post("/", json={"foo": in_})
+        assert res.status_code == 201
+        assert res.json() == {"foo": in_}


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
This PR simplifies the type that we apply to transfer models for pydantic field types in specific circumstances.

- `JsonValue`: this field type is an instance of `TypeAliasType` at runtime, and contains recursive type definitions. Pydantic allow `list`, `dict`, `str`, `bool`, `int`, `float` and `None`, and the value types of `list` and `dict` are allowed to be the same. We type this as `Any` on the transfer models as this is basically the same thing for msgspec ([ref][1]).
- `EmailStr`. These are typed as `EmailStr` which is a class at runtime which is not a `str`, however they are a string and `if TYPE_CHECKING` is used to get type checkers to play along. If we leave it typed as `EmailStr` and return a `str` from a msgspec decode hook for the type, msgspec fails input validation. So we must tell msgspec its a string. This also works well with encoding because it is one.
- IP/Network/Interface types. These are represented by types such as `IPvAnyAddress`, but they are actually parsed into instances of stdlib types such as `IPv4Address` and others from the `ipaddress` module. Given that an instance of `IPvAnyAddress` cannot be meaningfully returned from a decoding hook, we have to tell msgspec that these are strings on the transfer models and let pydantic do the disambiguation. Encoding the stdlib ip types to str is natively handled by msgspec.

There are other types that can adequately be handled by defining type encoders/decoders for them, so I've left them as out of scope for these changes.

Also  the `Json` type is tricky as it accepts a string and is parsed into builtin types by pydantic, however by default pydantic doesn't serialize that back into a string unless explicitly asked to do a round trip. For the DTO transfer models, this means we'd probably have to type it as `str`, but then we don't have a way to encode the decoded values back into a str b/c msgspec won't call an encoding hook for builtin types. So I've left this out of scope.

[1]: https://jcristharif.com/msgspec/supported-types.html#any

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Closes #2334