### PR TITLE
chore: tidy up some redundant comments

### DIFF
--- a/litestar/contrib/pydantic/pydantic_init_plugin.py
+++ b/litestar/contrib/pydantic/pydantic_init_plugin.py
@@ -20,14 +20,12 @@ except ImportError as e:
     raise MissingDependencyException("pydantic") from e
 
 try:
-    # check if we have pydantic v2 installed, and try to import both versions
     import pydantic as pydantic_v2
 
     assert pydantic_v2.__version__.startswith("2.")  # noqa: S101
 
     from pydantic import v1 as pydantic_v1
 except AssertionError:
-    # check if pydantic 1 is installed and import it
     import pydantic as pydantic_v1  # type: ignore[no-redef]
 
     pydantic_v2 = None  # type: ignore[assignment]

--- a/litestar/contrib/pydantic/pydantic_schema_plugin.py
+++ b/litestar/contrib/pydantic/pydantic_schema_plugin.py
@@ -26,14 +26,12 @@ except ImportError as e:
     raise MissingDependencyException("pydantic") from e
 
 try:
-    # check if we have pydantic v2 installed, and try to import both versions
     import pydantic as pydantic_v2
 
     assert pydantic_v2.__version__.startswith("2.")  # noqa: S101
 
     from pydantic import v1 as pydantic_v1
 except AssertionError:
-    # check if pydantic 1 is installed and import it
     import pydantic as pydantic_v1  # type: ignore[no-redef]
 
     pydantic_v2 = None  # type: ignore[assignment]


### PR DESCRIPTION
These comments aren't really valid any longer, now that we first attempt any import of a pydantic version at the top of the file. Should have been removed in earlier PR.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
