### PR TITLE
fix: allow non-Mapping Iterable parameters

### DIFF
--- a/litestar/_kwargs/parameter_definition.py
+++ b/litestar/_kwargs/parameter_definition.py
@@ -64,7 +64,7 @@ def create_parameter_definition(
         and default is None
         and not field_definition.is_optional
         and not field_definition.is_any,
-        is_sequence=field_definition.is_non_string_sequence,
+        is_sequence=field_definition.is_non_string_non_mapping_iterable,
     )
 
 

--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -30,6 +30,7 @@ from litestar.utils.predicates import (
     is_class_and_subclass,
     is_generic,
     is_non_string_iterable,
+    is_non_string_non_mapping_iterable,
     is_non_string_sequence,
     is_union,
 )
@@ -159,7 +160,7 @@ def _traverse_metadata(
 def _create_metadata_from_type(
     metadata: Sequence[Any], model: type[T], annotation: Any, extra: dict[str, Any] | None
 ) -> tuple[T | None, dict[str, Any]]:
-    is_sequence_container = is_non_string_sequence(annotation)
+    is_sequence_container = is_non_string_non_mapping_iterable(annotation)
     result = _traverse_metadata(metadata=metadata, is_sequence_container=is_sequence_container, extra=extra)
 
     constraints = {k: v for k, v in result.items() if k in dir(model)}
@@ -289,6 +290,17 @@ class FieldDefinition:
         if self.is_optional:
             annotation = make_non_optional_union(annotation)
         return is_non_string_sequence(annotation)
+
+    @property
+    def is_non_string_non_mapping_iterable(self) -> bool:
+        """Check if the field type is an Iterable other than string or mapping.
+
+        If ``self.annotation`` is an optional union, only the non-optional members of the union are evaluated.
+        """
+        annotation = self.annotation
+        if self.is_optional:
+            annotation = make_non_optional_union(annotation)
+        return is_non_string_non_mapping_iterable(annotation)
 
     @property
     def is_any(self) -> bool:

--- a/litestar/utils/predicates.py
+++ b/litestar/utils/predicates.py
@@ -228,7 +228,7 @@ def is_non_string_non_mapping_iterable(annotation: Any) -> TypeGuard[Iterable[An
         return False
     typ = origin or annotation
     try:
-        return issubclass(origin or annotation, Iterable) and not (
+        return issubclass(typ, Iterable) and not (
             issubclass(typ, (str, bytes)) or issubclass(typ, Mapping)
         )
     except TypeError:  # pragma: no cover

--- a/litestar/utils/predicates.py
+++ b/litestar/utils/predicates.py
@@ -55,6 +55,7 @@ __all__ = (
     "is_generic",
     "is_mapping",
     "is_non_string_iterable",
+    "is_non_string_non_mapping_iterable",
     "is_non_string_sequence",
     "is_optional_union",
     "is_undefined_sentinel",
@@ -207,6 +208,28 @@ def is_non_string_sequence(annotation: Any) -> TypeGuard[Sequence[Any]]:
                 set,
                 frozenset,
             ),
+        )
+    except TypeError:  # pragma: no cover
+        return False
+
+
+def is_non_string_non_mapping_iterable(annotation: Any) -> TypeGuard[Iterable[Any]]:
+    """Given a type annotation determine if the annotation is a sequence.
+
+    Args:
+    annotation: A type.
+
+    Returns:
+        A typeguard determining whether the type can be cast as :class`Iterable <typing.Iterable>`
+         that is not a string or Mapping.
+    """
+    origin = get_origin_or_inner_type(annotation)
+    if not origin and not isclass(annotation):
+        return False
+    typ = origin or annotation
+    try:
+        return issubclass(origin or annotation, Iterable) and not (
+            issubclass(typ, (str, bytes)) or issubclass(typ, Mapping)
         )
     except TypeError:  # pragma: no cover
         return False

--- a/tests/unit/test_utils/test_predicates.py
+++ b/tests/unit/test_utils/test_predicates.py
@@ -38,6 +38,7 @@ from litestar.utils.predicates import (
     is_generic,
     is_mapping,
     is_non_string_iterable,
+    is_non_string_non_mapping_iterable,
     is_non_string_sequence,
     is_undefined_sentinel,
 )
@@ -102,6 +103,36 @@ def test_is_class_and_subclass(args: Tuple[Any, Any], expected: bool) -> None:
 )
 def test_is_non_string_iterable(value: Any, expected: bool) -> None:
     assert is_non_string_iterable(value) is expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    (
+        (
+            (Tuple[int, ...], True),
+            (Tuple[int], True),
+            (List[str], True),
+            (Set[str], True),
+            (FrozenSet[str], True),
+            (Deque[str], True),
+            (Sequence[str], True),
+            (Iterable[str], True),
+            (list, True),
+            (tuple, True),
+            (deque, True),
+            (set, True),
+            (frozenset, True),
+            (str, False),
+            (bytes, False),
+            (dict, False),
+            (Dict[str, Any], False),
+            (Union[str, int], False),
+            (1, False),
+        )
+    ),
+)
+def test_is_non_string_non_mapping_iterable(value: Any, expected: bool) -> None:
+    assert is_non_string_non_mapping_iterable(value) is expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Allow `Iterable`s other than `str` or `Mapping`s to be used as `Sequence` parameters

## Closes

Closes #3631 