### PR TITLE
fix: logging middleware with multi-body response

### DIFF
--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -191,8 +191,8 @@ class LoggingMiddleware(AbstractMiddleware):
         connection_state = ScopeState.from_scope(scope)
         extracted_data = self.response_extractor(
             messages=(
-                connection_state.log_context.pop(HTTP_RESPONSE_START),
-                connection_state.log_context.pop(HTTP_RESPONSE_BODY),
+                connection_state.log_context[HTTP_RESPONSE_START],
+                connection_state.log_context[HTTP_RESPONSE_BODY],
             ),
         )
         response_body_compressed = value_or_default(connection_state.response_compressed, False)

--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -191,8 +191,10 @@ class LoggingMiddleware(AbstractMiddleware):
         connection_state = ScopeState.from_scope(scope)
         extracted_data = self.response_extractor(
             messages=(
+                # NOTE: we don't pop the start message from the logging context in case
+                #   there are multiple body messages to be logged
                 connection_state.log_context[HTTP_RESPONSE_START],
-                connection_state.log_context[HTTP_RESPONSE_BODY],
+                connection_state.log_context.pop(HTTP_RESPONSE_BODY),
             ),
         )
         response_body_compressed = value_or_default(connection_state.response_compressed, False)
@@ -224,6 +226,10 @@ class LoggingMiddleware(AbstractMiddleware):
             elif message["type"] == HTTP_RESPONSE_BODY:
                 connection_state.log_context[HTTP_RESPONSE_BODY] = message
                 self.log_response(scope=scope)
+
+                if not message["more_body"]:
+                    connection_state.log_context.clear()
+
             await send(message)
 
         return send_wrapper

--- a/tests/e2e/test_middleware/test_logging_middleware_with_multi_body_response.py
+++ b/tests/e2e/test_middleware/test_logging_middleware_with_multi_body_response.py
@@ -1,0 +1,30 @@
+from litestar import asgi
+from litestar.middleware.logging import LoggingMiddlewareConfig
+from litestar.testing import create_async_test_client
+from litestar.types.asgi_types import Receive, Scope, Send
+
+
+@asgi("/")
+async def asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [
+                (b"content-type", b"text/event-stream"),
+                (b"cache-control", b"no-cache"),
+                (b"connection", b"keep-alive"),
+            ],
+        }
+    )
+
+    # send two bodies
+    await send({"type": "http.response.body", "body": b"data: 1\n", "more_body": True})
+    await send({"type": "http.response.body", "body": b"data: 2\n", "more_body": False})
+
+
+async def test_app() -> None:
+    async with create_async_test_client(asgi_app, middleware=[LoggingMiddlewareConfig().middleware]) as client:
+        response = await client.get("/")
+        assert response.status_code == 200
+        assert response.text == "data: 1\ndata: 2\n"


### PR DESCRIPTION
Prevent logging middleware from failing with a KeyError when a response sends multiple "http.response.body" messages.

Closes #3477

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
