### PR TITLE
fix(dto): handle dto type nested in mapping

### DIFF
--- a/litestar/dto/_backend.py
+++ b/litestar/dto/_backend.py
@@ -701,6 +701,24 @@ def _transfer_type_data(
             )
 
         return transfer_type.field_definition.instantiable_origin(source_value)
+
+    if isinstance(transfer_type, MappingType):
+        if transfer_type.has_nested:
+            return transfer_type.field_definition.instantiable_origin(
+                (
+                    key,
+                    _transfer_type_data(
+                        source_value=value,
+                        transfer_type=transfer_type.value_type,
+                        nested_as_dict=False,
+                        is_data_field=is_data_field,
+                    ),
+                )
+                for key, value in source_value.items()
+            )
+
+        return transfer_type.field_definition.instantiable_origin(source_value)
+
     return source_value
 
 

--- a/litestar/dto/_codegen_backend.py
+++ b/litestar/dto/_codegen_backend.py
@@ -24,6 +24,7 @@ from litestar.dto._backend import DTOBackend
 from litestar.dto._types import (
     CollectionType,
     CompositeType,
+    MappingType,
     SimpleType,
     TransferDTOFieldDefinition,
     TransferType,
@@ -500,6 +501,21 @@ class TransferFunctionFactory:
                 transfer_type_data_name = self._add_to_fn_globals("transfer_type_data", transfer_type_data_fn)
                 self._add_stmt(
                     f"{assignment_target} = {origin_name}({transfer_type_data_name}(item) for item in {source_value_name})"
+                )
+                return
+
+            self._add_stmt(f"{assignment_target} = {origin_name}({source_value_name})")
+            return
+
+        if isinstance(transfer_type, MappingType):
+            origin_name = self._add_to_fn_globals("origin", transfer_type.field_definition.instantiable_origin)
+            if transfer_type.has_nested:
+                transfer_type_data_fn = TransferFunctionFactory.create_transfer_type_data(
+                    is_data_field=self.is_data_field, transfer_type=transfer_type.value_type
+                )
+                transfer_type_data_name = self._add_to_fn_globals("transfer_type_data", transfer_type_data_fn)
+                self._add_stmt(
+                    f"{assignment_target} = {origin_name}((key, {transfer_type_data_name}(item)) for key, item in {source_value_name}.items())"
                 )
                 return
 


### PR DESCRIPTION
Added handling for transferring data from a transfer model, to a DTO supported instance when the DTO supported type is nested in a mapping.

I.e, handles this case:

```py
@dataclass
class NestedDC:
    a: int
    b: str

@dataclass
class DC:
    nested_mapping: Dict[str, NestedDC]
```

Closes #3463

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
