### PR TITLE
chore(formatting): deprecation warning text for route handler classes

### DIFF
--- a/litestar/handlers/http_handlers/decorators.py
+++ b/litestar/handlers/http_handlers/decorators.py
@@ -49,7 +49,7 @@ MSG_SEMANTIC_ROUTE_HANDLER_WITH_HTTP = "semantic route handlers cannot define ht
 class _SubclassWarningMixin:
     def __init_subclass__(cls, **kwargs: Any) -> None:
         warnings.warn(
-            "Semantic HTTP route handler classes are deprecated and will be replaced by"
+            "Semantic HTTP route handler classes are deprecated and will be replaced by "
             "functional decorators in Litestar 3.0.",
             category=DeprecationWarning,
             stacklevel=2,


### PR DESCRIPTION
The deprecation warning is missing a space between "by" and "functional".

When printing to the screen, it would read a single work "byfunctional"

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
