### PR TITLE
fix(signature): Fix #3593: Ensure signature model internal function signatures don't clash with model signature

### DIFF
--- a/litestar/_kwargs/dependencies.py
+++ b/litestar/_kwargs/dependencies.py
@@ -58,7 +58,7 @@ async def resolve_dependency(
     """
     signature_model = dependency.provide.signature_model
     dependency_kwargs = (
-        signature_model.parse_values_from_connection_kwargs(connection=connection, **kwargs)
+        signature_model.parse_values_from_connection_kwargs(connection=connection, kwargs=kwargs)
         if signature_model._fields
         else {}
     )

--- a/litestar/_signature/model.py
+++ b/litestar/_signature/model.py
@@ -168,7 +168,9 @@ class SignatureModel(Struct):
         return message
 
     @classmethod
-    def _collect_errors(cls, deserializer: Callable[[Any, Any], Any], **kwargs: Any) -> list[tuple[str, Exception]]:
+    def _collect_errors(
+        cls, deserializer: Callable[[Any, Any], Any], kwargs: dict[str, Any]
+    ) -> list[tuple[str, Exception]]:
         exceptions: list[tuple[str, Exception]] = []
         for field_name in cls._fields:
             try:
@@ -181,12 +183,12 @@ class SignatureModel(Struct):
         return exceptions
 
     @classmethod
-    def parse_values_from_connection_kwargs(cls, connection: ASGIConnection, **kwargs: Any) -> dict[str, Any]:
+    def parse_values_from_connection_kwargs(cls, connection: ASGIConnection, kwargs: dict[str, Any]) -> dict[str, Any]:
         """Extract values from the connection instance and return a dict of parsed values.
 
         Args:
             connection: The ASGI connection instance.
-            **kwargs: A dictionary of kwargs.
+            kwargs: A dictionary of kwargs.
 
         Raises:
             ValidationException: If validation failed.
@@ -206,7 +208,7 @@ class SignatureModel(Struct):
                 messages.append(message)
             raise cls._create_exception(messages=messages, connection=connection) from e
         except ValidationError as e:
-            for field_name, exc in cls._collect_errors(deserializer=deserializer, **kwargs):  # type: ignore[assignment]
+            for field_name, exc in cls._collect_errors(deserializer=deserializer, kwargs=kwargs):  # type: ignore[assignment]
                 match = ERR_RE.search(str(exc))
                 keys = [field_name, str(match.group(1))] if match else [field_name]
                 message = cls._build_error_message(keys=keys, exc_msg=str(exc), connection=connection)

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -189,7 +189,7 @@ class HTTPRoute(BaseRoute):
                 cleanup_group = await parameter_model.resolve_dependencies(request, kwargs)
 
             parsed_kwargs = route_handler.signature_model.parse_values_from_connection_kwargs(
-                connection=request, **kwargs
+                connection=request, kwargs=kwargs
             )
 
         if cleanup_group:

--- a/litestar/routes/websocket.py
+++ b/litestar/routes/websocket.py
@@ -75,7 +75,7 @@ class WebSocketRoute(BaseRoute):
                 cleanup_group = await self.handler_parameter_model.resolve_dependencies(websocket, parsed_kwargs)
 
             parsed_kwargs = self.route_handler.signature_model.parse_values_from_connection_kwargs(
-                connection=websocket, **parsed_kwargs
+                connection=websocket, kwargs=parsed_kwargs
             )
 
         if cleanup_group:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,6 +310,11 @@ exclude-classes = """
 """
 
 [tool.ruff]
+include = [
+  "{litestar,tests,docs,test_apps,tools}/**/*.{py,pyi}",
+  "pyproject.toml"
+]
+
 lint.select = [
   "A", # flake8-builtins
   "B", # flake8-bugbear

--- a/tests/unit/test_signature/test_validation.py
+++ b/tests/unit/test_signature/test_validation.py
@@ -306,7 +306,7 @@ def test_validate_subscribed_generics() -> None:
 
 
 def test_separate_model_namespace() -> None:
-    # h ttps://github.com/litestar-org/litestar/issues/3593
+    # https://github.com/litestar-org/litestar/issues/3593
 
     async def provide_connection() -> str:
         return "connection"


### PR DESCRIPTION
Fix #3593 by ensuring that the functions used by the signature model itself do not interfere with the signature model created.