### PR TITLE
fix: examples omitted in schema produced by dto

### DIFF
--- a/litestar/dto/base_dto.py
+++ b/litestar/dto/base_dto.py
@@ -217,10 +217,13 @@ class AbstractDTO(Generic[T]):
             # generated transfer model type in the type arguments.
             transfer_model = backend.transfer_model_type
             generic_args = tuple(transfer_model if a is cls.model_type else a for a in field_definition.args)
-            return schema_creator.for_field_definition(
-                FieldDefinition.from_annotation(field_definition.origin[generic_args])
-            )
-        return schema_creator.for_field_definition(FieldDefinition.from_annotation(backend.annotation))
+            annotation = field_definition.safe_generic_origin[generic_args]
+        else:
+            annotation = backend.annotation
+
+        return schema_creator.for_field_definition(
+            FieldDefinition.from_annotation(annotation, kwarg_definition=field_definition.kwarg_definition)
+        )
 
     @classmethod
     def resolve_generic_wrapper_type(


### PR DESCRIPTION
Fixes issue where a `BodyKwarg` instance provided as metadata to a data type annotation was ignored for OpenAPI schema generation when the data type is managed by a DTO.

Closes #3505

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
