### PR TITLE
fix(prometheus): capture templated route name for metrics

### DIFF
--- a/docs/examples/contrib/prometheus/using_prometheus_exporter.py
+++ b/docs/examples/contrib/prometheus/using_prometheus_exporter.py
@@ -1,12 +1,13 @@
 from litestar import Litestar
 from litestar.contrib.prometheus import PrometheusConfig, PrometheusController
 
-# Default app name and prefix is litestar.
-prometheus_config = PrometheusConfig()
 
+def create_app(group_path: bool = False):
+    # Default app name and prefix is litestar.
+    prometheus_config = PrometheusConfig(group_path=group_path)
 
-# By default the metrics are available in prometheus format and the path is set to '/metrics'.
-# If you want to change the path and format you can do it by subclassing the PrometheusController class.
+    # By default the metrics are available in prometheus format and the path is set to '/metrics'.
+    # If you want to change the path and format you can do it by subclassing the PrometheusController class.
 
-# Creating the litestar app instance with our custom PrometheusConfig and PrometheusController.
-app = Litestar(route_handlers=[PrometheusController], middleware=[prometheus_config.middleware])
+    # Creating the litestar app instance with our custom PrometheusConfig and PrometheusController.
+    return Litestar(route_handlers=[PrometheusController], middleware=[prometheus_config.middleware])

--- a/litestar/contrib/prometheus/config.py
+++ b/litestar/contrib/prometheus/config.py
@@ -51,7 +51,7 @@ class PrometheusConfig:
     """The middleware class to use.
     """
     group_path: bool = field(default=False)
-    """Whether to group paths in the metrics ot avoid cardinality explosion.
+    """Whether to group paths in the metrics to avoid cardinality explosion.
     """
 
     @property

--- a/litestar/contrib/prometheus/config.py
+++ b/litestar/contrib/prometheus/config.py
@@ -50,6 +50,9 @@ class PrometheusConfig:
     middleware_class: type[PrometheusMiddleware] = field(default=PrometheusMiddleware)
     """The middleware class to use.
     """
+    group_path: bool = field(default=False)
+    """Whether to group paths in the metrics ot avoid cardinality explosion.
+    """
 
     @property
     def middleware(self) -> DefineMiddleware:

--- a/litestar/contrib/prometheus/middleware.py
+++ b/litestar/contrib/prometheus/middleware.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 from functools import wraps
+import re
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, cast
 
 from litestar.connection.request import Request
@@ -115,6 +116,19 @@ class PrometheusMiddleware(AbstractMiddleware):
             A dictionary of default labels.
         """
 
+        path = request.url.path
+        if self._config.group_path:
+            path_parts = path.split("/")
+            if path_parts[0] == "":
+                path_parts = path_parts[1:]
+            path = ""
+            for path_parameter, path_parameter_value in request.scope.get("path_params", {}).items():
+                for path_part in path_parts:
+                    path_parameter_value = str(path_parameter_value)
+                    if path_part == path_parameter_value:
+                        path += f"/[{path_parameter}]"
+                    else:
+                        path += f"/{path_part}"
         return {
             "method": request.method if request.scope["type"] == ScopeType.HTTP else request.scope["type"],
             "path": request.url.path,

--- a/litestar/contrib/prometheus/middleware.py
+++ b/litestar/contrib/prometheus/middleware.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import time
 from functools import wraps
-import re
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, cast
 
 from litestar.connection.request import Request

--- a/litestar/contrib/prometheus/middleware.py
+++ b/litestar/contrib/prometheus/middleware.py
@@ -125,12 +125,12 @@ class PrometheusMiddleware(AbstractMiddleware):
                 for path_part in path_parts:
                     path_parameter_value = str(path_parameter_value)
                     if path_part == path_parameter_value:
-                        path += f"/[{path_parameter}]"
+                        path += f"/{{{path_parameter}}}"
                     else:
                         path += f"/{path_part}"
         return {
             "method": request.method if request.scope["type"] == ScopeType.HTTP else request.scope["type"],
-            "path": request.url.path,
+            "path": path,
             "status_code": 200,
             "app_name": self._config.app_name,
         }

--- a/litestar/contrib/prometheus/middleware.py
+++ b/litestar/contrib/prometheus/middleware.py
@@ -117,9 +117,7 @@ class PrometheusMiddleware(AbstractMiddleware):
 
         path = request.url.path
         if self._config.group_path:
-            path_parts = path.split("/")
-            if path_parts[0] == "":
-                path_parts = path_parts[1:]
+            path_parts = path.split("/")[1:]
             path = ""
             for path_parameter, path_parameter_value in request.scope.get("path_params", {}).items():
                 for path_part in path_parts:

--- a/tests/examples/test_contrib/prometheus/test_prometheus_exporter_example.py
+++ b/tests/examples/test_contrib/prometheus/test_prometheus_exporter_example.py
@@ -31,7 +31,7 @@ def test_prometheus_exporter_example(group_path: bool, expected_path: str) -> No
 
     clear_collectors()
 
-    @get("/test/{name: str}")
+    @get("test/{name: str}")
     def home(name: str) -> Dict[str, Any]:
         return {"hello": name}
 

--- a/tests/examples/test_contrib/prometheus/test_prometheus_exporter_example.py
+++ b/tests/examples/test_contrib/prometheus/test_prometheus_exporter_example.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
-import pytest
 
+import pytest
 from prometheus_client import REGISTRY
 
 from litestar import get
@@ -18,15 +18,13 @@ def clear_collectors() -> None:
 
 
 @pytest.mark.parametrize(
-    "group_path, expected_path", [
+    "group_path, expected_path",
+    [
         (True, "/test/{name}"),
         (False, "/test/litestar"),
-    ]
+    ],
 )
-def test_prometheus_exporter_example(
-        group_path: bool,
-        expected_path: str
-) -> None:
+def test_prometheus_exporter_example(group_path: bool, expected_path: str) -> None:
     from docs.examples.contrib.prometheus.using_prometheus_exporter import create_app
 
     app = create_app(group_path=group_path)

--- a/tests/examples/test_contrib/prometheus/test_prometheus_exporter_example.py
+++ b/tests/examples/test_contrib/prometheus/test_prometheus_exporter_example.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict
+import pytest
 
 from prometheus_client import REGISTRY
 
@@ -16,25 +17,32 @@ def clear_collectors() -> None:
     PrometheusMiddleware._metrics = {}
 
 
-def test_prometheus_exporter_example() -> None:
-    from docs.examples.contrib.prometheus.using_prometheus_exporter import app
+@pytest.mark.parametrize(
+    "group_path, expected_path", [
+        (True, "/test/{name}"),
+        (False, "/test/litestar"),
+    ]
+)
+def test_prometheus_exporter_example(
+        group_path: bool,
+        expected_path: str
+) -> None:
+    from docs.examples.contrib.prometheus.using_prometheus_exporter import create_app
+
+    app = create_app(group_path=group_path)
 
     clear_collectors()
 
-    @get("/test")
-    def home() -> Dict[str, Any]:
-        return {"hello": "world"}
+    @get("/test/{name: str}")
+    def home(name: str) -> Dict[str, Any]:
+        return {"hello": name}
 
     app.register(home)
 
     with TestClient(app) as client:
-        client.get("/home")
+        client.get("/test/litestar")
         metrix_exporter_response = client.get("/metrics")
 
         assert metrix_exporter_response.status_code == HTTP_200_OK
         metrics = metrix_exporter_response.content.decode()
-
-        assert (
-            """litestar_requests_in_progress{app_name="litestar",method="GET",path="/metrics",status_code="200"} 1.0"""
-            in metrics
-        )
+        assert expected_path in metrics


### PR DESCRIPTION
Adding new extraction function for prometheus metrics to avoid high cardinality issue in prometheus, eg having metrics GET /v1/users/{id} is preferable over GET /v1/users/1, GET /v1/users/2,GET /v1/users/3

More info about prometheus high cardinality
https://grafana.com/blog/2022/02/15/what-are-cardinality-spikes-and-why-do-they-matter/