### PR TITLE
feat: Support strings in `media_type` for `ResponseSpec`

### DIFF
--- a/litestar/_openapi/responses.py
+++ b/litestar/_openapi/responses.py
@@ -252,7 +252,12 @@ class ResponseFactory:
             content: dict[str, OpenAPIMediaType] | None
             if additional_response.data_container is not None:
                 schema = schema_creator.for_field_definition(field_def)
-                content = {additional_response.media_type: OpenAPIMediaType(schema=schema, examples=examples)}
+                media_type = additional_response.media_type
+                content = {
+                    get_enum_string_value(media_type)
+                    if not isinstance(media_type, str)
+                    else media_type: OpenAPIMediaType(schema=schema, examples=examples)
+                }
             else:
                 content = None
 

--- a/litestar/openapi/datastructures.py
+++ b/litestar/openapi/datastructures.py
@@ -23,7 +23,7 @@ class ResponseSpec:
     """Generate examples for the response content."""
     description: str = field(default="Additional response")
     """A description of the response."""
-    media_type: MediaType = field(default=MediaType.JSON)
+    media_type: MediaType | str = field(default=MediaType.JSON)
     """Response media type."""
     examples: list[Example] | None = field(default=None)
     """A list of Example models."""

--- a/tests/unit/test_openapi/test_responses.py
+++ b/tests/unit/test_openapi/test_responses.py
@@ -361,6 +361,7 @@ def test_create_additional_responses(create_factory: CreateFactoryFixture) -> No
             401: ResponseSpec(data_container=AuthenticationError, description="Authentication error"),
             500: ResponseSpec(data_container=ServerError, generate_examples=False, media_type=MediaType.TEXT),
             505: ResponseSpec(data_container=UnknownError),
+            900: ResponseSpec(data_container=UnknownError, media_type="application/vnd.custom"),
         }
     )
     def handler() -> DataclassPerson:
@@ -397,6 +398,13 @@ def test_create_additional_responses(create_factory: CreateFactoryFixture) -> No
     third_response = next(responses)
     assert third_response[0] == "505"
     assert third_response[1].description == "Additional response"
+
+    fourth_response = next(responses)
+    assert fourth_response[0] == "900"
+    assert fourth_response[1].description == "Additional response"
+    custom_media_type_content = fourth_response[1].content.get("application/vnd.custom")  # type: ignore[union-attr]
+    assert custom_media_type_content
+    assert isinstance(custom_media_type_content, OpenAPIMediaType)
 
     with pytest.raises(StopIteration):
         next(responses)


### PR DESCRIPTION
Accept string for the `media_type` parameter of `ResponseSpec`, making it behave the same way as `Response.media_type` does.

Closes #3728.
