### PR TITLE
fix: top-level import of optional package

### DIFF
--- a/litestar/plugins/flash.py
+++ b/litestar/plugins/flash.py
@@ -1,15 +1,21 @@
 """Plugin for creating and retrieving flash messages."""
 
-from dataclasses import dataclass
-from typing import Any, Mapping
+from __future__ import annotations
 
-from litestar.config.app import AppConfig
-from litestar.connection import ASGIConnection
-from litestar.contrib.minijinja import MiniJinjaTemplateEngine
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Mapping
+
+from litestar.exceptions import MissingDependencyException
 from litestar.plugins import InitPluginProtocol
-from litestar.template import TemplateConfig
 from litestar.template.base import _get_request_from_context
 from litestar.utils.scope.state import ScopeState
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from litestar.config.app import AppConfig
+    from litestar.connection import ASGIConnection
+    from litestar.template import TemplateConfig
 
 
 @dataclass
@@ -39,14 +45,18 @@ class FlashPlugin(InitPluginProtocol):
         Returns:
             The application configuration with the message callable registered.
         """
-        if isinstance(self.config.template_config.engine_instance, MiniJinjaTemplateEngine):
-            from litestar.contrib.minijinja import _transform_state
-
-            self.config.template_config.engine_instance.register_template_callable(
-                "get_flashes", _transform_state(get_flashes)
-            )
+        template_callable: Callable[[Any], Any]
+        try:
+            from litestar.contrib.minijinja import MiniJinjaTemplateEngine, _transform_state
+        except MissingDependencyException:  # pragma: no cover
+            template_callable = get_flashes
         else:
-            self.config.template_config.engine_instance.register_template_callable("get_flashes", get_flashes)
+            if isinstance(self.config.template_config.engine_instance, MiniJinjaTemplateEngine):
+                template_callable = _transform_state(get_flashes)
+            else:
+                template_callable = get_flashes
+
+        self.config.template_config.engine_instance.register_template_callable("get_flashes", template_callable)  # pyright: ignore[reportGeneralTypeIssues]
         return app_config
 
 


### PR DESCRIPTION
Fix import from `contrib.minijinja` without handling for case where dependency is not installed.

Closes #3415

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
