### PR TITLE
docs: fix typos in examples.contrib.prometheus

### DIFF
--- a/docs/examples/contrib/prometheus/using_prometheus_exporter_with_extra_configs.py
+++ b/docs/examples/contrib/prometheus/using_prometheus_exporter_with_extra_configs.py
@@ -32,7 +32,7 @@ def custom_exemplar(request: Request[Any, Any, Any]) -> Dict[str, str]:
 
 
 # Creating the instance of PrometheusConfig with our own custom options.
-# The givenn options ara not necessary, you can use the default ones
+# The given options are not necessary, you can use the default ones
 # as well by just creating a raw instance PrometheusConfig()
 prometheus_config = PrometheusConfig(
     app_name="litestar-example",


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Removes typos from the comments in the prometheus exporter example.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
