### PR TITLE
fix(pydantic v1): field not optional if default value

### DIFF
--- a/litestar/contrib/pydantic/pydantic_schema_plugin.py
+++ b/litestar/contrib/pydantic/pydantic_schema_plugin.py
@@ -286,7 +286,8 @@ class PydanticSchemaPlugin(OpenAPISchemaPlugin):
         else:
             # pydantic v1 requires some workarounds here
             model_annotations = {
-                k: f.outer_type_ if f.required else Optional[f.outer_type_] for k, f in model.__fields__.items()
+                k: f.outer_type_ if f.required or f.default else Optional[f.outer_type_]
+                for k, f in model.__fields__.items()
             }
 
         if is_generic_model:

--- a/tests/e2e/test_pydantic.py
+++ b/tests/e2e/test_pydantic.py
@@ -1,6 +1,7 @@
 import pydantic
+from pydantic import v1 as pydantic_v1
 
-from litestar import get
+from litestar import get, post
 from litestar.testing import create_test_client
 
 
@@ -22,3 +23,80 @@ def test_app_with_v1_and_v2_models() -> None:
     with create_test_client([handler_v1, handler_v2]) as client:
         assert client.get("/v1").json() == {"foo": "bar"}
         assert client.get("/v2").json() == {"foo": "bar"}
+
+
+def test_pydantic_v1_model_with_field_default() -> None:
+    # https://github.com/litestar-org/litestar/issues/3471
+
+    class TestDto(pydantic_v1.BaseModel):
+        test_str: str = pydantic_v1.Field(default="some_default", max_length=100)
+
+    @post(path="/test")
+    async def test(data: TestDto) -> str:
+        return "success"
+
+    with create_test_client(route_handlers=[test]) as client:
+        response = client.get("/schema/openapi.json")
+        assert response.status_code == 200
+        assert response.json() == {
+            "components": {
+                "schemas": {
+                    "test_pydantic_v1_model_with_field_default.TestDto": {
+                        "properties": {"test_str": {"default": "some_default", "maxLength": 100, "type": "string"}},
+                        "required": [],
+                        "title": "TestDto",
+                        "type": "object",
+                    }
+                }
+            },
+            "info": {"title": "Litestar API", "version": "1.0.0"},
+            "openapi": "3.1.0",
+            "paths": {
+                "/test": {
+                    "post": {
+                        "deprecated": False,
+                        "operationId": "TestTest",
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/test_pydantic_v1_model_with_field_default.TestDto"
+                                    }
+                                }
+                            },
+                            "required": True,
+                        },
+                        "responses": {
+                            "201": {
+                                "content": {"text/plain": {"schema": {"type": "string"}}},
+                                "description": "Document " "created, " "URL " "follows",
+                                "headers": {},
+                            },
+                            "400": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "description": "Validation " "Exception",
+                                            "examples": [{"detail": "Bad " "Request", "extra": {}, "status_code": 400}],
+                                            "properties": {
+                                                "detail": {"type": "string"},
+                                                "extra": {
+                                                    "additionalProperties": {},
+                                                    "type": ["null", "object", "array"],
+                                                },
+                                                "status_code": {"type": "integer"},
+                                            },
+                                            "required": ["detail", "status_code"],
+                                            "type": "object",
+                                        }
+                                    }
+                                },
+                                "description": "Bad " "request " "syntax or " "unsupported " "method",
+                            },
+                        },
+                        "summary": "Test",
+                    }
+                }
+            },
+            "servers": [{"url": "/"}],
+        }


### PR DESCRIPTION
Fix issue where a pydantic v1 field annotation is wrapped with `Optional` if it is marked not required, but has a default value.

Closes #3471

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
