### PR TITLE
fix(DTO): Inconsistent use of strict mode 

### DIFF
--- a/litestar/dto/_backend.py
+++ b/litestar/dto/_backend.py
@@ -232,9 +232,9 @@ class DTOBackend:
         type_decoders = asgi_connection.route_handler.resolve_type_decoders()
 
         if request_encoding == RequestEncodingType.MESSAGEPACK:
-            result = decode_msgpack(value=raw, target_type=self.annotation, type_decoders=type_decoders)
+            result = decode_msgpack(value=raw, target_type=self.annotation, type_decoders=type_decoders, strict=False)
         else:
-            result = decode_json(value=raw, target_type=self.annotation, type_decoders=type_decoders)
+            result = decode_json(value=raw, target_type=self.annotation, type_decoders=type_decoders, strict=False)
 
         return cast("Struct | Collection[Struct]", result)
 

--- a/litestar/serialization/msgspec_hooks.py
+++ b/litestar/serialization/msgspec_hooks.py
@@ -165,25 +165,28 @@ def encode_json(value: Any, serializer: Callable[[Any], Any] | None = None) -> b
 
 
 @overload
-def decode_json(value: str | bytes) -> Any: ...
+def decode_json(value: str | bytes, strict: bool = ...) -> Any: ...
 
 
 @overload
-def decode_json(value: str | bytes, type_decoders: TypeDecodersSequence | None) -> Any: ...
+def decode_json(value: str | bytes, type_decoders: TypeDecodersSequence | None, strict: bool = ...) -> Any: ...
 
 
 @overload
-def decode_json(value: str | bytes, target_type: type[T]) -> T: ...
+def decode_json(value: str | bytes, target_type: type[T], strict: bool = ...) -> T: ...
 
 
 @overload
-def decode_json(value: str | bytes, target_type: type[T], type_decoders: TypeDecodersSequence | None) -> T: ...
+def decode_json(
+    value: str | bytes, target_type: type[T], type_decoders: TypeDecodersSequence | None, strict: bool = ...
+) -> T: ...
 
 
 def decode_json(  # type: ignore[misc]
     value: str | bytes,
     target_type: type[T] | EmptyType = Empty,  # pyright: ignore
     type_decoders: TypeDecodersSequence | None = None,
+    strict: bool = True,
 ) -> Any:
     """Decode a JSON string/bytes into an object.
 
@@ -191,6 +194,8 @@ def decode_json(  # type: ignore[misc]
         value: Value to decode
         target_type: An optional type to decode the data into
         type_decoders: Optional sequence of type decoders
+        strict: Whether type coercion rules should be strict. Setting to False enables
+            a wider set of coercion rules from string to non-string types for all values
 
     Returns:
         An object
@@ -202,7 +207,13 @@ def decode_json(  # type: ignore[misc]
         if target_type is Empty:
             return _msgspec_json_decoder.decode(value)
         return msgspec.json.decode(
-            value, dec_hook=partial(default_deserializer, type_decoders=type_decoders), type=target_type
+            value,
+            dec_hook=partial(
+                default_deserializer,
+                type_decoders=type_decoders,
+            ),
+            type=target_type,
+            strict=strict,
         )
     except msgspec.DecodeError as msgspec_error:
         raise SerializationException(str(msgspec_error)) from msgspec_error
@@ -230,25 +241,28 @@ def encode_msgpack(value: Any, serializer: Callable[[Any], Any] | None = default
 
 
 @overload
-def decode_msgpack(value: bytes) -> Any: ...
+def decode_msgpack(value: bytes, strict: bool = ...) -> Any: ...
 
 
 @overload
-def decode_msgpack(value: bytes, type_decoders: TypeDecodersSequence | None) -> Any: ...
+def decode_msgpack(value: bytes, type_decoders: TypeDecodersSequence | None, strict: bool = ...) -> Any: ...
 
 
 @overload
-def decode_msgpack(value: bytes, target_type: type[T]) -> T: ...
+def decode_msgpack(value: bytes, target_type: type[T], strict: bool = ...) -> T: ...
 
 
 @overload
-def decode_msgpack(value: bytes, target_type: type[T], type_decoders: TypeDecodersSequence | None) -> T: ...
+def decode_msgpack(
+    value: bytes, target_type: type[T], type_decoders: TypeDecodersSequence | None, strict: bool = ...
+) -> T: ...
 
 
 def decode_msgpack(  # type: ignore[misc]
     value: bytes,
     target_type: type[T] | EmptyType = Empty,  # pyright: ignore[reportInvalidTypeVarUse]
     type_decoders: TypeDecodersSequence | None = None,
+    strict: bool = True,
 ) -> Any:
     """Decode a MessagePack string/bytes into an object.
 
@@ -256,6 +270,8 @@ def decode_msgpack(  # type: ignore[misc]
         value: Value to decode
         target_type: An optional type to decode the data into
         type_decoders: Optional sequence of type decoders
+        strict: Whether type coercion rules should be strict. Setting to False enables
+            a wider set of coercion rules from string to non-string types for all values
 
     Returns:
         An object
@@ -267,7 +283,10 @@ def decode_msgpack(  # type: ignore[misc]
         if target_type is Empty:
             return _msgspec_msgpack_decoder.decode(value)
         return msgspec.msgpack.decode(
-            value, dec_hook=partial(default_deserializer, type_decoders=type_decoders), type=target_type
+            value,
+            dec_hook=partial(default_deserializer, type_decoders=type_decoders),
+            type=target_type,
+            strict=strict,
         )
     except msgspec.DecodeError as msgspec_error:
         raise SerializationException(str(msgspec_error)) from msgspec_error

--- a/tests/unit/test_dto/test_factory/test_backends/test_backends.py
+++ b/tests/unit/test_dto/test_factory/test_backends/test_backends.py
@@ -41,6 +41,7 @@ class DC:
     nested: NestedDC
     nested_list: List[NestedDC]
     nested_mapping: Dict[str, NestedDC]
+    integer: int
     b: str = field(default="b")
     c: List[int] = field(default_factory=list)
     optional: Optional[str] = None
@@ -53,10 +54,12 @@ DESTRUCTURED = {
     "nested": {"a": 1, "b": "two"},
     "nested_list": [{"a": 1, "b": "two"}],
     "nested_mapping": {"a": {"a": 1, "b": "two"}},
+    "integer": 1,
     "optional": None,
 }
-RAW = b'{"a":1,"nested":{"a":1,"b":"two"},"nested_list":[{"a":1,"b":"two"}],"nested_mapping":{"a":{"a":1,"b":"two"}},"b":"b","c":[],"optional":null}'
-COLLECTION_RAW = b'[{"a":1,"nested":{"a":1,"b":"two"},"nested_list":[{"a":1,"b":"two"}],"nested_mapping":{"a":{"a":1,"b":"two"}},"b":"b","c":[],"optional":null}]'
+RAW = b'{"a":1,"nested":{"a":1,"b":"two"},"nested_list":[{"a":1,"b":"two"}],"nested_mapping":{"a":{"a":1,"b":"two"}},"integer":1,"b":"b","c":[],"optional":null}'
+MSGPACK_RAW = b"\x88\xa1a\x01\xa6nested\x82\xa1a\x01\xa1b\xa3two\xabnested_list\x91\x82\xa1a\x01\xa1b\xa3two\xaenested_mapping\x81\xa1a\x82\xa1a\x01\xa1b\xa3two\xa7integer\x01\xa1b\xa1b\xa1c\x90\xa8optional\xc0"
+COLLECTION_RAW = b'[{"a":1,"nested":{"a":1,"b":"two"},"nested_list":[{"a":1,"b":"two"}],"nested_mapping":{"a":{"a":1,"b":"two"}},"integer":1,"b":"b","c":[],"optional":null}]'
 STRUCTURED = DC(
     a=1,
     b="b",
@@ -65,6 +68,7 @@ STRUCTURED = DC(
     nested_list=[NestedDC(a=1, b="two")],
     nested_mapping={"a": NestedDC(a=1, b="two")},
     optional=None,
+    integer=1,
 )
 
 
@@ -97,10 +101,7 @@ def test_backend_parse_raw_json(
                 wrapper_attribute_name=None,
                 is_data_field=True,
                 handler_id="test",
-            ).parse_raw(
-                b'{"a":1,"nested":{"a":1,"b":"two"},"nested_list":[{"a":1,"b":"two"}],"nested_mapping":{"a":{"a":1,"b":"two"}}}',
-                asgi_connection,
-            )
+            ).parse_raw(RAW, asgi_connection)
         )
         == DESTRUCTURED
     )
@@ -122,10 +123,7 @@ def test_backend_parse_raw_msgpack(dto_factory: type[DataclassDTO], backend_cls:
                 wrapper_attribute_name=None,
                 is_data_field=True,
                 handler_id="test",
-            ).parse_raw(
-                b"\x87\xa1a\x01\xa6nested\x82\xa1a\x01\xa1b\xa3two\xabnested_list\x91\x82\xa1a\x01\xa1b\xa3two\xaenested_mapping\x81\xa1a\x82\xa1a\x01\xa1b\xa3two\xa1b\xa1b\xa1c\x90\xa8optional\xc0",
-                asgi_connection,
-            )
+            ).parse_raw(MSGPACK_RAW, asgi_connection)
         )
         == DESTRUCTURED
     )


### PR DESCRIPTION
Fix inconsistent usage of msgspec's `strict` mode in the base DTO backend.

`strict=False` was being used when transferring from builtins, while `strict=True` was used transferring from raw data, causing an unwanted discrepancy in behaviour,