### PR TITLE
fix: updated type signature for `flash`

### DIFF
--- a/litestar/plugins/flash.py
+++ b/litestar/plugins/flash.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from litestar.config.app import AppConfig
+    from litestar.connection.base import AuthT, StateT, UserT
     from litestar.template import TemplateConfig
 
 
@@ -69,7 +70,7 @@ class FlashPlugin(InitPluginProtocol):
 
 
 def flash(
-    request: Request,
+    request: Request[UserT, AuthT, StateT],
     message: Any,
     category: str,
 ) -> None:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This PR updates the signature for the `flash` function.  Currently, I recent a pyright warning when importing because the signature is partially unknown.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
