### PR TITLE
fix(opentelemetry): wrap everything under Otel middleware if it Exists.

### DIFF
--- a/docs/usage/metrics/open-telemetry.rst
+++ b/docs/usage/metrics/open-telemetry.rst
@@ -23,10 +23,11 @@ the Litestar constructor:
 
    from litestar import Litestar
    from litestar.contrib.opentelemetry import OpenTelemetryConfig
+   from litestar.plugins.opentelemetry import OpenTelemetryPlugin
 
    open_telemetry_config = OpenTelemetryConfig()
 
-   app = Litestar(middleware=[open_telemetry_config.middleware])
+   app = Litestar(plugins=[OpenTelemetryPlugin(open_telemetry_config)])
 
 The above example will work out of the box if you configure a global ``tracer_provider`` and/or ``metric_provider`` and an
 exporter to use these (see the

--- a/litestar/config/app.py
+++ b/litestar/config/app.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from litestar.events.emitter import BaseEventEmitterBackend
     from litestar.events.listener import EventListener
     from litestar.logging.config import BaseLoggingConfig
+    from litestar.middleware.base import DefineMiddleware
     from litestar.openapi.config import OpenAPIConfig
     from litestar.openapi.spec import SecurityRequirement
     from litestar.plugins import PluginProtocol
@@ -214,6 +215,8 @@ class AppConfig:
     """The maximal number of allowed parts in a multipart/formdata request. This limit is intended to protect from
     DoS attacks."""
     experimental_features: list[ExperimentalFeatures] | None = None
+    otel: DefineMiddleware | None = None
+    """OpenTelemetryInstrumentationMiddleware that will be used to wrap all the middlewares if not None. Default is None"""
 
     def __post_init__(self) -> None:
         """Normalize the allowed hosts to be a config or None.

--- a/litestar/contrib/opentelemetry/_utils.py
+++ b/litestar/contrib/opentelemetry/_utils.py
@@ -27,5 +27,11 @@ def get_route_details_from_scope(scope: Scope) -> tuple[str, dict[Any, str]]:
     Returns:
         A tuple of the span name and a dict of attrs.
     """
-    route_handler_fn_name = scope["route_handler"].handler_name
-    return route_handler_fn_name, {SpanAttributes.HTTP_ROUTE: route_handler_fn_name}
+
+    path = scope.get("path", "").strip()
+    method = str(scope.get("method", "")).strip()
+
+    if method and path:  # http
+        return f"{method} {path}", {SpanAttributes.HTTP_ROUTE: f"{method} {path}"}
+
+    return path, {SpanAttributes.HTTP_ROUTE: path}  # websocket

--- a/litestar/plugins/opentelemetry.py
+++ b/litestar/plugins/opentelemetry.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from litestar.contrib.opentelemetry.config import OpenTelemetryConfig
+from litestar.contrib.opentelemetry.middleware import OpenTelemetryInstrumentationMiddleware
+from litestar.middleware.base import DefineMiddleware
+from litestar.plugins import InitPluginProtocol
+
+if TYPE_CHECKING:
+    from litestar.config.app import AppConfig
+    from litestar.types.composite_types import Middleware
+
+
+class OpenTelemetryPlugin(InitPluginProtocol):
+    """OpenTelemetry Plugin."""
+
+    __slots__ = ("_otel_config",)
+
+    def __init__(self, config: OpenTelemetryConfig | None = None) -> None:
+        if config is None:
+            config = OpenTelemetryConfig()
+        self._otel_config = config
+        super().__init__()
+
+    def on_app_init(self, app_config: AppConfig) -> AppConfig:
+        app_config.otel = self._otel_config.middleware
+        # check if the middleware is passed though the app_config.middlewares this should override the default middleware
+        app_config.otel = self._get_otel_middleware(app_config.middleware) or app_config.otel
+        return app_config
+
+    @staticmethod
+    def _get_otel_middleware(middlewares: list[Middleware]) -> DefineMiddleware | None:
+        """Get the OpenTelemetry middleware if it is enabled in the application.
+        Remove the middleware from the list of middlewares if it is found.
+        """
+        for middleware in middlewares:
+            if (
+                isinstance(middleware, DefineMiddleware)
+                and middleware.middleware == OpenTelemetryInstrumentationMiddleware
+            ):
+                middlewares.remove(middleware)
+                return middleware
+        return None

--- a/tests/unit/test_contrib/test_opentelemetry.py
+++ b/tests/unit/test_contrib/test_opentelemetry.py
@@ -14,8 +14,10 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 
 from litestar import WebSocket, get, websocket
 from litestar.contrib.opentelemetry import OpenTelemetryConfig
+from litestar.exceptions import http_exceptions
 from litestar.status_codes import HTTP_200_OK
 from litestar.testing import create_test_client
+from litestar.types.asgi_types import ASGIApp, Receive, Scope, Send
 
 
 def create_config(**kwargs: Any) -> Tuple[OpenTelemetryConfig, InMemoryMetricReader, InMemorySpanExporter]:
@@ -74,7 +76,7 @@ def test_open_telemetry_middleware_with_http_route() -> None:
             "http.user_agent": "testclient",
             "net.peer.ip": "testclient",
             "net.peer.port": 50000,
-            "http.route": "handler",
+            "http.route": "GET /",
             "http.status_code": 200,
         }
 
@@ -121,6 +123,118 @@ def test_open_telemetry_middleware_with_websocket_route() -> None:
             "http.user_agent": "testclient",
             "net.peer.ip": "testclient",
             "net.peer.port": 50000,
-            "http.route": "handler",
+            "http.route": "/",
             "http.status_code": 200,
+        }
+
+
+def test_open_telemetry_middleware_handles_route_not_found_under_span_http() -> None:
+    config, _, exporter = create_config()
+
+    @get("/")
+    def handler() -> dict:
+        raise Exception("random Exception")
+
+    with create_test_client(handler, middleware=[config.middleware]) as client:
+        response = client.get("/route_that_does_not_exist")
+        assert response.status_code
+
+        first_span, second_span, third_span = cast("Tuple[Span, Span, Span]", exporter.get_finished_spans())
+        assert dict(first_span.attributes) == {  # type: ignore[arg-type]
+            "http.status_code": 404,
+            "asgi.event.type": "http.response.start",
+        }
+        assert dict(second_span.attributes) == {"asgi.event.type": "http.response.body"}  # type: ignore[arg-type]
+        assert dict(third_span.attributes) == {  # type: ignore[arg-type]
+            "http.scheme": "http",
+            "http.host": "testserver.local",
+            "net.host.port": 80,
+            "http.flavor": "1.1",
+            "http.target": "/route_that_does_not_exist",
+            "http.url": "http://testserver.local/route_that_does_not_exist",
+            "http.method": "GET",
+            "http.server_name": "testserver.local",
+            "http.user_agent": "testclient",
+            "net.peer.ip": "testclient",
+            "net.peer.port": 50000,
+            "http.route": "GET /route_that_does_not_exist",
+            "http.status_code": 404,
+        }
+
+
+def test_open_telemetry_middleware_handles_method_not_allowed_under_span_http() -> None:
+    config, _, exporter = create_config()
+
+    @get("/")
+    def handler() -> dict:
+        raise Exception("random Exception")
+
+    with create_test_client(handler, middleware=[config.middleware]) as client:
+        response = client.post("/")
+        assert response.status_code
+
+        first_span, second_span, third_span = cast("Tuple[Span, Span, Span]", exporter.get_finished_spans())
+        assert dict(first_span.attributes) == {  # type: ignore[arg-type]
+            "http.status_code": 405,
+            "asgi.event.type": "http.response.start",
+        }
+        assert dict(second_span.attributes) == {"asgi.event.type": "http.response.body"}  # type: ignore[arg-type]
+        assert dict(third_span.attributes) == {  # type: ignore[arg-type]
+            "http.scheme": "http",
+            "http.host": "testserver.local",
+            "net.host.port": 80,
+            "http.flavor": "1.1",
+            "http.target": "/",
+            "http.url": "http://testserver.local/",
+            "http.method": "POST",
+            "http.server_name": "testserver.local",
+            "http.user_agent": "testclient",
+            "net.peer.ip": "testclient",
+            "net.peer.port": 50000,
+            "http.route": "POST /",
+            "http.status_code": 405,
+        }
+
+
+def test_open_telemetry_middleware_handles_errors_caused_on_middleware() -> None:
+    config, _, exporter = create_config()
+
+    raise_exception = True
+
+    def middleware_factory(app: ASGIApp) -> ASGIApp:
+        async def error_middleware(scope: Scope, receive: Receive, send: Send) -> None:
+            if raise_exception:
+                raise http_exceptions.NotAuthorizedException()
+            await app(scope, receive, send)
+
+        return error_middleware
+
+    @get("/")
+    def handler() -> dict:
+        raise Exception("random Exception")
+
+    with create_test_client(handler, middleware=[middleware_factory, config.middleware]) as client:
+        response = client.get("/")
+        assert response.status_code
+
+        first_span, second_span, third_span = cast("Tuple[Span, Span, Span]", exporter.get_finished_spans())
+        assert dict(first_span.attributes) == {  # type: ignore[arg-type]
+            "http.status_code": 401,
+            "asgi.event.type": "http.response.start",
+        }
+        assert dict(second_span.attributes) == {"asgi.event.type": "http.response.body"}  # type: ignore[arg-type]
+        assert dict(third_span.attributes) == {  # type: ignore[arg-type]
+            "http.scheme": "http",
+            "http.host": "testserver.local",
+            "net.host.port": 80,
+            "http.flavor": "1.1",
+            "http.target": "/",
+            "http.url": "http://testserver.local/",
+            "http.method": "GET",
+            "http.server_name": "testserver.local",
+            "http.user_agent": "testclient",
+            "net.peer.ip": "testclient",
+            "net.peer.port": 50000,
+            "http.route": "GET /",
+            "http.status_code": 401,
         }


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This PR addresses an issue with exception handling and span creation in the LiteStar application when using OpenTelemetry for observability. The problem occurred when exceptions were raised before the OpenTelemetry middleware was invoked, resulting in those exceptions not being captured under the current request span. This led to incomplete traces, making it difficult to monitor and debug the full lifecycle of requests.

## **Solution**

To solve this, I reordered the middleware chain to ensure that the OpenTelemetry middleware wraps the entire request lifecycle, including exception handling. The new order is as follows:

`Initial ExceptionHandler Middleware` -> `OpenTelemetry Middleware` -> `ASGIRouter` -> `Middleware n` -> `Exception Handler Middleware` -> `Route Handler`

This ensures that spans are created as early as possible in the request lifecycle and that any exceptions, regardless of where they occur, are logged within the appropriate span. **However, this will only occur if the OpenTelemetry middleware is included in the middleware stack.**

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
#3663 
