### PR TITLE
fix(prometheus): use path template for prometheus metrics

### DIFF
--- a/litestar/_asgi/asgi_router.py
+++ b/litestar/_asgi/asgi_router.py
@@ -87,7 +87,7 @@ class ASGIRouter:
         normalized_path = normalize_path(path)
 
         try:
-            asgi_app, route_handler, scope["path"], scope["path_params"] = self.handle_routing(
+            asgi_app, route_handler, scope["path"], scope["path_params"], path_template = self.handle_routing(
                 path=normalized_path, method=scope.get("method")
             )
         except Exception:
@@ -96,10 +96,11 @@ class ASGIRouter:
         else:
             ScopeState.from_scope(scope).exception_handlers = route_handler.resolve_exception_handlers()
             scope["route_handler"] = route_handler
+            scope["path_template"] = path_template
         await asgi_app(scope, receive, send)
 
     @lru_cache(1024)  # noqa: B019
-    def handle_routing(self, path: str, method: Method | None) -> tuple[ASGIApp, RouteHandlerType, str, dict[str, Any]]:
+    def handle_routing(self, path: str, method: Method | None) -> tuple[ASGIApp, RouteHandlerType, str, dict[str, Any], str]:
         """Handle routing for a given path / method combo. This method is meant to allow easy caching.
 
         Args:

--- a/litestar/_asgi/asgi_router.py
+++ b/litestar/_asgi/asgi_router.py
@@ -100,7 +100,9 @@ class ASGIRouter:
         await asgi_app(scope, receive, send)
 
     @lru_cache(1024)  # noqa: B019
-    def handle_routing(self, path: str, method: Method | None) -> tuple[ASGIApp, RouteHandlerType, str, dict[str, Any], str]:
+    def handle_routing(
+        self, path: str, method: Method | None
+    ) -> tuple[ASGIApp, RouteHandlerType, str, dict[str, Any], str]:
         """Handle routing for a given path / method combo. This method is meant to allow easy caching.
 
         Args:

--- a/litestar/_asgi/routing_trie/mapping.py
+++ b/litestar/_asgi/routing_trie/mapping.py
@@ -111,7 +111,7 @@ def add_route_to_trie(
                 next_node_key = component
 
             if next_node_key not in current_node.children:
-                current_node.children[next_node_key] = create_node()
+                current_node.children[next_node_key] = create_node(path_template=route.path_format)
 
             current_node.child_keys = set(current_node.children.keys())
             current_node = current_node.children[next_node_key]

--- a/litestar/_asgi/routing_trie/traversal.py
+++ b/litestar/_asgi/routing_trie/traversal.py
@@ -112,7 +112,7 @@ def parse_path_to_route(
     path: str,
     plain_routes: set[str],
     root_node: RouteTrieNode,
-) -> tuple[ASGIApp, RouteHandlerType, str, dict[str, Any]]:
+) -> tuple[ASGIApp, RouteHandlerType, str, dict[str, Any], str]:
     """Given a scope object, retrieve the asgi_handlers and is_mount boolean values from correct trie node.
 
     Args:
@@ -134,7 +134,7 @@ def parse_path_to_route(
     try:
         if path in plain_routes:
             asgi_app, handler = parse_node_handlers(node=root_node.children[path], method=method)
-            return asgi_app, handler, path, {}
+            return asgi_app, handler, path, {}, root_node.path_template
 
         if mount_paths_regex and (match := mount_paths_regex.match(path)):
             mount_path = path[: match.end()]
@@ -152,7 +152,7 @@ def parse_path_to_route(
                 remaining_path = remaining_path or "/"
                 if not mount_node.is_static:
                     remaining_path = remaining_path if remaining_path.endswith("/") else f"{remaining_path}/"
-                return asgi_app, handler, remaining_path, {}
+                return asgi_app, handler, remaining_path, {}, root_node.path_template
 
         node, path_parameters, path = traverse_route_map(
             root_node=root_node,
@@ -167,6 +167,7 @@ def parse_path_to_route(
             handler,
             path,
             parsed_path_parameters,
+            node.path_template,
         )
     except KeyError as e:
         raise MethodNotAllowedException() from e

--- a/litestar/_asgi/routing_trie/types.py
+++ b/litestar/_asgi/routing_trie/types.py
@@ -38,6 +38,7 @@ class RouteTrieNode:
         "is_path_param_node",
         "is_path_type",
         "path_parameters",
+        "path_template",
     )
 
     asgi_handlers: dict[Method | Literal["websocket", "asgi"], ASGIHandlerTuple]
@@ -63,9 +64,11 @@ class RouteTrieNode:
 
     This is used for parsing extracted path parameter values.
     """
+    path_template: str
+    """The path template string used to lower prometheus cardinality when group_path enabled"""
 
 
-def create_node() -> RouteTrieNode:
+def create_node(path_template: str = "") -> RouteTrieNode:
     """Create a RouteMapNode instance.
 
     Returns:
@@ -82,4 +85,5 @@ def create_node() -> RouteTrieNode:
         is_static=False,
         is_path_type=False,
         path_parameters={},
+        path_template=path_template,
     )

--- a/litestar/contrib/prometheus/middleware.py
+++ b/litestar/contrib/prometheus/middleware.py
@@ -117,15 +117,7 @@ class PrometheusMiddleware(AbstractMiddleware):
 
         path = request.url.path
         if self._config.group_path:
-            path_parts = path.split("/")[1:]
-            path = ""
-            for path_parameter, path_parameter_value in request.scope.get("path_params", {}).items():
-                for path_part in path_parts:
-                    path_parameter_value = str(path_parameter_value)
-                    if path_part == path_parameter_value:
-                        path += f"/{{{path_parameter}}}"
-                    else:
-                        path += f"/{path_part}"
+            path = request.scope["path_template"]
         return {
             "method": request.method if request.scope["type"] == ScopeType.HTTP else request.scope["type"],
             "path": path,

--- a/litestar/testing/client/base.py
+++ b/litestar/testing/client/base.py
@@ -56,7 +56,7 @@ def fake_asgi_connection(app: ASGIApp, cookies: dict[str, str]) -> ASGIConnectio
         "app": app,  # type: ignore[typeddict-item]
         "state": {},
         "path_params": {},
-        "route_handler": None,  # type: ignore[typeddict-item]
+        "route_handler": None,
         "asgi": {"version": "3.0", "spec_version": "2.1"},
         "auth": None,
         "session": None,

--- a/litestar/testing/request_factory.py
+++ b/litestar/testing/request_factory.py
@@ -165,7 +165,7 @@ class RequestFactory:
 
         if path_params is None:
             path_params = {}
-        a = 1
+
         return HTTPScope(
             type=ScopeType.HTTP,
             method=http_method.value,

--- a/litestar/testing/request_factory.py
+++ b/litestar/testing/request_factory.py
@@ -165,7 +165,7 @@ class RequestFactory:
 
         if path_params is None:
             path_params = {}
-
+        a = 1
         return HTTPScope(
             type=ScopeType.HTTP,
             method=http_method.value,
@@ -188,6 +188,7 @@ class RequestFactory:
             route_handler=route_handler
             or _create_default_route_handler(http_method, self.handler_kwargs, app=self.app),
             extensions={},
+            path_template="",
         )
 
     @classmethod

--- a/litestar/types/asgi_types.py
+++ b/litestar/types/asgi_types.py
@@ -132,6 +132,7 @@ class BaseScope(HeaderScope):
     http_version: str
     path: str
     path_params: dict[str, str]
+    path_template: str
     query_string: bytes
     raw_path: bytes
     root_path: str

--- a/tests/examples/test_contrib/prometheus/test_prometheus_exporter_example.py
+++ b/tests/examples/test_contrib/prometheus/test_prometheus_exporter_example.py
@@ -20,14 +20,26 @@ def clear_collectors() -> None:
 @pytest.mark.parametrize(
     "group_path, route_path, route_template, expected_path",
     [
-        (True,"/test/litestar", "test/{name:str}", "/test/{name}"),
-        (True,"/test/litestar", "test/{name:str}", "/test/{name}"),
-        (False,"/test/litestar", "test/{name:str}", "/test/litestar"),
-        (True,  "/project/123a/team/abc/test/hi", "project/{project:str}/team/{team:str}/test/{name:str}", "/project/{project}/team/{team}/test/{name}"),
-        (False, "/project/123a/team/abc/test/hi", "project/{project:str}/team/{team:str}/test/{name:str}", "/project/123a/team/abc/test/hi"),
+        (True, "/test/litestar", "test/{name:str}", "/test/{name}"),
+        (True, "/test/litestar", "test/{name:str}", "/test/{name}"),
+        (False, "/test/litestar", "test/{name:str}", "/test/litestar"),
+        (
+            True,
+            "/project/123a/team/abc/test/hi",
+            "project/{project:str}/team/{team:str}/test/{name:str}",
+            "/project/{project}/team/{team}/test/{name}",
+        ),
+        (
+            False,
+            "/project/123a/team/abc/test/hi",
+            "project/{project:str}/team/{team:str}/test/{name:str}",
+            "/project/123a/team/abc/test/hi",
+        ),
     ],
 )
-def test_prometheus_exporter_example(group_path: bool,route_path: str,route_template: str,  expected_path: str) -> None:
+def test_prometheus_exporter_example(
+    group_path: bool, route_path: str, route_template: str, expected_path: str
+) -> None:
     from docs.examples.contrib.prometheus.using_prometheus_exporter import create_app
 
     app = create_app(group_path=group_path)

--- a/tests/examples/test_contrib/prometheus/test_prometheus_exporter_example.py
+++ b/tests/examples/test_contrib/prometheus/test_prometheus_exporter_example.py
@@ -18,29 +18,32 @@ def clear_collectors() -> None:
 
 
 @pytest.mark.parametrize(
-    "group_path, expected_path",
+    "group_path, route_path, route_template, expected_path",
     [
-        (True, "/test/{name}"),
-        (False, "/test/litestar"),
+        (True,"/test/litestar", "test/{name:str}", "/test/{name}"),
+        (True,"/test/litestar", "test/{name:str}", "/test/{name}"),
+        (False,"/test/litestar", "test/{name:str}", "/test/litestar"),
+        (True,  "/project/123a/team/abc/test/hi", "project/{project:str}/team/{team:str}/test/{name:str}", "/project/{project}/team/{team}/test/{name}"),
+        (False, "/project/123a/team/abc/test/hi", "project/{project:str}/team/{team:str}/test/{name:str}", "/project/123a/team/abc/test/hi"),
     ],
 )
-def test_prometheus_exporter_example(group_path: bool, expected_path: str) -> None:
+def test_prometheus_exporter_example(group_path: bool,route_path: str,route_template: str,  expected_path: str) -> None:
     from docs.examples.contrib.prometheus.using_prometheus_exporter import create_app
 
     app = create_app(group_path=group_path)
 
     clear_collectors()
 
-    @get("test/{name: str}")
+    @get(route_template)
     def home(name: str) -> Dict[str, Any]:
         return {"hello": name}
 
     app.register(home)
 
     with TestClient(app) as client:
-        client.get("/test/litestar")
-        metrix_exporter_response = client.get("/metrics")
+        client.get(route_path)
+        metrics_exporter_response = client.get("/metrics")
 
-        assert metrix_exporter_response.status_code == HTTP_200_OK
-        metrics = metrix_exporter_response.content.decode()
+        assert metrics_exporter_response.status_code == HTTP_200_OK
+        metrics = metrics_exporter_response.content.decode()
         assert expected_path in metrics

--- a/tests/examples/test_contrib/prometheus/test_prometheus_exporter_example_with_extra_config.py
+++ b/tests/examples/test_contrib/prometheus/test_prometheus_exporter_example_with_extra_config.py
@@ -29,10 +29,10 @@ def test_prometheus_exporter_with_extra_config_example() -> None:
 
     with TestClient(app) as client:
         client.get("/home")
-        metrix_exporter_response = client.get("/custom-path")
+        metrics_exporter_response = client.get("/custom-path")
 
-        assert metrix_exporter_response.status_code == HTTP_200_OK
-        metrics = metrix_exporter_response.content.decode()
+        assert metrics_exporter_response.status_code == HTTP_200_OK
+        metrics = metrics_exporter_response.content.decode()
 
         assert (
             """litestar_requests_in_progress{app_name="litestar-example",location="earth",method="GET",path="/custom-path",status_code="200",version_no="v2.0"} 1.0"""

--- a/tests/unit/test_contrib/test_prometheus.py
+++ b/tests/unit/test_contrib/test_prometheus.py
@@ -42,10 +42,10 @@ def test_prometheus_exporter_metrics_with_http() -> None:
     ) as client:
         client.get("/error")
         client.get("/duration")
-        metrix_exporter_response = client.get("/metrics")
+        metrics_exporter_response = client.get("/metrics")
 
-        assert metrix_exporter_response.status_code == HTTP_200_OK
-        metrics = metrix_exporter_response.content.decode()
+        assert metrics_exporter_response.status_code == HTTP_200_OK
+        metrics = metrics_exporter_response.content.decode()
 
         assert (
             """litestar_request_duration_seconds_sum{app_name="litestar",method="GET",path="/duration",status_code="200"}"""
@@ -121,10 +121,10 @@ def test_prometheus_middleware_configurations() -> None:
     with create_test_client([test, ignore, PrometheusController], middleware=[config.middleware]) as client:
         client.get("/test")
         client.post("/ignore")
-        metrix_exporter_response = client.get("/metrics")
+        metrics_exporter_response = client.get("/metrics")
 
-        assert metrix_exporter_response.status_code == HTTP_200_OK
-        metrics = metrix_exporter_response.content.decode()
+        assert metrics_exporter_response.status_code == HTTP_200_OK
+        metrics = metrics_exporter_response.content.decode()
 
         assert (
             """litestar_rocks_requests_total{app_name="litestar_test",baz="qux",foo="bar",method="GET",path="/test",status_code="200"} 1.0"""
@@ -168,10 +168,10 @@ def test_prometheus_controller_configurations() -> None:
     with create_test_client([test, CustomPrometheusController], middleware=[config.middleware]) as client:
         client.get("/test")
 
-        metrix_exporter_response = client.get("/metrics/custom")
+        metrics_exporter_response = client.get("/metrics/custom")
 
-        assert metrix_exporter_response.status_code == HTTP_200_OK
-        metrics = metrix_exporter_response.content.decode()
+        assert metrics_exporter_response.status_code == HTTP_200_OK
+        metrics = metrics_exporter_response.content.decode()
 
         assert (
             """litestar_requests_total{app_name="litestar",method="GET",path="/test",status_code="200"} 1.0 # {trace_id="1234"} 1.0"""
@@ -191,10 +191,10 @@ def test_prometheus_with_websocket() -> None:
             websocket.send_text("litestar")
             websocket.receive_json()
 
-        metrix_exporter_response = client.get("/metrics")
+        metrics_exporter_response = client.get("/metrics")
 
-        assert metrix_exporter_response.status_code == HTTP_200_OK
-        metrics = metrix_exporter_response.content.decode()
+        assert metrics_exporter_response.status_code == HTTP_200_OK
+        metrics = metrics_exporter_response.content.decode()
 
         assert (
             """litestar_requests_total{app_name="litestar",method="websocket",path="/test",status_code="200"} 1.0"""


### PR DESCRIPTION
I changed previous 1-by-1 replacement logic for `PrometheusMiddleware.group_path=true` with a more robust and slightly faster solution