### PR TITLE
test: Fix for Pydantic private fields (2nd attempt)

### DIFF
--- a/tests/unit/test_contrib/test_pydantic/test_integration.py
+++ b/tests/unit/test_contrib/test_pydantic/test_integration.py
@@ -215,8 +215,6 @@ class V2ModelWithPrivateFields(pydantic_v2.BaseModel):
         underscore_fields_are_private = True
 
     _field: str = pydantic_v2.PrivateAttr()
-    # include an invalid annotation here to ensure we never touch those fields
-    _underscore_field: "foo"  # type: ignore[name-defined] # noqa: F821
     bar: str
 
 


### PR DESCRIPTION
Follow up #3731, at it seems to still be breaking in some cases. 

These test cases were initially added to ensure we never touch the fields, but Pydantic changed some internals which make it so *they* touch them, causing our invalid annotation to result in an exception. This means we can't use this as a check anymore, but also don't need to.