### PR TITLE
refactor(routing): Move kwargs model creation to handler

### DIFF
--- a/litestar/_asgi/routing_trie/mapping.py
+++ b/litestar/_asgi/routing_trie/mapping.py
@@ -150,21 +150,21 @@ def configure_node(
                 asgi_app=build_route_middleware_stack(app=app, route=route, route_handler=handler),
                 handler=handler,
             )
-            node.path_parameters[method] = route.path_parameters
+            node.path_parameters[method] = tuple(route.path_parameters.values())
 
     elif isinstance(route, WebSocketRoute):
         node.asgi_handlers["websocket"] = ASGIHandlerTuple(
             asgi_app=build_route_middleware_stack(app=app, route=route, route_handler=route.route_handler),
             handler=route.route_handler,
         )
-        node.path_parameters["websocket"] = route.path_parameters
+        node.path_parameters["websocket"] = tuple(route.path_parameters.values())
 
     else:
         node.asgi_handlers["asgi"] = ASGIHandlerTuple(
             asgi_app=build_route_middleware_stack(app=app, route=route, route_handler=route.route_handler),
             handler=route.route_handler,
         )
-        node.path_parameters["asgi"] = route.path_parameters
+        node.path_parameters["asgi"] = tuple(route.path_parameters.values())
         node.is_asgi = True
 
 

--- a/litestar/_openapi/parameters.py
+++ b/litestar/_openapi/parameters.py
@@ -81,7 +81,7 @@ class ParameterFactory:
         self,
         context: OpenAPIContext,
         route_handler: BaseRouteHandler,
-        path_parameters: tuple[PathParameterDefinition, ...],
+        path_parameters: dict[str, PathParameterDefinition],
     ) -> None:
         """Initialize ParameterFactory.
 
@@ -96,7 +96,7 @@ class ParameterFactory:
         self.parameters = ParameterCollection(route_handler)
         self.dependency_providers = route_handler.resolve_dependencies()
         self.layered_parameters = route_handler.resolve_layered_parameters()
-        self.path_parameters: dict[str, PathParameterDefinition] = {p.name: p for p in path_parameters}
+        self.path_parameters = path_parameters
 
     def create_parameter(self, field_definition: FieldDefinition, parameter_name: str) -> Parameter:
         """Create an OpenAPI Parameter instance for a field definition.
@@ -233,7 +233,7 @@ class ParameterFactory:
 def create_parameters_for_handler(
     context: OpenAPIContext,
     route_handler: BaseRouteHandler,
-    path_parameters: tuple[PathParameterDefinition, ...],
+    path_parameters: dict[str, PathParameterDefinition],
 ) -> list[Parameter]:
     """Create a list of path/query/header Parameter models for the given PathHandler."""
     factory = ParameterFactory(

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -670,7 +670,8 @@ class Litestar(Router):
                 route.create_handler_map()
 
             elif isinstance(route, WebSocketRoute):
-                route.handler_parameter_model = route.create_handler_kwargs_model(route.route_handler)
+                handler = route.route_handler
+                route.handler_parameter_model = handler.create_kwargs_model(path_parameters=route.path_parameters)
 
             for plugin in self.plugins.receive_route:
                 plugin.receive_route(route)
@@ -762,7 +763,7 @@ class Litestar(Router):
             (
                 route
                 for route in routes
-                if passed_parameters.issuperset({param.name for param in route.path_parameters})
+                if passed_parameters.issuperset(route.path_parameters)
             ),
             routes[-1],
         )

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -760,11 +760,7 @@ class Litestar(Router):
         passed_parameters = set(path_parameters.keys())
 
         selected_route = next(
-            (
-                route
-                for route in routes
-                if passed_parameters.issuperset(route.path_parameters)
-            ),
+            (route for route in routes if passed_parameters.issuperset(route.path_parameters)),
             routes[-1],
         )
         output: list[str] = []

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -27,6 +27,7 @@ from litestar.utils.signature import ParsedSignature, add_types_to_signature_nam
 if TYPE_CHECKING:
     from typing_extensions import Self
 
+    from litestar._kwargs import KwargsModel
     from litestar.app import Litestar
     from litestar.connection import ASGIConnection
     from litestar.controller import Controller
@@ -35,6 +36,7 @@ if TYPE_CHECKING:
     from litestar.router import Router
     from litestar.types import AnyCallable, AsyncAnyCallable, ExceptionHandler
     from litestar.types.empty import EmptyType
+    from litestar.types.internal_types import PathParameterDefinition
 
 __all__ = ("BaseRouteHandler",)
 
@@ -564,3 +566,18 @@ class BaseRouteHandler:
         if not hasattr(target, "__qualname__"):
             target = type(target)
         return f"{target.__module__}.{target.__qualname__}"
+
+    def create_kwargs_model(
+        self,
+        path_parameters: dict[str, PathParameterDefinition],
+    ) -> KwargsModel:
+        """Create a `KwargsModel` for a given route handler."""
+        from litestar._kwargs import KwargsModel
+
+        return KwargsModel.create_for_signature_model(
+            signature_model=self.signature_model,
+            parsed_signature=self.parsed_fn_signature,
+            dependencies=self.resolve_dependencies(),
+            path_parameters=set(path_parameters.keys()),
+            layered_parameters=self.resolve_layered_parameters(),
+        )

--- a/litestar/routes/base.py
+++ b/litestar/routes/base.py
@@ -138,7 +138,9 @@ class BaseRoute(ABC):
             )
 
     @classmethod
-    def _parse_path(cls, path: str) -> tuple[str, str, list[str | PathParameterDefinition], dict[str, PathParameterDefinition]]:
+    def _parse_path(
+        cls, path: str
+    ) -> tuple[str, str, list[str | PathParameterDefinition], dict[str, PathParameterDefinition]]:
         """Normalize and parse a path.
 
         Splits the path into a list of components, parsing any that are path parameters. Also builds the OpenAPI

--- a/litestar/routes/base.py
+++ b/litestar/routes/base.py
@@ -10,14 +10,12 @@ from uuid import UUID
 
 import msgspec
 
-from litestar._kwargs import KwargsModel
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types.internal_types import PathParameterDefinition
 from litestar.utils import join_paths, normalize_path
 
 if TYPE_CHECKING:
     from litestar.enums import ScopeType
-    from litestar.handlers.base import BaseRouteHandler
     from litestar.types import Method, Receive, Scope, Send
 
 
@@ -101,10 +99,7 @@ class BaseRoute(ABC):
             scope_type: Type of the ASGI scope
             methods: Supported methods
         """
-        self.path, self.path_format, self.path_components = self._parse_path(path)
-        self.path_parameters: tuple[PathParameterDefinition, ...] = tuple(
-            component for component in self.path_components if isinstance(component, PathParameterDefinition)
-        )
+        self.path, self.path_format, self.path_components, self.path_parameters = self._parse_path(path)
         self.handler_names = handler_names
         self.scope_type = scope_type
         self.methods = set(methods or [])
@@ -122,23 +117,6 @@ class BaseRoute(ABC):
             None
         """
         raise NotImplementedError("Route subclasses must implement handle which serves as the ASGI app entry point")
-
-    def create_handler_kwargs_model(self, route_handler: BaseRouteHandler) -> KwargsModel:
-        """Create a `KwargsModel` for a given route handler."""
-
-        path_parameters = set()
-        for param in self.path_parameters:
-            if param.name in path_parameters:
-                raise ImproperlyConfiguredException(f"Duplicate parameter '{param.name}' detected in '{self.path}'.")
-            path_parameters.add(param.name)
-
-        return KwargsModel.create_for_signature_model(
-            signature_model=route_handler.signature_model,
-            parsed_signature=route_handler.parsed_fn_signature,
-            dependencies=route_handler.resolve_dependencies(),
-            path_parameters=path_parameters,
-            layered_parameters=route_handler.resolve_layered_parameters(),
-        )
 
     @staticmethod
     def _validate_path_parameter(param: str, path: str) -> None:
@@ -160,7 +138,7 @@ class BaseRoute(ABC):
             )
 
     @classmethod
-    def _parse_path(cls, path: str) -> tuple[str, str, list[str | PathParameterDefinition]]:
+    def _parse_path(cls, path: str) -> tuple[str, str, list[str | PathParameterDefinition], dict[str, PathParameterDefinition]]:
         """Normalize and parse a path.
 
         Splits the path into a list of components, parsing any that are path parameters. Also builds the OpenAPI
@@ -173,6 +151,7 @@ class BaseRoute(ABC):
 
         parsed_components: list[str | PathParameterDefinition] = []
         path_format_components = []
+        path_parameters: dict[str, PathParameterDefinition] = {}
 
         components = [component for component in path.split("/") if component]
         for component in components:
@@ -182,9 +161,11 @@ class BaseRoute(ABC):
                 param_name, param_type = (p.strip() for p in param.split(":"))
                 type_class = param_type_map[param_type]
                 parser = parsers_map[type_class] if type_class not in {str, Path} else None
-                parsed_components.append(
-                    PathParameterDefinition(name=param_name, type=type_class, full=param, parser=parser)
-                )
+                if param_name in path_parameters:
+                    raise ImproperlyConfiguredException(f"Duplicate parameter '{param_name}' detected in '{path}'.")
+                param_definition = PathParameterDefinition(name=param_name, type=type_class, full=param, parser=parser)
+                parsed_components.append(param_definition)
+                path_parameters[param_name] = param_definition
                 path_format_components.append("{" + param_name + "}")
             else:
                 parsed_components.append(component)
@@ -192,4 +173,4 @@ class BaseRoute(ABC):
 
         path_format = join_paths(path_format_components)
 
-        return path, path_format, parsed_components
+        return path, path_format, parsed_components, path_parameters

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -96,7 +96,7 @@ class HTTPRoute(BaseRoute):
         http- methods and route handlers.
         """
         for route_handler in self.route_handlers:
-            kwargs_model = self.create_handler_kwargs_model(route_handler=route_handler)
+            kwargs_model = route_handler.create_kwargs_model(path_parameters=self.path_parameters)
             for http_method in route_handler.http_methods:
                 if self.route_handler_map.get(http_method):
                     raise ImproperlyConfiguredException(


### PR DESCRIPTION
Move the creation of the `KwargsModel` from the routes to the route handlers. Since this operates on the handlers almost exclusively, it makes more sense to have it in there. 