### PR TITLE
refactor: Make CORS outermost middleware

### DIFF
--- a/litestar/app.py
+++ b/litestar/app.py
@@ -839,14 +839,15 @@ class Litestar(Router):
 
         If CORS or TrustedHost configs are provided to the constructor, they will wrap the router as well.
         """
-        asgi_handler: ASGIApp = self.asgi_router
-        if self.cors_config:
-            asgi_handler = CORSMiddleware(app=asgi_handler, config=self.cors_config)
-
-        return wrap_in_exception_handler(
-            app=asgi_handler,
+        asgi_handler = wrap_in_exception_handler(
+            app=self.asgi_router,
             exception_handlers=self.exception_handlers or {},  # pyright: ignore
         )
+
+        if self.cors_config:
+            return CORSMiddleware(app=asgi_handler, config=self.cors_config)
+
+        return asgi_handler
 
     def _wrap_send(self, send: Send, scope: Scope) -> Send:
         """Wrap the ASGI send and handles any 'before send' hooks.

--- a/litestar/middleware/exceptions/middleware.py
+++ b/litestar/middleware/exceptions/middleware.py
@@ -7,17 +7,12 @@ from sys import exc_info
 from traceback import format_exception
 from typing import TYPE_CHECKING, Any, Type, cast
 
-from litestar.datastructures import Headers
 from litestar.enums import MediaType, ScopeType
 from litestar.exceptions import HTTPException, LitestarException, WebSocketException
-from litestar.middleware.cors import CORSMiddleware
 from litestar.middleware.exceptions._debug_response import _get_type_encoders_for_request, create_debug_response
 from litestar.serialization import encode_json, get_serializer
 from litestar.status_codes import HTTP_500_INTERNAL_SERVER_ERROR
 from litestar.utils.deprecation import warn_deprecation
-
-__all__ = ("ExceptionHandlerMiddleware", "ExceptionResponseContent", "create_exception_response")
-
 
 if TYPE_CHECKING:
     from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -36,6 +31,8 @@ if TYPE_CHECKING:
         Send,
     )
     from litestar.types.asgi_types import WebSocketCloseEvent
+
+__all__ = ("ExceptionHandlerMiddleware", "ExceptionResponseContent", "create_exception_response")
 
 
 def get_exception_handler(exception_handlers: ExceptionHandlersMap, exc: Exception) -> ExceptionHandler | None:
@@ -251,11 +248,6 @@ class ExceptionHandlerMiddleware:
         Returns:
             None.
         """
-
-        headers = Headers.from_scope(scope=scope)
-        if litestar_app.cors_config and (origin := headers.get("origin")):
-            cors_middleware = CORSMiddleware(app=self.app, config=litestar_app.cors_config)
-            send = cors_middleware.send_wrapper(send=send, origin=origin, has_cookie="cookie" in headers)
 
         exception_handler = get_exception_handler(self.exception_handlers, exc) or self.default_http_exception_handler
         request: Request[Any, Any, Any] = litestar_app.request_class(scope=scope, receive=receive, send=send)

--- a/tests/unit/test_middleware/test_cors_middleware.py
+++ b/tests/unit/test_middleware/test_cors_middleware.py
@@ -28,7 +28,7 @@ def test_setting_cors_middleware() -> None:
             cur = cast("Any", cur.app)
         unpacked_middleware.append(cur)
         assert len(unpacked_middleware) == 4
-        cors_middleware = cast("Any", unpacked_middleware[1])
+        cors_middleware = cast("Any", unpacked_middleware[0])
         assert isinstance(cors_middleware, CORSMiddleware)
         assert cors_middleware.config.allow_headers == ["*"]
         assert cors_middleware.config.allow_methods == ["*"]


### PR DESCRIPTION
Remove `ExceptionHandlerMiddleware`'s dependence on `CORSMiddleware` by making `CORSMiddleware` the outermost middleware in the stack if the app has CORS configured.

This makes responses sent via the exception middleware pass through the CORS middleware send wrapper if CORS is configured, which is behaviourally equal to the current behavior of wrapping the `send` coro inside the exception handler middleware with the CORS middleware send wrapper.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
