### PR TITLE
feat(logging): always log exceptions by default

### DIFF
--- a/litestar/logging/config.py
+++ b/litestar/logging/config.py
@@ -218,7 +218,7 @@ class LoggingConfig(BaseLoggingConfig):
     """
     configure_root_logger: bool = field(default=True)
     """Should the root logger be configured, defaults to True for ease of configuration."""
-    log_exceptions: Literal["always", "debug", "never"] = field(default="debug")
+    log_exceptions: Literal["always", "debug", "never"] = field(default="always")
     """Should exceptions be logged, defaults to log exceptions when 'app.debug == True'"""
     traceback_line_limit: int = field(default=-1)
     """Max number of lines to print for exception traceback.
@@ -438,7 +438,7 @@ class StructLoggingConfig(BaseLoggingConfig):
     """Logger factory to use."""
     cache_logger_on_first_use: bool = field(default=True)
     """Whether to cache the logger configuration and reuse."""
-    log_exceptions: Literal["always", "debug", "never"] = field(default="debug")
+    log_exceptions: Literal["always", "debug", "never"] = field(default="always")
     """Should exceptions be logged, defaults to log exceptions when 'app.debug == True'"""
     traceback_line_limit: int = field(default=-1)
     """Max number of lines to print for exception traceback.


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Better to always show exceptions by default.

In development, it will be easier for new users, even if using the debug mode will shows the exceptions.
In production, it's better to show the error if something goes wrong.

This would increase the log size.

While I think it's better to always log server errors (5xx errors), there is no real value to log expcetions for (some) client errors, at least for 404 errors.

So we might want to update the default `exception_logging_handler` at the same time to avoid that.

Happy to discuss more before merging this.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
