### PR TITLE
test: adds a test for middleware behavior

### DIFF
--- a/tests/e2e/test_middleware/test_middleware_send_wrapper_called_on_error.py
+++ b/tests/e2e/test_middleware/test_middleware_send_wrapper_called_on_error.py
@@ -1,0 +1,38 @@
+"""Test middleware send_wrapper called on exception."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from litestar import get
+from litestar.exceptions import InternalServerException
+from litestar.testing import create_test_client
+
+if TYPE_CHECKING:
+    from litestar.types.asgi_types import ASGIApp, Message, Receive, Scope, Send
+
+mock = MagicMock()
+
+
+def asgi_middleware(app: ASGIApp) -> ASGIApp:
+    async def middleware(scope: Scope, receive: Receive, send: Send) -> None:
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                mock(message["type"], message["status"])
+            await send(message)
+
+        await app(scope, receive, send_wrapper)
+
+    return middleware
+
+
+@get("/raising", sync_to_thread=False)
+def raising() -> None:
+    raise InternalServerException("This is an exception")
+
+
+def test_middleware_send_wrapper_called_on_exception() -> None:
+    with create_test_client([raising], middleware=[asgi_middleware]) as client:
+        client.get("/raising")
+        mock.assert_called_once_with("http.response.start", 500)


### PR DESCRIPTION
This tests that when a handler raises an exception, we call wrapped versions of the `send()` coroutine.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
