### PR TITLE
chore(docs): Fix `tools/sphinx_ext/missing_references.py` 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -236,7 +236,7 @@ ignore_missing_refs = {
     re.compile(r"litestar\.template\.(config|TemplateConfig).*"): re.compile(".*EngineType"),
     "litestar.concurrency.set_asyncio_executor": {"ThreadPoolExecutor"},
     "litestar.concurrency.get_asyncio_executor": {"ThreadPoolExecutor"},
-    re.compile(r"litestar\.channels\.backends\.asyncpg.*"): {"asyncpg.connection.Connection"},
+    re.compile(r"litestar\.channels\.backends\.asyncpg.*"): {"asyncpg.Connection"},
 }
 
 # Do not warn about broken links to the following:

--- a/tools/sphinx_ext/missing_references.py
+++ b/tools/sphinx_ext/missing_references.py
@@ -79,9 +79,10 @@ def on_warn_missing_reference(app: Sphinx, domain: str, node: Node) -> bool | No
     for pattern, targets in ignore_ref_rgs.items():
         if not pattern.match(source):
             continue
-        if isinstance(targets, set) and target in targets:
-            return True
-        if targets.match(target):
+        if isinstance(targets, set):
+            if target in targets:
+                return True
+        elif targets.match(target):
             return True
 
     return None


### PR DESCRIPTION
Fix a bug in `tools/sphinx_ext/missing_references.py` that would cause the docs build to fail: https://github.com/litestar-org/litestar/actions/runs/9602344070/job/26528903758