### PR TITLE
fix: Ambiguous default warning for no signature default

### DIFF
--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -512,13 +512,11 @@ class FieldDefinition:
         if not kwargs.get("kwarg_definition"):
             if isinstance(kwargs.get("default"), (KwargDefinition, DependencyKwarg)):
                 kwargs["kwarg_definition"] = kwargs.pop("default")
-            elif any(isinstance(v, (KwargDefinition, DependencyKwarg)) for v in metadata):
-                kwarg_definition = kwargs["kwarg_definition"] = next(  # pragma: no cover
-                    # see https://github.com/nedbat/coveragepy/issues/475
-                    v
-                    for v in metadata
-                    if isinstance(v, (KwargDefinition, DependencyKwarg))
-                )
+            elif kwarg_definition := next(
+                (v for v in metadata if isinstance(v, (KwargDefinition, DependencyKwarg))), None
+            ):
+                kwargs["kwarg_definition"] = kwarg_definition
+
                 if kwarg_definition.default is not Empty:
                     warnings.warn(
                         f"Deprecated default value specification for annotation '{annotation}'. Setting defaults "
@@ -529,7 +527,7 @@ class FieldDefinition:
                         category=DeprecationWarning,
                         stacklevel=2,
                     )
-                    if "default" in kwargs and kwarg_definition.default != kwargs["default"]:
+                    if kwargs.get("default", Empty) is not Empty and kwarg_definition.default != kwargs["default"]:
                         warnings.warn(
                             f"Ambiguous default values for annotation '{annotation}'. The default value "
                             f"'{kwarg_definition.default!r}' set inside the parameter annotation differs from the "

--- a/tests/unit/test_typing.py
+++ b/tests/unit/test_typing.py
@@ -9,6 +9,7 @@ import msgspec
 import pytest
 from typing_extensions import Annotated, NotRequired, Required, TypedDict, get_type_hints
 
+from litestar import get
 from litestar.exceptions import LitestarWarning
 from litestar.params import DependencyKwarg, KwargDefinition, Parameter, ParameterKwarg
 from litestar.typing import FieldDefinition, _unpack_predicate
@@ -461,3 +462,17 @@ def test_warn_ambiguous_default_values() -> None:
 def test_warn_defaults_inside_parameter_definition() -> None:
     with pytest.warns(DeprecationWarning, match="Deprecated default value specification"):
         FieldDefinition.from_annotation(Annotated[int, Parameter(default=1)], default=1)
+
+
+def test_warn_default_inside_kwarg_definition_and_default_empty() -> None:
+    with pytest.warns() as warnings:
+
+        @get(sync_to_thread=False)
+        def handler(foo: Annotated[int, Parameter(default=1)]) -> None:
+            pass
+
+        _ = handler.parsed_fn_signature
+
+    (record,) = warnings
+    assert record.category == DeprecationWarning
+    assert "Deprecated default value specification" in str(record.message)


### PR DESCRIPTION
We now only issue a single warning for the case where a default value is supplied via `Parameter()` and not via a regular signature default.

Closes #3372

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
