### PR TITLE
docs: fix broken url; swagger ui

### DIFF
--- a/docs/usage/openapi/ui_plugins.rst
+++ b/docs/usage/openapi/ui_plugins.rst
@@ -13,7 +13,7 @@ Litestar maintains and ships with UI plugins for a range of popular popular Open
 - `RapiDoc <https://rapidocweb.com/>`_
 - `ReDoc <https://redocly.com/>`_
 - `Stoplight Elements <https://stoplight.io/open-source/elements>`_
-- `Swagger UI <https://swagger.io/tools/swagger-ui/yy>`_
+- `Swagger UI <https://swagger.io/tools/swagger-ui/>`_
 - `YAML <https://yaml.org/>`_
 
 Each plugin is easily configurable, allowing developers to customize aspects like version, paths, CSS and JavaScript


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- I noticed that the current Swagger UI link provided in the [Litestar documentation](https://docs.litestar.dev/2/usage/openapi/ui_plugins.html#openapi-ui-plugins) leads to a 404 error page. It would be helpful to update this document with a working URL for the Swagger UI.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
