### PR TITLE
feat(JWT): Custom JWT payload classes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -213,6 +213,7 @@ nitpick_ignore_regex = [
     (PY_RE, r"advanced_alchemy\.config.common\.EngineT"),
     (PY_RE, r"advanced_alchemy\.config.common\.SessionT"),
     (PY_RE, r".*R"),
+    (PY_OBJ, r"litestar.security.jwt.auth.TokenT"),
 ]
 
 # Warnings about missing references to those targets in the specified location will be ignored.

--- a/docs/examples/security/jwt/custom_token_cls.py
+++ b/docs/examples/security/jwt/custom_token_cls.py
@@ -1,0 +1,38 @@
+import dataclasses
+import secrets
+from typing import Any, Dict
+
+from litestar import Litestar, Request, get
+from litestar.connection import ASGIConnection
+from litestar.security.jwt import JWTAuth, Token
+
+
+@dataclasses.dataclass
+class CustomToken(Token):
+    token_flag: bool = False
+
+
+@dataclasses.dataclass
+class User:
+    id: str
+
+
+async def retrieve_user_handler(token: CustomToken, connection: ASGIConnection) -> User:
+    return User(id=token.sub)
+
+
+TOKEN_SECRET = secrets.token_hex()
+
+jwt_auth = JWTAuth[User](
+    token_secret=TOKEN_SECRET,
+    retrieve_user_handler=retrieve_user_handler,
+    token_cls=CustomToken,
+)
+
+
+@get("/")
+def handler(request: Request[User, CustomToken, Any]) -> Dict[str, Any]:
+    return {"id": request.user.id, "token_flag": request.auth.token_flag}
+
+
+app = Litestar(middleware=[jwt_auth.middleware])

--- a/docs/usage/security/jwt.rst
+++ b/docs/usage/security/jwt.rst
@@ -44,3 +44,24 @@ OAuth 2.0 Bearer password flows.
 
     .. literalinclude:: /examples/security/jwt/using_oauth2_password_bearer.py
        :caption: Using OAUTH2 Bearer Password
+
+
+Using a custom token class
+--------------------------
+
+The token class used can be customized with arbitrary fields, by creating a subclass of
+:class:`~.security.jwt.Token`, and specifying it on the backend:
+
+.. literalinclude:: /examples/security/jwt/custom_token_cls.py
+   :caption: Using a custom token
+
+
+The token will be converted from JSON into the appropriate type, including basic type
+conversions.
+
+.. important::
+    Complex type conversions, especially those including third libraries such as
+    Pydantic or attrs, as well as any custom ``type_decoders`` are not available for
+    converting the token. To support more complex conversions, the
+    :meth:`~.security.jwt.Token.encode` and :meth:`~.security.jwt.Token.decode` methods
+    must be overwritten in the subclass.

--- a/litestar/security/jwt/auth.py
+++ b/litestar/security/jwt/auth.py
@@ -371,7 +371,6 @@ class JWTCookieAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, TokenT]):
     token_cls: type[Token] = Token
     """Target type the JWT payload will be converted into"""
 
-
     @property
     def openapi_components(self) -> Components:
         """Create OpenAPI documentation for the JWT Cookie auth scheme.

--- a/litestar/security/jwt/token.py
+++ b/litestar/security/jwt/token.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 import jwt
+import msgspec
 
 from litestar.exceptions import ImproperlyConfiguredException, NotAuthorizedException
 
@@ -86,15 +87,22 @@ class Token:
             NotAuthorizedException: If the token is invalid.
         """
         try:
-            payload = jwt.decode(jwt=encoded_token, key=secret, algorithms=[algorithm], options={"verify_aud": False})
-            exp = datetime.fromtimestamp(payload.pop("exp"), tz=timezone.utc)
-            iat = datetime.fromtimestamp(payload.pop("iat"), tz=timezone.utc)
-            field_names = {f.name for f in dataclasses.fields(Token)}
-            extra_fields = payload.keys() - field_names
-            extras = payload.pop("extras", {})
+            payload: dict[str, Any] = jwt.decode(
+                jwt=encoded_token,
+                key=secret,
+                algorithms=[algorithm],
+                options={"verify_aud": False},
+            )
+            # msgspec can do these conversions as well, but to keep backwards
+            # compatibility, we do it ourselves, since the datetime parsing works a
+            # little bit different there
+            payload["exp"] = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
+            payload["iat"] = datetime.fromtimestamp(payload["iat"], tz=timezone.utc)
+            extra_fields = payload.keys() - {f.name for f in dataclasses.fields(cls)}
+            extras = payload.setdefault("extras", {})
             for key in extra_fields:
                 extras[key] = payload.pop(key)
-            return cls(exp=exp, iat=iat, **payload, extras=extras)
+            return msgspec.convert(payload, cls, strict=False)
         except (KeyError, jwt.DecodeError, ImproperlyConfiguredException, jwt.exceptions.InvalidAlgorithmError) as e:
             raise NotAuthorizedException("Invalid token") from e
 
@@ -113,7 +121,9 @@ class Token:
         """
         try:
             return jwt.encode(
-                payload={k: v for k, v in asdict(self).items() if v is not None}, key=secret, algorithm=algorithm
+                payload={k: v for k, v in asdict(self).items() if v is not None},
+                key=secret,
+                algorithm=algorithm,
             )
         except (jwt.DecodeError, NotImplementedError) as e:
             raise ImproperlyConfiguredException("Failed to encode token") from e

--- a/litestar/security/jwt/token.py
+++ b/litestar/security/jwt/token.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import jwt
 import msgspec
@@ -42,13 +42,13 @@ class Token:
     """Subject - usually a unique identifier of the user or equivalent entity."""
     iat: datetime = field(default_factory=lambda: _normalize_datetime(datetime.now(timezone.utc)))
     """Issued at - should always be current now."""
-    iss: str | None = field(default=None)
+    iss: Optional[str] = field(default=None)  # noqa: UP007
     """Issuer - optional unique identifier for the issuer."""
-    aud: str | None = field(default=None)
+    aud: Optional[str] = field(default=None)  # noqa: UP007
     """Audience - intended audience."""
-    jti: str | None = field(default=None)
+    jti: Optional[str] = field(default=None)  # noqa: UP007
     """JWT ID - a unique identifier of the JWT between different issuers."""
-    extras: dict[str, Any] = field(default_factory=dict)
+    extras: Dict[str, Any] = field(default_factory=dict)  # noqa: UP006
     """Extra fields that were found on the JWT token."""
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
Support customizing the `Token` class the JWT backends decode the payload into.

- Add new `token_cls` field on the JWT auth config classes
- Add new `token_cls` parameter to JWT auth middlewares
- Switch to using msgspec to convert the JWT payload into tokens, providing type coercion for custom token types without having to override the `Token.decode` method

## Example:

```python
import dataclasses
import secrets
from typing import Any, Dict

from litestar import Litestar, Request, get
from litestar.connection import ASGIConnection
from litestar.security.jwt import JWTAuth, Token


@dataclasses.dataclass
class CustomToken(Token):
    token_flag: bool = False


@dataclasses.dataclass
class User:
    id: str


async def retrieve_user_handler(token: CustomToken, connection: ASGIConnection) -> User:
    return User(id=token.sub)


TOKEN_SECRET = secrets.token_hex()

jwt_auth = JWTAuth[User](
    token_secret=TOKEN_SECRET,
    retrieve_user_handler=retrieve_user_handler,
    token_cls=CustomToken,
)


@get("/")
def handler(request: Request[User, CustomToken, Any]) -> Dict[str, Any]:
    return {"id": request.user.id, "token_flag": request.auth.token_flag}
```
