### PR TITLE
fix(OpenAPI): Correctly handle `type` keyword

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,7 @@ jobs:
         with:
           name: coverage-data
           path: .coverage.pydantic_v1
+          include-hidden-files: true
 
   upload-test-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,3 +67,4 @@ jobs:
         with:
           name: coverage-data
           path: .coverage.${{ inputs.python-version }}
+          include-hidden-files: true

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -328,6 +328,8 @@ class SchemaCreator:
 
         if field_definition.is_new_type:
             result = self.for_new_type(field_definition)
+        elif field_definition.is_type_alias_type:
+            result = self.for_type_alias_type(field_definition)
         elif plugin_for_annotation := self.get_plugin_for(field_definition):
             result = self.for_plugin(field_definition, plugin_for_annotation)
         elif _should_create_enum_schema(field_definition):
@@ -363,6 +365,16 @@ class SchemaCreator:
                 annotation=unwrap_new_type(field_definition.annotation),
                 name=field_definition.name,
                 default=field_definition.default,
+            )
+        )
+
+    def for_type_alias_type(self, field_definition: FieldDefinition) -> Schema | Reference:
+        return self.for_field_definition(
+            FieldDefinition.from_kwarg(
+                annotation=field_definition.annotation.__value__,
+                name=field_definition.name,
+                default=field_definition.default,
+                kwarg_definition=field_definition.kwarg_definition,
             )
         )
 

--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -8,7 +8,17 @@ from inspect import Parameter, Signature
 from typing import Any, AnyStr, Callable, Collection, ForwardRef, Literal, Mapping, Protocol, Sequence, TypeVar, cast
 
 from msgspec import UnsetType
-from typing_extensions import NewType, NotRequired, Required, Self, get_args, get_origin, get_type_hints, is_typeddict
+from typing_extensions import (
+    NewType,
+    NotRequired,
+    Required,
+    Self,
+    TypeAliasType,
+    get_args,
+    get_origin,
+    get_type_hints,
+    is_typeddict,
+)
 
 from litestar.exceptions import ImproperlyConfiguredException, LitestarWarning
 from litestar.openapi.spec import Example
@@ -362,6 +372,11 @@ class FieldDefinition:
     @property
     def is_new_type(self) -> bool:
         return isinstance(self.annotation, NewType)
+
+    @property
+    def is_type_alias_type(self) -> bool:
+        """Whether the annotation is a ``TypeAliasType``"""
+        return isinstance(self.annotation, TypeAliasType)
 
     @property
     def is_type_var(self) -> bool:

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -617,21 +617,14 @@ def test_unconsumed_path_parameters_are_documented() -> None:
         assert param.param_in is ParamType.PATH
 
 
-@pytest.mark.parametrize(
-    "annotation, expected_type",
-    [
-        (TypeAliasType("IntAlias", int), OpenAPIType.INTEGER),  # pyright: ignore
-        (TypeAliasType("LiteralAlias", Literal[1]), OpenAPIType.INTEGER),  # pyright: ignore
-    ],
-)
-def test_type_alias_type(annotation: Any, expected_type: Any) -> None:
+def test_type_alias_type() -> None:
     @get("/")
-    def handler(query_param: Annotated[annotation, Parameter(description="foo")]) -> None:
+    def handler(query_param: Annotated[TypeAliasType("IntAlias", int), Parameter(description="foo")]) -> None:  # type: ignore[valid-type]
         pass
 
     app = Litestar([handler])
     param = app.openapi_schema.paths["/"].get.parameters[0]  # type: ignore[index, union-attr]
-    assert param.schema.type is expected_type  # type: ignore[union-attr]
+    assert param.schema.type is OpenAPIType.INTEGER  # type: ignore[union-attr]
     # ensure other attributes than the plain type are carried over correctly
     assert param.description == "foo"
 

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -21,7 +21,7 @@ import annotated_types
 import msgspec
 import pytest
 from msgspec import Struct
-from typing_extensions import Annotated, TypeAlias
+from typing_extensions import Annotated, TypeAlias, TypeAliasType
 
 from litestar import Controller, MediaType, get, post
 from litestar._openapi.schema_generation.plugins import openapi_schema_plugins
@@ -615,3 +615,39 @@ def test_unconsumed_path_parameters_are_documented() -> None:
         assert param.name == f"param{i}"
         assert param.required is True
         assert param.param_in is ParamType.PATH
+
+
+@pytest.mark.parametrize(
+    "annotation, expected_type",
+    [
+        (TypeAliasType("IntAlias", int), OpenAPIType.INTEGER),
+        (TypeAliasType("LiteralAlias", Literal[1]), OpenAPIType.INTEGER),
+    ],
+)
+def test_type_alias_type(annotation: Any, expected_type: Any) -> None:
+    @get("/")
+    def handler(query_param: Annotated[annotation, Parameter(description="foo")]) -> None:
+        pass
+
+    app = Litestar([handler])
+    param = app.openapi_schema.paths["/"].get.parameters[0]  # type: ignore[index, union-attr]
+    assert param.schema.type is expected_type  # type: ignore[union-attr]
+    # ensure other attributes than the plain type are carried over correctly
+    assert param.description == "foo"
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="type keyword not available before 3.12")
+def test_type_alias_type_keyword() -> None:
+    ctx: Dict[str, Any] = {}
+    exec("type IntAlias = int", ctx, None)
+    annotation = ctx["IntAlias"]
+
+    @get("/")
+    def handler(query_param: Annotated[annotation, Parameter(description="foo")]) -> None:  # type: ignore[valid-type]
+        pass
+
+    app = Litestar([handler])
+    param = app.openapi_schema.paths["/"].get.parameters[0]  # type: ignore[union-attr, index]
+    assert param.schema.type is OpenAPIType.INTEGER  # type: ignore[union-attr]
+    # ensure other attributes than the plain type are carried over correctly
+    assert param.description == "foo"

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -620,8 +620,8 @@ def test_unconsumed_path_parameters_are_documented() -> None:
 @pytest.mark.parametrize(
     "annotation, expected_type",
     [
-        (TypeAliasType("IntAlias", int), OpenAPIType.INTEGER),
-        (TypeAliasType("LiteralAlias", Literal[1]), OpenAPIType.INTEGER),
+        (TypeAliasType("IntAlias", int), OpenAPIType.INTEGER),  # pyright: ignore
+        (TypeAliasType("LiteralAlias", Literal[1]), OpenAPIType.INTEGER),  # pyright: ignore
     ],
 )
 def test_type_alias_type(annotation: Any, expected_type: Any) -> None:

--- a/tests/unit/test_typing.py
+++ b/tests/unit/test_typing.py
@@ -481,8 +481,8 @@ def test_warn_default_inside_kwarg_definition_and_default_empty() -> None:
 @pytest.mark.parametrize(
     "annotation, expected_type",
     [
-        (TypeAliasType("IntAlias", int), int),
-        (TypeAliasType("LiteralAlias", Literal["1"]), Literal["1"]),
+        (TypeAliasType("IntAlias", int), int),  # pyright: ignore
+        (TypeAliasType("LiteralAlias", Literal["1"]), Literal["1"]),  # pyright: ignore
     ],
 )
 def test_is_type_alias_type(annotation: Any, expected_type: Any) -> None:

--- a/tests/unit/test_typing.py
+++ b/tests/unit/test_typing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass
-from typing import Any, ForwardRef, Generic, List, Literal, Optional, Tuple, TypeVar, Union
+from typing import Any, ForwardRef, Generic, List, Optional, Tuple, TypeVar, Union
 
 import annotated_types
 import msgspec
@@ -478,15 +478,8 @@ def test_warn_default_inside_kwarg_definition_and_default_empty() -> None:
     assert "Deprecated default value specification" in str(record.message)
 
 
-@pytest.mark.parametrize(
-    "annotation, expected_type",
-    [
-        (TypeAliasType("IntAlias", int), int),  # pyright: ignore
-        (TypeAliasType("LiteralAlias", Literal["1"]), Literal["1"]),  # pyright: ignore
-    ],
-)
-def test_is_type_alias_type(annotation: Any, expected_type: Any) -> None:
-    field_definition = FieldDefinition.from_annotation(annotation)
+def test_is_type_alias_type() -> None:
+    field_definition = FieldDefinition.from_annotation(TypeAliasType("IntAlias", int))  # pyright: ignore
     assert field_definition.is_type_alias_type
 
 


### PR DESCRIPTION
Correctly handle OpenAPI schema generation for type aliases generated with the `type` keyword.

Fixes #3714.