### PR TITLE
fix: csrf middleware excluding router

### DIFF
--- a/litestar/middleware/csrf.py
+++ b/litestar/middleware/csrf.py
@@ -119,12 +119,7 @@ class CSRFMiddleware(MiddlewareProtocol):
             existing_csrf_token = form.get("_csrf_token", None)
 
         connection_state = ScopeState.from_scope(scope)
-        if request.method in self.config.safe_methods or should_bypass_middleware(
-            scope=scope,
-            scopes=self.scopes,
-            exclude_opt_key=self.config.exclude_from_csrf_key,
-            exclude_path_pattern=self.exclude,
-        ):
+        if request.method in self.config.safe_methods:
             token = connection_state.csrf_token = csrf_cookie or generate_csrf_token(secret=self.config.secret)
             await self.app(scope, receive, self.create_send_wrapper(send=send, csrf_cookie=csrf_cookie, token=token))
         elif (

--- a/litestar/middleware/csrf.py
+++ b/litestar/middleware/csrf.py
@@ -32,7 +32,6 @@ if TYPE_CHECKING:
 
 __all__ = ("CSRFMiddleware",)
 
-
 CSRF_SECRET_BYTES = 32
 CSRF_SECRET_LENGTH = CSRF_SECRET_BYTES * 2
 
@@ -95,6 +94,15 @@ class CSRFMiddleware(MiddlewareProtocol):
             None
         """
         if scope["type"] != ScopeType.HTTP:
+            await self.app(scope, receive, send)
+            return
+
+        if should_bypass_middleware(
+            scope=scope,
+            scopes=self.scopes,
+            exclude_opt_key=self.config.exclude_from_csrf_key,
+            exclude_path_pattern=self.exclude,
+        ):
             await self.app(scope, receive, send)
             return
 

--- a/tests/unit/test_middleware/test_csrf_middleware.py
+++ b/tests/unit/test_middleware/test_csrf_middleware.py
@@ -236,10 +236,12 @@ def test_csrf_middleware_exclude_from_check() -> None:
         data = {"field": "value"}
         response = client.post("/protected-handler", data=data)
         assert response.status_code == HTTP_403_FORBIDDEN
+        assert "set-cookie" in response.headers
 
         response = client.post("/unprotected-handler", data=data)
         assert response.status_code == HTTP_201_CREATED
         assert response.json() == data
+        assert "set-cookie" not in response.headers
 
 
 def test_csrf_middleware_configure_name_for_exclude_from_check_via_opts() -> None:

--- a/tests/unit/test_middleware/test_csrf_middleware.py
+++ b/tests/unit/test_middleware/test_csrf_middleware.py
@@ -244,7 +244,6 @@ def test_csrf_middleware_exclude_from_check() -> None:
         data = {"field": "value"}
         response = client.post("/protected-handler", data=data)
         assert response.status_code == HTTP_403_FORBIDDEN
-        assert "set-cookie" in response.headers
 
         response = client.post("/unprotected-handler", data=data)
         assert response.status_code == HTTP_201_CREATED

--- a/tests/unit/test_middleware/test_csrf_middleware.py
+++ b/tests/unit/test_middleware/test_csrf_middleware.py
@@ -243,6 +243,9 @@ def test_csrf_middleware_exclude_from_check() -> None:
 
 
 def test_csrf_middleware_exclude_from_set_cookies() -> None:
+    #  https://github.com/litestar-org/litestar/issues/3688
+    #  middleware should be bypassed completely when excluded, so no cookies should be set
+
     @get("/protected-handler")
     def get_handler() -> dict:
         return {}

--- a/tests/unit/test_middleware/test_csrf_middleware.py
+++ b/tests/unit/test_middleware/test_csrf_middleware.py
@@ -229,8 +229,16 @@ def test_csrf_middleware_exclude_from_check() -> None:
     def post_handler2(data: dict = Body(media_type=RequestEncodingType.URL_ENCODED)) -> dict:
         return data
 
+    @get("/protected-handler")
+    def get_handler() -> dict:
+        return {}
+
+    @get("/unprotected-handler")
+    def get_handler2() -> dict:
+        return {}
+
     with create_test_client(
-        route_handlers=[post_handler, post_handler2],
+        route_handlers=[post_handler, post_handler2, get_handler, get_handler2],
         csrf_config=CSRFConfig(secret=str(urandom(10)), exclude=["unprotected-handler"]),
     ) as client:
         data = {"field": "value"}
@@ -241,6 +249,13 @@ def test_csrf_middleware_exclude_from_check() -> None:
         response = client.post("/unprotected-handler", data=data)
         assert response.status_code == HTTP_201_CREATED
         assert response.json() == data
+
+        response = client.get("/protected-handler")
+        assert response.status_code == HTTP_200_OK
+        assert "set-cookie" in response.headers
+
+        response = client.get("/unprotected-handler")
+        assert response.status_code == HTTP_200_OK
         assert "set-cookie" not in response.headers
 
 

--- a/tests/unit/test_middleware/test_csrf_middleware.py
+++ b/tests/unit/test_middleware/test_csrf_middleware.py
@@ -253,13 +253,13 @@ def test_csrf_middleware_exclude_from_check() -> None:
         route_handlers=[get_handler, get_handler2],
         csrf_config=CSRFConfig(secret=str(urandom(10)), exclude=["unprotected-handler"]),
     ) as client:
-        response = client.get("/protected-handler")
-        assert response.status_code == HTTP_200_OK
-        assert "set-cookie" in response.headers
-
         response = client.get("/unprotected-handler")
         assert response.status_code == HTTP_200_OK
         assert "set-cookie" not in response.headers
+
+        response = client.get("/protected-handler")
+        assert response.status_code == HTTP_200_OK
+        assert "set-cookie" in response.headers
 
 
 def test_csrf_middleware_configure_name_for_exclude_from_check_via_opts() -> None:

--- a/tests/unit/test_middleware/test_csrf_middleware.py
+++ b/tests/unit/test_middleware/test_csrf_middleware.py
@@ -249,6 +249,10 @@ def test_csrf_middleware_exclude_from_check() -> None:
         assert response.status_code == HTTP_201_CREATED
         assert response.json() == data
 
+    with create_test_client(
+        route_handlers=[get_handler, get_handler2],
+        csrf_config=CSRFConfig(secret=str(urandom(10)), exclude=["unprotected-handler"]),
+    ) as client:
         response = client.get("/protected-handler")
         assert response.status_code == HTTP_200_OK
         assert "set-cookie" in response.headers

--- a/tests/unit/test_middleware/test_csrf_middleware.py
+++ b/tests/unit/test_middleware/test_csrf_middleware.py
@@ -229,16 +229,8 @@ def test_csrf_middleware_exclude_from_check() -> None:
     def post_handler2(data: dict = Body(media_type=RequestEncodingType.URL_ENCODED)) -> dict:
         return data
 
-    @get("/protected-handler")
-    def get_handler() -> dict:
-        return {}
-
-    @get("/unprotected-handler")
-    def get_handler2() -> dict:
-        return {}
-
     with create_test_client(
-        route_handlers=[post_handler, post_handler2, get_handler, get_handler2],
+        route_handlers=[post_handler, post_handler2],
         csrf_config=CSRFConfig(secret=str(urandom(10)), exclude=["unprotected-handler"]),
     ) as client:
         data = {"field": "value"}
@@ -248,6 +240,16 @@ def test_csrf_middleware_exclude_from_check() -> None:
         response = client.post("/unprotected-handler", data=data)
         assert response.status_code == HTTP_201_CREATED
         assert response.json() == data
+
+
+def test_csrf_middleware_exclude_from_set_cookies() -> None:
+    @get("/protected-handler")
+    def get_handler() -> dict:
+        return {}
+
+    @get("/unprotected-handler")
+    def get_handler2() -> dict:
+        return {}
 
     with create_test_client(
         route_handlers=[get_handler, get_handler2],


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- csrf middleware should skip router entirely on match exclude config

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
close https://github.com/litestar-org/litestar/issues/3688
