### PR TITLE
feat(JWT): Customised token verification

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -215,6 +215,7 @@ nitpick_ignore_regex = [
     (PY_RE, r".*R"),
     (PY_OBJ, r"litestar.security.jwt.auth.TokenT"),
     (PY_CLASS, "ExceptionToProblemDetailMapType"),
+    (PY_CLASS, "litestar.security.jwt.token.JWTDecodeOptions"),
 ]
 
 # Warnings about missing references to those targets in the specified location will be ignored.

--- a/docs/examples/security/jwt/custom_decode_payload.py
+++ b/docs/examples/security/jwt/custom_decode_payload.py
@@ -1,0 +1,28 @@
+import dataclasses
+from typing import Any, List, Optional, Sequence, Union
+
+from litestar.security.jwt.token import JWTDecodeOptions, Token
+
+
+@dataclasses.dataclass
+class CustomToken(Token):
+    @classmethod
+    def decode_payload(
+        cls,
+        encoded_token: str,
+        secret: str,
+        algorithms: List[str],
+        issuer: Optional[List[str]] = None,
+        audience: Union[str, Sequence[str], None] = None,
+        options: Optional[JWTDecodeOptions] = None,
+    ) -> Any:
+        payload = super().decode_payload(
+            encoded_token=encoded_token,
+            secret=secret,
+            algorithms=algorithms,
+            issuer=issuer,
+            audience=audience,
+            options=options,
+        )
+        payload["sub"] = payload["sub"].split("@", maxsplit=1)[1]
+        return payload

--- a/docs/examples/security/jwt/verify_issuer_audience.py
+++ b/docs/examples/security/jwt/verify_issuer_audience.py
@@ -1,0 +1,32 @@
+import dataclasses
+import secrets
+from typing import Any, Dict
+
+from litestar import Litestar, Request, get
+from litestar.connection import ASGIConnection
+from litestar.security.jwt import JWTAuth, Token
+
+
+@dataclasses.dataclass
+class User:
+    id: str
+
+
+async def retrieve_user_handler(token: Token, connection: ASGIConnection) -> User:
+    return User(id=token.sub)
+
+
+jwt_auth = JWTAuth[User](
+    token_secret=secrets.token_hex(),
+    retrieve_user_handler=retrieve_user_handler,
+    accepted_audiences=["https://api.testserver.local"],
+    accepted_issuers=["https://auth.testserver.local"],
+)
+
+
+@get("/")
+def handler(request: Request[User, Token, Any]) -> Dict[str, Any]:
+    return {"id": request.user.id}
+
+
+app = Litestar([handler], middleware=[jwt_auth.middleware])

--- a/docs/usage/security/jwt.rst
+++ b/docs/usage/security/jwt.rst
@@ -80,3 +80,17 @@ a :exc:`NotAuthorizedException` will be raised, returning a response with a
 
 .. literalinclude:: /examples/security/jwt/verify_issuer_audience.py
    :caption: Verifying issuer and audience
+
+
+Customizing token validation
+----------------------------
+
+Token decoding / validation can be further customized by overriding the
+:meth:`~.security.jwt.Token.decode_payload` method. It will be called by
+:meth:`~.security.jwt.Token.decode` with the encoded token string, and must return a
+dictionary representing the decoded payload, which will then used by
+:meth:`~.security.jwt.Token.decode` to construct an instance of the token class.
+
+
+.. literalinclude:: /examples/security/jwt/custom_decode_payload.py
+   :caption: Customizing payload decoding

--- a/docs/usage/security/jwt.rst
+++ b/docs/usage/security/jwt.rst
@@ -65,3 +65,18 @@ conversions.
     converting the token. To support more complex conversions, the
     :meth:`~.security.jwt.Token.encode` and :meth:`~.security.jwt.Token.decode` methods
     must be overwritten in the subclass.
+
+
+Verifying issuer and audience
+-----------------------------
+
+To verify the JWT ``iss`` (*issuer*) and ``aud`` (*audience*) claim, a list of accepted
+issuers or audiences can bet set on the authentication backend. When a JWT is decoded,
+the issuer or audience on the token is compared to the list of accepted issuers /
+audiences. If the value in the token does not match any value in the respective list,
+a :exc:`NotAuthorizedException` will be raised, returning a response with a
+``401 Unauthorized`` status.
+
+
+.. literalinclude:: /examples/security/jwt/verify_issuer_audience.py
+   :caption: Verifying issuer and audience

--- a/litestar/security/jwt/auth.py
+++ b/litestar/security/jwt/auth.py
@@ -83,7 +83,7 @@ class BaseJWTAuth(Generic[UserType, TokenT], AbstractSecurityConfig[UserType, To
     verify_expiry: bool = True
     """Verify that the value of the ``exp`` (*expiration*) claim is in the future"""
     verify_not_before: bool = True
-    """Verify that the value of the ``nbf``(*not before*) claim is in the past"""
+    """Verify that the value of the ``nbf`` (*not before*) claim is in the past"""
     strict_audience: bool = False
     """Verify that the value of the ``aud`` (*audience*) claim is a single value, and
     not a list of values, and matches ``audience`` exactly. Requires that
@@ -332,7 +332,7 @@ class JWTAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, TokenT]):
     verify_expiry: bool = True
     """Verify that the value of the ``exp`` (*expiration*) claim is in the future"""
     verify_not_before: bool = True
-    """Verify that the value of the ``nbf``(*not before*) claim is in the past"""
+    """Verify that the value of the ``nbf`` (*not before*) claim is in the past"""
     strict_audience: bool = False
     """Verify that the value of the ``aud`` (*audience*) claim is a single value, and
     not a list of values, and matches ``audience`` exactly. Requires that
@@ -433,7 +433,7 @@ class JWTCookieAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, TokenT]):
     verify_expiry: bool = True
     """Verify that the value of the ``exp`` (*expiration*) claim is in the future"""
     verify_not_before: bool = True
-    """Verify that the value of the ``nbf``(*not before*) claim is in the past"""
+    """Verify that the value of the ``nbf`` (*not before*) claim is in the past"""
     strict_audience: bool = False
     """Verify that the value of the ``aud`` (*audience*) claim is a single value, and
     not a list of values, and matches ``audience`` exactly. Requires that
@@ -669,7 +669,7 @@ class OAuth2PasswordBearerAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, 
     verify_expiry: bool = True
     """Verify that the value of the ``exp`` (*expiration*) claim is in the future"""
     verify_not_before: bool = True
-    """Verify that the value of the ``nbf``(*not before*) claim is in the past"""
+    """Verify that the value of the ``nbf`` (*not before*) claim is in the past"""
     strict_audience: bool = False
     """Verify that the value of the ``aud`` (*audience*) claim is a single value, and
     not a list of values, and matches ``audience`` exactly. Requires that

--- a/litestar/security/jwt/auth.py
+++ b/litestar/security/jwt/auth.py
@@ -68,6 +68,14 @@ class BaseJWTAuth(Generic[UserType, TokenT], AbstractSecurityConfig[UserType, To
     """
     token_cls: type[Token] = Token
     """Target type the JWT payload will be converted into"""
+    accepted_audiences: Sequence[str] | None = None
+    """Audiences to accept when verifying the token. If given, and the audience in the
+    token does not match, a 401 response is returned
+    """
+    accepted_issuers: Sequence[str] | None = None
+    """Issuers to accept when verifying the token. If given, and the issuer in the
+    token does not match, a 401 response is returned
+    """
 
     @property
     def openapi_components(self) -> Components:
@@ -120,6 +128,8 @@ class BaseJWTAuth(Generic[UserType, TokenT], AbstractSecurityConfig[UserType, To
             scopes=self.scopes,
             token_secret=self.token_secret,
             token_cls=self.token_cls,
+            token_issuer=self.accepted_issuers,
+            token_audience=self.accepted_audiences,
         )
 
     def login(
@@ -290,6 +300,14 @@ class JWTAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, TokenT]):
     """
     token_cls: type[Token] = Token
     """Target type the JWT payload will be converted into"""
+    accepted_audiences: Sequence[str] | None = None
+    """Audiences to accept when verifying the token. If given, and the audience in the
+    token does not match, a 401 response is returned
+    """
+    accepted_issuers: Sequence[str] | None = None
+    """Issuers to accept when verifying the token. If given, and the issuer in the
+    token does not match, a 401 response is returned
+    """
 
 
 @dataclass
@@ -370,6 +388,8 @@ class JWTCookieAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, TokenT]):
     """
     token_cls: type[Token] = Token
     """Target type the JWT payload will be converted into"""
+    accepted_audiences: Sequence[str] | None = None
+    accepted_issuers: Sequence[str] | None = None
 
     @property
     def openapi_components(self) -> Components:
@@ -411,6 +431,8 @@ class JWTCookieAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, TokenT]):
             scopes=self.scopes,
             token_secret=self.token_secret,
             token_cls=self.token_cls,
+            token_issuer=self.accepted_issuers,
+            token_audience=self.accepted_audiences,
         )
 
     def login(
@@ -579,6 +601,14 @@ class OAuth2PasswordBearerAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, 
     """
     token_cls: type[Token] = Token
     """Target type the JWT payload will be converted into"""
+    accepted_audiences: Sequence[str] | None = None
+    """Audiences to accept when verifying the token. If given, and the audience in the
+    token does not match, a 401 response is returned
+    """
+    accepted_issuers: Sequence[str] | None = None
+    """Issuers to accept when verifying the token. If given, and the issuer in the
+    token does not match, a 401 response is returned
+    """
 
     @property
     def middleware(self) -> DefineMiddleware:
@@ -600,6 +630,8 @@ class OAuth2PasswordBearerAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, 
             scopes=self.scopes,
             token_secret=self.token_secret,
             token_cls=self.token_cls,
+            token_issuer=self.accepted_issuers,
+            token_audience=self.accepted_audiences,
         )
 
     @property

--- a/litestar/security/jwt/auth.py
+++ b/litestar/security/jwt/auth.py
@@ -76,6 +76,19 @@ class BaseJWTAuth(Generic[UserType, TokenT], AbstractSecurityConfig[UserType, To
     """Issuers to accept when verifying the token. If given, and the issuer in the
     token does not match, a 401 response is returned
     """
+    require_claims: Sequence[str] | None = None
+    """Require these claims to be present in the JWT payload. If any of those claims
+    is missing, a 401 response is returned
+    """
+    verify_expiry: bool = True
+    """Verify that the value of the ``exp`` (*expiration*) claim is in the future"""
+    verify_not_before: bool = True
+    """Verify that the value of the ``nbf``(*not before*) claim is in the past"""
+    strict_audience: bool = False
+    """Verify that the value of the ``aud`` (*audience*) claim is a single value, and
+    not a list of values, and matches ``audience`` exactly. Requires that
+    ``accepted_audiences`` is a sequence of length 1
+    """
 
     @property
     def openapi_components(self) -> Components:
@@ -130,6 +143,10 @@ class BaseJWTAuth(Generic[UserType, TokenT], AbstractSecurityConfig[UserType, To
             token_cls=self.token_cls,
             token_issuer=self.accepted_issuers,
             token_audience=self.accepted_audiences,
+            require_claims=self.require_claims,
+            verify_expiry=self.verify_expiry,
+            verify_not_before=self.verify_not_before,
+            strict_audience=self.strict_audience,
         )
 
     def login(
@@ -308,6 +325,19 @@ class JWTAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, TokenT]):
     """Issuers to accept when verifying the token. If given, and the issuer in the
     token does not match, a 401 response is returned
     """
+    require_claims: Sequence[str] | None = None
+    """Require these claims to be present in the JWT payload. If any of those claims
+    is missing, a 401 response is returned
+    """
+    verify_expiry: bool = True
+    """Verify that the value of the ``exp`` (*expiration*) claim is in the future"""
+    verify_not_before: bool = True
+    """Verify that the value of the ``nbf``(*not before*) claim is in the past"""
+    strict_audience: bool = False
+    """Verify that the value of the ``aud`` (*audience*) claim is a single value, and
+    not a list of values, and matches ``audience`` exactly. Requires that
+    ``accepted_audiences`` is a sequence of length 1
+    """
 
 
 @dataclass
@@ -389,7 +419,26 @@ class JWTCookieAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, TokenT]):
     token_cls: type[Token] = Token
     """Target type the JWT payload will be converted into"""
     accepted_audiences: Sequence[str] | None = None
+    """Audiences to accept when verifying the token. If given, and the audience in the
+    token does not match, a 401 response is returned
+    """
     accepted_issuers: Sequence[str] | None = None
+    """Issuers to accept when verifying the token. If given, and the issuer in the
+    token does not match, a 401 response is returned
+    """
+    require_claims: Sequence[str] | None = None
+    """Require these claims to be present in the JWT payload. If any of those claims
+    is missing, a 401 response is returned
+    """
+    verify_expiry: bool = True
+    """Verify that the value of the ``exp`` (*expiration*) claim is in the future"""
+    verify_not_before: bool = True
+    """Verify that the value of the ``nbf``(*not before*) claim is in the past"""
+    strict_audience: bool = False
+    """Verify that the value of the ``aud`` (*audience*) claim is a single value, and
+    not a list of values, and matches ``audience`` exactly. Requires that
+    ``accepted_audiences`` is a sequence of length 1
+    """
 
     @property
     def openapi_components(self) -> Components:
@@ -433,6 +482,10 @@ class JWTCookieAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, TokenT]):
             token_cls=self.token_cls,
             token_issuer=self.accepted_issuers,
             token_audience=self.accepted_audiences,
+            require_claims=self.require_claims,
+            verify_expiry=self.verify_expiry,
+            verify_not_before=self.verify_not_before,
+            strict_audience=self.strict_audience,
         )
 
     def login(
@@ -609,6 +662,19 @@ class OAuth2PasswordBearerAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, 
     """Issuers to accept when verifying the token. If given, and the issuer in the
     token does not match, a 401 response is returned
     """
+    require_claims: Sequence[str] | None = None
+    """Require these claims to be present in the JWT payload. If any of those claims
+    is missing, a 401 response is returned
+    """
+    verify_expiry: bool = True
+    """Verify that the value of the ``exp`` (*expiration*) claim is in the future"""
+    verify_not_before: bool = True
+    """Verify that the value of the ``nbf``(*not before*) claim is in the past"""
+    strict_audience: bool = False
+    """Verify that the value of the ``aud`` (*audience*) claim is a single value, and
+    not a list of values, and matches ``audience`` exactly. Requires that
+    ``accepted_audiences`` is a sequence of length 1
+    """
 
     @property
     def middleware(self) -> DefineMiddleware:
@@ -632,6 +698,10 @@ class OAuth2PasswordBearerAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, 
             token_cls=self.token_cls,
             token_issuer=self.accepted_issuers,
             token_audience=self.accepted_audiences,
+            require_claims=self.require_claims,
+            verify_expiry=self.verify_expiry,
+            verify_not_before=self.verify_not_before,
+            strict_audience=self.strict_audience,
         )
 
     @property

--- a/litestar/security/jwt/middleware.py
+++ b/litestar/security/jwt/middleware.py
@@ -31,6 +31,8 @@ class JWTAuthenticationMiddleware(AbstractAuthenticationMiddleware):
         "retrieve_user_handler",
         "token_secret",
         "token_cls",
+        "token_audience",
+        "token_issuer",
     )
 
     def __init__(
@@ -45,6 +47,8 @@ class JWTAuthenticationMiddleware(AbstractAuthenticationMiddleware):
         scopes: Scopes,
         token_secret: str,
         token_cls: type[Token] = Token,
+        token_audience: Sequence[str] | None = None,
+        token_issuer: Sequence[str] | None = None,
     ) -> None:
         """Check incoming requests for an encoded token in the auth header specified, and if present retrieve the user
         from persistence using the provided function.
@@ -62,6 +66,12 @@ class JWTAuthenticationMiddleware(AbstractAuthenticationMiddleware):
             token_secret: Secret for decoding the JWT. This value should be equivalent to the secret used to
                 encode it.
             token_cls: Token class used when encoding / decoding JWTs
+            token_audience: Verify the audience when decoding the token. If the audience
+                in the token does not match any audience given, raise a
+                :exc:`NotAuthorizedException`
+            token_issuer: Verify the issuer when decoding the token. If the issuer in
+                the token does not match any issuer given, raise a
+                :exc:`NotAuthorizedException`
         """
         super().__init__(
             app=app,
@@ -75,6 +85,8 @@ class JWTAuthenticationMiddleware(AbstractAuthenticationMiddleware):
         self.retrieve_user_handler = retrieve_user_handler
         self.token_secret = token_secret
         self.token_cls = token_cls
+        self.token_audience = token_audience
+        self.token_issuer = token_issuer
 
     async def authenticate_request(self, connection: ASGIConnection[Any, Any, Any, Any]) -> AuthenticationResult:
         """Given an HTTP Connection, parse the JWT api key stored in the header and retrieve the user correlating to the
@@ -114,6 +126,8 @@ class JWTAuthenticationMiddleware(AbstractAuthenticationMiddleware):
             encoded_token=encoded_token,
             secret=self.token_secret,
             algorithm=self.algorithm,
+            audience=self.token_audience,
+            issuer=self.token_issuer,
         )
 
         user = await self.retrieve_user_handler(token, connection)
@@ -142,6 +156,8 @@ class JWTCookieAuthenticationMiddleware(JWTAuthenticationMiddleware):
         scopes: Scopes,
         token_secret: str,
         token_cls: type[Token] = Token,
+        token_audience: Sequence[str] | None = None,
+        token_issuer: Sequence[str] | None = None,
     ) -> None:
         """Check incoming requests for an encoded token in the auth header or cookie name specified, and if present
         retrieves the user from persistence using the provided function.
@@ -160,6 +176,12 @@ class JWTCookieAuthenticationMiddleware(JWTAuthenticationMiddleware):
             token_secret: Secret for decoding the JWT. This value should be equivalent to the secret used to
                 encode it.
             token_cls: Token class used when encoding / decoding JWTs
+            token_audience: Verify the audience when decoding the token. If the audience
+                in the token does not match any audience given, raise a
+                :exc:`NotAuthorizedException`
+            token_issuer: Verify the issuer when decoding the token. If the issuer in
+                the token does not match any issuer given, raise a
+                :exc:`NotAuthorizedException`
         """
         super().__init__(
             algorithm=algorithm,
@@ -172,6 +194,8 @@ class JWTCookieAuthenticationMiddleware(JWTAuthenticationMiddleware):
             scopes=scopes,
             token_secret=token_secret,
             token_cls=token_cls,
+            token_audience=token_audience,
+            token_issuer=token_issuer,
         )
         self.auth_cookie_key = auth_cookie_key
 

--- a/litestar/security/jwt/middleware.py
+++ b/litestar/security/jwt/middleware.py
@@ -82,7 +82,7 @@ class JWTAuthenticationMiddleware(AbstractAuthenticationMiddleware):
                 :exc:`NotAuthorizedException`
             require_claims: Require these claims to be present in the JWT payload
             verify_expiry: Verify that the value of the ``exp`` (*expiration*) claim is in the future
-            verify_not_before: Verify that the value of the ``nbf``(*not before*) claim is in the past
+            verify_not_before: Verify that the value of the ``nbf`` (*not before*) claim is in the past
             strict_audience: Verify that the value of the ``aud`` (*audience*) claim is a single value, and
                 not a list of values, and matches ``audience`` exactly. Requires that
                 ``accepted_audiences`` is a sequence of length 1
@@ -210,7 +210,7 @@ class JWTCookieAuthenticationMiddleware(JWTAuthenticationMiddleware):
                 :exc:`NotAuthorizedException`
             require_claims: Require these claims to be present in the JWT payload
             verify_expiry: Verify that the value of the ``exp`` (*expiration*) claim is in the future
-            verify_not_before: Verify that the value of the ``nbf``(*not before*) claim is in the past
+            verify_not_before: Verify that the value of the ``nbf`` (*not before*) claim is in the past
             strict_audience: Verify that the value of the ``aud`` (*audience*) claim is a single value, and
                 not a list of values, and matches ``audience`` exactly. Requires that
                 ``accepted_audiences`` is a sequence of length 1

--- a/litestar/security/jwt/token.py
+++ b/litestar/security/jwt/token.py
@@ -91,7 +91,7 @@ class Token:
         issuer: list[str] | None = None,
         audience: str | Sequence[str] | None = None,
         options: JWTDecodeOptions | None = None,
-    ) -> dict[str, Any]:
+    ) -> Any:
         """Decode and verify the JWT and return its payload"""
         return jwt.decode(
             jwt=encoded_token,

--- a/litestar/security/jwt/token.py
+++ b/litestar/security/jwt/token.py
@@ -35,6 +35,8 @@ def _normalize_datetime(value: datetime) -> datetime:
 
 
 class JWTDecodeOptions(TypedDict, total=False):
+    """``options`` for PyJWTs :func:`jwt.decode`"""
+
     verify_aud: bool
     verify_iss: bool
     verify_exp: bool
@@ -119,7 +121,7 @@ class Token:
 
         Args:
             encoded_token: A base64 string containing an encoded JWT.
-            secret: The secret with which the JWT is encoded. It may optionally be an individual JWK or JWS set dict
+            secret: The secret with which the JWT is encoded.
             algorithm: The algorithm used to encode the JWT.
             audience: Verify the audience when decoding the token. If the audience in
                 the token does not match any audience given, raise a

--- a/litestar/security/jwt/token.py
+++ b/litestar/security/jwt/token.py
@@ -98,7 +98,7 @@ class Token:
             require_claims: Verify that the given claims are present in the token
             verify_exp: Verify that the value of the ``exp`` (*expiration*) claim is in
                 the future
-            verify_nbf: Verify that the value of the ``nbf``(*not before*) claim is in
+            verify_nbf: Verify that the value of the ``nbf`` (*not before*) claim is in
                 the past
             strict_audience: Verify that the value of the ``aud`` (*audience*) claim is
                 a single value, and not a list of values, and matches ``audience``

--- a/tests/examples/test_security/test_jwt/test_verify_issuer_audience.py
+++ b/tests/examples/test_security/test_jwt/test_verify_issuer_audience.py
@@ -1,0 +1,18 @@
+from litestar.testing import TestClient
+
+
+def test_app() -> None:
+    from docs.examples.security.jwt.verify_issuer_audience import app, jwt_auth
+
+    valid_token = jwt_auth.create_token(
+        "foo",
+        token_audience=jwt_auth.accepted_audiences[0],
+        token_issuer=jwt_auth.accepted_issuers[0],
+    )
+    invalid_token = jwt_auth.create_token("foo")
+
+    with TestClient(app) as client:
+        response = client.get("/", headers={"Authorization": jwt_auth.format_auth_header(valid_token)})
+        assert response.status_code == 200
+        response = client.get("/", headers={"Authorization": jwt_auth.format_auth_header(invalid_token)})
+        assert response.status_code == 401

--- a/tests/unit/test_security/test_jwt/test_auth.py
+++ b/tests/unit/test_security/test_jwt/test_auth.py
@@ -727,6 +727,7 @@ def auth_cls(request: pytest.FixtureRequest) -> Any:
     "accepted_audiences, token_audience, expected_status_code",
     [
         (["audience_a"], "audience_a", 200),
+        ("audience_a", "audience_a", 200),
         (["audience_a"], ["audience_a", "audience_b"], 401),
         (["audience_b"], "audience_a", 401),
     ],

--- a/tests/unit/test_security/test_jwt/test_auth.py
+++ b/tests/unit/test_security/test_jwt/test_auth.py
@@ -2,7 +2,7 @@ import dataclasses
 import secrets
 import string
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 from uuid import uuid4
 
 import jwt
@@ -10,12 +10,13 @@ import msgspec
 import pytest
 from hypothesis import given, settings
 from hypothesis.strategies import dictionaries, integers, none, one_of, sampled_from, text, timedeltas
+from typing_extensions import TypeAlias
 
 from litestar import Litestar, Request, Response, get
 from litestar.security.jwt import JWTAuth, JWTCookieAuth, OAuth2PasswordBearerAuth, Token
 from litestar.status_codes import HTTP_200_OK, HTTP_201_CREATED, HTTP_401_UNAUTHORIZED
 from litestar.stores.memory import MemoryStore
-from litestar.testing import create_test_client
+from litestar.testing import TestClient, create_test_client
 from tests.models import User, UserFactory
 
 if TYPE_CHECKING:
@@ -682,3 +683,159 @@ async def test_jwt_auth_verify_audience(
     with create_test_client(route_handlers=[handler]) as client:
         response = client.get("/", headers={"Authorization": header})
         assert response.status_code == expected_status_code
+
+
+CreateJWTApp: TypeAlias = Callable[..., Tuple[JWTAuth, TestClient]]
+
+
+@pytest.fixture()
+def create_jwt_app(auth_cls: Any, request: pytest.FixtureRequest) -> CreateJWTApp:
+    def create(**kwargs: Any) -> Tuple[JWTAuth, TestClient]:
+        async def retrieve_user_handler(token: Token, _: "ASGIConnection") -> Any:
+            return object()
+
+        if auth_cls is OAuth2PasswordBearerAuth:
+            jwt_auth = auth_cls(
+                token_secret=secrets.token_hex(),
+                retrieve_user_handler=retrieve_user_handler,
+                token_url="http://testserver.local",
+                **kwargs,
+            )
+        else:
+            jwt_auth = auth_cls[Any](
+                token_secret=secrets.token_hex(), retrieve_user_handler=retrieve_user_handler, **kwargs
+            )
+
+        @get("/", middleware=[jwt_auth.middleware])
+        def handler() -> None:
+            return None
+
+        client = create_test_client(route_handlers=[handler]).__enter__()
+        request.addfinalizer(client.__exit__)
+
+        return jwt_auth, client
+
+    return create
+
+
+@pytest.fixture(params=[JWTAuth, JWTCookieAuth, OAuth2PasswordBearerAuth])
+def auth_cls(request: pytest.FixtureRequest) -> Any:
+    return request.param
+
+
+@pytest.mark.parametrize(
+    "accepted_audiences, token_audience, expected_status_code",
+    [
+        (["audience_a"], "audience_a", 200),
+        (["audience_a"], ["audience_a", "audience_b"], 401),
+        (["audience_b"], "audience_a", 401),
+    ],
+)
+async def test_jwt_auth_strict_audience(
+    accepted_audiences: List[str],
+    token_audience: str,
+    expected_status_code: int,
+    create_jwt_app: CreateJWTApp,
+) -> None:
+    jwt_auth, client = create_jwt_app(strict_audience=True, accepted_audiences=accepted_audiences)
+
+    header = jwt_auth.format_auth_header(
+        jwt_auth.create_token(
+            identifier="foo",
+            token_audience=token_audience,
+        ),
+    )
+
+    response = client.get("/", headers={"Authorization": header})
+    assert response.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
+    "require_claims, token_claims, expected_status_code",
+    [
+        (["aud"], {"token_audience": "foo"}, 200),
+        (["aud"], {}, 401),
+        ([], {}, 200),
+    ],
+)
+async def test_jwt_auth_require_claims(
+    require_claims: List[str],
+    token_claims: Dict[str, str],
+    expected_status_code: int,
+    create_jwt_app: CreateJWTApp,
+) -> None:
+    jwt_auth, client = create_jwt_app(require_claims=require_claims)
+
+    header = jwt_auth.format_auth_header(
+        jwt_auth.create_token(
+            identifier="foo",
+            **token_claims,  # type: ignore[arg-type]
+        ),
+    )
+
+    response = client.get("/", headers={"Authorization": header})
+    assert response.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
+    "token_expiration, verify_expiry, expected_status_code",
+    [
+        pytest.param((datetime.now(tz=timezone.utc) + timedelta(days=1)).timestamp(), True, 200, id="valid-verify"),
+        pytest.param((datetime.now(tz=timezone.utc) + timedelta(days=1)).timestamp(), False, 200, id="valid-no_verify"),
+        pytest.param(
+            (datetime.now(tz=timezone.utc) - timedelta(days=1)).timestamp(), False, 200, id="invalid-no_verify"
+        ),
+        pytest.param((datetime.now(tz=timezone.utc) - timedelta(days=1)).timestamp(), True, 401, id="invalid-verify"),
+    ],
+)
+async def test_jwt_auth_verify_exp(
+    token_expiration: datetime,
+    verify_expiry: bool,
+    expected_status_code: int,
+    create_jwt_app: CreateJWTApp,
+) -> None:
+    @dataclasses.dataclass
+    class CustomToken(Token):
+        def __post_init__(self) -> None:
+            pass
+
+    jwt_auth, client = create_jwt_app(verify_expiry=verify_expiry, token_cls=CustomToken)
+
+    header = jwt_auth.format_auth_header(
+        CustomToken(
+            sub="foo",
+            exp=token_expiration,
+        ).encode(jwt_auth.token_secret, jwt_auth.algorithm),
+    )
+
+    response = client.get("/", headers={"Authorization": header})
+    assert response.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
+    "token_nbf, verify_not_before, expected_status_code",
+    [
+        pytest.param((datetime.now(tz=timezone.utc) - timedelta(days=1)).timestamp(), True, 200, id="valid-verify"),
+        pytest.param((datetime.now(tz=timezone.utc) - timedelta(days=1)).timestamp(), False, 200, id="valid-no_verify"),
+        pytest.param(
+            (datetime.now(tz=timezone.utc) + timedelta(days=1)).timestamp(), False, 200, id="invalid-no_verify"
+        ),
+        pytest.param((datetime.now(tz=timezone.utc) + timedelta(days=1)).timestamp(), True, 401, id="invalid-verify"),
+    ],
+)
+async def test_jwt_auth_verify_nbf(
+    token_nbf: datetime,
+    verify_not_before: bool,
+    expected_status_code: int,
+    create_jwt_app: CreateJWTApp,
+) -> None:
+    @dataclasses.dataclass()
+    class CustomToken(Token):
+        nbf: Optional[float] = None
+
+    jwt_auth, client = create_jwt_app(verify_not_before=verify_not_before, token_cls=CustomToken)
+
+    header = jwt_auth.format_auth_header(jwt_auth.create_token("foo", nbf=token_nbf))
+
+    response = client.get("/", headers={"Authorization": header})
+    assert response.status_code == expected_status_code

--- a/tests/unit/test_security/test_jwt/test_token.py
+++ b/tests/unit/test_security/test_jwt/test_token.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import secrets
 import sys
 from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional
+from typing import Any
 from uuid import uuid4
 
 import jwt
@@ -23,10 +25,10 @@ from litestar.security.jwt import Token
 @pytest.mark.parametrize("token_extras", [None, {"email": "test@test.com"}])
 def test_token(
     algorithm: str,
-    token_issuer: Optional[str],
-    token_audience: Optional[str],
-    token_unique_jwt_id: Optional[str],
-    token_extras: Optional[Dict[str, Any]],
+    token_issuer: str | None,
+    token_audience: str | None,
+    token_unique_jwt_id: str | None,
+    token_extras: dict[str, Any] | None,
 ) -> None:
     token_secret = secrets.token_hex()
     token = Token(


### PR DESCRIPTION
Customise the automatic verification of JWTs.

- [x] Config to verify `aud`
- [x] Config to verify `iss`
- [x] Config to verify `iat`
- [x] Config to verify `nbf`
- [x] Config for strict `aud` verification
- [x] Config for required claims
- [x] Update ocumentation

<hr>

**JWT backend changes**

- Add `accepted_audiences` field
- Add `accepted_issuers` field 
- Add `require_claims` field 
- Add `verify_expiry` field 
- Add `verify_not_before` field 
- Add `strict_audience` field 

**JWT middleware changes**

- Add token_audience` parameter
- Add `token_issuer` parameter
- Add `require_claims` parameter 
- Add `verify_expiry` parameter 
- Add `verify_not_before` parameter 
- Add `strict_audience` parameter 

**Token changes** 
 
- Add `audience` parameter to `Token.decode`
- Add `issuer` parameter to `Token.decode`
- Add `require_claims` parameter to `Token.decode`
- Add `verify_exp` parameter to `Token.decode`
- Add `verify_nbf` parameter to `Token.decode`
- Add `strict_audience` parameter to `Token.decode`
- Add `decode_payload` method