### PR TITLE
feat(middleware): Warn about greedy exclude patterns

### DIFF
--- a/docs/usage/middleware/creating-middleware.rst
+++ b/docs/usage/middleware/creating-middleware.rst
@@ -213,6 +213,10 @@ Thus, in the following example, the middleware will only run against the route h
 .. literalinclude:: /examples/middleware/base.py
     :language: python
 
+.. danger::
+
+    Using ``/`` as an exclude pattern, will disable authentication for all routes,#
+    since, as a regex, it matches *every* path
 
 
 Using DefineMiddleware to pass arguments

--- a/docs/usage/middleware/creating-middleware.rst
+++ b/docs/usage/middleware/creating-middleware.rst
@@ -215,7 +215,7 @@ Thus, in the following example, the middleware will only run against the route h
 
 .. danger::
 
-    Using ``/`` as an exclude pattern, will disable authentication for all routes,#
+    Using ``/`` as an exclude pattern, will disable this middleware for all routes,
     since, as a regex, it matches *every* path
 
 

--- a/docs/usage/security/excluding-and-including-endpoints.rst
+++ b/docs/usage/security/excluding-and-including-endpoints.rst
@@ -1,16 +1,26 @@
 Excluding and including endpoints
 =================================
 
-Please make sure you read the :doc:`security backends documentation </usage/security/security-backends>` first for learning how to set up a security backend. This section focuses on configuring the ``exclude`` rule for those backends.
+Please make sure you read the :doc:`security backends documentation </usage/security/security-backends>` first for
+learning how to set up a security backend. This section focuses on configuring the ``exclude`` rule for those backends.
 
-There are multiple ways for including or excluding endpoints in the authentication flow. The default rules are configured in the ``Auth`` object used (subclass of :class:`~.security.base.AbstractSecurityConfig`). The examples below use :class:`~.security.session_auth.auth.SessionAuth` but it is the same for :class:`~.security.jwt.auth.JWTAuth` and :class:`~.security.jwt.auth.JWTCookieAuth`.
+There are multiple ways for including or excluding endpoints in the authentication flow. The default rules are
+configured in the ``Auth`` object used (subclass of :class:`~.security.base.AbstractSecurityConfig`). The examples
+below use :class:`~.security.session_auth.auth.SessionAuth` but it is the same for :class:`~.security.jwt.auth.JWTAuth`
+and :class:`~.security.jwt.auth.JWTCookieAuth`.
 
 Excluding routes
 --------------------
 
-The ``exclude`` argument takes a :class:`string <str>` or :class:`list` of :class:`strings <str>` that are interpreted as regex patterns. For example, the configuration below would apply authentication to all endpoints except those where the route starts with ``/login``, ``/signup``, or ``/schema``. Thus, one does not have to exclude ``/schema/swagger`` as well - it is included in the ``/schema`` pattern.
+The ``exclude`` argument takes a :class:`string <str>` or :class:`list` of :class:`strings <str>` that are interpreted
+as regex patterns. For example, the configuration below would apply authentication to all endpoints except those where
+the route starts with ``/login``, ``/signup``, or ``/schema``. Thus, one does not have to exclude ``/schema/swagger``
+as well - it is included in the ``/schema`` pattern.
 
-This also means that passing ``/`` will disable authentication for all routes.
+.. danger::
+
+    Passing ``/`` will disable authentication for all routes, since, as a regex, it
+    matches *every* path.
 
 .. code-block:: python
 
@@ -28,7 +38,9 @@ This also means that passing ``/`` will disable authentication for all routes.
 Including routes
 ----------------
 
-Since the exclusion rules are evaluated as regex, it is possible to pass a rule that inverts exclusion - meaning, no path but the one specified in the pattern will be protected by authentication. In the example below, only endpoints under the ``/secured`` route will require authentication - all other routes do not.
+Since the exclusion rules are evaluated as regex, it is possible to pass a rule that inverts exclusion - meaning, no
+path but the one specified in the pattern will be protected by authentication. In the example below, only endpoints
+under the ``/secured`` route will require authentication - all other routes do not.
 
 .. code-block:: python
 
@@ -46,7 +58,8 @@ Since the exclusion rules are evaluated as regex, it is possible to pass a rule 
 
 Exclude from auth
 --------------------
-Sometimes, you might want to apply authentication to all endpoints under a route but a few selected. In this case, you can pass ``exclude_from_auth=True`` to the route handler as shown below.
+Sometimes, you might want to apply authentication to all endpoints under a route but a few selected. In this case, you
+can pass ``exclude_from_auth=True`` to the route handler as shown below.
 
 .. code-block:: python
 
@@ -60,7 +73,8 @@ Sometimes, you might want to apply authentication to all endpoints under a route
         ...
     ...
 
-You can set an alternative option key in the security configuration, e.g., you can use ``no_auth`` instead of ``exclude_from_auth``.
+You can set an alternative option key in the security configuration, e.g., you can use ``no_auth`` instead of
+``exclude_from_auth``.
 
 .. code-block:: python
 

--- a/litestar/middleware/authentication.py
+++ b/litestar/middleware/authentication.py
@@ -61,7 +61,7 @@ class AbstractAuthenticationMiddleware(ABC):
             scopes: ASGI scopes processed by the authentication middleware.
         """
         self.app = app
-        self.exclude = build_exclude_path_pattern(exclude=exclude)
+        self.exclude = build_exclude_path_pattern(exclude=exclude, middleware_cls=type(self))
         self.exclude_http_methods = (HttpMethod.OPTIONS,) if exclude_http_methods is None else exclude_http_methods
         self.exclude_opt_key = exclude_from_auth_key
         self.scopes = scopes or {ScopeType.HTTP, ScopeType.WEBSOCKET}

--- a/litestar/middleware/base.py
+++ b/litestar/middleware/base.py
@@ -109,7 +109,7 @@ class AbstractMiddleware:
         self.app = app
         self.scopes = scopes or self.scopes
         self.exclude_opt_key = exclude_opt_key or self.exclude_opt_key
-        self.exclude_pattern = build_exclude_path_pattern(exclude=(exclude or self.exclude))
+        self.exclude_pattern = build_exclude_path_pattern(exclude=(exclude or self.exclude), middleware_cls=type(self))
 
     @classmethod
     def __init_subclass__(cls, **kwargs: Any) -> None:

--- a/litestar/middleware/csrf.py
+++ b/litestar/middleware/csrf.py
@@ -81,7 +81,7 @@ class CSRFMiddleware(MiddlewareProtocol):
         """
         self.app = app
         self.config = config
-        self.exclude = build_exclude_path_pattern(exclude=config.exclude)
+        self.exclude = build_exclude_path_pattern(exclude=config.exclude, middleware_cls=type(self))
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI callable.

--- a/litestar/utils/warnings.py
+++ b/litestar/utils/warnings.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
 import os
 import warnings
+from typing import TYPE_CHECKING
 
 from litestar.exceptions import LitestarWarning
-from litestar.types import AnyCallable, AnyGenerator
+
+if TYPE_CHECKING:
+    import re
+
+    from litestar.types import AnyCallable, AnyGenerator
 
 
 def warn_implicit_sync_to_thread(source: AnyCallable, stacklevel: int = 2) -> None:
@@ -49,3 +56,17 @@ def warn_sync_to_thread_with_generator(source: AnyGenerator, stacklevel: int = 2
 
 def warn_pdb_on_exception(stacklevel: int = 2) -> None:
     warnings.warn("Python Debugger on exception enabled", category=LitestarWarning, stacklevel=stacklevel)
+
+
+def warn_middleware_excluded_on_all_routes(
+    pattern: re.Pattern,
+    middleware_cls: type | None = None,
+) -> None:
+    middleware_name = f" {middleware_cls.__name__!r}" if middleware_cls else ""
+    warnings.warn(
+        f"Middleware{middleware_name} exclude pattern {pattern.pattern!r} greedily "
+        "matches all paths, effectively disabling this middleware. If this was "
+        "intentional, consider removing this middleware entirely",
+        category=LitestarWarning,
+        stacklevel=2,
+    )

--- a/tests/unit/test_security/test_security.py
+++ b/tests/unit/test_security/test_security.py
@@ -48,6 +48,7 @@ def test_abstract_security_config_sets_dependencies(session_backend_config_memor
         assert client.app.dependencies.get("value")
 
 
+@pytest.mark.filterwarnings("ignore:Middleware 'SessionAuthMiddleware' exclude pattern")
 def test_abstract_security_config_registers_route_handlers(
     session_backend_config_memory: ServerSideSessionConfig,
 ) -> None:


### PR DESCRIPTION
Raise a warning when a middlewares `exclude` pattern greedily matches all paths.

Also document this footgun more prominently.