### PR TITLE
fix: multiple file uploads for optional handler data

### DIFF
--- a/litestar/_kwargs/extractors.py
+++ b/litestar/_kwargs/extractors.py
@@ -348,7 +348,15 @@ async def _extract_multipart(
 
     if field_definition.is_non_string_sequence:
         values = list(form_values.values())
-        if field_definition.has_inner_subclass_of(UploadFile) and isinstance(values[0], list):
+        if (
+            values
+            and isinstance(values[0], list)
+            and (
+                field_definition.has_inner_subclass_of(UploadFile)
+                or field_definition.is_optional
+                and any(fd.has_inner_subclass_of(UploadFile) for fd in field_definition.inner_types)
+            )
+        ):
             return values[0]
 
         return values


### PR DESCRIPTION
This PR fixes the case where multiple files are uploaded to a handler's `data` parameter with the type `Optional[List[FormData]]`.

Closes #3409

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
