### PR TITLE
docs: fixed create_ws_route_handlers typo.

### DIFF
--- a/docs/usage/channels.rst
+++ b/docs/usage/channels.rst
@@ -438,7 +438,7 @@ route handlers.
 
 .. literalinclude:: /examples/channels/create_route_handlers.py
     :language: python
-    :caption: Setting ``create_route_handlers=True`` will create route handlers for all ``channels``
+    :caption: Setting ``create_ws_route_handlers=True`` will create route handlers for all ``channels``
 
 
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Fixes the `create_ws_route_handlers` typo in the docs by changing `create_route_handlers=True` to `create_ws_route_handlers=True`

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Fixes #3596 
