### PR TITLE
fix: Fix dangling coroutines in request extraction handling cleanup

### DIFF
--- a/litestar/_kwargs/types.py
+++ b/litestar/_kwargs/types.py
@@ -1,0 +1,10 @@
+# pragma: no cover
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Dict
+
+from typing_extensions import TypeAlias
+
+from litestar.connection import ASGIConnection
+
+Extractor: TypeAlias = Callable[[Dict[str, Any], ASGIConnection], Awaitable[None]]

--- a/litestar/_kwargs/types.py
+++ b/litestar/_kwargs/types.py
@@ -1,4 +1,3 @@
-# pragma: no cover
 from __future__ import annotations
 
 from typing import Any, Awaitable, Callable, Dict

--- a/litestar/routes/websocket.py
+++ b/litestar/routes/websocket.py
@@ -69,7 +69,7 @@ class WebSocketRoute(BaseRoute):
         cleanup_group: DependencyCleanupGroup | None = None
 
         if self.handler_parameter_model.has_kwargs and self.route_handler.signature_model:
-            parsed_kwargs = self.handler_parameter_model.to_kwargs(connection=websocket)
+            parsed_kwargs = await self.handler_parameter_model.to_kwargs(connection=websocket)
 
             if self.handler_parameter_model.dependency_batches:
                 cleanup_group = await self.handler_parameter_model.resolve_dependencies(websocket, parsed_kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,7 +201,7 @@ skip = 'pdm.lock,docs/examples/contrib/sqlalchemy/us_state_lookup.json'
 
 [tool.coverage.run]
 concurrency = ["multiprocessing", "thread"]
-omit = ["*/tests/*", "*/litestar/plugins/sqlalchemy.py"]
+omit = ["*/tests/*", "*/litestar/plugins/sqlalchemy.py", "*/litestar/_kwargs/types.py"]
 parallel = true
 plugins = ["covdefaults"]
 source = ["litestar"]

--- a/tests/unit/test_kwargs/test_header_params.py
+++ b/tests/unit/test_kwargs/test_header_params.py
@@ -1,8 +1,9 @@
 from typing import Dict, Optional, Union
 
 import pytest
+from typing_extensions import Annotated
 
-from litestar import get
+from litestar import get, post
 from litestar.params import Parameter, ParameterKwarg
 from litestar.status_codes import HTTP_200_OK, HTTP_400_BAD_REQUEST
 from litestar.testing import create_test_client
@@ -37,3 +38,13 @@ def test_header_params(
             assert response.status_code == HTTP_400_BAD_REQUEST, response.json()
         else:
             assert response.status_code == HTTP_200_OK, response.json()
+
+
+def test_header_param_with_post() -> None:
+    # https://github.com/litestar-org/litestar/issues/3734
+    @post()
+    async def handler(data: str, secret: Annotated[str, Parameter(header="x-secret")]) -> None:
+        return None
+
+    with create_test_client([handler], raise_server_exceptions=True) as client:
+        assert client.post("/", json={}).status_code == 400


### PR DESCRIPTION
Fix #3734. 

Ensure all data extractors are properly awaited by removing the delayed `await`