### PR TITLE
fix(tests): windows compat error

### DIFF
--- a/tests/unit/test_static_files/test_static_files_validation.py
+++ b/tests/unit/test_static_files/test_static_files_validation.py
@@ -1,5 +1,5 @@
 import asyncio
-from pathlib import Path, PosixPath
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, List, cast
 
 import pytest
@@ -146,6 +146,6 @@ def test_config_validation_of_path_prevents_directory_traversal(tmpdir: "Path") 
     coroutine = static_files_handler.get_fs_info(directories=static_files_handler.directories, file_path=string_path)
     resolved_path, fs_info = asyncio.run(coroutine)
 
-    expected_resolved_path = PosixPath(str(tmpdir / "test.txt"))
+    expected_resolved_path = tmpdir / "test.txt"
     assert resolved_path == expected_resolved_path  # Because the resolved path is inside the static directory
     assert fs_info is not None  # Because the file exists, so there is info


### PR DESCRIPTION
A test was directly using `PosixPath`, changed to `Path`.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
