### PR TITLE
fix: add OPTIONS to the default safe methods for CSRFConfig

### DIFF
--- a/litestar/config/csrf.py
+++ b/litestar/config/csrf.py
@@ -34,7 +34,7 @@ class CSRFConfig:
     """The value to set in the ``SameSite`` attribute of the cookie."""
     cookie_domain: str | None = field(default=None)
     """Specifies which hosts can receive the cookie."""
-    safe_methods: set[Method] = field(default_factory=lambda: {"GET", "HEAD"})
+    safe_methods: set[Method] = field(default_factory=lambda: {"GET", "HEAD", "OPTIONS"})
     """A set of "safe methods" that can set the cookie."""
     exclude: str | list[str] | None = field(default=None)
     """A pattern or list of patterns to skip in the CSRF middleware."""


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- make OPTIONS the default safe method for CSRFConfig
- related [doc](https://developer.mozilla.org/en-US/docs/Glossary/Safe)
- related PR #340 

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
