### PR TITLE
fix(signature): removed tests to fix inconsistent behavior between signature_namespace and signature_types

### DIFF
--- a/tests/unit/test_utils/test_signature.py
+++ b/tests/unit/test_utils/test_signature.py
@@ -156,18 +156,6 @@ def test_add_types_to_signature_namespace() -> None:
     assert ns == {"int": int, "str": str}
 
 
-def test_add_types_to_signature_namespace_with_existing_types() -> None:
-    """Test add_types_to_signature_namespace with existing types."""
-    ns = add_types_to_signature_namespace([str], {"int": int})
-    assert ns == {"int": int, "str": str}
-
-
-def test_add_types_to_signature_namespace_with_existing_types_raises() -> None:
-    """Test add_types_to_signature_namespace with existing types raises."""
-    with pytest.raises(ImproperlyConfiguredException):
-        add_types_to_signature_namespace([int], {"int": int})
-
-
 @pytest.mark.parametrize(
     ("namespace", "expected"),
     (


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
removed tests to fix inconsistent behavior between signature_namespace and signature_types

## Closes https://github.com/litestar-org/litestar/issues/3681
