### PR TITLE
refactor(typing): Remove "unpacking" of `annotated_types`

### DIFF
--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -26,7 +26,6 @@ from litestar.params import BodyKwarg, DependencyKwarg, KwargDefinition, Paramet
 from litestar.types import Empty
 from litestar.types.builtin_types import NoneType, UnionTypes
 from litestar.utils.predicates import (
-    is_annotated_type,
     is_any,
     is_class_and_subclass,
     is_generic,
@@ -150,13 +149,6 @@ def _traverse_metadata(
                     metadata=cast("Sequence[Any]", value), is_sequence_container=is_sequence_container, extra=extra
                 )
             )
-        elif is_annotated_type(value) and (type_args := [v for v in get_args(value) if v is not None]):
-            # annotated values can be nested inside other annotated values
-            # this behaviour is buggy in python 3.8, hence we need to guard here.
-            if len(type_args) > 1:
-                constraints.update(
-                    _traverse_metadata(metadata=type_args[1:], is_sequence_container=is_sequence_container, extra=extra)
-                )
         elif unpacked_predicate := _unpack_predicate(value):
             constraints.update(unpacked_predicate)
         else:

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -309,8 +309,7 @@ def test_annotated_types() -> None:
         constrained_lower_case: annotated_types.LowerCase[str]
         constrained_upper_case: annotated_types.UpperCase[str]
         constrained_is_ascii: annotated_types.IsAscii[str]
-        constrained_is_ascii: annotated_types.IsAscii[str]
-        constrained_is_digit: annotated_types.IsDigits[str]
+        constrained_is_digit: annotated_types.IsDigit[str]
 
     schema = get_schema_for_field_definition(FieldDefinition.from_kwarg(name="MyDataclass", annotation=MyDataclass))
 

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -306,10 +306,11 @@ def test_annotated_types() -> None:
         constrained_int: Annotated[int, annotated_types.Gt(1), annotated_types.Lt(10)]
         constrained_float: Annotated[float, annotated_types.Ge(1), annotated_types.Le(10)]
         constrained_date: Annotated[date, annotated_types.Interval(gt=historical_date, lt=today)]
-        constrained_lower_case: Annotated[str, annotated_types.LowerCase]
-        constrained_upper_case: Annotated[str, annotated_types.UpperCase]
-        constrained_is_ascii: Annotated[str, annotated_types.IsAscii]
-        constrained_is_digit: Annotated[str, annotated_types.IsDigits]
+        constrained_lower_case: annotated_types.LowerCase[str]
+        constrained_upper_case: annotated_types.UpperCase[str]
+        constrained_is_ascii: annotated_types.IsAscii[str]
+        constrained_is_ascii: annotated_types.IsAscii[str]
+        constrained_is_digit: annotated_types.IsDigits[str]
 
     schema = get_schema_for_field_definition(FieldDefinition.from_kwarg(name="MyDataclass", annotation=MyDataclass))
 


### PR DESCRIPTION
Fix some improperly constructed test cases, where annotated types were constructed as `Annotated[str, annotated_types.LowerCase]` instead of `annotated_types.LowerCase[str]`, which lead to code that handled this incorrect case.

I stumbled across this during another refactor, where I wrote a correct test case that passed without this special code, while the old case was failing.

