### PR TITLE
fix(validation): fix handling validation of subscribed generics

### DIFF
--- a/litestar/serialization/msgspec_hooks.py
+++ b/litestar/serialization/msgspec_hooks.py
@@ -22,6 +22,7 @@ import msgspec
 from litestar.datastructures.secret_values import SecretBytes, SecretString
 from litestar.exceptions import SerializationException
 from litestar.types import Empty, EmptyType, Serializer, TypeDecodersSequence
+from litestar.utils.typing import get_origin_or_inner_type
 
 if TYPE_CHECKING:
     from litestar.types import TypeEncodersMap
@@ -107,8 +108,19 @@ def default_deserializer(
 
     from litestar.datastructures.state import ImmutableState
 
-    if isinstance(value, target_type):
-        return value
+    try:
+        if isinstance(value, target_type):
+            return value
+    except TypeError as exc:
+        # we might get a TypeError here if target_type is a subscribed generic. For
+        # performance reasons, we let this happen and only unwrap this when we're
+        # certain this might be the case
+        if (origin := get_origin_or_inner_type(target_type)) is not None:
+            target_type = origin
+            if isinstance(value, target_type):
+                return value
+        else:
+            raise exc
 
     if type_decoders:
         for predicate, decoder in type_decoders:

--- a/tests/unit/test_signature/test_validation.py
+++ b/tests/unit/test_signature/test_validation.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Generic, List, Optional, TypeVar
 
 import pytest
 from attr import define
@@ -289,3 +289,17 @@ def test_parse_values_from_connection_kwargs_with_multiple_errors() -> None:
         {"message": "Expected `int` >= 6", "key": "a", "source": ParamType.QUERY},
         {"message": "Expected `int` <= 4", "key": "b", "source": ParamType.QUERY},
     ]
+
+
+def test_validate_subscribed_generics() -> None:
+    T = TypeVar("T")
+
+    class Foo(Generic[T]):
+        pass
+
+    @get("/")
+    async def something(foo: Foo[str] = Foo()) -> None:
+        return None
+
+    with create_test_client([something]) as client:
+        assert client.get("/").status_code == 200


### PR DESCRIPTION
Fix a bug that would lead to a `TypeError` when subscribed generics were used in a route handler signature and subject to validation.

```python
from typing import Generic, TypeVar
from litestar import get
from litestar.testing import create_test_client

T = TypeVar("T")

class Foo(Generic[T]):
    pass

async def provide_foo() -> Foo[str]:
    return Foo()

@get("/", dependencies={"foo": provide_foo})
async def something(foo: Foo[str]) -> None:
    return None

with create_test_client([something]) as client:
    client.get("/")
```

