### PR TITLE
refactor(routing)!: Refactor routes and route handlers

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -192,7 +192,6 @@ nitpick_ignore = [
     (PY_CLASS, "litestar.middleware.compression.gzip_facade.GzipCompression"),
     (PY_CLASS, "litestar.openapi.OpenAPIController"),
     (PY_CLASS, "openapi.controller.OpenAPIController"),
-    (PY_OBJ, "ScopeT"),
 ]
 
 nitpick_ignore_regex = [
@@ -221,6 +220,7 @@ nitpick_ignore_regex = [
     (PY_RE, r"advanced_alchemy\.config.common\.EngineT"),
     (PY_RE, r"advanced_alchemy\.config.common\.SessionT"),
     (PY_RE, r".*R"),
+    (PY_RE, r".*ScopeT"),
 ]
 
 # Warnings about missing references to those targets in the specified location will be ignored.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -192,6 +192,7 @@ nitpick_ignore = [
     (PY_CLASS, "litestar.middleware.compression.gzip_facade.GzipCompression"),
     (PY_CLASS, "litestar.openapi.OpenAPIController"),
     (PY_CLASS, "openapi.controller.OpenAPIController"),
+    (PY_OBJ, "ScopeT"),
 ]
 
 nitpick_ignore_regex = [

--- a/docs/release-notes/2.x-changelog.rst
+++ b/docs/release-notes/2.x-changelog.rst
@@ -423,7 +423,7 @@
 
         Static file serving has been implemented with regular route handlers instead of
         a specialised ASGI app. At the moment, this is complementary to the usage of
-        :class:`~litestar.static_files.StaticFilesConfig` to maintain backwards
+        `litestar.static_files.StaticFilesConfig`` to maintain backwards
         compatibility.
 
         This achieves a few things:
@@ -431,7 +431,7 @@
         - Fixes https://github.com/litestar-org/litestar/issues/2629
         - Circumvents special casing needed in the routing logic for the static files app
         - Removes the need for a ``static_files_config`` attribute on the app
-        - Removes the need for a special :meth:`~litestar.app.Litestar.url_for_static_asset`
+        - Removes the need for a special ``litestar.app.Litestar.url_for_static_asset``
           method on the app since `route_reverse` can be used instead
 
         Additionally:
@@ -1943,7 +1943,7 @@
         :pr: 2154
 
         Fixed a bug that would result in a ``404 - Not Found`` when requesting a static
-        file where the :attr:`~litestar.static_files.StaticFilesConfig.path` was also
+        file where the ``litestar.static_files.StaticFilesConfig.path`` was also
         used by a route handler.
 
     .. change:: HTMX: Missing default values for ``receive`` and ``send`` parameters of ``HTMXRequest``

--- a/docs/release-notes/2.x-changelog.rst
+++ b/docs/release-notes/2.x-changelog.rst
@@ -423,7 +423,7 @@
 
         Static file serving has been implemented with regular route handlers instead of
         a specialised ASGI app. At the moment, this is complementary to the usage of
-        `litestar.static_files.StaticFilesConfig`` to maintain backwards
+        :class:`~litestar.static_files.StaticFilesConfig` to maintain backwards
         compatibility.
 
         This achieves a few things:
@@ -431,7 +431,7 @@
         - Fixes https://github.com/litestar-org/litestar/issues/2629
         - Circumvents special casing needed in the routing logic for the static files app
         - Removes the need for a ``static_files_config`` attribute on the app
-        - Removes the need for a special ``litestar.app.Litestar.url_for_static_asset``
+        - Removes the need for a special :meth:`~litestar.app.Litestar.url_for_static_asset`
           method on the app since `route_reverse` can be used instead
 
         Additionally:
@@ -1943,7 +1943,7 @@
         :pr: 2154
 
         Fixed a bug that would result in a ``404 - Not Found`` when requesting a static
-        file where the ``litestar.static_files.StaticFilesConfig.path`` was also
+        file where the :attr:`~litestar.static_files.StaticFilesConfig.path` was also
         used by a route handler.
 
     .. change:: HTMX: Missing default values for ``receive`` and ``send`` parameters of ``HTMXRequest``

--- a/litestar/_asgi/routing_trie/mapping.py
+++ b/litestar/_asgi/routing_trie/mapping.py
@@ -143,8 +143,7 @@ def configure_node(
         node.path_parameters = {}
 
     if isinstance(route, HTTPRoute):
-        for method, handler_mapping in route.route_handler_map.items():
-            handler, _ = handler_mapping
+        for method, handler in route.route_handler_map.items():
             node.asgi_handlers[method] = ASGIHandlerTuple(
                 asgi_app=build_route_middleware_stack(app=app, route=route, route_handler=handler),
                 handler=handler,

--- a/litestar/_openapi/path_item.py
+++ b/litestar/_openapi/path_item.py
@@ -35,9 +35,7 @@ class PathItemFactory:
         Returns:
             A PathItem instance.
         """
-        for http_method, handler_tuple in self.route.route_handler_map.items():
-            route_handler, _ = handler_tuple
-
+        for http_method, route_handler in self.route.route_handler_map.items():
             if not route_handler.resolve_include_in_schema():
                 continue
 

--- a/litestar/_openapi/plugin.py
+++ b/litestar/_openapi/plugin.py
@@ -198,7 +198,7 @@ class OpenAPIPlugin(InitPluginProtocol, ReceiveRoutePlugin):
         if not isinstance(route, HTTPRoute):
             return
 
-        if any(route_handler.resolve_include_in_schema() for route_handler, _ in route.route_handler_map.values()):
+        if any(route_handler.resolve_include_in_schema() for route_handler in route.route_handler_map.values()):
             # Force recompute the schema if a new route is added
             self._openapi = None
             self.included_routes[route.path] = route

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -44,7 +44,6 @@ from litestar.plugins import (
 )
 from litestar.plugins.base import CLIPlugin
 from litestar.router import Router
-from litestar.routes import ASGIRoute, HTTPRoute, WebSocketRoute
 from litestar.stores.registry import StoreRegistry
 from litestar.types import Empty, TypeDecodersSequence
 from litestar.types.internal_types import PathParameterDefinition, TemplateConfigType
@@ -66,6 +65,7 @@ if TYPE_CHECKING:
     from litestar.openapi.spec import SecurityRequirement
     from litestar.openapi.spec.open_api import OpenAPI
     from litestar.response import Response
+    from litestar.routes import ASGIRoute, HTTPRoute, WebSocketRoute
     from litestar.stores.base import Store
     from litestar.types import (
         AfterExceptionHookHandler,
@@ -649,9 +649,6 @@ class Litestar(Router):
 
             for route_handler in route_handlers:
                 route_handler.on_registration(self, route=route)
-
-            if isinstance(route, HTTPRoute):
-                route.create_handler_map()
 
             for plugin in self.plugins.receive_route:
                 plugin.receive_route(route)

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -648,14 +648,10 @@ class Litestar(Router):
             route_handlers = get_route_handlers(route)
 
             for route_handler in route_handlers:
-                route_handler.on_registration(self)
+                route_handler.on_registration(self, route=route)
 
             if isinstance(route, HTTPRoute):
                 route.create_handler_map()
-
-            elif isinstance(route, WebSocketRoute):
-                handler = route.route_handler
-                route.handler_parameter_model = handler.create_kwargs_model(path_parameters=route.path_parameters)
 
             for plugin in self.plugins.receive_route:
                 plugin.receive_route(route)

--- a/litestar/handlers/asgi_handlers.py
+++ b/litestar/handlers/asgi_handlers.py
@@ -85,14 +85,14 @@ class ASGIRouteHandler(BaseRouteHandler):
 
     async def handle(self, connection: ASGIConnection[ASGIRouteHandler, Any, Any, Any]) -> None:
         """ASGI app that authorizes the connection and then awaits the handler function.
-    
-    .. versionadded: 3.0
+
+        .. versionadded: 3.0
 
         Args:
-            connection: The ASGI connection
+                connection: The ASGI connection
 
         Returns:
-            None
+                None
         """
 
         if self.resolve_guards():

--- a/litestar/handlers/asgi_handlers.py
+++ b/litestar/handlers/asgi_handlers.py
@@ -85,6 +85,8 @@ class ASGIRouteHandler(BaseRouteHandler):
 
     async def handle(self, connection: ASGIConnection[ASGIRouteHandler, Any, Any, Any]) -> None:
         """ASGI app that authorizes the connection and then awaits the handler function.
+    
+    .. versionadded: 3.0
 
         Args:
             connection: The ASGI connection

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -62,7 +62,6 @@ class BaseRouteHandler:
         "_resolved_type_decoders",
         "_resolved_type_encoders",
         "_signature_model",
-        "_kwargs_model",
         "dependencies",
         "dto",
         "exception_handlers",
@@ -133,7 +132,6 @@ class BaseRouteHandler:
         self._resolved_type_decoders: TypeDecodersSequence | EmptyType = Empty
         self._resolved_type_encoders: TypeEncodersMap | EmptyType = Empty
         self._signature_model: type[SignatureModel] | EmptyType = Empty
-        self._kwargs_model: KwargsModel | EmptyType = Empty
 
         self.dependencies = dependencies
         self.dto = dto
@@ -570,14 +568,14 @@ class BaseRouteHandler:
             target = type(target)
         return f"{target.__module__}.{target.__qualname__}"
 
-    def create_kwargs_model(
+    def _create_kwargs_model(
         self,
         path_parameters: dict[str, PathParameterDefinition],
-    ) -> None:
+    ) -> KwargsModel:
         """Create a `KwargsModel` for a given route handler."""
         from litestar._kwargs import KwargsModel
 
-        self._kwargs_model = KwargsModel.create_for_signature_model(
+        return KwargsModel.create_for_signature_model(
             signature_model=self.signature_model,
             parsed_signature=self.parsed_fn_signature,
             dependencies=self.resolve_dependencies(),

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -531,6 +531,7 @@ class BaseRouteHandler:
 
         Args:
             app: The :class:`Litestar<.app.Litestar>` app object.
+            route: The route this handler is being registered on
 
         Returns:
             None

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from copy import copy
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Mapping, Sequence, cast
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, Sequence, cast
 
 from litestar._signature import SignatureModel
 from litestar.di import Provide
@@ -37,7 +37,6 @@ if TYPE_CHECKING:
     from litestar.routes import BaseRoute
     from litestar.types import AnyCallable, AsyncAnyCallable, ExceptionHandler
     from litestar.types.empty import EmptyType
-    from litestar.types.internal_types import PathParameterDefinition
 
 __all__ = ("BaseRouteHandler",)
 
@@ -570,7 +569,7 @@ class BaseRouteHandler:
 
     def _create_kwargs_model(
         self,
-        path_parameters: dict[str, PathParameterDefinition],
+        path_parameters: Iterable[str],
     ) -> KwargsModel:
         """Create a `KwargsModel` for a given route handler."""
         from litestar._kwargs import KwargsModel
@@ -579,6 +578,6 @@ class BaseRouteHandler:
             signature_model=self.signature_model,
             parsed_signature=self.parsed_fn_signature,
             dependencies=self.resolve_dependencies(),
-            path_parameters=set(path_parameters.keys()),
+            path_parameters=set(path_parameters),
             layered_parameters=self.resolve_layered_parameters(),
         )

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from litestar.dto import AbstractDTO
     from litestar.params import ParameterKwarg
     from litestar.router import Router
+    from litestar.routes import BaseRoute
     from litestar.types import AnyCallable, AsyncAnyCallable, ExceptionHandler
     from litestar.types.empty import EmptyType
     from litestar.types.internal_types import PathParameterDefinition
@@ -61,6 +62,7 @@ class BaseRouteHandler:
         "_resolved_type_decoders",
         "_resolved_type_encoders",
         "_signature_model",
+        "_kwargs_model",
         "dependencies",
         "dto",
         "exception_handlers",
@@ -131,6 +133,7 @@ class BaseRouteHandler:
         self._resolved_type_decoders: TypeDecodersSequence | EmptyType = Empty
         self._resolved_type_encoders: TypeEncodersMap | EmptyType = Empty
         self._signature_model: type[SignatureModel] | EmptyType = Empty
+        self._kwargs_model: KwargsModel | EmptyType = Empty
 
         self.dependencies = dependencies
         self.dto = dto
@@ -526,7 +529,7 @@ class BaseRouteHandler:
                     f"If you wish to override a provider, it must have the same key."
                 )
 
-    def on_registration(self, app: Litestar) -> None:
+    def on_registration(self, app: Litestar, route: BaseRoute) -> None:
         """Called once per handler when the app object is instantiated.
 
         Args:
@@ -570,11 +573,11 @@ class BaseRouteHandler:
     def create_kwargs_model(
         self,
         path_parameters: dict[str, PathParameterDefinition],
-    ) -> KwargsModel:
+    ) -> None:
         """Create a `KwargsModel` for a given route handler."""
         from litestar._kwargs import KwargsModel
 
-        return KwargsModel.create_for_signature_model(
+        self._kwargs_model = KwargsModel.create_for_signature_model(
             signature_model=self.signature_model,
             parsed_signature=self.parsed_fn_signature,
             dependencies=self.resolve_dependencies(),

--- a/litestar/handlers/http_handlers/_options.py
+++ b/litestar/handlers/http_handlers/_options.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable
+
+from litestar.constants import DEFAULT_ALLOWED_CORS_HEADERS
+from litestar.datastructures import Headers
+from litestar.enums import HttpMethod, MediaType
+from litestar.handlers import HTTPRouteHandler
+from litestar.response import Response
+from litestar.status_codes import HTTP_204_NO_CONTENT, HTTP_400_BAD_REQUEST
+
+if TYPE_CHECKING:
+    from litestar.types import Method, Scope
+
+
+def create_options_handler(path: str, allow_methods: Iterable[Method]) -> HTTPRouteHandler:
+    """Args:
+        path: The route path
+
+    Returns:
+        An HTTP route handler for OPTIONS requests.
+    """
+
+    def options_handler() -> Response:
+        """Handler function for OPTIONS requests.
+
+        Returns:
+            Response
+        """
+        return Response(
+            content=None,
+            status_code=HTTP_204_NO_CONTENT,
+            headers={"Allow": ", ".join(sorted(allow_methods))},  # pyright: ignore
+            media_type=MediaType.TEXT,
+        )
+
+    return HTTPRouteHandler(
+        path=path,
+        http_method=[HttpMethod.OPTIONS],
+        include_in_schema=False,
+        sync_to_thread=False,
+    )(options_handler)

--- a/litestar/handlers/http_handlers/_options.py
+++ b/litestar/handlers/http_handlers/_options.py
@@ -2,15 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterable
 
-from litestar.constants import DEFAULT_ALLOWED_CORS_HEADERS
-from litestar.datastructures import Headers
 from litestar.enums import HttpMethod, MediaType
 from litestar.handlers import HTTPRouteHandler
 from litestar.response import Response
-from litestar.status_codes import HTTP_204_NO_CONTENT, HTTP_400_BAD_REQUEST
+from litestar.status_codes import HTTP_204_NO_CONTENT
 
 if TYPE_CHECKING:
-    from litestar.types import Method, Scope
+    from litestar.types import Method
 
 
 def create_options_handler(path: str, allow_methods: Iterable[Method]) -> HTTPRouteHandler:

--- a/litestar/handlers/http_handlers/_utils.py
+++ b/litestar/handlers/http_handlers/_utils.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 from inspect import isawaitable
 from typing import TYPE_CHECKING, Any, Sequence, cast
 
+from litestar.datastructures import UploadFile
 from litestar.enums import HttpMethod
 from litestar.exceptions import ValidationException
 from litestar.response import Response
@@ -215,3 +216,9 @@ def is_empty_response_annotation(return_annotation: FieldDefinition) -> bool:
 
 
 HTTP_METHOD_NAMES = {m.value for m in HttpMethod}
+
+
+async def cleanup_temporary_files(form_data: dict[str, Any]) -> None:
+    for v in form_data.values():
+        if isinstance(v, UploadFile) and not v.file.closed:
+            await v.close()

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -621,15 +621,15 @@ class HTTPRouteHandler(BaseRouteHandler):
 
     async def handle(self, connection: Request[Any, Any, Any]) -> None:
         """ASGI app that creates a :class:`~.connection.Request` from the passed in args, determines which handler function to call and then
-        handles the call.
-    
-    .. versionadded: 3.0
+            handles the call.
+
+        .. versionadded: 3.0
 
         Args:
-            connection: The request
+                connection: The request
 
         Returns:
-            None
+                None
         """
 
         if self.resolve_guards():

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -3,17 +3,22 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING, AnyStr, Mapping, Sequence, TypedDict, cast
 
+from msgspec.msgpack import decode as _decode_msgpack_plain
+
 from litestar._layers.utils import narrow_response_cookies, narrow_response_headers
 from litestar.connection import Request
 from litestar.datastructures.cookie import Cookie
 from litestar.datastructures.response_header import ResponseHeader
 from litestar.enums import HttpMethod, MediaType
 from litestar.exceptions import (
+    ClientException,
     HTTPException,
     ImproperlyConfiguredException,
+    SerializationException,
 )
 from litestar.handlers.base import BaseRouteHandler
 from litestar.handlers.http_handlers._utils import (
+    cleanup_temporary_files,
     create_data_handler,
     create_generic_asgi_response_handler,
     create_response_handler,
@@ -36,20 +41,26 @@ from litestar.types import (
     EmptyType,
     ExceptionHandlersMap,
     Guard,
+    HTTPScope,
     Method,
     Middleware,
+    Receive,
     ResponseCookies,
     ResponseHeaders,
+    Scope,
+    Send,
     TypeEncodersMap,
 )
 from litestar.utils import ensure_async_callable
 from litestar.utils.predicates import is_async_callable
+from litestar.utils.scope.state import ScopeState
 from litestar.utils.warnings import warn_implicit_sync_to_thread, warn_sync_to_thread_with_async_callable
 
 if TYPE_CHECKING:
     from typing import Any, Awaitable, Callable
 
     from litestar._kwargs import KwargsModel
+    from litestar._kwargs.cleanup import DependencyCleanupGroup
     from litestar.app import Litestar
     from litestar.background_tasks import BackgroundTask, BackgroundTasks
     from litestar.config.response_cache import CACHE_FOREVER
@@ -57,7 +68,7 @@ if TYPE_CHECKING:
     from litestar.dto import AbstractDTO
     from litestar.openapi.datastructures import ResponseSpec
     from litestar.openapi.spec import SecurityRequirement
-    from litestar.routes import BaseRoute
+    from litestar.routes import BaseRoute, HTTPRoute
     from litestar.types.callable_types import AsyncAnyCallable, OperationIDCreator
     from litestar.types.composite_types import TypeDecodersSequence
 
@@ -608,6 +619,149 @@ class HTTPRouteHandler(BaseRouteHandler):
 
         if "data" in self.parsed_fn_signature.parameters and "GET" in self.http_methods:
             raise ImproperlyConfiguredException("'data' kwarg is unsupported for 'GET' request handlers")
+
+    async def handle(self, scope: HTTPScope, receive: Receive, send: Send, route: HTTPRoute) -> None:
+        """ASGI app that creates a Request from the passed in args, determines which handler function to call and then
+        handles the call.
+
+        Args:
+            scope: The ASGI connection scope.
+            receive: The ASGI receive function.
+            send: The ASGI send function.
+            route: The http route the connection was established on
+
+        Returns:
+            None
+        """
+        request: Request[Any, Any, Any] = self.resolve_request_class()(scope=scope, receive=receive, send=send)
+
+        if self.resolve_guards():
+            await self.authorize_connection(connection=request)
+
+        response = await self._get_response_for_request(scope=scope, request=request, route=route)
+
+        await response(scope, receive, send)
+
+        if after_response_handler := self.resolve_after_response():
+            await after_response_handler(request)
+
+        if form_data := scope.get("_form", {}):
+            await cleanup_temporary_files(form_data=cast("dict[str, Any]", form_data))
+
+    async def _get_response_for_request(
+        self,
+        scope: Scope,
+        request: Request[Any, Any, Any],
+        route: HTTPRoute,
+    ) -> ASGIApp:
+        """Return a response for the request.
+
+        If caching is enabled and a response exist in the cache, the cached response will be returned.
+        If caching is enabled and a response does not exist in the cache, the newly created
+        response will be cached.
+
+        Args:
+            scope: The Request's scope
+            request: The Request instance
+            route_handler: The HTTPRouteHandler instance
+
+        Returns:
+            An instance of Response or a compatible ASGIApp or a subclass of it
+        """
+        if self.cache and (response := await self._get_cached_response(request=request)):
+            return response
+
+        return await self._call_handler_function(scope=scope, request=request, route=route)
+
+    async def _call_handler_function(self, scope: Scope, request: Request, route: HTTPRoute) -> ASGIApp:
+        """Call the before request handlers, retrieve any data required for the route handler, and call the route
+        handler's ``to_response`` method.
+
+        This is wrapped in a try except block - and if an exception is raised,
+        it tries to pass it to an appropriate exception handler - if defined.
+        """
+        response_data: Any = None
+        cleanup_group: DependencyCleanupGroup | None = None
+
+        if before_request_handler := self.resolve_before_request():
+            response_data = await before_request_handler(request)
+
+        if not response_data:
+            response_data, cleanup_group = await self._get_response_data(request=request, route=route)
+
+        response: ASGIApp = await self.to_response(app=scope["app"], data=response_data, request=request)
+
+        if cleanup_group:
+            await cleanup_group.cleanup()
+
+        return response
+
+    async def _get_response_data(self, route: HTTPRoute, request: Request) -> tuple[Any, DependencyCleanupGroup | None]:
+        """Determine what kwargs are required for the given route handler's ``fn`` and calls it."""
+        parsed_kwargs: dict[str, Any] = {}
+        cleanup_group: DependencyCleanupGroup | None = None
+        parameter_model = self._get_kwargs_model_for_route(route)
+
+        if parameter_model.has_kwargs and self.signature_model:
+            kwargs = parameter_model.to_kwargs(connection=request)
+
+            if "data" in kwargs:
+                try:
+                    data = await kwargs["data"]
+                except SerializationException as e:
+                    raise ClientException(str(e)) from e
+
+                if data is Empty:
+                    del kwargs["data"]
+                else:
+                    kwargs["data"] = data
+
+            if "body" in kwargs:
+                kwargs["body"] = await kwargs["body"]
+
+            if parameter_model.dependency_batches:
+                cleanup_group = await parameter_model.resolve_dependencies(request, kwargs)
+
+            parsed_kwargs = self.signature_model.parse_values_from_connection_kwargs(connection=request, **kwargs)
+
+        if cleanup_group:
+            async with cleanup_group:
+                data = self.fn(**parsed_kwargs) if self.has_sync_callable else await self.fn(**parsed_kwargs)
+        elif self.has_sync_callable:
+            data = self.fn(**parsed_kwargs)
+        else:
+            data = await self.fn(**parsed_kwargs)
+
+        return data, cleanup_group
+
+    async def _get_cached_response(self, request: Request) -> ASGIApp | None:
+        """Retrieve and un-pickle the cached response, if existing.
+
+        Args:
+            request: The :class:`Request <litestar.connection.Request>` instance
+            route_handler: The :class:`~.handlers.HTTPRouteHandler` instance
+
+        Returns:
+            A cached response instance, if existing.
+        """
+
+        cache_config = request.app.response_cache_config
+        cache_key = (self.cache_key_builder or cache_config.key_builder)(request)
+        store = cache_config.get_store_from_app(request.app)
+
+        if not (cached_response_data := await store.get(key=cache_key)):
+            return None
+
+        # we use the regular msgspec.msgpack.decode here since we don't need any of
+        # the added decoders
+        messages = _decode_msgpack_plain(cached_response_data)
+
+        async def cached_response(scope: Scope, receive: Receive, send: Send) -> None:
+            ScopeState.from_scope(scope).is_cached = True
+            for message in messages:
+                await send(message)
+
+        return cached_response
 
 
 route = HTTPRouteHandler

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -620,8 +620,10 @@ class HTTPRouteHandler(BaseRouteHandler):
             raise ImproperlyConfiguredException("'data' kwarg is unsupported for 'GET' request handlers")
 
     async def handle(self, connection: Request[Any, Any, Any]) -> None:
-        """ASGI app that creates a Request from the passed in args, determines which handler function to call and then
+        """ASGI app that creates a :class:`~.connection.Request` from the passed in args, determines which handler function to call and then
         handles the call.
+    
+    .. versionadded: 3.0
 
         Args:
             connection: The request

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from litestar.dto import AbstractDTO
     from litestar.openapi.datastructures import ResponseSpec
     from litestar.openapi.spec import SecurityRequirement
+    from litestar.routes import BaseRoute
     from litestar.types.callable_types import AsyncAnyCallable, OperationIDCreator
     from litestar.types.composite_types import TypeDecodersSequence
 
@@ -555,8 +556,9 @@ class HTTPRouteHandler(BaseRouteHandler):
         response_handler = self.get_response_handler(is_response_type_data=isinstance(data, Response))
         return await response_handler(data=data, request=request)
 
-    def on_registration(self, app: Litestar) -> None:
-        super().on_registration(app)
+    def on_registration(self, app: Litestar, route: BaseRoute) -> None:
+        super().on_registration(app, route=route)
+        self.create_kwargs_model(path_parameters=route.path_parameters)
         self.resolve_after_response()
         self.resolve_include_in_schema()
         self.has_sync_callable = not is_async_callable(self.fn)

--- a/litestar/handlers/websocket_handlers/route_handler.py
+++ b/litestar/handlers/websocket_handlers/route_handler.py
@@ -5,13 +5,15 @@ from typing import TYPE_CHECKING, Any, Mapping
 from litestar.connection import WebSocket
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.handlers import BaseRouteHandler
+from litestar.types import Empty
 from litestar.types.builtin_types import NoneType
 from litestar.utils.predicates import is_async_callable
 
 if TYPE_CHECKING:
+    from litestar._kwargs import KwargsModel
     from litestar.app import Litestar
     from litestar.routes import BaseRoute
-    from litestar.types import Dependencies, ExceptionHandler, Guard, Middleware
+    from litestar.types import Dependencies, EmptyType, ExceptionHandler, Guard, Middleware
 
 
 class WebsocketRouteHandler(BaseRouteHandler):
@@ -20,7 +22,7 @@ class WebsocketRouteHandler(BaseRouteHandler):
     Use this decorator to decorate websocket handler functions.
     """
 
-    __slots__ = ("websocket_class",)
+    __slots__ = ("websocket_class", "_kwargs_model")
 
     def __init__(
         self,
@@ -56,6 +58,7 @@ class WebsocketRouteHandler(BaseRouteHandler):
                 default websocket class.
         """
         self.websocket_class = websocket_class
+        self._kwargs_model: KwargsModel | EmptyType = Empty
 
         super().__init__(
             path=path,
@@ -101,7 +104,7 @@ class WebsocketRouteHandler(BaseRouteHandler):
 
     def on_registration(self, app: Litestar, route: BaseRoute) -> None:
         super().on_registration(app=app, route=route)
-        self.create_kwargs_model(path_parameters=route.path_parameters)
+        self._kwargs_model = self._create_kwargs_model(path_parameters=route.path_parameters)
 
 
 websocket = WebsocketRouteHandler

--- a/litestar/handlers/websocket_handlers/route_handler.py
+++ b/litestar/handlers/websocket_handlers/route_handler.py
@@ -9,6 +9,8 @@ from litestar.types.builtin_types import NoneType
 from litestar.utils.predicates import is_async_callable
 
 if TYPE_CHECKING:
+    from litestar.app import Litestar
+    from litestar.routes import BaseRoute
     from litestar.types import Dependencies, ExceptionHandler, Guard, Middleware
 
 
@@ -96,6 +98,10 @@ class WebsocketRouteHandler(BaseRouteHandler):
 
         if not is_async_callable(self.fn):
             raise ImproperlyConfiguredException("Functions decorated with 'websocket' must be async functions")
+
+    def on_registration(self, app: Litestar, route: BaseRoute) -> None:
+        super().on_registration(app=app, route=route)
+        self.create_kwargs_model(path_parameters=route.path_parameters)
 
 
 websocket = WebsocketRouteHandler

--- a/litestar/middleware/_internal.py
+++ b/litestar/middleware/_internal.py
@@ -46,7 +46,7 @@ class CORSMiddleware(AbstractMiddleware):
         if scope["type"] == ScopeType.HTTP and scope["method"] == HttpMethod.OPTIONS and origin:
             request = scope["app"].request_class(scope=scope, receive=receive, send=send)
             asgi_response = self._create_preflight_response(origin=origin, request_headers=headers).to_asgi_response(
-                app=None, request=request
+                request=request
             )
             await asgi_response(scope, receive, send)
         elif origin:

--- a/litestar/router.py
+++ b/litestar/router.py
@@ -260,17 +260,15 @@ class Router:
 
     @property
     def route_handler_method_map(self) -> dict[str, RouteHandlerMapItem]:
-        """Map route paths to :class:`RouteHandlerMapItem <litestar.types.internal_typ es.RouteHandlerMapItem>`
+        """Map route paths to :class:`RouteHandlerMapItem <litestar.types.internal_types.RouteHandlerMapItem>`
 
         Returns:
              A dictionary mapping paths to route handlers
         """
-        route_map: dict[str, RouteHandlerMapItem] = defaultdict(dict)
+        route_map: defaultdict[str, RouteHandlerMapItem] = defaultdict(dict)
         for route in self.routes:
             if isinstance(route, HTTPRoute):
-                for route_handler in route.route_handlers:
-                    for method in route_handler.http_methods:
-                        route_map[route.path][method] = route_handler
+                route_map[route.path] = route.route_handler_map  # type: ignore[assignment]
             else:
                 route_map[route.path]["websocket" if isinstance(route, WebSocketRoute) else "asgi"] = (
                     route.route_handler
@@ -297,6 +295,7 @@ class Router:
                 for path in value.paths
             }
 
+        # handle controllers
         handlers_map: defaultdict[str, RouteHandlerMapItem] = defaultdict(dict)
         for route_handler in value.get_route_handlers():
             for handler_path in route_handler.paths:

--- a/litestar/router.py
+++ b/litestar/router.py
@@ -260,7 +260,7 @@ class Router:
 
     @property
     def route_handler_method_map(self) -> dict[str, RouteHandlerMapItem]:
-        """Map route paths to :class:`RouteHandlerMapItem <litestar.types.internal_types.RouteHandlerMapItem>`
+        """Map route paths to :class:`~litestar.types.internal_types.RouteHandlerMapItem`
 
         Returns:
              A dictionary mapping paths to route handlers

--- a/litestar/router.py
+++ b/litestar/router.py
@@ -341,7 +341,7 @@ class Router:
 def _maybe_add_options_handler(path: str, http_handlers: list[HTTPRouteHandler]) -> list[HTTPRouteHandler]:
     handler_methods = {method for handler in http_handlers for method in handler.http_methods}
     if "OPTIONS" not in handler_methods:
-        options_handler = create_options_handler(path=path, allow_methods=handler_methods)  # pyright: ignore
+        options_handler = create_options_handler(path=path, allow_methods={*handler_methods, "OPTIONS"})  # pyright: ignore
         options_handler.owner = http_handlers[0].owner
         return [*http_handlers, options_handler]
     return http_handlers

--- a/litestar/router.py
+++ b/litestar/router.py
@@ -341,7 +341,7 @@ class Router:
 def _maybe_add_options_handler(path: str, http_handlers: list[HTTPRouteHandler]) -> list[HTTPRouteHandler]:
     handler_methods = {method for handler in http_handlers for method in handler.http_methods}
     if "OPTIONS" not in handler_methods:
-        options_handler = create_options_handler(path=path, allow_methods=handler_methods)
+        options_handler = create_options_handler(path=path, allow_methods=handler_methods)  # pyright: ignore
         options_handler.owner = http_handlers[0].owner
         return [*http_handlers, options_handler]
     return http_handlers

--- a/litestar/routes/asgi.py
+++ b/litestar/routes/asgi.py
@@ -32,7 +32,6 @@ class ASGIRoute(BaseRoute):
         super().__init__(
             path=path,
             scope_type=ScopeType.ASGI,
-            handler_names=[route_handler.handler_name],
         )
 
     async def handle(self, scope: Scope, receive: Receive, send: Send) -> None:

--- a/litestar/routes/asgi.py
+++ b/litestar/routes/asgi.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from litestar.enums import ScopeType
 from litestar.routes.base import BaseRoute
 from litestar.types import Scope
 
@@ -29,10 +28,7 @@ class ASGIRoute(BaseRoute[Scope]):
             route_handler: An instance of :class:`~.handlers.ASGIRouteHandler`.
         """
         self.route_handler = route_handler
-        super().__init__(
-            path=path,
-            scope_type=ScopeType.ASGI,
-        )
+        super().__init__(path=path)
 
     async def handle(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI app that authorizes the connection and then awaits the handler function.

--- a/litestar/routes/asgi.py
+++ b/litestar/routes/asgi.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from litestar.connection import ASGIConnection
 from litestar.enums import ScopeType
 from litestar.routes.base import BaseRoute
+from litestar.types import Scope
 
 if TYPE_CHECKING:
     from litestar.handlers.asgi_handlers import ASGIRouteHandler
-    from litestar.types import Receive, Scope, Send
+    from litestar.types import Receive, Send
 
 
-class ASGIRoute(BaseRoute):
+class ASGIRoute(BaseRoute[Scope]):
     """An ASGI route, handling a single ``ASGIRouteHandler``"""
 
     __slots__ = ("route_handler",)
@@ -46,8 +46,4 @@ class ASGIRoute(BaseRoute):
             None
         """
 
-        if self.route_handler.resolve_guards():
-            connection = ASGIConnection["ASGIRouteHandler", Any, Any, Any](scope=scope, receive=receive)
-            await self.route_handler.authorize_connection(connection=connection)
-
-        await self.route_handler.fn(scope=scope, receive=receive, send=send)
+        await self.route_handler.handle(scope=scope, receive=receive, send=send)

--- a/litestar/routes/asgi.py
+++ b/litestar/routes/asgi.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from litestar.connection import ASGIConnection
 from litestar.routes.base import BaseRoute
 from litestar.types import Scope
 
@@ -41,5 +42,5 @@ class ASGIRoute(BaseRoute[Scope]):
         Returns:
             None
         """
-
-        await self.route_handler.handle(scope=scope, receive=receive, send=send)
+        connection = ASGIConnection["ASGIRouteHandler", Any, Any, Any](scope=scope, receive=receive, send=send)
+        await self.route_handler.handle(connection=connection)

--- a/litestar/routes/base.py
+++ b/litestar/routes/base.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar
 from uuid import UUID
 
 import msgspec
@@ -14,9 +14,11 @@ from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types.internal_types import PathParameterDefinition
 from litestar.utils import join_paths, normalize_path
 
+ScopeT = TypeVar("ScopeT", bound="BaseScope")
+
 if TYPE_CHECKING:
     from litestar.enums import ScopeType
-    from litestar.types import Receive, Scope, Send
+    from litestar.types import BaseScope, Receive, Send
 
 
 def _parse_datetime(value: str) -> datetime:
@@ -66,7 +68,7 @@ parsers_map: dict[Any, Callable[[Any], Any]] = {
 }
 
 
-class BaseRoute(ABC):
+class BaseRoute(ABC, Generic[ScopeT]):
     """Base Route class used by Litestar.
 
     It's an abstract class meant to be extended.
@@ -99,7 +101,7 @@ class BaseRoute(ABC):
         self.scope_type = scope_type
 
     @abstractmethod
-    async def handle(self, scope: Scope, receive: Receive, send: Send) -> None:
+    async def handle(self, scope: ScopeT, receive: Receive, send: Send) -> None:
         """ASGI App of the route.
 
         Args:

--- a/litestar/routes/base.py
+++ b/litestar/routes/base.py
@@ -17,7 +17,6 @@ from litestar.utils import join_paths, normalize_path
 ScopeT = TypeVar("ScopeT", bound="BaseScope")
 
 if TYPE_CHECKING:
-    from litestar.enums import ScopeType
     from litestar.types import BaseScope, Receive, Send
 
 
@@ -89,16 +88,13 @@ class BaseRoute(ABC, Generic[ScopeT]):
         self,
         *,
         path: str,
-        scope_type: ScopeType,
     ) -> None:
         """Initialize the route.
 
         Args:
             path: Base path of the route
-            scope_type: Type of the ASGI scope
         """
         self.path, self.path_format, self.path_components, self.path_parameters = self._parse_path(path)
-        self.scope_type = scope_type
 
     @abstractmethod
     async def handle(self, scope: ScopeT, receive: Receive, send: Send) -> None:

--- a/litestar/routes/base.py
+++ b/litestar/routes/base.py
@@ -86,7 +86,6 @@ class BaseRoute(ABC):
     def __init__(
         self,
         *,
-        handler_names: list[str],
         path: str,
         scope_type: ScopeType,
         methods: list[Method] | None = None,
@@ -94,13 +93,11 @@ class BaseRoute(ABC):
         """Initialize the route.
 
         Args:
-            handler_names: Names of the associated handler functions
             path: Base path of the route
             scope_type: Type of the ASGI scope
             methods: Supported methods
         """
         self.path, self.path_format, self.path_components, self.path_parameters = self._parse_path(path)
-        self.handler_names = handler_names
         self.scope_type = scope_type
         self.methods = set(methods or [])
 

--- a/litestar/routes/base.py
+++ b/litestar/routes/base.py
@@ -16,7 +16,7 @@ from litestar.utils import join_paths, normalize_path
 
 if TYPE_CHECKING:
     from litestar.enums import ScopeType
-    from litestar.types import Method, Receive, Scope, Send
+    from litestar.types import Receive, Scope, Send
 
 
 def _parse_datetime(value: str) -> datetime:
@@ -88,18 +88,15 @@ class BaseRoute(ABC):
         *,
         path: str,
         scope_type: ScopeType,
-        methods: list[Method] | None = None,
     ) -> None:
         """Initialize the route.
 
         Args:
             path: Base path of the route
             scope_type: Type of the ASGI scope
-            methods: Supported methods
         """
         self.path, self.path_format, self.path_components, self.path_parameters = self._parse_path(path)
         self.scope_type = scope_type
-        self.methods = set(methods or [])
 
     @abstractmethod
     async def handle(self, scope: Scope, receive: Receive, send: Send) -> None:

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -49,7 +49,7 @@ class HTTPRoute(BaseRoute[HTTPScope]):
             None
         """
         route_handler = self.route_handler_map[scope["method"]]
-        await route_handler.handle(scope=scope, receive=receive, send=send, route=self)
+        await route_handler.handle(scope=scope, receive=receive, send=send)
 
     def create_handler_map(self, route_handlers: Iterable[HTTPRouteHandler]) -> dict[Method, HTTPRouteHandler]:
         """Parse the ``router_handlers`` of this route and return a mapping of

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -49,7 +49,8 @@ class HTTPRoute(BaseRoute[HTTPScope]):
             None
         """
         route_handler = self.route_handler_map[scope["method"]]
-        await route_handler.handle(scope=scope, receive=receive, send=send)
+        connection = route_handler.resolve_request_class()(scope=scope, receive=receive, send=send)
+        await route_handler.handle(connection=connection)
 
     def create_handler_map(self, route_handlers: Iterable[HTTPRouteHandler]) -> dict[Method, HTTPRouteHandler]:
         """Parse the ``router_handlers`` of this route and return a mapping of

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -1,25 +1,18 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable, cast
+from typing import TYPE_CHECKING, Iterable
 
-from msgspec.msgpack import decode as _decode_msgpack_plain
-
-from litestar.datastructures.upload_file import UploadFile
 from litestar.enums import ScopeType
-from litestar.exceptions import ClientException, ImproperlyConfiguredException, SerializationException
+from litestar.exceptions import ImproperlyConfiguredException
 from litestar.routes.base import BaseRoute
-from litestar.status_codes import HTTP_204_NO_CONTENT
-from litestar.types.empty import Empty
-from litestar.utils.scope.state import ScopeState
+from litestar.types import HTTPScope
 
 if TYPE_CHECKING:
-    from litestar._kwargs.cleanup import DependencyCleanupGroup
-    from litestar.connection import Request
     from litestar.handlers.http_handlers import HTTPRouteHandler
-    from litestar.types import ASGIApp, HTTPScope, Method, Receive, Scope, Send
+    from litestar.types import Method, Receive, Send
 
 
-class HTTPRoute(BaseRoute):
+class HTTPRoute(BaseRoute[HTTPScope]):
     """An HTTP route, capable of handling multiple ``HTTPRouteHandler``\\ s."""  # noqa: D301
 
     __slots__ = (
@@ -47,7 +40,7 @@ class HTTPRoute(BaseRoute):
         self.route_handlers = tuple(self.route_handler_map.values())
         self.methods = tuple(self.route_handler_map)
 
-    async def handle(self, scope: HTTPScope, receive: Receive, send: Send) -> None:  # type: ignore[override]
+    async def handle(self, scope: HTTPScope, receive: Receive, send: Send) -> None:
         """ASGI app that creates a Request from the passed in args, determines which handler function to call and then
         handles the call.
 
@@ -60,20 +53,7 @@ class HTTPRoute(BaseRoute):
             None
         """
         route_handler = self.route_handler_map[scope["method"]]
-        request: Request[Any, Any, Any] = route_handler.resolve_request_class()(scope=scope, receive=receive, send=send)
-
-        if route_handler.resolve_guards():
-            await route_handler.authorize_connection(connection=request)
-
-        response = await self._get_response_for_request(scope=scope, request=request, route_handler=route_handler)
-
-        await response(scope, receive, send)
-
-        if after_response_handler := route_handler.resolve_after_response():
-            await after_response_handler(request)
-
-        if form_data := scope.get("_form", {}):
-            await self._cleanup_temporary_files(form_data=cast("dict[str, Any]", form_data))
+        await route_handler.handle(scope=scope, receive=receive, send=send, route=self)
 
     def create_handler_map(self, route_handlers: Iterable[HTTPRouteHandler]) -> dict[Method, HTTPRouteHandler]:
         """Parse the ``router_handlers`` of this route and return a mapping of
@@ -88,135 +68,3 @@ class HTTPRoute(BaseRoute):
                     )
                 handler_map[http_method] = route_handler
         return handler_map
-
-    async def _get_response_for_request(
-        self,
-        scope: Scope,
-        request: Request[Any, Any, Any],
-        route_handler: HTTPRouteHandler,
-    ) -> ASGIApp:
-        """Return a response for the request.
-
-        If caching is enabled and a response exist in the cache, the cached response will be returned.
-        If caching is enabled and a response does not exist in the cache, the newly created
-        response will be cached.
-
-        Args:
-            scope: The Request's scope
-            request: The Request instance
-            route_handler: The HTTPRouteHandler instance
-
-        Returns:
-            An instance of Response or a compatible ASGIApp or a subclass of it
-        """
-        if route_handler.cache and (
-            response := await self._get_cached_response(request=request, route_handler=route_handler)
-        ):
-            return response
-
-        return await self._call_handler_function(scope=scope, request=request, route_handler=route_handler)
-
-    async def _call_handler_function(self, scope: Scope, request: Request, route_handler: HTTPRouteHandler) -> ASGIApp:
-        """Call the before request handlers, retrieve any data required for the route handler, and call the route
-        handler's ``to_response`` method.
-
-        This is wrapped in a try except block - and if an exception is raised,
-        it tries to pass it to an appropriate exception handler - if defined.
-        """
-        response_data: Any = None
-        cleanup_group: DependencyCleanupGroup | None = None
-
-        if before_request_handler := route_handler.resolve_before_request():
-            response_data = await before_request_handler(request)
-
-        if not response_data:
-            response_data, cleanup_group = await self._get_response_data(route_handler=route_handler, request=request)
-
-        response: ASGIApp = await route_handler.to_response(data=response_data, request=request)
-
-        if cleanup_group:
-            await cleanup_group.cleanup()
-
-        return response
-
-    async def _get_response_data(
-        self, route_handler: HTTPRouteHandler, request: Request
-    ) -> tuple[Any, DependencyCleanupGroup | None]:
-        """Determine what kwargs are required for the given route handler's ``fn`` and calls it."""
-        parsed_kwargs: dict[str, Any] = {}
-        cleanup_group: DependencyCleanupGroup | None = None
-        parameter_model = route_handler._get_kwargs_model_for_route(self)
-
-        if parameter_model.has_kwargs and route_handler.signature_model:
-            kwargs = parameter_model.to_kwargs(connection=request)
-
-            if "data" in kwargs:
-                try:
-                    data = await kwargs["data"]
-                except SerializationException as e:
-                    raise ClientException(str(e)) from e
-
-                if data is Empty:
-                    del kwargs["data"]
-                else:
-                    kwargs["data"] = data
-
-            if "body" in kwargs:
-                kwargs["body"] = await kwargs["body"]
-
-            if parameter_model.dependency_batches:
-                cleanup_group = await parameter_model.resolve_dependencies(request, kwargs)
-
-            parsed_kwargs = route_handler.signature_model.parse_values_from_connection_kwargs(
-                connection=request, **kwargs
-            )
-
-        if cleanup_group:
-            async with cleanup_group:
-                data = (
-                    route_handler.fn(**parsed_kwargs)
-                    if route_handler.has_sync_callable
-                    else await route_handler.fn(**parsed_kwargs)
-                )
-        elif route_handler.has_sync_callable:
-            data = route_handler.fn(**parsed_kwargs)
-        else:
-            data = await route_handler.fn(**parsed_kwargs)
-
-        return data, cleanup_group
-
-    @staticmethod
-    async def _get_cached_response(request: Request, route_handler: HTTPRouteHandler) -> ASGIApp | None:
-        """Retrieve and un-pickle the cached response, if existing.
-
-        Args:
-            request: The :class:`Request <litestar.connection.Request>` instance
-            route_handler: The :class:`~.handlers.HTTPRouteHandler` instance
-
-        Returns:
-            A cached response instance, if existing.
-        """
-
-        cache_config = request.app.response_cache_config
-        cache_key = (route_handler.cache_key_builder or cache_config.key_builder)(request)
-        store = cache_config.get_store_from_app(request.app)
-
-        if not (cached_response_data := await store.get(key=cache_key)):
-            return None
-
-        # we use the regular msgspec.msgpack.decode here since we don't need any of
-        # the added decoders
-        messages = _decode_msgpack_plain(cached_response_data)
-
-        async def cached_response(scope: Scope, receive: Receive, send: Send) -> None:
-            ScopeState.from_scope(scope).is_cached = True
-            for message in messages:
-                await send(message)
-
-        return cached_response
-
-    @staticmethod
-    async def _cleanup_temporary_files(form_data: dict[str, Any]) -> None:
-        for v in form_data.values():
-            if isinstance(v, UploadFile) and not v.file.closed:
-                await v.close()

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Iterable, cast
 
 from msgspec.msgpack import decode as _decode_msgpack_plain
 
@@ -31,7 +31,7 @@ class HTTPRoute(BaseRoute):
         self,
         *,
         path: str,
-        route_handlers: list[HTTPRouteHandler],
+        route_handlers: Iterable[HTTPRouteHandler],
     ) -> None:
         """Initialize ``HTTPRoute``.
 
@@ -75,7 +75,7 @@ class HTTPRoute(BaseRoute):
         if form_data := scope.get("_form", {}):
             await self._cleanup_temporary_files(form_data=cast("dict[str, Any]", form_data))
 
-    def create_handler_map(self, route_handlers: list[HTTPRouteHandler]) -> dict[Method, HTTPRouteHandler]:
+    def create_handler_map(self, route_handlers: Iterable[HTTPRouteHandler]) -> dict[Method, HTTPRouteHandler]:
         """Parse the ``router_handlers`` of this route and return a mapping of
         http- methods and route handlers.
         """

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -14,7 +14,6 @@ from litestar.types.empty import Empty
 from litestar.utils.scope.state import ScopeState
 
 if TYPE_CHECKING:
-    from litestar._kwargs import KwargsModel
     from litestar._kwargs.cleanup import DependencyCleanupGroup
     from litestar.connection import Request
     from litestar.handlers.http_handlers import HTTPRouteHandler
@@ -43,7 +42,7 @@ class HTTPRoute(BaseRoute):
         """
         self.methods = set(chain.from_iterable([route_handler.http_methods for route_handler in route_handlers]))
         self.route_handlers = route_handlers
-        self.route_handler_map: dict[Method, tuple[HTTPRouteHandler, KwargsModel]] = {}
+        self.route_handler_map: dict[Method, HTTPRouteHandler] = {}
 
         super().__init__(
             path=path,
@@ -62,15 +61,13 @@ class HTTPRoute(BaseRoute):
         Returns:
             None
         """
-        route_handler, parameter_model = self.route_handler_map[scope["method"]]
+        route_handler = self.route_handler_map[scope["method"]]
         request: Request[Any, Any, Any] = route_handler.resolve_request_class()(scope=scope, receive=receive, send=send)
 
         if route_handler.resolve_guards():
             await route_handler.authorize_connection(connection=request)
 
-        response = await self._get_response_for_request(
-            scope=scope, request=request, route_handler=route_handler, parameter_model=parameter_model
-        )
+        response = await self._get_response_for_request(scope=scope, request=request, route_handler=route_handler)
 
         await response(scope, receive, send)
 
@@ -86,18 +83,17 @@ class HTTPRoute(BaseRoute):
         """
         for route_handler in self.route_handlers:
             for http_method in route_handler.http_methods:
-                if self.route_handler_map.get(http_method):
+                if http_method in self.route_handler_map:
                     raise ImproperlyConfiguredException(
                         f"Handler already registered for path {self.path!r} and http method {http_method}"
                     )
-                self.route_handler_map[http_method] = (route_handler, route_handler._kwargs_model)
+                self.route_handler_map[http_method] = route_handler
 
     async def _get_response_for_request(
         self,
         scope: Scope,
         request: Request[Any, Any, Any],
         route_handler: HTTPRouteHandler,
-        parameter_model: KwargsModel,
     ) -> ASGIApp:
         """Return a response for the request.
 
@@ -109,7 +105,6 @@ class HTTPRoute(BaseRoute):
             scope: The Request's scope
             request: The Request instance
             route_handler: The HTTPRouteHandler instance
-            parameter_model: The Handler's KwargsModel
 
         Returns:
             An instance of Response or a compatible ASGIApp or a subclass of it
@@ -119,13 +114,9 @@ class HTTPRoute(BaseRoute):
         ):
             return response
 
-        return await self._call_handler_function(
-            scope=scope, request=request, parameter_model=parameter_model, route_handler=route_handler
-        )
+        return await self._call_handler_function(scope=scope, request=request, route_handler=route_handler)
 
-    async def _call_handler_function(
-        self, scope: Scope, request: Request, parameter_model: KwargsModel, route_handler: HTTPRouteHandler
-    ) -> ASGIApp:
+    async def _call_handler_function(self, scope: Scope, request: Request, route_handler: HTTPRouteHandler) -> ASGIApp:
         """Call the before request handlers, retrieve any data required for the route handler, and call the route
         handler's ``to_response`` method.
 
@@ -139,9 +130,7 @@ class HTTPRoute(BaseRoute):
             response_data = await before_request_handler(request)
 
         if not response_data:
-            response_data, cleanup_group = await self._get_response_data(
-                route_handler=route_handler, parameter_model=parameter_model, request=request
-            )
+            response_data, cleanup_group = await self._get_response_data(route_handler=route_handler, request=request)
 
         response: ASGIApp = await route_handler.to_response(data=response_data, request=request)
 
@@ -150,13 +139,13 @@ class HTTPRoute(BaseRoute):
 
         return response
 
-    @staticmethod
     async def _get_response_data(
-        route_handler: HTTPRouteHandler, parameter_model: KwargsModel, request: Request
+        self, route_handler: HTTPRouteHandler, request: Request
     ) -> tuple[Any, DependencyCleanupGroup | None]:
         """Determine what kwargs are required for the given route handler's ``fn`` and calls it."""
         parsed_kwargs: dict[str, Any] = {}
         cleanup_group: DependencyCleanupGroup | None = None
+        parameter_model = route_handler._get_kwargs_model_for_route(self)
 
         if parameter_model.has_kwargs and route_handler.signature_model:
             kwargs = parameter_model.to_kwargs(connection=request)

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -41,12 +41,11 @@ class HTTPRoute(BaseRoute):
             path: The path for the route.
             route_handlers: A list of :class:`~.handlers.HTTPRouteHandler`.
         """
-        methods = list(chain.from_iterable([route_handler.http_methods for route_handler in route_handlers]))
+        self.methods = set(chain.from_iterable([route_handler.http_methods for route_handler in route_handlers]))
         self.route_handlers = route_handlers
         self.route_handler_map: dict[Method, tuple[HTTPRouteHandler, KwargsModel]] = {}
 
         super().__init__(
-            methods=methods,
             path=path,
             scope_type=ScopeType.HTTP,
         )

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterable
 
-from litestar.enums import ScopeType
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.routes.base import BaseRoute
 from litestar.types import HTTPScope
@@ -32,10 +31,7 @@ class HTTPRoute(BaseRoute[HTTPScope]):
             path: The path for the route.
             route_handlers: A list of :class:`~.handlers.HTTPRouteHandler`.
         """
-        super().__init__(
-            path=path,
-            scope_type=ScopeType.HTTP,
-        )
+        super().__init__(path=path)
         self.route_handler_map: dict[Method, HTTPRouteHandler] = self.create_handler_map(route_handlers)
         self.route_handlers = tuple(self.route_handler_map.values())
         self.methods = tuple(self.route_handler_map)

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -56,7 +56,6 @@ class HTTPRoute(BaseRoute):
             methods=methods,
             path=path,
             scope_type=ScopeType.HTTP,
-            handler_names=[route_handler.handler_name for route_handler in self.route_handlers],
         )
 
     async def handle(self, scope: HTTPScope, receive: Receive, send: Send) -> None:  # type: ignore[override]

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -85,13 +85,12 @@ class HTTPRoute(BaseRoute):
         http- methods and route handlers.
         """
         for route_handler in self.route_handlers:
-            kwargs_model = route_handler.create_kwargs_model(path_parameters=self.path_parameters)
             for http_method in route_handler.http_methods:
                 if self.route_handler_map.get(http_method):
                     raise ImproperlyConfiguredException(
                         f"Handler already registered for path {self.path!r} and http method {http_method}"
                     )
-                self.route_handler_map[http_method] = (route_handler, kwargs_model)
+                self.route_handler_map[http_method] = (route_handler, route_handler._kwargs_model)
 
     async def _get_response_for_request(
         self,

--- a/litestar/routes/websocket.py
+++ b/litestar/routes/websocket.py
@@ -42,5 +42,5 @@ class WebSocketRoute(BaseRoute[WebSocketScope]):
         Returns:
             None
         """
-
-        await self.route_handler.handle(scope=scope, receive=receive, send=send)
+        socket = self.route_handler.resolve_websocket_class()(scope=scope, receive=receive, send=send)
+        await self.route_handler.handle(connection=socket)

--- a/litestar/routes/websocket.py
+++ b/litestar/routes/websocket.py
@@ -40,7 +40,6 @@ class WebSocketRoute(BaseRoute):
         super().__init__(
             path=path,
             scope_type=ScopeType.WEBSOCKET,
-            handler_names=[route_handler.handler_name],
         )
 
     async def handle(self, scope: WebSocketScope, receive: Receive, send: Send) -> None:  # type: ignore[override]

--- a/litestar/routes/websocket.py
+++ b/litestar/routes/websocket.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from litestar.enums import ScopeType
 from litestar.routes.base import BaseRoute
 from litestar.types import WebSocketScope
 
@@ -30,10 +29,7 @@ class WebSocketRoute(BaseRoute[WebSocketScope]):
         """
         self.route_handler = route_handler
 
-        super().__init__(
-            path=path,
-            scope_type=ScopeType.WEBSOCKET,
-        )
+        super().__init__(path=path)
 
     async def handle(self, scope: WebSocketScope, receive: Receive, send: Send) -> None:
         """ASGI app that creates a WebSocket from the passed in args, and then awaits the handler function.

--- a/tests/e2e/test_router_registration.py
+++ b/tests/e2e/test_router_registration.py
@@ -16,6 +16,7 @@ from litestar import (
 )
 from litestar import route as route_decorator
 from litestar.exceptions import ImproperlyConfiguredException
+from litestar.routes import HTTPRoute
 
 
 @pytest.fixture
@@ -46,12 +47,13 @@ def test_register_with_controller_class(controller: Type[Controller]) -> None:
     router = Router(path="/base", route_handlers=[controller])
     assert len(router.routes) == 3
     for route in router.routes:
-        if len(route.methods) == 2:
-            assert sorted(route.methods) == sorted(["GET", "OPTIONS"])  # pyright: ignore
-            assert route.path == "/base/test/{id:int}"
-        elif len(route.methods) == 3:
-            assert sorted(route.methods) == sorted(["GET", "POST", "OPTIONS"])  # pyright: ignore
-            assert route.path == "/base/test"
+        if isinstance(route, HTTPRoute):
+            if len(route.methods) == 2:
+                assert sorted(route.methods) == sorted(["GET", "OPTIONS"])  # pyright: ignore
+                assert route.path == "/base/test/{id:int}"
+            elif len(route.methods) == 3:
+                assert sorted(route.methods) == sorted(["GET", "POST", "OPTIONS"])  # pyright: ignore
+                assert route.path == "/base/test"
 
 
 def test_register_controller_on_different_routers(controller: Type[Controller]) -> None:
@@ -82,12 +84,13 @@ def test_register_with_router_instance(controller: Type[Controller]) -> None:
 
     assert len(base_router.routes) == 3
     for route in base_router.routes:
-        if len(route.methods) == 2:
-            assert sorted(route.methods) == sorted(["GET", "OPTIONS"])  # pyright: ignore
-            assert route.path == "/base/top-level/test/{id:int}"
-        elif len(route.methods) == 3:
-            assert sorted(route.methods) == sorted(["GET", "POST", "OPTIONS"])  # pyright: ignore
-            assert route.path == "/base/top-level/test"
+        if isinstance(route, HTTPRoute):
+            if len(route.methods) == 2:
+                assert sorted(route.methods) == sorted(["GET", "OPTIONS"])  # pyright: ignore
+                assert route.path == "/base/top-level/test/{id:int}"
+            elif len(route.methods) == 3:
+                assert sorted(route.methods) == sorted(["GET", "POST", "OPTIONS"])  # pyright: ignore
+                assert route.path == "/base/top-level/test"
 
 
 def test_register_with_route_handler_functions() -> None:
@@ -106,13 +109,14 @@ def test_register_with_route_handler_functions() -> None:
     router = Router(path="/base", route_handlers=[first_route_handler, second_route_handler, third_route_handler])
     assert len(router.routes) == 2
     for route in router.routes:
-        if len(route.methods) == 2:
-            assert sorted(route.methods) == sorted(["GET", "OPTIONS"])  # pyright: ignore
-            assert route.path == "/base/second"
-        else:
-            assert sorted(route.methods) == sorted(["GET", "POST", "PATCH", "OPTIONS"])  # pyright: ignore
-            assert route.path == "/base/first"
-            assert route.path == "/base/first"
+        if isinstance(route, HTTPRoute):
+            if len(route.methods) == 2:
+                assert sorted(route.methods) == sorted(["GET", "OPTIONS"])  # pyright: ignore
+                assert route.path == "/base/second"
+            else:
+                assert sorted(route.methods) == sorted(["GET", "POST", "PATCH", "OPTIONS"])  # pyright: ignore
+                assert route.path == "/base/first"
+                assert route.path == "/base/first"
 
 
 def test_register_validation_wrong_class() -> None:

--- a/tests/unit/test_handlers/test_asgi_handlers/test_validations.py
+++ b/tests/unit/test_handlers/test_asgi_handlers/test_validations.py
@@ -4,6 +4,7 @@ import pytest
 
 from litestar import Litestar, asgi
 from litestar.exceptions import ImproperlyConfiguredException
+from litestar.routes import ASGIRoute
 from litestar.testing import create_test_client
 
 if TYPE_CHECKING:
@@ -15,25 +16,29 @@ def test_asgi_handler_validation() -> None:
         pass
 
     with pytest.raises(ImproperlyConfiguredException):
-        asgi(path="/")(fn_without_scope_arg).on_registration(Litestar())
+        handler = asgi(path="/")(fn_without_scope_arg)
+        handler.on_registration(Litestar(), ASGIRoute(path="/", route_handler=handler))
 
     async def fn_without_receive_arg(scope: "Scope", send: "Send") -> None:
         pass
 
     with pytest.raises(ImproperlyConfiguredException):
-        asgi(path="/")(fn_without_receive_arg).on_registration(Litestar())
+        handler = asgi(path="/")(fn_without_receive_arg)
+        handler.on_registration(Litestar(), ASGIRoute(path="/", route_handler=handler))
 
     async def fn_without_send_arg(scope: "Scope", receive: "Receive") -> None:
         pass
 
     with pytest.raises(ImproperlyConfiguredException):
-        asgi(path="/")(fn_without_send_arg).on_registration(Litestar())
+        handler = asgi(path="/")(fn_without_send_arg)
+        handler.on_registration(Litestar(), ASGIRoute(path="/", route_handler=handler))
 
     async def fn_with_return_annotation(scope: "Scope", receive: "Receive", send: "Send") -> dict:
         return {}
 
     with pytest.raises(ImproperlyConfiguredException):
-        asgi(path="/")(fn_with_return_annotation).on_registration(Litestar())
+        handler = asgi(path="/")(fn_with_return_annotation)
+        handler.on_registration(Litestar(), ASGIRoute(path="/", route_handler=handler))
 
     asgi_handler_with_no_fn = asgi(path="/")
 
@@ -44,4 +49,5 @@ def test_asgi_handler_validation() -> None:
         return None
 
     with pytest.raises(ImproperlyConfiguredException):
-        asgi(path="/")(sync_fn).on_registration(Litestar())  # type: ignore[arg-type]
+        handler = asgi(path="/")(sync_fn)  # type: ignore[arg-type]
+        handler.on_registration(Litestar(), ASGIRoute(path="/", route_handler=handler))

--- a/tests/unit/test_handlers/test_http_handlers/test_head.py
+++ b/tests/unit/test_handlers/test_http_handlers/test_head.py
@@ -5,6 +5,7 @@ import pytest
 from litestar import HttpMethod, Litestar, head
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.response.file import ASGIFileResponse, File
+from litestar.routes import HTTPRoute
 from litestar.status_codes import HTTP_200_OK
 from litestar.testing import create_test_client
 
@@ -26,7 +27,7 @@ def test_head_decorator_raises_validation_error_if_body_is_declared() -> None:
         def handler() -> dict:
             return {}
 
-        handler.on_registration(Litestar())
+        handler.on_registration(Litestar(), HTTPRoute(path="/", route_handlers=[handler]))
 
 
 def test_head_decorator_raises_validation_error_if_method_is_passed() -> None:
@@ -36,7 +37,7 @@ def test_head_decorator_raises_validation_error_if_method_is_passed() -> None:
         def handler() -> None:
             return
 
-        handler.on_registration(Litestar())
+        handler.on_registration(Litestar(), HTTPRoute(path="/", route_handlers=[handler]))
 
 
 def test_head_decorator_does_not_raise_for_file_response() -> None:
@@ -46,7 +47,7 @@ def test_head_decorator_does_not_raise_for_file_response() -> None:
 
     Litestar(route_handlers=[handler])
 
-    handler.on_registration(Litestar())
+    handler.on_registration(Litestar(), HTTPRoute(path="/", route_handlers=[handler]))
 
 
 def test_head_decorator_does_not_raise_for_asgi_file_response() -> None:
@@ -56,4 +57,4 @@ def test_head_decorator_does_not_raise_for_asgi_file_response() -> None:
 
     Litestar(route_handlers=[handler])
 
-    handler.on_registration(Litestar())
+    handler.on_registration(Litestar(), HTTPRoute(path="/", route_handlers=[handler]))

--- a/tests/unit/test_handlers/test_http_handlers/test_media_type.py
+++ b/tests/unit/test_handlers/test_http_handlers/test_media_type.py
@@ -4,6 +4,7 @@ from typing import Any, AnyStr
 import pytest
 
 from litestar import Litestar, MediaType, get
+from litestar.routes import HTTPRoute
 from tests.models import DataclassPerson
 
 
@@ -38,5 +39,5 @@ def test_media_type_inference(annotation: Any, expected_media_type: MediaType) -
 
     Litestar(route_handlers=[handler])
 
-    handler.on_registration(Litestar())
+    handler.on_registration(Litestar(), HTTPRoute(path="/", route_handlers=[handler]))
     assert handler.media_type == expected_media_type

--- a/tests/unit/test_handlers/test_http_handlers/test_validations.py
+++ b/tests/unit/test_handlers/test_http_handlers/test_validations.py
@@ -8,6 +8,7 @@ from litestar import HttpMethod, Litestar, WebSocket, delete, get, route
 from litestar.exceptions import ImproperlyConfiguredException, ValidationException
 from litestar.handlers.http_handlers import HTTPRouteHandler
 from litestar.response import File, Redirect
+from litestar.routes import HTTPRoute
 from litestar.status_codes import (
     HTTP_100_CONTINUE,
     HTTP_200_OK,
@@ -44,7 +45,9 @@ async def test_function_validation() -> None:
 
         Litestar(route_handlers=[method_with_no_annotation])
 
-        method_with_no_annotation.on_registration(Litestar())
+        method_with_no_annotation.on_registration(
+            Litestar(), HTTPRoute(path="/", route_handlers=[method_with_no_annotation])
+        )
 
     with pytest.raises(ImproperlyConfiguredException):
 
@@ -54,7 +57,7 @@ async def test_function_validation() -> None:
 
         Litestar(route_handlers=[method_with_no_content])
 
-        method_with_no_content.on_registration(Litestar())
+        method_with_no_content.on_registration(Litestar(), HTTPRoute(path="/", route_handlers=[method_with_no_content]))
 
     with pytest.raises(ImproperlyConfiguredException):
 
@@ -64,7 +67,9 @@ async def test_function_validation() -> None:
 
         Litestar(route_handlers=[method_with_not_modified])
 
-        method_with_not_modified.on_registration(Litestar())
+        method_with_not_modified.on_registration(
+            Litestar(), HTTPRoute(path="/", route_handlers=[method_with_not_modified])
+        )
 
     with pytest.raises(ImproperlyConfiguredException):
 
@@ -74,7 +79,9 @@ async def test_function_validation() -> None:
 
         Litestar(route_handlers=[method_with_status_lower_than_200])
 
-        method_with_status_lower_than_200.on_registration(Litestar())
+        method_with_status_lower_than_200.on_registration(
+            Litestar(), HTTPRoute(path="/", route_handlers=[method_with_status_lower_than_200])
+        )
 
     @get(path="/", status_code=HTTP_307_TEMPORARY_REDIRECT)
     def redirect_method() -> Redirect:
@@ -82,7 +89,7 @@ async def test_function_validation() -> None:
 
     Litestar(route_handlers=[redirect_method])
 
-    redirect_method.on_registration(Litestar())
+    redirect_method.on_registration(Litestar(), HTTPRoute(path="/", route_handlers=[redirect_method]))
 
     @get(path="/")
     def file_method() -> File:
@@ -90,7 +97,7 @@ async def test_function_validation() -> None:
 
     Litestar(route_handlers=[file_method])
 
-    file_method.on_registration(Litestar())
+    file_method.on_registration(Litestar(), HTTPRoute(path="/", route_handlers=[file_method]))
 
     assert not file_method.media_type
 
@@ -100,7 +107,7 @@ async def test_function_validation() -> None:
         def test_function_1(socket: WebSocket) -> None:
             return None
 
-        test_function_1.on_registration(Litestar())
+        test_function_1.on_registration(Litestar(), HTTPRoute(path="/", route_handlers=[test_function_1]))
 
     with pytest.raises(ImproperlyConfiguredException):
 
@@ -110,7 +117,7 @@ async def test_function_validation() -> None:
 
         Litestar(route_handlers=[test_function_2])
 
-        test_function_2.on_registration(Litestar())
+        test_function_2.on_registration(Litestar(), HTTPRoute(path="/", route_handlers=[test_function_2]))
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_handlers/test_websocket_handlers/test_listeners.py
+++ b/tests/unit/test_handlers/test_websocket_handlers/test_listeners.py
@@ -12,6 +12,7 @@ from litestar.di import Provide
 from litestar.dto import DataclassDTO, dto_field
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.handlers.websocket_handlers import WebsocketListener, websocket_listener
+from litestar.routes import WebSocketRoute
 from litestar.testing import create_test_client
 from litestar.types.asgi_types import WebSocketMode
 
@@ -235,7 +236,7 @@ def test_listener_callback_no_data_arg_raises() -> None:
         @websocket_listener("/")
         def handler() -> None: ...
 
-        handler.on_registration(Litestar())
+        handler.on_registration(Litestar(), WebSocketRoute(path="/", route_handler=handler))
 
 
 def test_listener_callback_request_and_body_arg_raises() -> None:
@@ -244,14 +245,14 @@ def test_listener_callback_request_and_body_arg_raises() -> None:
         @websocket_listener("/")
         def handler_request(data: str, request: Request) -> None: ...
 
-        handler_request.on_registration(Litestar())
+        handler_request.on_registration(Litestar(), WebSocketRoute(path="/", route_handler=handler_request))
 
     with pytest.raises(ImproperlyConfiguredException):
 
         @websocket_listener("/")
         def handler_body(data: str, body: bytes) -> None: ...
 
-        handler_body.on_registration(Litestar())
+        handler_body.on_registration(Litestar(), WebSocketRoute(path="/", route_handler=handler_body))
 
 
 def test_listener_accept_connection_callback() -> None:

--- a/tests/unit/test_handlers/test_websocket_handlers/test_validations.py
+++ b/tests/unit/test_handlers/test_websocket_handlers/test_validations.py
@@ -4,6 +4,7 @@ import pytest
 
 from litestar import Litestar, WebSocket, websocket
 from litestar.exceptions import ImproperlyConfiguredException
+from litestar.routes import WebSocketRoute
 from litestar.testing import create_test_client
 
 
@@ -12,7 +13,8 @@ def test_raises_when_socket_arg_is_missing() -> None:
         pass
 
     with pytest.raises(ImproperlyConfiguredException):
-        websocket(path="/")(fn_without_socket_arg).on_registration(Litestar())  # type: ignore[arg-type]
+        handler = websocket(path="/")(fn_without_socket_arg)  # type: ignore[arg-type]
+        handler.on_registration(Litestar(), WebSocketRoute(path="/", route_handler=handler))
 
 
 def test_raises_for_return_annotation() -> None:
@@ -20,7 +22,8 @@ def test_raises_for_return_annotation() -> None:
         return {}
 
     with pytest.raises(ImproperlyConfiguredException):
-        websocket(path="/")(fn_with_return_annotation).on_registration(Litestar())
+        handler = websocket(path="/")(fn_with_return_annotation)
+        handler.on_registration(Litestar(), WebSocketRoute(path="/", route_handler=handler))
 
 
 def test_raises_when_no_function() -> None:
@@ -36,7 +39,9 @@ def test_raises_when_sync_handler_user() -> None:
         @websocket(path="/")  # type: ignore[arg-type]
         def sync_websocket_handler(socket: WebSocket) -> None: ...
 
-        sync_websocket_handler.on_registration(Litestar())
+        sync_websocket_handler.on_registration(
+            Litestar(), WebSocketRoute(path="/", route_handler=sync_websocket_handler)
+        )
 
 
 def test_raises_when_data_kwarg_is_used() -> None:
@@ -45,7 +50,9 @@ def test_raises_when_data_kwarg_is_used() -> None:
         @websocket(path="/")
         async def websocket_handler_with_data_kwarg(socket: WebSocket, data: Any) -> None: ...
 
-        websocket_handler_with_data_kwarg.on_registration(Litestar())
+        websocket_handler_with_data_kwarg.on_registration(
+            Litestar(), WebSocketRoute(path="/", route_handler=websocket_handler_with_data_kwarg)
+        )
 
 
 def test_raises_when_request_kwarg_is_used() -> None:
@@ -54,7 +61,9 @@ def test_raises_when_request_kwarg_is_used() -> None:
         @websocket(path="/")
         async def websocket_handler_with_request_kwarg(socket: WebSocket, request: Any) -> None: ...
 
-        websocket_handler_with_request_kwarg.on_registration(Litestar())
+        websocket_handler_with_request_kwarg.on_registration(
+            Litestar(), WebSocketRoute(path="/", route_handler=websocket_handler_with_request_kwarg)
+        )
 
 
 def test_raises_when_body_kwarg_is_used() -> None:
@@ -63,4 +72,6 @@ def test_raises_when_body_kwarg_is_used() -> None:
         @websocket(path="/")
         async def websocket_handler_with_request_kwarg(socket: WebSocket, body: bytes) -> None: ...
 
-        websocket_handler_with_request_kwarg.on_registration(Litestar())
+        websocket_handler_with_request_kwarg.on_registration(
+            Litestar(), WebSocketRoute(path="/", route_handler=websocket_handler_with_request_kwarg)
+        )

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -38,7 +38,7 @@ def create_factory(route: BaseRoute, handler: HTTPRouteHandler) -> ParameterFact
 def _create_parameters(app: Litestar, path: str) -> List["OpenAPIParameter"]:
     index = find_index(app.routes, lambda x: x.path_format == path)
     route = app.routes[index]
-    route_handler = route.route_handler_map["GET"][0]  # type: ignore[union-attr]
+    route_handler = route.route_handler_map["GET"]  # type: ignore[union-attr]
     handler = route_handler.fn
     assert callable(handler)
     return create_factory(route, route_handler).create_parameters_for_handler()

--- a/tests/unit/test_openapi/test_request_body.py
+++ b/tests/unit/test_openapi/test_request_body.py
@@ -50,7 +50,7 @@ def create_request(openapi_context: OpenAPIContext) -> RequestBodyFactory:
 
 def test_create_request_body(person_controller: Type[Controller], create_request: RequestBodyFactory) -> None:
     for route in Litestar(route_handlers=[person_controller]).routes:
-        for route_handler, _ in route.route_handler_map.values():  # type: ignore[union-attr]
+        for route_handler in route.route_handler_map.values():  # type: ignore[union-attr]
             handler_fields = route_handler.parsed_fn_signature.parameters
             if "data" in handler_fields:
                 request_body = create_request(route_handler, handler_fields["data"])

--- a/tests/unit/test_openapi/test_responses.py
+++ b/tests/unit/test_openapi/test_responses.py
@@ -71,7 +71,7 @@ def test_create_responses(
 ) -> None:
     for route in Litestar(route_handlers=[person_controller]).routes:
         assert isinstance(route, HTTPRoute)
-        for route_handler, _ in route.route_handler_map.values():
+        for route_handler in route.route_handler_map.values():
             if route_handler.resolve_include_in_schema():
                 responses = create_factory(route_handler).create_responses(True)
                 assert responses

--- a/tests/unit/test_response/test_response_cookies.py
+++ b/tests/unit/test_response/test_response_cookies.py
@@ -37,7 +37,7 @@ def test_response_cookies() -> None:
         response_cookies=[app_first, app_second],
         route_handlers=[first_router, second_router],
     )
-    route_handler, _ = app.routes[0].route_handler_map[HttpMethod.GET]  # type: ignore[union-attr]
+    route_handler = app.routes[0].route_handler_map[HttpMethod.GET]  # type: ignore[union-attr]
     response_cookies = {cookie.key: cookie.value for cookie in route_handler.resolve_response_cookies()}
     assert response_cookies["first"] == local_first.value
     assert response_cookies["second"] == controller_second.value

--- a/tests/unit/test_response/test_response_headers.py
+++ b/tests/unit/test_response/test_response_headers.py
@@ -38,7 +38,7 @@ def test_response_headers() -> None:
         route_handlers=[first_router, second_router],
     )
 
-    route_handler, _ = app.routes[0].route_handler_map[HttpMethod.GET]  # type: ignore[union-attr]
+    route_handler = app.routes[0].route_handler_map[HttpMethod.GET]  # type: ignore[union-attr]
     resolved_headers = {header.name: header for header in route_handler.resolve_response_headers()}
     assert resolved_headers["first"].value == local_first.value
     assert resolved_headers["second"].value == controller_second.value
@@ -184,6 +184,6 @@ def test_explicit_headers_override_response_headers(
 
     app = Litestar(route_handlers=[my_handler])
 
-    route_handler, _ = app.routes[0].route_handler_map[HttpMethod.GET]  # type: ignore[union-attr]
+    route_handler = app.routes[0].route_handler_map[HttpMethod.GET]  # type: ignore[union-attr]
     resolved_headers = {header.name: header for header in route_handler.resolve_response_headers()}
     assert resolved_headers[header.HEADER_NAME].value == header.to_header()

--- a/tests/unit/test_response/test_type_encoders.py
+++ b/tests/unit/test_response/test_type_encoders.py
@@ -32,7 +32,7 @@ def test_resolve_type_encoders() -> None:
     router = Router("/router", type_encoders={router_type: router_encoder}, route_handlers=[MyController])
     app = Litestar([router], type_encoders={app_type: app_encoder})
 
-    route_handler = app.routes[0].route_handler_map[HttpMethod.GET][0]  # type: ignore[union-attr]
+    route_handler = app.routes[0].route_handler_map[HttpMethod.GET]  # type: ignore[union-attr]
     encoders = route_handler.resolve_type_encoders()
     assert encoders.get(handler_type) == handler_encoder
     assert encoders.get(controller_type) == controller_encoder


### PR DESCRIPTION
Refactor routes and route handlers in an attempt to simplify configuration.

The two general goals here are:

1. Routes should not be concerned with any logic pertaining to handlers
2. Routing layers (e.g. app/router instances) should not perform any manual handler setup

In general I'd like to restrict the routes to an internal part of the ASGI routing, only taking care of mapping a path > route handler(s), and establishing the connection. Everything else should be taken care of by the handlers.

What this currently does:

- Remove the `handler_names` property from `HTTPRoute`
- Move the `OPTIONS` handler creation from the `HTTPRoute` to the route registration process
- Remove the `methods` attribute from `BaseRoute`; It does not make sense on the asgi/websocket routes
- Move the creation of the `KwargsModel` from the routes to the handlers and remove the outside mutation of the handlers
- Move the mapping of route > handler > kwargsmodel to the handler itself
- Move the actual route handling to the handler
- Establish `ASGIConnection`/`WebSocket`/`Request` in the routes and pass them to handlers instead of raw ASGI objects (`scope`, `receive`, `send`)
- Some minor refactorings that were enabled by these things
