### PR TITLE
refactor!: Remove deprecated `app` param of `Response.to_asgi_response`

### DIFF
--- a/docs/release-notes/whats-new-3.rst
+++ b/docs/release-notes/whats-new-3.rst
@@ -105,3 +105,11 @@ the root path (``/``), in which case that plugin will be used.
 
 For those previously using the ``root_schema_site`` attribute, the migration involves ensuring that the UI intended to
 be served at the ``/schema`` endpoint is the first plugin listed in the :attr:`OpenAPIConfig.render_plugins`.
+
+
+Deprecated ``app`` parameter for ``Response.to_asgi_response`` has been removed
+-------------------------------------------------------------------------------
+
+The parameter ``app`` for :meth:`~response.Response.to_asgi_response` has been removed.
+If you need access to the app instance inside a custom ``to_asgi_response`` method,
+replace the usages of ``app`` with ``request.app``.

--- a/litestar/handlers/http_handlers/_utils.py
+++ b/litestar/handlers/http_handlers/_utils.py
@@ -11,7 +11,6 @@ from litestar.status_codes import HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CON
 from litestar.types.builtin_types import NoneType
 
 if TYPE_CHECKING:
-    from litestar.app import Litestar
     from litestar.background_tasks import BackgroundTask, BackgroundTasks
     from litestar.connection import Request
     from litestar.datastructures import Cookie, ResponseHeader
@@ -59,7 +58,6 @@ def create_data_handler(
     async def handler(
         data: Any,
         request: Request[Any, Any, Any],
-        app: Litestar,
         **kwargs: Any,
     ) -> ASGIApp:
         if isawaitable(data):
@@ -76,7 +74,7 @@ def create_data_handler(
         if after_request:
             response = await after_request(response)  # type: ignore[arg-type,misc]
 
-        return response.to_asgi_response(app=None, request=request, headers=normalize_headers(headers), cookies=cookies)  # pyright: ignore
+        return response.to_asgi_response(request=request, headers=normalize_headers(headers), cookies=cookies)  # pyright: ignore
 
     return handler
 
@@ -144,13 +142,11 @@ def create_response_handler(
 
     async def handler(
         data: Response,
-        app: Litestar,
         request: Request,
         **kwargs: Any,  # kwargs is for return dto
     ) -> ASGIApp:
         response = await after_request(data) if after_request else data  # type:ignore[arg-type,misc]
         return response.to_asgi_response(  # type: ignore[no-any-return]
-            app=None,
             background=background,
             cookies=cookie_list,
             headers=normalized_headers,

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -472,7 +472,7 @@ class HTTPRouteHandler(BaseRouteHandler):
 
         return self._resolved_tags
 
-    def get_response_handler(self, is_response_type_data: bool = False) -> Callable[[Any], Awaitable[ASGIApp]]:
+    def get_response_handler(self, is_response_type_data: bool = False) -> Callable[..., Awaitable[ASGIApp]]:
         """Resolve the response_handler function for the route handler.
 
         This method is memoized so the computation occurs only once.
@@ -538,11 +538,10 @@ class HTTPRouteHandler(BaseRouteHandler):
             else self._response_handler_mapping["default_handler"],
         )
 
-    async def to_response(self, app: Litestar, data: Any, request: Request) -> ASGIApp:
+    async def to_response(self, data: Any, request: Request) -> ASGIApp:
         """Return a :class:`Response <.response.Response>` from the handler by resolving and calling it.
 
         Args:
-            app: The :class:`Litestar <litestar.app.Litestar>` app instance
             data: Either an instance of a :class:`Response <.response.Response>`,
                 a Response instance or an arbitrary value.
             request: A :class:`Request <.connection.Request>` instance
@@ -554,7 +553,7 @@ class HTTPRouteHandler(BaseRouteHandler):
             data = return_dto_type(request).data_to_encodable_type(data)
 
         response_handler = self.get_response_handler(is_response_type_data=isinstance(data, Response))
-        return await response_handler(app=app, data=data, request=request)  # type: ignore[call-arg]
+        return await response_handler(data=data, request=request)
 
     def on_registration(self, app: Litestar) -> None:
         super().on_registration(app)

--- a/litestar/middleware/exceptions/middleware.py
+++ b/litestar/middleware/exceptions/middleware.py
@@ -260,7 +260,7 @@ class ExceptionHandlerMiddleware:
         exception_handler = get_exception_handler(self.exception_handlers, exc) or self.default_http_exception_handler
         request: Request[Any, Any, Any] = litestar_app.request_class(scope=scope, receive=receive, send=send)
         response = exception_handler(request, exc)
-        await response.to_asgi_response(app=None, request=request)(scope=scope, receive=receive, send=send)
+        await response.to_asgi_response(request=request)(scope=scope, receive=receive, send=send)
 
     @staticmethod
     async def handle_websocket_exception(send: Send, exc: Exception) -> None:

--- a/litestar/response/base.py
+++ b/litestar/response/base.py
@@ -17,7 +17,6 @@ from litestar.utils.helpers import get_enum_string_value
 if TYPE_CHECKING:
     from typing import Optional
 
-    from litestar.app import Litestar
     from litestar.background_tasks import BackgroundTask, BackgroundTasks
     from litestar.connection import Request
     from litestar.types import (
@@ -397,7 +396,6 @@ class Response(Generic[T]):
 
     def to_asgi_response(
         self,
-        app: Litestar | None,
         request: Request,
         *,
         background: BackgroundTask | BackgroundTasks | None = None,
@@ -412,7 +410,6 @@ class Response(Generic[T]):
         """Create an ASGIResponse from a Response instance.
 
         Args:
-            app: The :class:`Litestar <.app.Litestar>` application instance.
             background: Background task(s) to be executed after the response is sent.
             cookies: A list of cookies to be set on the response.
             encoded_headers: A list of already encoded headers.
@@ -426,15 +423,6 @@ class Response(Generic[T]):
         Returns:
             An ASGIResponse instance.
         """
-
-        if app is not None:
-            warn_deprecation(
-                version="2.1",
-                deprecated_name="app",
-                kind="parameter",
-                removal_in="3.0.0",
-                alternative="request.app",
-            )
 
         headers = {**headers, **self.headers} if headers is not None else self.headers
         cookies = self.cookies if cookies is None else itertools.chain(self.cookies, cookies)

--- a/litestar/response/file.py
+++ b/litestar/response/file.py
@@ -13,7 +13,6 @@ from litestar.exceptions import ImproperlyConfiguredException
 from litestar.file_system import BaseLocalFileSystem, FileSystemAdapter
 from litestar.response.base import Response
 from litestar.response.streaming import ASGIStreamingResponse
-from litestar.utils.deprecation import warn_deprecation
 from litestar.utils.helpers import get_enum_string_value
 
 if TYPE_CHECKING:
@@ -22,7 +21,6 @@ if TYPE_CHECKING:
 
     from anyio import Path
 
-    from litestar.app import Litestar
     from litestar.background_tasks import BackgroundTask, BackgroundTasks
     from litestar.connection import Request
     from litestar.datastructures.cookie import Cookie
@@ -319,7 +317,6 @@ class File(Response):
 
     def to_asgi_response(
         self,
-        app: Litestar | None,
         request: Request,
         *,
         background: BackgroundTask | BackgroundTasks | None = None,
@@ -348,14 +345,6 @@ class File(Response):
         Returns:
             A low-level ASGI file response.
         """
-        if app is not None:
-            warn_deprecation(
-                version="2.1",
-                deprecated_name="app",
-                kind="parameter",
-                removal_in="3.0.0",
-                alternative="request.app",
-            )
 
         headers = {**headers, **self.headers} if headers is not None else self.headers
         cookies = self.cookies if cookies is None else itertools.chain(self.cookies, cookies)

--- a/litestar/response/redirect.py
+++ b/litestar/response/redirect.py
@@ -9,11 +9,9 @@ from litestar.exceptions import ImproperlyConfiguredException
 from litestar.response.base import ASGIResponse, Response
 from litestar.status_codes import HTTP_302_FOUND
 from litestar.utils import url_quote
-from litestar.utils.deprecation import warn_deprecation
 from litestar.utils.helpers import get_enum_string_value
 
 if TYPE_CHECKING:
-    from litestar.app import Litestar
     from litestar.background_tasks import BackgroundTask, BackgroundTasks
     from litestar.connection import Request
     from litestar.datastructures import Cookie
@@ -129,7 +127,6 @@ class Redirect(Response[Any]):
 
     def to_asgi_response(
         self,
-        app: Litestar | None,
         request: Request,
         *,
         background: BackgroundTask | BackgroundTasks | None = None,
@@ -144,15 +141,6 @@ class Redirect(Response[Any]):
         headers = {**headers, **self.headers} if headers is not None else self.headers
         cookies = self.cookies if cookies is None else itertools.chain(self.cookies, cookies)
         media_type = get_enum_string_value(self.media_type or media_type or MediaType.TEXT)
-
-        if app is not None:
-            warn_deprecation(
-                version="2.1",
-                deprecated_name="app",
-                kind="parameter",
-                removal_in="3.0.0",
-                alternative="request.app",
-            )
 
         return ASGIRedirectResponse(
             path=self.url,

--- a/litestar/response/streaming.py
+++ b/litestar/response/streaming.py
@@ -9,12 +9,10 @@ from anyio import CancelScope, create_task_group
 from litestar.enums import MediaType
 from litestar.response.base import ASGIResponse, Response
 from litestar.types.helper_types import StreamType
-from litestar.utils.deprecation import warn_deprecation
 from litestar.utils.helpers import get_enum_string_value
 from litestar.utils.sync import AsyncIteratorWrapper
 
 if TYPE_CHECKING:
-    from litestar.app import Litestar
     from litestar.background_tasks import BackgroundTask, BackgroundTasks
     from litestar.connection import Request
     from litestar.datastructures.cookie import Cookie
@@ -177,7 +175,6 @@ class Stream(Response[StreamType[Union[str, bytes]]]):
 
     def to_asgi_response(
         self,
-        app: Litestar | None,
         request: Request,
         *,
         background: BackgroundTask | BackgroundTasks | None = None,
@@ -192,7 +189,6 @@ class Stream(Response[StreamType[Union[str, bytes]]]):
         """Create an ASGIStreamingResponse from a StremaingResponse instance.
 
         Args:
-            app: The :class:`Litestar <.app.Litestar>` application instance.
             background: Background task(s) to be executed after the response is sent.
             cookies: A list of cookies to be set on the response.
             encoded_headers: A list of already encoded headers.
@@ -206,14 +202,6 @@ class Stream(Response[StreamType[Union[str, bytes]]]):
         Returns:
             An ASGIStreamingResponse instance.
         """
-        if app is not None:
-            warn_deprecation(
-                version="2.1",
-                deprecated_name="app",
-                kind="parameter",
-                removal_in="3.0.0",
-                alternative="request.app",
-            )
 
         headers = {**headers, **self.headers} if headers is not None else self.headers
         cookies = self.cookies if cookies is None else itertools.chain(self.cookies, cookies)

--- a/litestar/response/template.py
+++ b/litestar/response/template.py
@@ -9,12 +9,10 @@ from litestar.enums import MediaType
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.response.base import ASGIResponse, Response
 from litestar.status_codes import HTTP_200_OK
-from litestar.utils.deprecation import warn_deprecation
 from litestar.utils.empty import value_or_default
 from litestar.utils.scope.state import ScopeState
 
 if TYPE_CHECKING:
-    from litestar.app import Litestar
     from litestar.background_tasks import BackgroundTask, BackgroundTasks
     from litestar.connection import Request
     from litestar.datastructures import Cookie
@@ -99,7 +97,6 @@ class Template(Response[bytes]):
 
     def to_asgi_response(
         self,
-        app: Litestar | None,
         request: Request,
         *,
         background: BackgroundTask | BackgroundTasks | None = None,
@@ -111,15 +108,6 @@ class Template(Response[bytes]):
         status_code: int | None = None,
         type_encoders: TypeEncodersMap | None = None,
     ) -> ASGIResponse:
-        if app is not None:
-            warn_deprecation(
-                version="2.1",
-                deprecated_name="app",
-                kind="parameter",
-                removal_in="3.0.0",
-                alternative="request.app",
-            )
-
         if not (template_engine := request.app.template_engine):
             raise ImproperlyConfiguredException("Template engine is not configured")
 

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -155,7 +155,7 @@ class HTTPRoute(BaseRoute):
                 route_handler=route_handler, parameter_model=parameter_model, request=request
             )
 
-        response: ASGIApp = await route_handler.to_response(app=scope["app"], data=response_data, request=request)
+        response: ASGIApp = await route_handler.to_response(data=response_data, request=request)
 
         if cleanup_group:
             await cleanup_group.cleanup()

--- a/tests/unit/test_cli/test_core_commands.py
+++ b/tests/unit/test_cli/test_core_commands.py
@@ -499,6 +499,7 @@ def test_run_command_custom_app_name(
 
 
 @pytest.mark.usefixtures("mock_uvicorn_run", "unset_env")
+@pytest.mark.xfail(reason="Regression; LITESTAR_PDB seems to not be set correctly anymore")
 def test_run_command_pdb(
     app_file: Path,
     runner: CliRunner,

--- a/tests/unit/test_cli/test_core_commands.py
+++ b/tests/unit/test_cli/test_core_commands.py
@@ -499,7 +499,6 @@ def test_run_command_custom_app_name(
 
 
 @pytest.mark.usefixtures("mock_uvicorn_run", "unset_env")
-@pytest.mark.xfail(reason="Regression; LITESTAR_PDB seems to not be set correctly anymore")
 def test_run_command_pdb(
     app_file: Path,
     runner: CliRunner,


### PR DESCRIPTION
Remove the deprecated `app` parameter of `Response.to_asgi_response`; Its usage has been replaced internally by `request.app`, and custom response classes can follow the same pattern.