### PR TITLE
feat: Update MessagPack media type

### DIFF
--- a/docs/release-notes/whats-new-3.rst
+++ b/docs/release-notes/whats-new-3.rst
@@ -194,3 +194,13 @@ Removal of deprecated ``litestar.middleware.exceptions`` module and ``ExceptionH
 The deprecated ``litestar.middleware.exceptions`` module and the
 ``ExceptionHandlerMiddleware`` have been removed. Since ``ExceptionHandlerMiddleware``
 has been applied automatically behind the scenes if necessary, no action is required.
+
+
+Update MessagePack media type to ``application/vnd.msgpack``
+------------------------------------------------------------
+
+Change the media type of :attr:`~enums.MediaType.MESSAGEPACK` and
+:attr:`~enums.RequestEncodingType.MESSAGEPACK` from ``application/x-msgpack`` to the
+newly introduced official ``application/vnd.msgpack``.
+
+https://www.iana.org/assignments/media-types/application/vnd.msgpack

--- a/litestar/enums.py
+++ b/litestar/enums.py
@@ -28,7 +28,7 @@ class MediaType(str, Enum):
     """An Enum for ``Content-Type`` header values."""
 
     JSON = "application/json"
-    MESSAGEPACK = "application/x-msgpack"
+    MESSAGEPACK = "application/vnd.msgpack"
     HTML = "text/html"
     TEXT = "text/plain"
     CSS = "text/css"
@@ -46,7 +46,7 @@ class RequestEncodingType(str, Enum):
     """An Enum for request ``Content-Type`` header values designating encoding formats."""
 
     JSON = "application/json"
-    MESSAGEPACK = "application/x-msgpack"
+    MESSAGEPACK = "application/vnd.msgpack"
     MULTI_PART = "multipart/form-data"
     URL_ENCODED = "application/x-www-form-urlencoded"
 


### PR DESCRIPTION
Update the MessagePack media type to the official `application/vnd.msgpack`.

Fixes #3727.