### PR TITLE
docs: fix link to available issues

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -360,5 +360,5 @@ Example Applications
     :hidden:
 
     contribution-guide
-    Available Issues <https://github.com/search?q=user%3Alitestar-org+state%3Aopen+label%3A%22good+first+issue%22+++no%3Aassignee+&type=issues=>
+    Available Issues <https://github.com/search?q=user%3Alitestar-org+state%3Aopen+label%3A%22good+first+issue%22+++no%3Aassignee+&type=issues>
     Code of Conduct <https://github.com/litestar-org/.github?tab=coc-ov-file#readme>


### PR DESCRIPTION
## Description

This PR fixes the "Available Issues" link in the sidebar of the litestar docs.

Currently I get redirected to a list of repositories in the litestar org with open issues. Deleting the trailing `=` links to the open issues themselves. I assume the latter was the intended destination.