### PR TITLE
fix(OpenAPI): Correctly handle `typing.NewType` 

### DIFF
--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -63,6 +63,7 @@ from litestar.utils.predicates import (
 from litestar.utils.typing import (
     get_origin_or_inner_type,
     make_non_optional_union,
+    unwrap_new_type,
 )
 
 if TYPE_CHECKING:
@@ -359,7 +360,7 @@ class SchemaCreator:
     def for_new_type(self, field_definition: FieldDefinition) -> Schema | Reference:
         return self.for_field_definition(
             FieldDefinition.from_kwarg(
-                annotation=field_definition.raw.__supertype__,
+                annotation=unwrap_new_type(field_definition.raw),
                 name=field_definition.name,
                 default=field_definition.default,
             )

--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -5,22 +5,10 @@ from collections import abc, deque
 from copy import deepcopy
 from dataclasses import dataclass, is_dataclass, replace
 from inspect import Parameter, Signature
-from typing import (
-    Any,
-    AnyStr,
-    Callable,
-    Collection,
-    ForwardRef,
-    Literal,
-    Mapping,
-    Protocol,
-    Sequence,
-    TypeVar,
-    cast,
-)
+from typing import Any, AnyStr, Callable, Collection, ForwardRef, Literal, Mapping, Protocol, Sequence, TypeVar, cast
 
 from msgspec import UnsetType
-from typing_extensions import NotRequired, Required, Self, get_args, get_origin, get_type_hints, is_typeddict
+from typing_extensions import NewType, NotRequired, Required, Self, get_args, get_origin, get_type_hints, is_typeddict
 
 from litestar.exceptions import ImproperlyConfiguredException, LitestarWarning
 from litestar.openapi.spec import Example
@@ -314,7 +302,12 @@ class FieldDefinition:
     def is_simple_type(self) -> bool:
         """Check if the field type is a singleton value (e.g. int, str etc.)."""
         return not (
-            self.is_generic or self.is_optional or self.is_union or self.is_mapping or self.is_non_string_iterable
+            self.is_generic
+            or self.is_optional
+            or self.is_union
+            or self.is_mapping
+            or self.is_non_string_iterable
+            or self.is_new_type
         )
 
     @property
@@ -365,6 +358,10 @@ class FieldDefinition:
     def is_tuple(self) -> bool:
         """Whether the annotation is a ``tuple`` or not."""
         return self.is_subclass_of(tuple)
+
+    @property
+    def is_new_type(self) -> bool:
+        return isinstance(self.annotation, NewType)
 
     @property
     def is_type_var(self) -> bool:

--- a/litestar/utils/typing.py
+++ b/litestar/utils/typing.py
@@ -37,7 +37,7 @@ from typing import (
     cast,
 )
 
-from typing_extensions import Annotated, NotRequired, Required, get_args, get_origin, get_type_hints
+from typing_extensions import Annotated, NewType, NotRequired, Required, get_args, get_origin, get_type_hints
 
 from litestar.types.builtin_types import NoneType, UnionTypes
 
@@ -172,6 +172,14 @@ def unwrap_annotation(annotation: Any) -> tuple[Any, tuple[Any, ...], set[Any]]:
         metadata.extend(meta)
         origin = get_origin(annotation)
     return annotation, tuple(metadata), wrappers
+
+
+def unwrap_new_type(new_type: Any) -> Any:
+    """Unwrap a (nested) ``typing.NewType``"""
+    inner = new_type
+    while isinstance(inner, NewType):
+        inner = inner.__supertype__
+    return inner
 
 
 def get_origin_or_inner_type(annotation: Any) -> Any:

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -404,3 +404,17 @@ def test_unwrap_new_type() -> None:
         app.openapi_schema.paths["/{path_param}"].get.responses["200"].content["application/json"].schema.type  # type: ignore[index, union-attr]
         == OpenAPIType.STRING
     )
+
+
+def test_unwrap_nested_new_type() -> None:
+    FancyString = NewType("FancyString", str)
+    FancierString = NewType("FancierString", FancyString)
+
+    @get("/")
+    async def handler(
+        param: FancierString,
+    ) -> None:
+        return None
+
+    app = Litestar([handler])
+    assert app.openapi_schema.paths["/"].get.parameters[0].schema.type == OpenAPIType.STRING  # type: ignore[index, union-attr]

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -408,7 +408,7 @@ def test_unwrap_new_type() -> None:
 
 def test_unwrap_nested_new_type() -> None:
     FancyString = NewType("FancyString", str)
-    FancierString = NewType("FancierString", FancyString)
+    FancierString = NewType("FancierString", FancyString)  # pyright: ignore
 
     @get("/")
     async def handler(


### PR DESCRIPTION
When encountering a `typing.NewType` during OpenAPI schema generation, we currently treat it as an opaque type. This PR changes the behaviour such that `typing.NewType`s are always unwrapped during schema generation.