### PR TITLE
fix: schema for generic wrapped return types with DTO

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import sys
 from datetime import datetime
 from os import urandom
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Generator, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Generator, Union, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -30,6 +30,7 @@ from litestar.stores.file import FileStore
 from litestar.stores.memory import MemoryStore
 from litestar.stores.redis import RedisStore
 from litestar.testing import RequestFactory
+from tests.helpers import not_none
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -228,11 +229,6 @@ def create_module(tmp_path: Path, monkeypatch: MonkeyPatch) -> Callable[[str], M
         Returns:
             An imported module.
         """
-        T = TypeVar("T")
-
-        def not_none(val: T | T | None) -> T:
-            assert val is not None
-            return val
 
         def module_name_generator() -> str:
             letters = string.ascii_lowercase

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -106,3 +106,8 @@ def cleanup_logging_impl() -> Generator:
         queue_listener_handler.listener.stop()
         queue_listener_handler.close()
         del queue_listener_handler
+
+
+def not_none(val: T | T | None) -> T:
+    assert val is not None
+    return val

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -108,6 +108,6 @@ def cleanup_logging_impl() -> Generator:
         del queue_listener_handler
 
 
-def not_none(val: T | T | None) -> T:
+def not_none(val: T | None) -> T:
     assert val is not None
     return val

--- a/tests/unit/test_dto/test_factory/test_integration.py
+++ b/tests/unit/test_dto/test_factory/test_integration.py
@@ -18,13 +18,18 @@ from litestar.datastructures import UploadFile
 from litestar.dto import DataclassDTO, DTOConfig, DTOData, MsgspecDTO, dto_field
 from litestar.dto.types import RenameStrategy
 from litestar.enums import MediaType, RequestEncodingType
+from litestar.openapi.spec.response import OpenAPIResponse
+from litestar.openapi.spec.schema import Schema
 from litestar.pagination import ClassicPagination, CursorPagination, OffsetPagination
 from litestar.params import Body
 from litestar.serialization import encode_json
 from litestar.testing import create_test_client
+from tests.helpers import not_none
 
 if TYPE_CHECKING:
     from typing import Any
+
+    from litestar import Litestar
 
 
 def test_url_encoded_form_data(use_experimental_dto_backend: bool) -> None:
@@ -898,3 +903,55 @@ def test_msgspec_dto_dont_copy_length_constraint_for_partial_dto() -> None:
 
     with create_test_client([handler]) as client:
         assert client.post("/", json={"bar": "1", "baz": "123"}).status_code == 201
+
+
+def test_openapi_schema_for_type_with_generic_wrapper(create_module: Callable[[str], ModuleType]) -> None:
+    module = create_module(
+        """
+from dataclasses import dataclass
+
+from litestar import Litestar, get
+from litestar.dto import DataclassDTO
+from litestar.pagination import ClassicPagination
+
+
+@dataclass
+class Test:
+    name: str
+    age: int
+
+
+@get("/without-dto", sync_to_thread=False)
+def without_dto() -> ClassicPagination[Test]:
+    return ClassicPagination(
+        items=[Test("John", 25), Test("Jane", 30)],
+        page_size=1,
+        current_page=2,
+        total_pages=2,
+    )
+
+
+@get("/with-dto", return_dto=DataclassDTO[Test], sync_to_thread=False)
+def with_dto() -> ClassicPagination[Test]:
+    return ClassicPagination(
+        items=[Test("John", 25), Test("Jane", 30)],
+        page_size=1,
+        current_page=2,
+        total_pages=2,
+    )
+
+
+app = Litestar([without_dto, with_dto])
+"""
+    )
+    openapi = cast("Litestar", module.app).openapi_schema
+    paths = not_none(openapi.paths)
+    without_dto_response = not_none(not_none(paths["/without-dto"].get).responses)["200"]
+    with_dto_response = not_none(not_none(paths["/with-dto"].get).responses)["200"]
+    assert isinstance(without_dto_response, OpenAPIResponse)
+    assert isinstance(with_dto_response, OpenAPIResponse)
+    without_dto_schema = not_none(without_dto_response.content)["application/json"].schema
+    with_dto_schema = not_none(with_dto_response.content)["application/json"].schema
+    assert isinstance(without_dto_schema, Schema)
+    assert isinstance(with_dto_schema, Schema)
+    assert not_none(without_dto_schema.properties).keys() == not_none(with_dto_schema.properties).keys()


### PR DESCRIPTION




<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Changelog

Fix schema generated for DTOs where the supported type is wrapped in a generic outer type.

## Description

Prior behavior of using the `backend.annotation` as the basis for generating the openapi schema for the represented type is not applicable for the case where the DTO supported type is wrapped in a generic outer object. In that case `backend.annotation` only represents the type of the attribute on the generic type that holds the DTO supported type annotation.

This PR detects the case where we unwrap an outer generic type, and rebuilds the generic annotation in a manner appropriate for schema generation, before generating the schema for the annotation. It does this by substituting the DTOs transfer model for the original model in the original annotations type arguments.

`<tangent>`
This is really treating a symptom of the generic outer type being removed from the annotation before the DTO backend receives it, which is a design flaw that adds quite a bit of complexity. The DTOs should treat annotations at a whole, rebuild the complete annotation substituting out any supported types found within with transfer models.

Also, we don't really have a need for a separate backend anymore, now that we are only supporting one serialization library (backends were introduced when we were trying to support either pydantic or msgspec (and attrs?)) throughout the whole application.
`</tangent>`

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
Closes #2929