### PR TITLE
fix: Solve a caching issue in `CacheControlHeader`

### DIFF
--- a/litestar/datastructures/headers.py
+++ b/litestar/datastructures/headers.py
@@ -5,7 +5,6 @@ from copy import copy
 from dataclasses import dataclass, fields
 from typing import (
     TYPE_CHECKING,
-    AbstractSet,
     Any,
     ClassVar,
     Dict,
@@ -302,8 +301,6 @@ class CacheControlHeader(Header):
     stale_while_revalidate: Optional[int] = None
     """Accessor for the ``stale-while-revalidate`` directive."""
 
-    _field_names: ClassVar[AbstractSet[str]]
-
     def _get_header_value(self) -> str:
         """Get the header value as string."""
 
@@ -325,7 +322,7 @@ class CacheControlHeader(Header):
         """
 
         kwargs: Dict[str, Any] = {}
-        field_names = cls._get_field_names()
+        field_names = {f.name for f in fields(cls)}
         for cc_item in (stripped for v in header_value.split(",") if (stripped := v.strip())):
             key, *value = cc_item.split("=", maxsplit=1)
             key = key.replace("-", "_")
@@ -348,23 +345,6 @@ class CacheControlHeader(Header):
         """
 
         return cls(no_store=True)
-
-    @classmethod
-    def _get_field_names(cls) -> AbstractSet[str]:
-        """Get the type annotations for the ``CacheControlHeader`` class properties.
-
-        This is needed due to the conversion from pydantic models to dataclasses. Dataclasses do not support
-        automatic conversion of types like pydantic models do.
-
-        Returns:
-            A dictionary of type annotations
-
-        """
-        try:
-            names = cls._field_names
-        except AttributeError:
-            names = cls._field_names = {f.name for f in fields(cls)}
-        return names
 
 
 @dataclass

--- a/tests/unit/test_datastructures/test_headers.py
+++ b/tests/unit/test_datastructures/test_headers.py
@@ -296,7 +296,7 @@ def test_cache_control_header_prevent_storing() -> None:
 def test_cache_control_header_unsupported_type_annotation() -> None:
     @dataclass
     class InvalidCacheControlHeader(CacheControlHeader):
-        unsupported_type: Union[int, str] = "foo"
+        foo_field: Union[int, str] = "foo"
 
     with pytest.raises(ImproperlyConfiguredException):
         InvalidCacheControlHeader.from_header("unsupported_type")


### PR DESCRIPTION
I noticed [this](https://github.com/litestar-org/litestar/blob/c3af6c6b5b2b7db9203be17969fd3c9b29b2d540/tests/unit/test_datastructures/test_headers.py#L296) test was breaking when executed standalone or in a particular order. It turns that the test case (added in #1917) never worked in the first place and was only passing because invalid results of the `_get_field_names` classmethod were saved on the class.

Since the caching isn't really needed for performance here I have just removed it and fixed the test.