### PR TITLE
refactor: CORS pre-flight response generated by middleware.

### DIFF
--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -5,15 +5,13 @@ from typing import TYPE_CHECKING, Any, cast
 
 from msgspec.msgpack import decode as _decode_msgpack_plain
 
-from litestar.constants import DEFAULT_ALLOWED_CORS_HEADERS
-from litestar.datastructures.headers import Headers
 from litestar.datastructures.upload_file import UploadFile
 from litestar.enums import HttpMethod, MediaType, ScopeType
 from litestar.exceptions import ClientException, ImproperlyConfiguredException, SerializationException
 from litestar.handlers.http_handlers import HTTPRouteHandler
 from litestar.response import Response
 from litestar.routes.base import BaseRoute
-from litestar.status_codes import HTTP_204_NO_CONTENT, HTTP_400_BAD_REQUEST
+from litestar.status_codes import HTTP_204_NO_CONTENT
 from litestar.types.empty import Empty
 from litestar.utils.scope.state import ScopeState
 
@@ -255,57 +253,6 @@ class HTTPRoute(BaseRoute):
             Returns:
                 Response
             """
-            cors_config = scope["app"].cors_config
-            request_headers = Headers.from_scope(scope=scope)
-            origin = request_headers.get("origin")
-
-            if cors_config and origin:
-                pre_flight_method = request_headers.get("Access-Control-Request-Method")
-                failures = []
-
-                if not cors_config.is_allow_all_methods and (
-                    pre_flight_method and pre_flight_method not in cors_config.allow_methods
-                ):
-                    failures.append("method")
-
-                response_headers = cors_config.preflight_headers.copy()
-
-                if not cors_config.is_origin_allowed(origin):
-                    failures.append("Origin")
-                elif response_headers.get("Access-Control-Allow-Origin") != "*":
-                    response_headers["Access-Control-Allow-Origin"] = origin
-
-                pre_flight_requested_headers = [
-                    header.strip()
-                    for header in request_headers.get("Access-Control-Request-Headers", "").split(",")
-                    if header.strip()
-                ]
-
-                if pre_flight_requested_headers:
-                    if cors_config.is_allow_all_headers:
-                        response_headers["Access-Control-Allow-Headers"] = ", ".join(
-                            sorted(set(pre_flight_requested_headers) | DEFAULT_ALLOWED_CORS_HEADERS)  # pyright: ignore
-                        )
-                    elif any(
-                        header.lower() not in cors_config.allow_headers for header in pre_flight_requested_headers
-                    ):
-                        failures.append("headers")
-
-                return (
-                    Response(
-                        content=f"Disallowed CORS {', '.join(failures)}",
-                        status_code=HTTP_400_BAD_REQUEST,
-                        media_type=MediaType.TEXT,
-                    )
-                    if failures
-                    else Response(
-                        content=None,
-                        status_code=HTTP_204_NO_CONTENT,
-                        media_type=MediaType.TEXT,
-                        headers=response_headers,
-                    )
-                )
-
             return Response(
                 content=None,
                 status_code=HTTP_204_NO_CONTENT,

--- a/tests/e2e/test_cors/test_cors_allowed_headers.py
+++ b/tests/e2e/test_cors/test_cors_allowed_headers.py
@@ -1,0 +1,49 @@
+from litestar import Litestar, get
+from litestar.config.cors import CORSConfig
+from litestar.status_codes import HTTP_204_NO_CONTENT, HTTP_400_BAD_REQUEST
+from litestar.testing import TestClient
+
+
+@get("/headers-test")
+async def headers_handler() -> str:
+    return "Test Successful!"
+
+
+cors_config = CORSConfig(
+    allow_methods=["GET"],
+    allow_origins=["https://allowed-origin.com"],
+    allow_headers=["X-Custom-Header", "Content-Type"],
+)
+app = Litestar(route_handlers=[headers_handler], cors_config=cors_config)
+
+
+def test_cors_with_specific_allowed_headers() -> None:
+    with TestClient(app) as client:
+        response = client.options(
+            "/endpoint",
+            headers={
+                "Origin": "https://allowed-origin.com",
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "X-Custom-Header, Content-Type",
+            },
+        )
+        assert response.status_code == HTTP_204_NO_CONTENT
+        assert "x-custom-header" in response.headers["access-control-allow-headers"]
+        assert "content-type" in response.headers["access-control-allow-headers"]
+
+
+def test_cors_with_unauthorized_headers() -> None:
+    with TestClient(app) as client:
+        response = client.options(
+            "/endpoint",
+            headers={
+                "Origin": "https://allowed-origin.com",
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "X-Not-Allowed-Header",
+            },
+        )
+        assert response.status_code == HTTP_400_BAD_REQUEST
+        assert (
+            "access-control-allow-headers" not in response.headers
+            or "x-not-allowed-header" not in response.headers.get("access-control-allow-headers", "")
+        )

--- a/tests/e2e/test_cors/test_cors_allowed_methods.py
+++ b/tests/e2e/test_cors/test_cors_allowed_methods.py
@@ -1,0 +1,39 @@
+from http import HTTPStatus
+
+from litestar import Litestar, get
+from litestar.config.cors import CORSConfig
+from litestar.testing import TestClient
+
+
+@get("/method-test")
+async def method_handler() -> str:
+    return "Method Test Successful!"
+
+
+cors_config = CORSConfig(allow_methods=["GET", "POST"], allow_origins=["https://allowed-origin.com"])
+app = Litestar(route_handlers=[method_handler], cors_config=cors_config)
+
+
+def test_cors_allowed_methods() -> None:
+    with TestClient(app) as client:
+        response = client.options(
+            "/method-test", headers={"Origin": "https://allowed-origin.com", "Access-Control-Request-Method": "GET"}
+        )
+        assert response.status_code == HTTPStatus.NO_CONTENT
+        assert response.headers["access-control-allow-origin"] == "https://allowed-origin.com"
+        assert "GET" in response.headers["access-control-allow-methods"]
+
+        response = client.options(
+            "/method-test", headers={"Origin": "https://allowed-origin.com", "Access-Control-Request-Method": "POST"}
+        )
+        assert response.status_code == HTTPStatus.NO_CONTENT
+        assert "POST" in response.headers["access-control-allow-methods"]
+
+
+def test_cors_disallowed_methods() -> None:
+    with TestClient(app) as client:
+        response = client.options(
+            "/method-test", headers={"Origin": "https://allowed-origin.com", "Access-Control-Request-Method": "PUT"}
+        )
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert "PUT" not in response.headers.get("access-control-allow-methods", "")

--- a/tests/e2e/test_cors/test_cors_credentials.py
+++ b/tests/e2e/test_cors/test_cors_credentials.py
@@ -1,0 +1,39 @@
+from litestar import Litestar, get
+from litestar.config.cors import CORSConfig
+from litestar.status_codes import HTTP_204_NO_CONTENT
+from litestar.testing import TestClient
+
+
+@get("/credentials-test")
+async def credentials_handler() -> str:
+    return "Test Successful!"
+
+
+def test_cors_with_credentials_allowed() -> None:
+    cors_config = CORSConfig(
+        allow_methods=["GET"], allow_origins=["https://allowed-origin.com"], allow_credentials=True
+    )
+    app = Litestar(route_handlers=[credentials_handler], cors_config=cors_config)
+
+    with TestClient(app) as client:
+        response = client.options(
+            "/endpoint", headers={"Origin": "https://allowed-origin.com", "Access-Control-Request-Method": "GET"}
+        )
+        assert response.status_code == HTTP_204_NO_CONTENT
+        assert response.headers["access-control-allow-credentials"] == "true"
+
+
+def test_cors_with_credentials_disallowed() -> None:
+    cors_config = CORSConfig(
+        allow_methods=["GET"],
+        allow_origins=["https://allowed-origin.com"],
+        allow_credentials=False,  # Credentials should not be allowed
+    )
+    app = Litestar(route_handlers=[credentials_handler], cors_config=cors_config)
+
+    with TestClient(app) as client:
+        response = client.options(
+            "/endpoint", headers={"Origin": "https://allowed-origin.com", "Access-Control-Request-Method": "GET"}
+        )
+        assert response.status_code == HTTP_204_NO_CONTENT
+        assert "access-control-allow-credentials" not in response.headers

--- a/tests/e2e/test_cors/test_cors_for_middleware_exception.py
+++ b/tests/e2e/test_cors/test_cors_for_middleware_exception.py
@@ -1,0 +1,30 @@
+from http import HTTPStatus
+
+from litestar import Litestar, get
+from litestar.config.cors import CORSConfig
+from litestar.exceptions import HTTPException
+from litestar.middleware import AbstractMiddleware
+from litestar.testing import TestClient
+from litestar.types.asgi_types import Receive, Scope, Send
+
+
+class ExceptionMiddleware(AbstractMiddleware):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Intentional Error")
+
+
+@get("/test")
+async def handler() -> str:
+    return "Should not reach this"
+
+
+cors_config = CORSConfig(allow_methods=["GET"], allow_origins=["https://allowed-origin.com"], allow_credentials=True)
+app = Litestar(route_handlers=[handler], cors_config=cors_config, middleware=[ExceptionMiddleware])
+
+
+def test_cors_on_middleware_exception() -> None:
+    with TestClient(app) as client:
+        response = client.get("/test", headers={"Origin": "https://allowed-origin.com"})
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert response.headers["access-control-allow-origin"] == "https://allowed-origin.com"
+        assert response.headers["access-control-allow-credentials"] == "true"

--- a/tests/e2e/test_cors/test_cors_for_mount.py
+++ b/tests/e2e/test_cors/test_cors_for_mount.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
+import pytest
+
+from litestar import Litestar, asgi
+from litestar.config.cors import CORSConfig
+from litestar.enums import ScopeType
+from litestar.testing import TestClient
+from litestar.types.asgi_types import ASGIApp, Receive, Scope, Send
+
+
+@pytest.fixture(name="asgi_mock")
+def asgi_mock_fixture() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture(name="asgi_app")
+def asgi_app_fixture(asgi_mock: MagicMock) -> ASGIApp:
+    async def asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
+        asgi_mock()
+
+        assert scope["type"] == ScopeType.HTTP
+
+        while True:
+            event = await receive()
+            if event["type"] == "http.request" and not event.get("more_body", False):
+                break
+
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    (b"content-type", b"text/plain"),
+                ],
+            }
+        )
+
+        await send(
+            {
+                "type": "http.response.body",
+                "body": b"Hello, world!",
+                "more_body": False,
+            }
+        )
+
+    return asgi_app
+
+
+def test_cors_middleware_for_mount(asgi_app: ASGIApp, asgi_mock: MagicMock) -> None:
+    cors_config = CORSConfig(allow_methods=["*"], allow_origins=["https://some-domain.com"])
+    app = Litestar(
+        cors_config=cors_config,
+        route_handlers=[
+            asgi("/app", is_mount=True)(asgi_app),
+        ],
+        openapi_config=None,
+    )
+
+    with TestClient(app) as client:
+        response = client.options(
+            "http://127.0.0.1:8000/app",
+            headers={"origin": "https://some-domain.com"},
+        )
+        assert response.status_code == HTTPStatus.NO_CONTENT
+        assert response.headers["access-control-allow-origin"] == "https://some-domain.com"
+    asgi_mock.assert_not_called()
+
+
+def test_asgi_app_no_origin_header(asgi_app: ASGIApp, asgi_mock: MagicMock) -> None:
+    cors_config = CORSConfig(allow_methods=["*"], allow_origins=["https://some-domain.com"])
+    app = Litestar(
+        cors_config=cors_config,
+        route_handlers=[
+            asgi("/app", is_mount=True)(asgi_app),
+        ],
+        openapi_config=None,
+    )
+
+    with TestClient(app) as client:
+        response = client.options("http://127.0.0.1/app")
+        assert response.status_code == HTTPStatus.OK
+        assert response.headers["content-type"] == "text/plain"
+        asgi_mock.assert_called()
+
+
+def test_asgi_app_without_cors_configuration(asgi_app: ASGIApp, asgi_mock: MagicMock) -> None:
+    non_cors_app = Litestar(
+        route_handlers=[asgi("/app", is_mount=True)(asgi_app)],
+        openapi_config=None,
+    )
+
+    with TestClient(non_cors_app) as client:
+        response = client.options("http://127.0.0.1:8000/app")
+        assert response.status_code == HTTPStatus.OK
+        assert response.headers["content-type"] == "text/plain"
+        asgi_mock.assert_called()

--- a/tests/e2e/test_cors/test_cors_for_routing_exception.py
+++ b/tests/e2e/test_cors/test_cors_for_routing_exception.py
@@ -1,0 +1,22 @@
+from http import HTTPStatus
+
+from litestar import Litestar, get
+from litestar.config.cors import CORSConfig
+from litestar.testing import TestClient
+
+
+@get("/test")
+async def handler() -> str:
+    return "Should not reach this"
+
+
+cors_config = CORSConfig(allow_methods=["GET"], allow_origins=["https://allowed-origin.com"], allow_credentials=True)
+app = Litestar(route_handlers=[handler], cors_config=cors_config)
+
+
+def test_cors_on_middleware_exception_with_origin_header() -> None:
+    with TestClient(app) as client:
+        response = client.get("/testing", headers={"Origin": "https://allowed-origin.com"})
+        assert response.status_code == HTTPStatus.NOT_FOUND
+        assert response.headers["access-control-allow-origin"] == "https://allowed-origin.com"
+        assert response.headers["access-control-allow-credentials"] == "true"

--- a/tests/e2e/test_cors/test_cors_origins.py
+++ b/tests/e2e/test_cors/test_cors_origins.py
@@ -1,0 +1,42 @@
+from http import HTTPStatus
+
+from litestar import Litestar, get
+from litestar.config.cors import CORSConfig
+from litestar.testing import TestClient
+
+
+@get("/endpoint")
+async def handler() -> str:
+    return "Hello, world!"
+
+
+cors_config = CORSConfig(
+    allow_methods=["GET"], allow_origins=["https://allowed-origin.com", "https://another-allowed-origin.com"]
+)
+app = Litestar(route_handlers=[handler], cors_config=cors_config)
+
+
+def test_cors_with_allowed_origins() -> None:
+    with TestClient(app) as client:
+        response = client.options(
+            "/custom-options", headers={"Origin": "https://allowed-origin.com", "Access-Control-Request-Method": "GET"}
+        )
+        assert response.status_code == HTTPStatus.NO_CONTENT
+        assert response.headers["access-control-allow-origin"] == "https://allowed-origin.com"
+
+        response = client.options(
+            "/custom-options",
+            headers={"Origin": "https://another-allowed-origin.com", "Access-Control-Request-Method": "GET"},
+        )
+        assert response.status_code == HTTPStatus.NO_CONTENT
+        assert response.headers["access-control-allow-origin"] == "https://another-allowed-origin.com"
+
+
+def test_cors_with_disallowed_origin() -> None:
+    with TestClient(app) as client:
+        response = client.options(
+            "/custom-options",
+            headers={"Origin": "https://disallowed-origin.com", "Access-Control-Request-Method": "GET"},
+        )
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert "access-control-allow-origin" not in response.headers

--- a/tests/e2e/test_cors/test_custom_options_handlers.py
+++ b/tests/e2e/test_cors/test_custom_options_handlers.py
@@ -1,0 +1,38 @@
+from http import HTTPStatus
+
+from litestar import Litestar, route
+from litestar.config.cors import CORSConfig
+from litestar.enums import HttpMethod
+from litestar.response import Response
+from litestar.testing import TestClient
+
+
+@route("/custom-options", http_method=HttpMethod.OPTIONS)
+async def custom_options_handler() -> Response[str]:
+    return Response(
+        status_code=200,
+        headers={"Custom-Handler": "Active"},
+        content="Handled by Custom Options",
+    )
+
+
+cors_config = CORSConfig(allow_methods=["GET", "OPTIONS"], allow_origins=["https://allowed-origin.com"])
+app = Litestar(route_handlers=[custom_options_handler], cors_config=cors_config)
+
+
+def test_custom_options_handler_cors_pre_flight_request() -> None:
+    with TestClient(app) as client:
+        response = client.options(
+            "/custom-options", headers={"Origin": "https://allowed-origin.com", "Access-Control-Request-Method": "GET"}
+        )
+        assert response.status_code == HTTPStatus.NO_CONTENT
+        assert "access-control-allow-origin" in response.headers
+        assert "Custom-Handler" not in response.headers
+
+
+def test_custom_options_handler_non_cors_request() -> None:
+    with TestClient(app) as client:
+        response = client.options("/custom-options")
+        assert response.status_code == 200
+        assert response.headers.get("Custom-Handler") == "Active"
+        assert response.text == "Handled by Custom Options"

--- a/tests/e2e/test_cors/test_non_cors_options.py
+++ b/tests/e2e/test_cors/test_non_cors_options.py
@@ -1,0 +1,33 @@
+from litestar import Litestar, get
+from litestar.config.cors import CORSConfig
+from litestar.status_codes import HTTP_204_NO_CONTENT
+from litestar.testing import TestClient
+
+
+@get("/handler")
+async def handler() -> str:
+    return "Handler"
+
+
+def test_non_cors_options_request_no_origin_header() -> None:
+    cors_config = CORSConfig(
+        allow_methods=["PUT"],
+        allow_origins=["https://specific-domain.com"],
+    )
+    app = Litestar(route_handlers=[handler], cors_config=cors_config)
+
+    with TestClient(app) as client:
+        # Request without an 'Origin' header
+        response = client.options("/handler")
+        assert response.status_code == HTTP_204_NO_CONTENT
+        assert response.headers["allow"] == "GET, OPTIONS"
+
+
+def test_non_cors_options_no_config() -> None:
+    app = Litestar(route_handlers=[handler])
+
+    with TestClient(app) as client:
+        # Request with an origin that does not require CORS handling
+        response = client.options("/handler", headers={"Origin": "https://not-configured-origin.com"})
+        assert response.status_code == HTTP_204_NO_CONTENT
+        assert response.headers["allow"] == "GET, OPTIONS"


### PR DESCRIPTION
Move pre-flight response generation from the generated OPTIONS handlers to the CORS middleware.

Fixes case where pre-flight response not applied to mounted ASGI apps.

Fixes the case where a user defined OPTIONS handler may not include CORS logic. In fact, this is they only way we can be sure that we honor CORS pre-flight if the config object is provided.

Adds a stack of CORS e2e tests.

Closes #3402 

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
