### PR TITLE
fix: exclude static file from schema

### DIFF
--- a/litestar/static_files/config.py
+++ b/litestar/static_files/config.py
@@ -10,7 +10,6 @@ from litestar.handlers import asgi, get, head
 from litestar.response.file import ASGIFileResponse  # noqa: TCH001
 from litestar.router import Router
 from litestar.static_files.base import StaticFiles
-from litestar.types import Empty
 from litestar.utils import normalize_path, warn_deprecation
 
 __all__ = ("StaticFilesConfig",)
@@ -119,7 +118,7 @@ def create_static_files_router(
     cache_control: CacheControlHeader | None = None,
     exception_handlers: ExceptionHandlersMap | None = None,
     guards: list[Guard] | None = None,
-    include_in_schema: bool | EmptyType = Empty,
+    include_in_schema: bool | EmptyType = False,
     middleware: Sequence[Middleware] | None = None,
     opt: dict[str, Any] | None = None,
     security: Sequence[SecurityRequirement] | None = None,


### PR DESCRIPTION
## Description
Running the provided MCVE (with an additional hello_world) results in this: ![image](https://github.com/litestar-org/litestar/assets/75096465/26317388-ce5b-4b9d-a242-5ea4a2a0f53c)

## Closes
Fixes #3374
