### PR TITLE
fix: Path param consumed by dependency treated as unconsumed

### DIFF
--- a/litestar/_openapi/parameters.py
+++ b/litestar/_openapi/parameters.py
@@ -218,11 +218,15 @@ class ParameterFactory:
         # not all path parameters have to be consumed by the handler. Because even not
         # consumed path parameters must still be specified, we create stub parameters
         # for the unconsumed ones so a correct OpenAPI schema can be generated
+        dependency_fields = {
+            name for dep in self.dependency_providers.values() for name in dep.parsed_fn_signature.parameters
+        }
         params_not_consumed_by_handler = set(self.path_parameters) - handler_fields.keys()
+        unconsumed_path_parameters = params_not_consumed_by_handler - dependency_fields
         handler_fields.update(
             {
                 param_name: FieldDefinition.from_kwarg(self.path_parameters[param_name].type, name=param_name)
-                for param_name in params_not_consumed_by_handler
+                for param_name in unconsumed_path_parameters
             }
         )
 


### PR DESCRIPTION
Consider parameters defined in handler dependencies in order to determine if a path parameter has been consumed for openapi generation purposes.

Fixes an issue where path parameters not consumed by the handler, but consumed by dependencies would cause an `ImproperlyConfiguredException`.

Closes #3369

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
