### PR TITLE
fix: Remove use of asserts for control flow.

### DIFF
--- a/litestar/contrib/pydantic/pydantic_dto_factory.py
+++ b/litestar/contrib/pydantic/pydantic_dto_factory.py
@@ -6,7 +6,7 @@ from warnings import warn
 
 from typing_extensions import Annotated, TypeAlias, override
 
-from litestar.contrib.pydantic.utils import is_pydantic_undefined
+from litestar.contrib.pydantic.utils import is_pydantic_undefined, is_pydantic_v2
 from litestar.dto.base_dto import AbstractDTO
 from litestar.dto.data_structures import DTOFieldDefinition
 from litestar.dto.field import DTO_FIELD_META_KEY, extract_dto_field
@@ -26,7 +26,8 @@ except ImportError as e:
 try:
     import pydantic as pydantic_v2
 
-    assert pydantic_v2.__version__.startswith("2.")  # noqa: S101
+    if not is_pydantic_v2(pydantic_v2):
+        raise ImportError
 
     from pydantic import ValidationError as ValidationErrorV2
     from pydantic import v1 as pydantic_v1
@@ -34,7 +35,7 @@ try:
 
     ModelType: TypeAlias = "pydantic_v1.BaseModel | pydantic_v2.BaseModel"
 
-except AssertionError:
+except ImportError:
     import pydantic as pydantic_v1  # type: ignore[no-redef]
 
     pydantic_v2 = Empty  # type: ignore[assignment]

--- a/litestar/contrib/pydantic/pydantic_init_plugin.py
+++ b/litestar/contrib/pydantic/pydantic_init_plugin.py
@@ -8,7 +8,7 @@ from msgspec import ValidationError
 from typing_extensions import Buffer, TypeGuard
 
 from litestar._signature.types import ExtendedMsgSpecValidationError
-from litestar.contrib.pydantic.utils import is_pydantic_constrained_field
+from litestar.contrib.pydantic.utils import is_pydantic_constrained_field, is_pydantic_v2
 from litestar.exceptions import MissingDependencyException
 from litestar.plugins import InitPluginProtocol
 from litestar.typing import _KWARG_META_EXTRACTORS
@@ -22,10 +22,11 @@ except ImportError as e:
 try:
     import pydantic as pydantic_v2
 
-    assert pydantic_v2.__version__.startswith("2.")  # noqa: S101
+    if not is_pydantic_v2(pydantic_v2):
+        raise ImportError
 
     from pydantic import v1 as pydantic_v1
-except AssertionError:
+except ImportError:
     import pydantic as pydantic_v1  # type: ignore[no-redef]
 
     pydantic_v2 = None  # type: ignore[assignment]

--- a/litestar/contrib/pydantic/pydantic_schema_plugin.py
+++ b/litestar/contrib/pydantic/pydantic_schema_plugin.py
@@ -10,6 +10,7 @@ from litestar.contrib.pydantic.utils import (
     is_pydantic_constrained_field,
     is_pydantic_model_class,
     is_pydantic_undefined,
+    is_pydantic_v2,
     pydantic_get_type_hints_with_generics_resolved,
     pydantic_unwrap_and_get_origin,
 )
@@ -28,10 +29,11 @@ except ImportError as e:
 try:
     import pydantic as pydantic_v2
 
-    assert pydantic_v2.__version__.startswith("2.")  # noqa: S101
+    if not is_pydantic_v2(pydantic_v2):
+        raise ImportError
 
     from pydantic import v1 as pydantic_v1
-except AssertionError:
+except ImportError:
     import pydantic as pydantic_v1  # type: ignore[no-redef]
 
     pydantic_v2 = None  # type: ignore[assignment]

--- a/litestar/contrib/pydantic/utils.py
+++ b/litestar/contrib/pydantic/utils.py
@@ -227,4 +227,4 @@ def is_pydantic_v2(module: ModuleType) -> bool:
     Returns:
         True if the module is pydantic v2, otherwise False.
     """
-    return module.__version__.startswith("2.")
+    return bool(module.__version__.startswith("2."))

--- a/litestar/contrib/pydantic/utils.py
+++ b/litestar/contrib/pydantic/utils.py
@@ -41,6 +41,8 @@ except ImportError:
 
 
 if TYPE_CHECKING:
+    from types import ModuleType
+
     from typing_extensions import TypeGuard
 
 
@@ -212,3 +214,17 @@ def create_field_definitions_for_computed_fields(
         )
         for k, dec in pydantic_decorators.computed_fields.items()
     }
+
+
+def is_pydantic_v2(module: ModuleType) -> bool:
+    """Determine if the given module is pydantic v2.
+
+    Given a module we expect to be a pydantic version, determine if it is pydantic v2.
+
+    Args:
+        module: A module.
+
+    Returns:
+        True if the module is pydantic v2, otherwise False.
+    """
+    return module.__version__.startswith("2.")


### PR DESCRIPTION
#3347 introduced a new pattern to differentiate between Pydantic v1 and v2 installs, however it relies on using `assert` which is an issue as can optimised away.

This PR changes the approach to manually throw an `ImportError` instead.

Closes #3354

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
