### PR TITLE
fix(JWT): Response with 401 on token payload validation

### DIFF
--- a/litestar/security/jwt/token.py
+++ b/litestar/security/jwt/token.py
@@ -103,7 +103,13 @@ class Token:
             for key in extra_fields:
                 extras[key] = payload.pop(key)
             return msgspec.convert(payload, cls, strict=False)
-        except (KeyError, jwt.DecodeError, ImproperlyConfiguredException, jwt.exceptions.InvalidAlgorithmError) as e:
+        except (
+            KeyError,
+            jwt.DecodeError,
+            ImproperlyConfiguredException,
+            jwt.exceptions.InvalidAlgorithmError,
+            msgspec.ValidationError,
+        ) as e:
             raise NotAuthorizedException("Invalid token") from e
 
     def encode(self, secret: str, algorithm: str) -> str:


### PR DESCRIPTION
Fix a bug introduced in #3692 that would cause a `500` status response to be returned when `ValidationError` was raised during the token payload conversion.

This was caused by the switch to `msgspec` for converting the token payload after decoding and verification, and the lack of error handling for this case.