### PR TITLE
refactor: use contextlib.suppress

### DIFF
--- a/litestar/plugins/flash.py
+++ b/litestar/plugins/flash.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Mapping
 
@@ -45,16 +46,12 @@ class FlashPlugin(InitPluginProtocol):
         Returns:
             The application configuration with the message callable registered.
         """
-        template_callable: Callable[[Any], Any]
-        try:
+        template_callable: Callable[[Any], Any] = get_flashes
+        with suppress(MissingDependencyException):
             from litestar.contrib.minijinja import MiniJinjaTemplateEngine, _transform_state
-        except MissingDependencyException:  # pragma: no cover
-            template_callable = get_flashes
-        else:
+
             if isinstance(self.config.template_config.engine_instance, MiniJinjaTemplateEngine):
                 template_callable = _transform_state(get_flashes)
-            else:
-                template_callable = get_flashes
 
         self.config.template_config.engine_instance.register_template_callable("get_flashes", template_callable)  # pyright: ignore[reportGeneralTypeIssues]
         return app_config


### PR DESCRIPTION
Minor refactor that replaces a `try...except...else` with `context.suppress` so that is better in line with certain places where `MissingDependencyException`s are handled. Feel free to close if it's redundant / less impactful. 🙂 