### PR TITLE
fix(typing): "Fix" typing for `Controller.as_router`

### DIFF
--- a/litestar/controller.py
+++ b/litestar/controller.py
@@ -209,7 +209,7 @@ class Controller:
 
         router = Router(
             path=self.path,
-            route_handlers=self.get_route_handlers(),
+            route_handlers=self.get_route_handlers(),  # type: ignore[arg-type]
             after_request=self.after_request,
             after_response=self.after_response,
             before_request=self.before_request,


### PR DESCRIPTION
Ignore a type error in `Controller.as_router` that's not really easily fixable otherwise