### PR TITLE
fix: use `ASGIConnection` instead of `Request` for `flash`

### DIFF
--- a/litestar/plugins/flash.py
+++ b/litestar/plugins/flash.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Mapping
 
 import litestar.exceptions
-from litestar import Request
 from litestar.exceptions import MissingDependencyException
 from litestar.middleware import DefineMiddleware
 from litestar.middleware.session import SessionMiddleware
@@ -20,7 +19,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from litestar.config.app import AppConfig
-    from litestar.connection.base import AuthT, StateT, UserT
+    from litestar.connection.base import ASGIConnection
     from litestar.template import TemplateConfig
 
 
@@ -70,7 +69,7 @@ class FlashPlugin(InitPluginProtocol):
 
 
 def flash(
-    request: Request[UserT, AuthT, StateT],
+    request: ASGIConnection[Any, Any, Any, Any],
     message: Any,
     category: str,
 ) -> None:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Currently, the `FlashPlugin` expects the `request` parameter to be a type of `Request`.  However, there's no reason it can't use the parent class `ASGIConnection`. 

Doing this, allows for flash to be called in guards that expect an `ASGIConnection` instead of `Request`:
```python
def requires_active_user(connection: ASGIConnection, _: BaseRouteHandler) -> None:
    if connection.user.is_active:
        return
    msg = "Your user account is inactive."
    flash(connection, msg, category="error")
    raise PermissionDeniedException(msg)
```

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
