### PR TITLE
fix(OpenAPI): YAML schema dump

### DIFF
--- a/litestar/openapi/controller.py
+++ b/litestar/openapi/controller.py
@@ -172,7 +172,7 @@ class OpenAPIController(Controller):
         from yaml import dump as dump_yaml
 
         if self.should_serve_endpoint(request):
-            if not self._dumped_json_schema:
+            if not self._dumped_yaml_schema:
                 schema_json = decode_json(self._get_schema_as_json(request))
                 schema_yaml = dump_yaml(schema_json, default_flow_style=False)
                 self._dumped_yaml_schema = schema_yaml.encode("utf-8")

--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -112,6 +112,23 @@ def test_openapi_json_not_allowed(person_controller: type[Controller], pet_contr
         assert response.status_code == HTTP_404_NOT_FOUND
 
 
+@pytest.mark.parametrize(
+    "schema_paths",
+    [
+        ("/schema/openapi.json", "/schema/openapi.yaml"),
+        ("/schema/openapi.yaml", "/schema/openapi.json"),
+    ],
+)
+def test_openapi_controller_internal_schema_conversion(schema_paths: list[str]) -> None:
+    openapi_config = OpenAPIConfig("Example API", "1.0.0", openapi_controller=OpenAPIController)
+
+    with create_test_client([], openapi_config=openapi_config) as client:
+        for schema_path in schema_paths:
+            response = client.get(schema_path)
+            assert response.status_code == HTTP_200_OK
+            assert "Example API" in response.text
+
+
 def test_openapi_custom_path(openapi_controller: type[OpenAPIController] | None) -> None:
     openapi_config = OpenAPIConfig(
         title="my title", version="1.0.0", path="/custom_schema_path", openapi_controller=openapi_controller


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Fixes an issue in the OpenAPI YAML schema dump logic of `OpenAPIController` where the endpoint for the OpenAPI YAML schema file returns an empty response if a request has been made to the OpenAPI JSON schema previously due to an incorrect variable check.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes


Edit from @Alc-Alc: https://discord.com/channels/919193495116337154/919193495690936353/1246024918487793744 explains the need for this
