### PR TITLE
ci: Fix pull request labeller job

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -2,7 +2,6 @@ name: "Pull Request Labeler"
 
 on:
   pull_request_target:
-  pull_request:
 
 jobs:
   apply-labels:


### PR DESCRIPTION
Remove redundant `pull_request` trigger that makes the job run twice and fail for PRs on forks.