### PR TITLE
feat(DTO): Support `extra="forbid"` model config for `PydanticDTO`

### DIFF
--- a/litestar/dto/base_dto.py
+++ b/litestar/dto/base_dto.py
@@ -84,6 +84,24 @@ class AbstractDTO(Generic[T]):
 
         return type(f"{cls.__name__}[{annotation}]", (cls,), cls_dict)  # pyright: ignore
 
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        if (config := getattr(cls, "config", None)) and (model_type := getattr(cls, "model_type", None)):
+            # it's a concrete class
+            cls.config = cls.get_config_for_model_type(config, model_type)
+
+    @classmethod
+    def get_config_for_model_type(cls, config: DTOConfig, model_type: type[Any]) -> DTOConfig:
+        """Create a new configuration for this specific ``model_type``, during the
+        creation of the factory.
+
+        The returned config object will be set as the ``config`` attribute on the newly
+        defined factory class.
+
+        .. versionadded: 2.11
+
+        """
+        return config
+
     def decode_builtins(self, value: dict[str, Any]) -> Any:
         """Decode a dictionary of Python values into an the DTO's datatype."""
 


### PR DESCRIPTION
Set `forbid_unkown_fields=True` for `PydanticDTOs` where the Pydantic model has an [`extra="forbid"`](https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.extra) config.

<hr>

- Add a new `get_config_for_model_type` method to `AbstractDTO`, that allows to customise the base config defined on the DTO factory for a specific model type
- Use `get_config_for_model_type` to set `forbid_unkown_fields=True` for Pydantic models that use the `extra="forbid" config

<hr>

Depends on #3690. Don't merge before that one :)