### PR TITLE
docs: Fix misplaced comment in dependency-injection.rst for better clarity

### DIFF
--- a/docs/usage/dependency-injection.rst
+++ b/docs/usage/dependency-injection.rst
@@ -37,9 +37,8 @@ the application:
            local_dependency: int,
        ) -> None: ...
 
-       # on the router
 
-
+   # on the router
    my_router = Router(
        path="/router",
        dependencies={"router_dependency": Provide(dict_fn)},


### PR DESCRIPTION
The comment "on the router" was incorrectly placed below the `my_route_handler()`, which could cause confusion. I've moved the comment to the appropriate location above the router configuration for better clarity. 

No functional changes were made.