### PR TITLE
docs: Changed cli to concurrency in concurrency.rst

### DIFF
--- a/docs/reference/concurrency.rst
+++ b/docs/reference/concurrency.rst
@@ -1,5 +1,5 @@
 concurrency
-===
+===========
 
 .. automodule:: litestar.concurrency
     :members:

--- a/docs/reference/concurrency.rst
+++ b/docs/reference/concurrency.rst
@@ -1,4 +1,4 @@
-cli
+concurrency
 ===
 
 .. automodule:: litestar.concurrency


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
This PR will change "cli" to "concurrency" in concurrency.rst to fix #2987 

## Closes
- #2987 