### PR TITLE
fix: regular handler under mounted app

### DIFF
--- a/litestar/_asgi/routing_trie/traversal.py
+++ b/litestar/_asgi/routing_trie/traversal.py
@@ -142,7 +142,11 @@ def parse_path_to_route(
             remaining_path = path[match.end() :]
             # since we allow regular handlers under static paths, we must validate that the request does not match
             # any such handler.
-            children = (normalize_path(sub_route) for sub_route in mount_node.children or [] if sub_route != mount_path)
+            children = (
+                normalize_path(sub_route)
+                for sub_route in mount_node.children or []
+                if sub_route != mount_path and isinstance(sub_route, str)
+            )
             if not any(remaining_path.startswith(f"{sub_route}/") for sub_route in children):
                 asgi_app, handler = parse_node_handlers(node=mount_node, method=method)
                 remaining_path = remaining_path or "/"

--- a/litestar/_asgi/routing_trie/traversal.py
+++ b/litestar/_asgi/routing_trie/traversal.py
@@ -142,8 +142,8 @@ def parse_path_to_route(
             remaining_path = path[match.end() :]
             # since we allow regular handlers under static paths, we must validate that the request does not match
             # any such handler.
-            children = [sub_route for sub_route in mount_node.children or [] if sub_route != mount_path]
-            if not children or all(sub_route not in path for sub_route in children):  # type: ignore[operator]
+            children = (normalize_path(sub_route) for sub_route in mount_node.children or [] if sub_route != mount_path)
+            if not any(remaining_path.startswith(f"{sub_route}/") for sub_route in children):
                 asgi_app, handler = parse_node_handlers(node=mount_node, method=method)
                 remaining_path = remaining_path or "/"
                 if not mount_node.is_static:

--- a/tests/e2e/test_regular_handler_under_asgi_mount_path.py
+++ b/tests/e2e/test_regular_handler_under_asgi_mount_path.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from litestar import Litestar, asgi, get
+from litestar.testing import TestClient
+
+if TYPE_CHECKING:
+    from litestar.types.asgi_types import Receive, Scope, Send
+
+
+async def asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
+    assert scope["type"] == "http"
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [
+                (b"content-type", b"text/plain"),
+                (b"content-length", b"%d" % len(scope["raw_path"])),
+            ],
+        }
+    )
+    await send(
+        {
+            "type": "http.response.body",
+            "body": scope["raw_path"],
+        }
+    )
+
+
+asgi_handler = asgi("/", is_mount=True)(asgi_app)
+
+
+@get("/path")
+async def get_handler() -> str:
+    return "Hello, world!"
+
+
+def test_regular_handler_under_mounted_asgi_app() -> None:
+    app = Litestar(
+        route_handlers=[asgi("/", is_mount=True)(asgi_app), get_handler],
+        openapi_config=None,
+        debug=True,
+    )
+
+    with TestClient(app) as client:
+        resp = client.get("/some/path")
+        assert resp.content == b"/some/path"

--- a/tests/e2e/test_regular_handler_under_asgi_mount_path.py
+++ b/tests/e2e/test_regular_handler_under_asgi_mount_path.py
@@ -37,13 +37,15 @@ async def get_handler() -> str:
     return "Hello, world!"
 
 
-def test_regular_handler_under_mounted_asgi_app() -> None:
-    app = Litestar(
-        route_handlers=[asgi("/", is_mount=True)(asgi_app), get_handler],
-        openapi_config=None,
-        debug=True,
-    )
+app = Litestar(
+    route_handlers=[asgi_handler, get_handler],
+    openapi_config=None,
+    debug=True,
+)
 
+
+def test_regular_handler_under_mounted_asgi_app() -> None:
+    # https://github.com/litestar-org/litestar/issues/3429
     with TestClient(app) as client:
         resp = client.get("/some/path")
         assert resp.content == b"/some/path"

--- a/tests/e2e/test_regular_handler_under_asgi_mount_path.py
+++ b/tests/e2e/test_regular_handler_under_asgi_mount_path.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from litestar import Litestar, asgi, get
+from litestar.enums import ScopeType
 from litestar.testing import TestClient
 
 if TYPE_CHECKING:
@@ -10,7 +11,7 @@ if TYPE_CHECKING:
 
 
 async def asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
-    assert scope["type"] == "http"
+    assert scope["type"] == ScopeType.HTTP
     await send(
         {
             "type": "http.response.start",
@@ -25,6 +26,7 @@ async def asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
         {
             "type": "http.response.body",
             "body": scope["raw_path"],
+            "more_body": False,
         }
     )
 


### PR DESCRIPTION
Fix an issue where a regular handler under a mounted asgi app would prevent a request from routing through the mounted application if the request path contained the path of the regular handler as a substring.

Closes #3429

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
