### PR TITLE
fix(docs): fixed typo in routing overview

### DIFF
--- a/docs/usage/routing/overview.rst
+++ b/docs/usage/routing/overview.rst
@@ -260,7 +260,7 @@ The handler function will receive all requests with an url that begins with ``/s
     :class: info
 
     If we are sending a request to the above with the url ``/some/sub-path``, the handler will be invoked and
-    the value of ``scope["path"]`` will equal ``"/`"``. If we send a request to ``/some/sub-path/abc``, it will also be
+    the value of ``scope["path"]`` will equal ``"/"``. If we send a request to ``/some/sub-path/abc``, it will also be
     invoked,and ``scope["path"]`` will equal ``"/abc"``.
 
 Mounting is especially useful when you need to combine components of other ASGI applications - for example, for third


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- docs
Hey! I fixed a typo on the docs where it said "/`" when it should be "/".

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Fixes
Fixes #3550