### PR TITLE
fix(logging): do not log exceptions twice, deprecate `traceback_line_limit` and fix `pretty_print_tty`

### DIFF
--- a/litestar/logging/config.py
+++ b/litestar/logging/config.py
@@ -430,9 +430,9 @@ class StructLoggingConfig(BaseLoggingConfig):
 
     def __post_init__(self) -> None:
         if self.processors is None:
-            self.processors = default_structlog_processors(not sys.stderr.isatty() and self.pretty_print_tty)
+            self.processors = default_structlog_processors(as_json=self.as_json())
         if self.logger_factory is None:
-            self.logger_factory = default_logger_factory(not sys.stderr.isatty() and self.pretty_print_tty)
+            self.logger_factory = default_logger_factory(as_json=self.as_json())
         if self.log_exceptions != "never" and self.exception_logging_handler is None:
             self.exception_logging_handler = _default_exception_logging_handler_factory(
                 is_struct_logger=True, traceback_line_limit=self.traceback_line_limit
@@ -445,14 +445,15 @@ class StructLoggingConfig(BaseLoggingConfig):
                     formatters={
                         "standard": {
                             "()": structlog.stdlib.ProcessorFormatter,
-                            "processors": default_structlog_standard_lib_processors(
-                                as_json=not sys.stderr.isatty() and self.pretty_print_tty
-                            ),
+                            "processors": default_structlog_standard_lib_processors(as_json=self.as_json()),
                         }
                     }
                 )
         except ImportError:
             self.standard_lib_logging_config = LoggingConfig()
+
+    def as_json(self) -> bool:
+        return not (sys.stderr.isatty() and self.pretty_print_tty)
 
     def configure(self) -> GetLogger:
         """Return logger with the given configuration.

--- a/tests/unit/test_logging/test_logging_config.py
+++ b/tests/unit/test_logging/test_logging_config.py
@@ -219,3 +219,16 @@ def test_customizing_handler(handlers: Any, expected_handler_class: Any, monkeyp
     else:
         formatter = root_logger_handler.formatter
     assert formatter._fmt == log_format
+
+
+@pytest.mark.parametrize(
+    "traceback_line_limit, expected_warning_deprecation_called",
+    [
+        [-1, False],
+        [20, True],
+    ],
+)
+def test_traceback_line_limit_deprecation(traceback_line_limit: int, expected_warning_deprecation_called: bool) -> None:
+    with patch("litestar.logging.config.warn_deprecation") as mock_warning_deprecation:
+        LoggingConfig(traceback_line_limit=traceback_line_limit)
+        assert mock_warning_deprecation.called is expected_warning_deprecation_called

--- a/tests/unit/test_logging/test_structlog_config.py
+++ b/tests/unit/test_logging/test_structlog_config.py
@@ -1,6 +1,7 @@
 import datetime
 import sys
 from typing import Callable
+from unittest.mock import patch
 
 import pytest
 import structlog
@@ -155,3 +156,19 @@ def test_structlog_config_specify_processors(capsys: CaptureFixture) -> None:
             {"key": "value1", "event": "message1"},
             {"key": "value2", "event": "message2"},
         ]
+
+
+@pytest.mark.parametrize(
+    "isatty, pretty_print_tty, expected_as_json",
+    [
+        (True, True, False),
+        (True, False, True),
+        (False, True, True),
+        (False, False, True),
+    ],
+)
+def test_structlog_config_as_json(isatty: bool, pretty_print_tty: bool, expected_as_json: bool) -> None:
+    with patch("litestar.logging.config.sys.stderr.isatty") as isatty_mock:
+        isatty_mock.return_value = isatty
+        logging_config = StructLoggingConfig(pretty_print_tty=pretty_print_tty)
+        assert logging_config.as_json() is expected_as_json

--- a/tests/unit/test_middleware/test_exception_handler_middleware.py
+++ b/tests/unit/test_middleware/test_exception_handler_middleware.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Callable, Generator, Optional
 from unittest.mock import MagicMock
 
 import pytest
-from _pytest.capture import CaptureFixture
 from pytest_mock import MockerFixture
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from structlog.testing import capture_logs
@@ -205,12 +204,10 @@ def test_exception_handler_default_logging(
         if should_log:
             assert len(caplog.records) == 1
             assert caplog.records[0].levelname == "ERROR"
-            assert caplog.records[0].message.startswith(
-                "exception raised on http connection to route /test\n\nTraceback (most recent call last):\n"
-            )
+            assert caplog.records[0].message.startswith("Uncaught exception (connection_type=http, path=/test):")
         else:
             assert not caplog.records
-            assert "exception raised on http connection request to route /test" not in response.text
+            assert "Uncaught exception" not in response.text
 
 
 @pytest.mark.parametrize(
@@ -228,7 +225,6 @@ def test_exception_handler_default_logging(
 )
 def test_exception_handler_struct_logging(
     get_logger: "GetLogger",
-    capsys: CaptureFixture,
     is_debug: bool,
     logging_config: Optional[LoggingConfig],
     should_log: bool,
@@ -251,48 +247,10 @@ def test_exception_handler_struct_logging(
             assert len(cap_logs) == 1
             assert cap_logs[0].get("connection_type") == "http"
             assert cap_logs[0].get("path") == "/test"
-            assert cap_logs[0].get("traceback")
-            assert cap_logs[0].get("event") == "Uncaught Exception"
+            assert cap_logs[0].get("event") == "Uncaught exception"
             assert cap_logs[0].get("log_level") == "error"
         else:
             assert not cap_logs
-
-
-def test_traceback_truncate_default_logging(
-    get_logger: "GetLogger",
-    caplog: "LogCaptureFixture",
-) -> None:
-    @get("/test")
-    def handler() -> None:
-        raise ValueError("Test debug exception")
-
-    app = Litestar([handler], logging_config=LoggingConfig(log_exceptions="always", traceback_line_limit=1))
-
-    with caplog.at_level("ERROR", "litestar"), TestClient(app=app) as client:
-        client.app.logger = get_logger("litestar")
-        response = client.get("/test")
-        assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
-        assert "Internal Server Error" in response.text
-
-        assert len(caplog.records) == 1
-        assert caplog.records[0].levelname == "ERROR"
-        assert caplog.records[0].message == (
-            "exception raised on http connection to route /test\n\nTraceback (most recent call last):\nValueError: Test debug exception\n"
-        )
-
-
-def test_traceback_truncate_struct_logging() -> None:
-    @get("/test")
-    def handler() -> None:
-        raise ValueError("Test debug exception")
-
-    app = Litestar([handler], logging_config=StructLoggingConfig(log_exceptions="always", traceback_line_limit=1))
-
-    with TestClient(app=app) as client, capture_logs() as cap_logs:
-        response = client.get("/test")
-        assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
-        assert len(cap_logs) == 1
-        assert cap_logs[0].get("traceback") == "ValueError: Test debug exception\n"
 
 
 def handler(_: Any, __: Any) -> Any:
@@ -358,9 +316,7 @@ def test_get_debug_from_scope(get_logger: "GetLogger", caplog: "LogCaptureFixtur
         assert "Test debug exception" in response.text
         assert len(caplog.records) == 1
         assert caplog.records[0].levelname == "ERROR"
-        assert caplog.records[0].message.startswith(
-            "exception raised on http connection to route /test\n\nTraceback (most recent call last):\n"
-        )
+        assert caplog.records[0].message.startswith("Uncaught exception (connection_type=http, path=/test):")
 
 
 def test_get_symbol_name_where_type_doesnt_support_bool() -> None:


### PR DESCRIPTION
## Description

Currently we're logging the exceptions twice: the full one and a truncated one.
This PR tries to improve this, ~~which implies small breaking changes~~.

~~Almost finished but still a WIP, I need some feedback please!~~

Outlines:

* The wording of the log message, when logging an exception, has been updated.
* For structlog, the `traceback` field in the log message (which contained a truncated stacktrace) has been removed. The `exception` field is still around and contains the full stacktrace.
* The option `traceback_line_limit` has been deprecated. The value is now ignored, the full stacktrace will be logged.

### Summary

⚠️ The former code has been introduced to solve #1294, unfortunately I haven't been able to reproduce the issue. It's not clear in which cases it happened, or if the PR (#1296) fixed the original issue (I don't think so because exception are logged twice in the end).
❓ **TODO** Anyway, to solve the original issue (#1294), truncating the request's body would have been a better solution. I'd be happy to dig a little bit more here. Any idea about how to reproduce the issue? (I already tried to write a test with a file upload, but the request's body doesn't get printed)
⚠️ ~~Type `ExceptionLoggingHandler` and signature of `handle_exception_logging()` get updated by this PR, seems better and more flexible this way.~~

#### Logging
~~✅ Behavior is still the same, just slightly changed how we count the lines to display (see the code and the test `test_traceback_truncate_default_logging`).~~
~~✅ Ability to set `traceback_line_limit` to `None`.~~
~~⚠️ Default value for `traceback_line_limit` is `None`~~, I don't think we should truncate stacktraces by default.
❓ → ✅ Maybe we could deprecate `traceback_line_limit` to keep things in sync with Structlog. And if it's really something wanted by users, they can bring it back easily via a custom `exception_logging_handler`.
ℹ️ Updated log messages to get something similar to structlog.

#### StructLog
✅ Fixed a bug with `pretty_print_tty` (as a separated commit).
✅ When `pretty_print_tty=True`, we don't log the stacktrace twice and the remaining one gets truncated automatically by structlog (see below).
✅ When `pretty_print_tty=False`, exception gets logged as json. Previously it was logged in 2 separate fields (`exception` contains the full stacktrace & `traceback` a truncated version). This PR removes `traceback`. It will reduce the log size. It's still possible to parse the JSON after, with some tools, to limit the lines displayed.
❓ → ✅ If it's fine on your side, can I mark `traceback_line_limit` as deprecated and document it?

#### Extras
⚠️ Note: A few tests use `structlog.testing.capture_logs`. When using it to capture the `logging.exception()` output, the traceback is not yet rendered. That's something to keep in mind.
❓ What about turning `log_exceptions` to `always` by default? (Hiding errors by default seems a bad choice according to my sysadmin background).

###  Structlog: before & after

#### With `pretty_print_tty=False`

Before, both `traceback` and `exception` were logged:
```
{
  "connection_type": "http",
  "path": "/test",
  "traceback": "  File \"/Users/jderrien/projects/litestar/litestar/middleware/_internal/exceptions/middleware.py\", line 158, in __call__\n    await self.app(scope, receive, capture_response_started)\n  File \"/Users/jderrien/projects/litestar/litestar/_asgi/asgi_router.py\", line 99, in __call__\n    await asgi_app(scope, receive, send)\n  File \"/Users/jderrien/projects/litestar/litestar/routes/http.py\", line 80, in handle\n    response = await self._get_response_for_request(\n               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/jderrien/projects/litestar/litestar/routes/http.py\", line 132, in _get_response_for_request\n    return await self._call_handler_function(\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/jderrien/projects/litestar/litestar/routes/http.py\", line 152, in _call_handler_function\n    response_data, cleanup_group = await self._get_response_data(\n                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/jderrien/projects/litestar/litestar/routes/http.py\", line 203, in _get_response_data\n    data = route_handler.fn(**parsed_kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/jderrien/projects/litestar/tests/unit/test_middleware/test_exception_handler_middleware.py\", line 299, in handler\n    raise ValueError(\"Test debug exception\")\nValueError: Test debug exception\n",
  "event": "Uncaught Exception",
  "level": "error",
  "exception": "Traceback (most recent call last):\n  File \"/Users/jderrien/projects/litestar/litestar/middleware/_internal/exceptions/middleware.py\", line 158, in __call__\n    await self.app(scope, receive, capture_response_started)\n  File \"/Users/jderrien/projects/litestar/litestar/_asgi/asgi_router.py\", line 99, in __call__\n    await asgi_app(scope, receive, send)\n  File \"/Users/jderrien/projects/litestar/litestar/routes/http.py\", line 80, in handle\n    response = await self._get_response_for_request(\n               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/jderrien/projects/litestar/litestar/routes/http.py\", line 132, in _get_response_for_request\n    return await self._call_handler_function(\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/jderrien/projects/litestar/litestar/routes/http.py\", line 152, in _call_handler_function\n    response_data, cleanup_group = await self._get_response_data(\n                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/jderrien/projects/litestar/litestar/routes/http.py\", line 203, in _get_response_data\n    data = route_handler.fn(**parsed_kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/jderrien/projects/litestar/tests/unit/test_middleware/test_exception_handler_middleware.py\", line 299, in handler\n    raise ValueError(\"Test debug exception\")\nValueError: Test debug exception",
  "timestamp": "2024-05-16T22:07:01.991184Z"
}
```

After, we only log `exception` and the global size is reduced:
```
{
  "connection_type": "http",
  "path": "/test",
  "event": "Uncaught exception",
  "level": "error",
  "exception": "Traceback (most recent call last):\n  File \"/Users/jderrien/projects/litestar/litestar/middleware/_internal/exceptions/middleware.py\", line 156, in __call__\n    await self.app(scope, receive, capture_response_started)\n  File \"/Users/jderrien/projects/litestar/litestar/_asgi/asgi_router.py\", line 99, in __call__\n    await asgi_app(scope, receive, send)\n  File \"/Users/jderrien/projects/litestar/litestar/routes/http.py\", line 80, in handle\n    response = await self._get_response_for_request(\n               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/jderrien/projects/litestar/litestar/routes/http.py\", line 132, in _get_response_for_request\n    return await self._call_handler_function(\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/jderrien/projects/litestar/litestar/routes/http.py\", line 152, in _call_handler_function\n    response_data, cleanup_group = await self._get_response_data(\n                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/jderrien/projects/litestar/litestar/routes/http.py\", line 203, in _get_response_data\n    data = route_handler.fn(**parsed_kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/jderrien/projects/litestar/tests/unit/test_middleware/test_exception_handler_middleware.py\", line 310, in handler\n    raise ValueError(\"Test debug exception\")\nValueError: Test debug exception",
  "timestamp": "2024-05-16T22:15:12.091675Z"
}
```

#### With `pretty_print_tty=True`:

Before, the truncated `traceback` value doesn't really help.
```
2024-05-16T22:03:40.912722Z [error    ] Uncaught Exception             connection_type=http path=/test traceback=  File "/Users/jderrien/projects/litestar/litestar/middleware/_internal/exceptions/middleware.py", line 158, in __call__
    await self.app(scope, receive, capture_response_started)
  File "/Users/jderrien/projects/litestar/litestar/_asgi/asgi_router.py", line 99, in __call__
    await asgi_app(scope, receive, send)
  File "/Users/jderrien/projects/litestar/litestar/routes/http.py", line 80, in handle
    response = await self._get_response_for_request(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jderrien/projects/litestar/litestar/routes/http.py", line 132, in _get_response_for_request
    return await self._call_handler_function(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jderrien/projects/litestar/litestar/routes/http.py", line 152, in _call_handler_function
    response_data, cleanup_group = await self._get_response_data(
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jderrien/projects/litestar/litestar/routes/http.py", line 203, in _get_response_data
    data = route_handler.fn(**parsed_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jderrien/projects/litestar/tests/unit/test_middleware/test_exception_handler_middleware.py", line 299, in handler
    raise ValueError("Test debug exception")
ValueError: Test debug exception

╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│ /Users/jderrien/projects/litestar/litestar/middleware/_internal/exceptions/m │
│ iddleware.py:158 in __call__                                                 │
│                                                                              │
│   155 │   │   │   await send(event)                                          │
│   156 │   │                                                                  │
│   157 │   │   try:                                                           │
│ ❱ 158 │   │   │   await self.app(scope, receive, capture_response_started)   │
│   159 │   │   except Exception as e:                                         │
│   160 │   │   │   if scope_state.response_started:                           │
│   161 │   │   │   │   raise LitestarException("Exception caught after respon │
│                                                                              │
│ /Users/jderrien/projects/litestar/litestar/_asgi/asgi_router.py:99 in        │
│ __call__                                                                     │
│                                                                              │
│    96 │   │   else:                                                          │
│    97 │   │   │   ScopeState.from_scope(scope).exception_handlers = route_ha │
│    98 │   │   │   scope["route_handler"] = route_handler                     │
│ ❱  99 │   │   await asgi_app(scope, receive, send)                           │
│   100 │                                                                      │
│   101 │   @lru_cache(1024)  # noqa: B019                                     │
│   102 │   def handle_routing(self, path: str, method: Method | None) -> tupl │
│                                                                              │
│                           ... 3 frames hidden ...                            │
│                                                                              │
│ /Users/jderrien/projects/litestar/litestar/routes/http.py:203 in             │
│ _get_response_data                                                           │
│                                                                              │
│   200 │   │   │   │   │   else await route_handler.fn(**parsed_kwargs)       │
│   201 │   │   │   │   )                                                      │
│   202 │   │   elif route_handler.has_sync_callable:                          │
│ ❱ 203 │   │   │   data = route_handler.fn(**parsed_kwargs)                   │
│   204 │   │   else:                                                          │
│   205 │   │   │   data = await route_handler.fn(**parsed_kwargs)             │
│   206                                                                        │
│                                                                              │
│ /Users/jderrien/projects/litestar/tests/unit/test_middleware/test_exception_ │
│ handler_middleware.py:299 in handler                                         │
│                                                                              │
│   296 def test_traceback_truncate_struct_logging() -> None:                  │
│   297 │   @get("/test")                                                      │
│   298 │   def handler() -> None:                                             │
│ ❱ 299 │   │   raise ValueError("Test debug exception")                       │
│   300 │                                                                      │
│   301 │   app = Litestar([handler], logging_config=StructLoggingConfig(log_e │
│   302                                                                        │
╰──────────────────────────────────────────────────────────────────────────────╯
ValueError: Test debug exception
```

After (more concise):
```
2024-05-16T22:17:36.360643Z [error    ] Uncaught exception             connection_type=http path=/test
╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│ /Users/jderrien/projects/litestar/litestar/middleware/_internal/exceptions/m │
│ iddleware.py:156 in __call__                                                 │
│                                                                              │
│   153 │   │   │   await send(event)                                          │
│   154 │   │                                                                  │
│   155 │   │   try:                                                           │
│ ❱ 156 │   │   │   await self.app(scope, receive, capture_response_started)   │
│   157 │   │   except Exception as e:                                         │
│   158 │   │   │   if scope_state.response_started:                           │
│   159 │   │   │   │   raise LitestarException("Exception caught after respon │
│                                                                              │
│ /Users/jderrien/projects/litestar/litestar/_asgi/asgi_router.py:99 in        │
│ __call__                                                                     │
│                                                                              │
│    96 │   │   else:                                                          │
│    97 │   │   │   ScopeState.from_scope(scope).exception_handlers = route_ha │
│    98 │   │   │   scope["route_handler"] = route_handler                     │
│ ❱  99 │   │   await asgi_app(scope, receive, send)                           │
│   100 │                                                                      │
│   101 │   @lru_cache(1024)  # noqa: B019                                     │
│   102 │   def handle_routing(self, path: str, method: Method | None) -> tupl │
│                                                                              │
│                           ... 3 frames hidden ...                            │
│                                                                              │
│ /Users/jderrien/projects/litestar/litestar/routes/http.py:203 in             │
│ _get_response_data                                                           │
│                                                                              │
│   200 │   │   │   │   │   else await route_handler.fn(**parsed_kwargs)       │
│   201 │   │   │   │   )                                                      │
│   202 │   │   elif route_handler.has_sync_callable:                          │
│ ❱ 203 │   │   │   data = route_handler.fn(**parsed_kwargs)                   │
│   204 │   │   else:                                                          │
│   205 │   │   │   data = await route_handler.fn(**parsed_kwargs)             │
│   206                                                                        │
│                                                                              │
│ /Users/jderrien/projects/litestar/tests/unit/test_middleware/test_exception_ │
│ handler_middleware.py:310 in handler                                         │
│                                                                              │
│   307 def test_traceback_truncate_struct_logging() -> None:                  │
│   308 │   @get("/test")                                                      │
│   309 │   def handler() -> None:                                             │
│ ❱ 310 │   │   raise ValueError("Test debug exception")                       │
│   311 │                                                                      │
│   312 │   app = Litestar([handler], logging_config=StructLoggingConfig(log_e │
│   313                                                                        │
╰──────────────────────────────────────────────────────────────────────────────╯
ValueError: Test debug exception
```

## Closes

Closes #3228