### PR TITLE
fix: Small docs update.

### DIFF
--- a/docs/examples/parameters/header_and_cookie_parameters.py
+++ b/docs/examples/parameters/header_and_cookie_parameters.py
@@ -29,7 +29,7 @@ async def get_user(
 ) -> User:
     if token != VALID_TOKEN or cookie != VALID_COOKIE_VALUE:
         raise NotAuthorizedException
-    return User.parse_obj(USER_DB[user_id])
+    return User.model_validate(USER_DB[user_id])
 
 
 app = Litestar(route_handlers=[get_user])

--- a/docs/examples/parameters/path_parameters_1.py
+++ b/docs/examples/parameters/path_parameters_1.py
@@ -12,7 +12,7 @@ class User(BaseModel):
 
 @get("/user/{user_id:int}", sync_to_thread=False)
 def get_user(user_id: int) -> User:
-    return User.parse_obj(USER_DB[user_id])
+    return User.model_validate(USER_DB[user_id])
 
 
 app = Litestar(route_handlers=[get_user])


### PR DESCRIPTION
Starting from version 2, Pydantic uses `model_validate()` instead of `parse_obj()`. 
https://docs.pydantic.dev/2.8/migration/#changes-to-pydanticbasemodel

I have updated 2 places in the docs where the old deprecated method is used.