### PR TITLE
fix(connection): Fix creation of FormMultiDict in Request.form to properly handle multi-keys

### DIFF
--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -51,18 +51,17 @@ async def form_multi_item_handler(request: Request) -> DefaultDict[str, list]:
     data = await request.form()
     output = defaultdict(list)
     for key, value in data.multi_items():
-        for v in value:
-            if isinstance(v, UploadFile):
-                content = await v.read()
-                output[key].append(
-                    {
-                        "filename": v.filename,
-                        "content": content.decode(),
-                        "content_type": v.content_type,
-                    }
-                )
-            else:
-                output[key].append(v)
+        if isinstance(value, UploadFile):
+            content = await value.read()
+            output[key].append(
+                {
+                    "filename": value.filename,
+                    "content": content.decode(),
+                    "content_type": value.content_type,
+                }
+            )
+        else:
+            output[key].append(value)
     return output
 
 


### PR DESCRIPTION
Fix #3627 by properly handling the creation of `FormMultiDict` where multiple values are given for a single key, to make `Request.form()` match the behaviour of receiving form data via the `data` kwarg.

<hr>

**Before**

```python
@post("/")
async def handler(request: Request) -> Any:
    return (await request.form()).getall("foo")

with create_test_client(handler) as client:
    print(client.post("/", data={"foo": ["1", "2"]}).json()) # [["1", "2"]]
```

**After**

```python
@post("/")
async def handler(request: Request) -> Any:
    return (await request.form()).getall("foo")

with create_test_client(handler) as client:
    print(client.post("/", data={"foo": ["1", "2"]}).json()) # ["1", "2"]
```