### PR TITLE
fix(OpenAPI): handle invalid schema keys

### DIFF
--- a/litestar/_openapi/datastructures.py
+++ b/litestar/_openapi/datastructures.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections import defaultdict
 from typing import TYPE_CHECKING, Iterator, Sequence, _GenericAlias  # type: ignore[attr-defined]
 
@@ -11,6 +12,9 @@ if TYPE_CHECKING:
     from litestar.openapi import OpenAPIConfig
     from litestar.plugins import OpenAPISchemaPluginProtocol
     from litestar.typing import FieldDefinition
+
+
+INVALID_KEY_CHARACTER_PATTERN = re.compile(r"[^a-zA-Z0-9._-]+")
 
 
 def _longest_common_prefix(tuples_: list[tuple[str, ...]]) -> tuple[str, ...]:
@@ -61,7 +65,7 @@ def _get_normalized_schema_key(field_definition: FieldDefinition) -> tuple[str, 
     module = getattr(annotation, "__module__", "")
     name = str(annotation)[len(module) + 1 :] if isinstance(annotation, _GenericAlias) else annotation.__qualname__
     name = name.replace(".<locals>.", ".")
-    return *module.split("."), name
+    return *module.split("."), re.sub(INVALID_KEY_CHARACTER_PATTERN, "_", name)
 
 
 class RegisteredSchema:

--- a/tests/unit/test_dto/test_factory/test_integration.py
+++ b/tests/unit/test_dto/test_factory/test_integration.py
@@ -999,7 +999,7 @@ app = Litestar(route_handlers=[get_users])
 """
     )
     openapi = cast("Litestar", module.app).openapi_schema
-    schema = openapi.components.schemas["WithCount[litestar.dto._backend.GetUsersUserResponseBody]"]
+    schema = openapi.components.schemas["WithCount_litestar.dto._backend.GetUsersUserResponseBody_"]
     assert not_none(schema.properties).keys() == {"count", "data"}
     model_schema = openapi.components.schemas["GetUsersUserResponseBody"]
     assert not_none(model_schema.properties).keys() == {"id", "name"}

--- a/tests/unit/test_openapi/test_datastructures.py
+++ b/tests/unit/test_openapi/test_datastructures.py
@@ -72,13 +72,13 @@ def test_get_normalized_schema_key() -> None:
     builtin_dict = Dict[str, List[int]]
     assert _get_normalized_schema_key(FieldDefinition.from_annotation(builtin_dict)) == (
         "typing",
-        "Dict[str, typing.List[int]]",
+        "Dict_str_typing.List_int_",
     )
 
     builtin_with_custom = Dict[str, DataclassPerson]
     assert _get_normalized_schema_key(FieldDefinition.from_annotation(builtin_with_custom)) == (
         "typing",
-        "Dict[str, tests.models.DataclassPerson]",
+        "Dict_str_tests.models.DataclassPerson_",
     )
 
     class LocalGeneric(Generic[T]):
@@ -100,7 +100,7 @@ def test_get_normalized_schema_key() -> None:
         "unit",
         "test_openapi",
         "test_datastructures",
-        "test_get_normalized_schema_key.LocalGeneric[int]",
+        "test_get_normalized_schema_key.LocalGeneric_int_",
     )
 
     assert _get_normalized_schema_key(FieldDefinition.from_annotation(generic_str)) == (
@@ -108,7 +108,7 @@ def test_get_normalized_schema_key() -> None:
         "unit",
         "test_openapi",
         "test_datastructures",
-        "test_get_normalized_schema_key.LocalGeneric[str]",
+        "test_get_normalized_schema_key.LocalGeneric_str_",
     )
 
     assert _get_normalized_schema_key(FieldDefinition.from_annotation(generic_int)) != _get_normalized_schema_key(

--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -331,7 +331,7 @@ def test_with_generic_class(openapi_controller: type[OpenAPIController] | None) 
                             "200": {
                                 "description": "Request fulfilled, document follows",
                                 "headers": {},
-                                "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Foo[str]"}}},
+                                "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Foo_str_"}}},
                             }
                         },
                         "deprecated": False,
@@ -345,7 +345,7 @@ def test_with_generic_class(openapi_controller: type[OpenAPIController] | None) 
                             "200": {
                                 "description": "Request fulfilled, document follows",
                                 "headers": {},
-                                "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Foo[int]"}}},
+                                "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Foo_int_"}}},
                             }
                         },
                         "deprecated": False,
@@ -354,13 +354,13 @@ def test_with_generic_class(openapi_controller: type[OpenAPIController] | None) 
             },
             "components": {
                 "schemas": {
-                    "Foo[str]": {
+                    "Foo_str_": {
                         "properties": {"foo": {"type": "string"}},
                         "type": "object",
                         "required": ["foo"],
                         "title": "Foo[str]",
                     },
-                    "Foo[int]": {
+                    "Foo_int_": {
                         "properties": {"foo": {"type": "integer"}},
                         "type": "object",
                         "required": ["foo"],


### PR DESCRIPTION
## Description
This PR changes OpenAPI schema key generation function [`_get_normalized_schema_key`](https://github.com/litestar-org/litestar/blob/8c4c15bb501879dabaecfbf0af541ac571c08cf3/litestar/_openapi/schema_generation/utils.py#L86) to use valid characters according to the [OpenAPI specification](https://spec.openapis.org/oas/latest.html#fixed-fields-5), section `4.8.7.1`.

The strategy adopted by this PR was to replace sequences of invalid characters with underscores. Examples:
- `Foo[Bar]` -> `Foo_Bar`
- `dict[str, int]` -> `dict_str_int_`

Some tests had to be changed, because they were expecting the use of invalid characters (like square brackets, spaces and colons).

## Closes
Closes #3630