### PR TITLE
test: Fix tests for pydantic private fields

### DIFF
--- a/tests/unit/test_contrib/test_pydantic/test_schema_plugin.py
+++ b/tests/unit/test_contrib/test_pydantic/test_schema_plugin.py
@@ -88,7 +88,7 @@ class V1ModelWithPrivateFields(pydantic_v1.BaseModel):
 
     _field: str = pydantic_v1.PrivateAttr()
     # include an invalid annotation here to ensure we never touch those fields
-    _underscore_field: "foo"  # type: ignore[name-defined]  # noqa: F821
+    _underscore_field: str = "foo"
 
 
 class V1GenericModelWithPrivateFields(pydantic_v1.generics.GenericModel, Generic[T]):  # pyright: ignore
@@ -97,19 +97,19 @@ class V1GenericModelWithPrivateFields(pydantic_v1.generics.GenericModel, Generic
 
     _field: str = pydantic_v1.PrivateAttr()
     # include an invalid annotation here to ensure we never touch those fields
-    _underscore_field: "foo"  # type: ignore[name-defined]  # noqa: F821
+    _underscore_field: str = "foo"
 
 
 class V2ModelWithPrivateFields(pydantic_v2.BaseModel):
     _field: str = pydantic_v2.PrivateAttr()
     # include an invalid annotation here to ensure we never touch those fields
-    _underscore_field: "foo"  # type: ignore[name-defined] # noqa: F821
+    _underscore_field: str = "foo"
 
 
 class V2GenericModelWithPrivateFields(pydantic_v2.BaseModel, Generic[T]):
     _field: str = pydantic_v2.PrivateAttr()
     # include an invalid annotation here to ensure we never touch those fields
-    _underscore_field: "foo"  # type: ignore[name-defined] # noqa: F821
+    _underscore_field: str = "foo"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Remove some laziness in testing Pydantic private fields, which is currently causing some [failing tests](https://github.com/litestar-org/litestar/actions/runs/10860782969/job/30141813399?pr=3364#step:7:178), due to a change in Pydantic's internals. 