### PR TITLE
refactor!: Remove deprecated utils

### DIFF
--- a/docs/release-notes/whats-new-3.rst
+++ b/docs/release-notes/whats-new-3.rst
@@ -113,3 +113,32 @@ Deprecated ``app`` parameter for ``Response.to_asgi_response`` has been removed
 The parameter ``app`` for :meth:`~response.Response.to_asgi_response` has been removed.
 If you need access to the app instance inside a custom ``to_asgi_response`` method,
 replace the usages of ``app`` with ``request.app``.
+
+
+Deprecated scope state utilities removed
+----------------------------------------
+
+Litestar has previously made available utilities for storing and retrieving data in the ASGI scope state. These
+utilities have been removed in version 3.0.0. If you need to store data in the ASGI scope state, you should use do so
+using a namespace that is unique to your application and unlikely to conflict with other applications.
+
+The following utilities have been removed:
+
+- ``get_litestar_scope_state``
+- ``set_litestar_scope_state``
+- ``delete_litestar_scope_state``
+
+
+Deprecated utility function ``is_sync_or_async_generator`` removed
+------------------------------------------------------------------
+
+The utility function ``is_sync_or_async_generator`` has been removed as it is no longer used internally.
+
+If you were relying on this utility, you can define it yourself as follows:
+
+.. code-block:: python
+
+    from inspect import isasyncgenfunction, isgeneratorfunction
+
+    def is_sync_or_async_generator(obj: Any) -> bool:
+        return isgeneratorfunction(obj) or isasyncgenfunction(obj)

--- a/litestar/constants.py
+++ b/litestar/constants.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 from dataclasses import MISSING
 from inspect import Signature
-from typing import Any, Final
+from typing import Final
 from uuid import uuid4
 
 from msgspec import UnsetType
 
 from litestar.enums import MediaType
 from litestar.types import Empty
-from litestar.utils.deprecation import warn_deprecation
 
 DEFAULT_ALLOWED_CORS_HEADERS: Final = {"Accept", "Accept-Language", "Content-Language", "Content-Type"}
 DEFAULT_CHUNK_SIZE: Final = 1024 * 128  # 128KB
@@ -26,35 +25,3 @@ SKIP_VALIDATION_NAMES: Final = {"request", "socket", "scope", "receive", "send"}
 UNDEFINED_SENTINELS: Final = {Signature.empty, Empty, Ellipsis, MISSING, UnsetType}
 WEBSOCKET_CLOSE: Final = "websocket.close"
 WEBSOCKET_DISCONNECT: Final = "websocket.disconnect"
-
-# deprecated constants
-_SCOPE_STATE_CSRF_TOKEN_KEY = "csrf_token"  # noqa: S105  # possible hardcoded password
-_SCOPE_STATE_DEPENDENCY_CACHE: Final = "dependency_cache"
-_SCOPE_STATE_NAMESPACE: Final = "__litestar__"
-_SCOPE_STATE_RESPONSE_COMPRESSED: Final = "response_compressed"
-_SCOPE_STATE_DO_CACHE: Final = "do_cache"
-_SCOPE_STATE_IS_CACHED: Final = "is_cached"
-
-_deprecated_names = {
-    "SCOPE_STATE_CSRF_TOKEN_KEY": _SCOPE_STATE_CSRF_TOKEN_KEY,
-    "SCOPE_STATE_DEPENDENCY_CACHE": _SCOPE_STATE_DEPENDENCY_CACHE,
-    "SCOPE_STATE_NAMESPACE": _SCOPE_STATE_NAMESPACE,
-    "SCOPE_STATE_RESPONSE_COMPRESSED": _SCOPE_STATE_RESPONSE_COMPRESSED,
-    "SCOPE_STATE_DO_CACHE": _SCOPE_STATE_DO_CACHE,
-    "SCOPE_STATE_IS_CACHED": _SCOPE_STATE_IS_CACHED,
-}
-
-
-def __getattr__(name: str) -> Any:
-    if name in _deprecated_names:
-        warn_deprecation(
-            deprecated_name=f"litestar.constants.{name}",
-            version="2.4",
-            kind="import",
-            removal_in="3.0",
-            info=f"'{name}' from 'litestar.constants' is deprecated and will be removed in 3.0. "
-            "Direct access to Litestar scope state is not recommended.",
-        )
-
-        return globals()["_deprecated_names"][name]
-    raise AttributeError(f"module {__name__} has no attribute {name}")  # pragma: no cover

--- a/litestar/utils/__init__.py
+++ b/litestar/utils/__init__.py
@@ -1,11 +1,8 @@
-from typing import Any
-
 from litestar.utils.deprecation import deprecated, warn_deprecation
 
 from .helpers import get_enum_string_value, get_name, unique_name_for_scope, url_quote
 from .path import join_paths, normalize_path
 from .predicates import (
-    _is_sync_or_async_generator,
     is_annotated_type,
     is_any,
     is_async_callable,
@@ -21,10 +18,7 @@ from .predicates import (
     is_undefined_sentinel,
     is_union,
 )
-from .scope import (  # type: ignore[attr-defined]
-    _delete_litestar_scope_state,
-    _get_litestar_scope_state,
-    _set_litestar_scope_state,
+from .scope import (
     get_serializer_from_scope,
 )
 from .sequence import find_index, unique
@@ -62,23 +56,3 @@ __all__ = (
     "url_quote",
     "warn_deprecation",
 )
-
-_deprecated_names = {
-    "get_litestar_scope_state": _get_litestar_scope_state,
-    "set_litestar_scope_state": _set_litestar_scope_state,
-    "delete_litestar_scope_state": _delete_litestar_scope_state,
-    "is_sync_or_async_generator": _is_sync_or_async_generator,
-}
-
-
-def __getattr__(name: str) -> Any:
-    if name in _deprecated_names:
-        warn_deprecation(
-            deprecated_name=f"litestar.utils.{name}",
-            version="2.4",
-            kind="import",
-            removal_in="3.0",
-            info=f"'litestar.utils.{name}' is deprecated.",
-        )
-        return globals()["_deprecated_names"][name]
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")  # pragma: no cover

--- a/litestar/utils/predicates.py
+++ b/litestar/utils/predicates.py
@@ -4,7 +4,7 @@ from asyncio import iscoroutinefunction
 from collections import defaultdict, deque
 from collections.abc import Iterable as CollectionsIterable
 from dataclasses import is_dataclass
-from inspect import isasyncgenfunction, isclass, isgeneratorfunction
+from inspect import isclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -35,12 +35,10 @@ from typing_extensions import (
 
 from litestar.constants import UNDEFINED_SENTINELS
 from litestar.types.builtin_types import NoneType, UnionTypes
-from litestar.utils.deprecation import warn_deprecation
 from litestar.utils.helpers import unwrap_partial
 from litestar.utils.typing import get_origin_or_inner_type
 
 if TYPE_CHECKING:
-    from litestar.types.callable_types import AnyGenerator
     from litestar.types.protocols import DataclassProtocol
 
 
@@ -269,18 +267,6 @@ def is_class_var(annotation: Any) -> bool:
     return annotation is ClassVar
 
 
-def _is_sync_or_async_generator(obj: Any) -> TypeGuard[AnyGenerator]:
-    """Check if the given annotation is a sync or async generator.
-
-    Args:
-        obj: type to be tested for sync or async generator.
-
-    Returns:
-        A boolean.
-    """
-    return isgeneratorfunction(obj) or isasyncgenfunction(obj)
-
-
 def is_annotated_type(annotation: Any) -> bool:
     """Check if the given annotation is an Annotated.
 
@@ -303,19 +289,3 @@ def is_undefined_sentinel(value: Any) -> bool:
         A boolean.
     """
     return any(v is value for v in UNDEFINED_SENTINELS)
-
-
-_deprecated_names = {"is_sync_or_async_generator": _is_sync_or_async_generator}
-
-
-def __getattr__(name: str) -> Any:
-    if name in _deprecated_names:
-        warn_deprecation(
-            deprecated_name=f"litestar.utils.scope.{name}",
-            version="2.4",
-            kind="import",
-            removal_in="3.0",
-            info=f"'litestar.utils.predicates.{name}' is deprecated.",
-        )
-        return globals()["_deprecated_names"][name]
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")  # pragma: no cover

--- a/litestar/utils/scope/__init__.py
+++ b/litestar/utils/scope/__init__.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from litestar.serialization import get_serializer
-from litestar.utils.deprecation import warn_deprecation
-from litestar.utils.scope.state import delete_litestar_scope_state as _delete_litestar_scope_state
-from litestar.utils.scope.state import get_litestar_scope_state as _get_litestar_scope_state
-from litestar.utils.scope.state import set_litestar_scope_state as _set_litestar_scope_state
 
 if TYPE_CHECKING:
     from litestar.types import Scope, Serializer
@@ -39,24 +35,3 @@ def get_serializer_from_scope(scope: Scope) -> Serializer:
         type_encoders = {**type_encoders, **(response_class.type_encoders or {})}
 
     return get_serializer(type_encoders)
-
-
-_deprecated_names = {
-    "get_litestar_scope_state": _get_litestar_scope_state,
-    "set_litestar_scope_state": _set_litestar_scope_state,
-    "delete_litestar_scope_state": _delete_litestar_scope_state,
-}
-
-
-def __getattr__(name: str) -> Any:
-    if name in _deprecated_names:
-        warn_deprecation(
-            deprecated_name=f"litestar.utils.scope.{name}",
-            version="2.4",
-            kind="import",
-            removal_in="3.0",
-            info=f"'litestar.utils.scope.{name}' is deprecated. The Litestar scope state is private and should not be "
-            f"used. Plugin authors should maintain their own scope state namespace.",
-        )
-        return globals()["_deprecated_names"][name]
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")  # pragma: no cover

--- a/litestar/utils/scope/state.py
+++ b/litestar/utils/scope/state.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final
 
 from litestar.types import Empty, EmptyType
-from litestar.utils.empty import value_or_default
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -44,7 +43,6 @@ class ScopeState:
         "response_compressed",
         "session_id",
         "url",
-        "_compat_ns",
     )
 
     def __init__(self) -> None:
@@ -67,7 +65,6 @@ class ScopeState:
         self.response_compressed = Empty
         self.session_id = Empty
         self.url = Empty
-        self._compat_ns: dict[str, Any] = {}
 
     accept: Accept | EmptyType
     base_url: URL | EmptyType
@@ -88,7 +85,6 @@ class ScopeState:
     response_compressed: bool | EmptyType
     session_id: str | None | EmptyType
     url: URL | EmptyType
-    _compat_ns: dict[str, Any]
 
     @classmethod
     def from_scope(cls, scope: Scope) -> Self:
@@ -106,56 +102,3 @@ class ScopeState:
         if (state := base_scope_state.get(CONNECTION_STATE_KEY)) is None:
             state = base_scope_state[CONNECTION_STATE_KEY] = cls()
         return state
-
-
-def get_litestar_scope_state(scope: Scope, key: str, default: Any = None, pop: bool = False) -> Any:
-    """Get an internal value from connection scope state.
-
-    Args:
-        scope: The connection scope.
-        key: Key to get from internal namespace in scope state.
-        default: Default value to return.
-        pop: Boolean flag dictating whether the value should be deleted from the state.
-
-    Returns:
-        Value mapped to ``key`` in internal connection scope namespace.
-    """
-    scope_state = ScopeState.from_scope(scope)
-    try:
-        val = value_or_default(getattr(scope_state, key), default)
-        if pop:
-            setattr(scope_state, key, Empty)
-        return val
-    except AttributeError:
-        if pop:
-            return scope_state._compat_ns.pop(key, default)
-        return scope_state._compat_ns.get(key, default)
-
-
-def set_litestar_scope_state(scope: Scope, key: str, value: Any) -> None:
-    """Set an internal value in connection scope state.
-
-    Args:
-        scope: The connection scope.
-        key: Key to set under internal namespace in scope state.
-        value: Value for key.
-    """
-    scope_state = ScopeState.from_scope(scope)
-    if hasattr(scope_state, key):
-        setattr(scope_state, key, value)
-    else:
-        scope_state._compat_ns[key] = value
-
-
-def delete_litestar_scope_state(scope: Scope, key: str) -> None:
-    """Delete an internal value from connection scope state.
-
-    Args:
-        scope: The connection scope.
-        key: Key to set under internal namespace in scope state.
-    """
-    scope_state = ScopeState.from_scope(scope)
-    if hasattr(scope_state, key):
-        setattr(scope_state, key, Empty)
-    else:
-        del scope_state._compat_ns[key]

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -115,34 +115,3 @@ def test_litestar_templates_template_context_deprecation() -> None:
 def test_minijinja_from_state_deprecation() -> None:
     with pytest.warns(DeprecationWarning):
         from litestar.contrib.minijinja import minijinja_from_state  # noqa: F401
-
-
-def test_constants_deprecations() -> None:
-    with pytest.warns(DeprecationWarning):
-        from litestar.constants import SCOPE_STATE_NAMESPACE  # noqa: F401
-
-
-def test_utils_deprecations() -> None:
-    with pytest.warns(DeprecationWarning):
-        from litestar.utils import (  # noqa: F401
-            delete_litestar_scope_state,
-            get_litestar_scope_state,
-            set_litestar_scope_state,
-        )
-
-
-def test_utils_scope_deprecations() -> None:
-    with pytest.warns(DeprecationWarning):
-        from litestar.utils.scope import (  # noqa: F401
-            delete_litestar_scope_state,
-            get_litestar_scope_state,
-            set_litestar_scope_state,
-        )
-
-
-def test_is_sync_or_async_generator_deprecation() -> None:
-    with pytest.warns(DeprecationWarning):
-        from litestar.utils.predicates import is_sync_or_async_generator  # noqa: F401
-
-    with pytest.warns(DeprecationWarning):
-        from litestar.utils import is_sync_or_async_generator as _  # noqa: F401

--- a/tests/unit/test_utils/test_scope.py
+++ b/tests/unit/test_utils/test_scope.py
@@ -1,78 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
-
-import pytest
-
-from litestar.types.empty import Empty
-from litestar.utils import (
-    delete_litestar_scope_state,
-    get_litestar_scope_state,
-    set_litestar_scope_state,
-)
 from litestar.utils.scope.state import CONNECTION_STATE_KEY, ScopeState
-
-if TYPE_CHECKING:
-    from litestar.types.asgi_types import Scope
-
-
-@pytest.fixture()
-def scope(create_scope: Callable[..., Scope]) -> Scope:
-    return create_scope()
 
 
 def test_from_scope_without_state() -> None:
     scope = {}  # type: ignore[var-annotated]
     state = ScopeState.from_scope(scope)  # type: ignore[arg-type]
     assert scope["state"][CONNECTION_STATE_KEY] is state
-
-
-@pytest.mark.parametrize(("pop",), [(True,), (False,)])
-def test_get_litestar_scope_state_arbitrary_value(pop: bool, scope: Scope) -> None:
-    key = "test"
-    value = {"key": "value"}
-    connection_state = ScopeState.from_scope(scope)
-    connection_state._compat_ns[key] = value
-    retrieved_value = get_litestar_scope_state(scope, key, pop=pop)
-    assert retrieved_value == value
-    if pop:
-        assert connection_state._compat_ns.get(key) is None
-    else:
-        assert connection_state._compat_ns.get(key) == value
-
-
-@pytest.mark.parametrize(("pop",), [(True,), (False,)])
-def test_get_litestar_scope_state_defined_value(pop: bool, scope: Scope) -> None:
-    connection_state = ScopeState.from_scope(scope)
-    connection_state.is_cached = True
-    assert get_litestar_scope_state(scope, "is_cached", pop=pop) is True
-    if pop:
-        assert connection_state.is_cached is Empty  # type: ignore[comparison-overlap]
-    else:
-        assert connection_state.is_cached is True
-
-
-def test_set_litestar_scope_state_arbitrary_value(scope: Scope) -> None:
-    connection_state = ScopeState.from_scope(scope)
-    set_litestar_scope_state(scope, "key", "value")
-    assert connection_state._compat_ns["key"] == "value"
-
-
-def test_set_litestar_scope_state_defined_value(scope: Scope) -> None:
-    connection_state = ScopeState.from_scope(scope)
-    set_litestar_scope_state(scope, "is_cached", True)
-    assert connection_state.is_cached is True
-
-
-def test_delete_litestar_scope_state_arbitrary_value(scope: Scope) -> None:
-    connection_state = ScopeState.from_scope(scope)
-    connection_state._compat_ns["key"] = "value"
-    delete_litestar_scope_state(scope, "key")
-    assert "key" not in connection_state._compat_ns
-
-
-def test_delete_litestar_scope_state_defined_value(scope: Scope) -> None:
-    connection_state = ScopeState.from_scope(scope)
-    connection_state.is_cached = True
-    delete_litestar_scope_state(scope, "is_cached")
-    assert connection_state.is_cached is Empty  # type: ignore[comparison-overlap]


### PR DESCRIPTION
Remove the deprecated utility functions, ``get_litestar_scope_state``, ``set_litestar_scope_state``, ``delete_litestar_scope_state``, and ``is_sync_or_async_generator``.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
