### PR TITLE
fix: `httponly` correction in CSRFMiddleware

### DIFF
--- a/litestar/middleware/csrf.py
+++ b/litestar/middleware/csrf.py
@@ -118,6 +118,9 @@ class CSRFMiddleware(MiddlewareProtocol):
             form = await request.form()
             existing_csrf_token = form.get("_csrf_token", None)
 
+        if not existing_csrf_token and self.config.cookie_httponly:
+            existing_csrf_token = csrf_cookie
+
         connection_state = ScopeState.from_scope(scope)
         if request.method in self.config.safe_methods:
             token = connection_state.csrf_token = csrf_cookie or generate_csrf_token(secret=self.config.secret)

--- a/tests/unit/test_middleware/test_csrf_middleware.py
+++ b/tests/unit/test_middleware/test_csrf_middleware.py
@@ -69,6 +69,7 @@ def test_csrf_successful_flow(get_handler: HTTPRouteHandler, post_handler: HTTPR
         response = client.post("/", headers={"x-csrftoken": csrf_token})
         assert response.status_code == HTTP_201_CREATED
 
+
 def test_csrf_httponly_flow(get_handler: HTTPRouteHandler, post_handler: HTTPRouteHandler) -> None:
     with create_test_client(
         route_handlers=[get_handler, post_handler], csrf_config=CSRFConfig(secret="secret", cookie_httponly=True)
@@ -80,8 +81,9 @@ def test_csrf_httponly_flow(get_handler: HTTPRouteHandler, post_handler: HTTPRou
         assert csrf_token is not None
         assert "set-cookie" in response.headers
         if csrf_token:
-          response = client.post("/" )
-          assert response.status_code == HTTP_201_CREATED
+            response = client.post("/")
+            assert response.status_code == HTTP_201_CREATED
+
 
 @pytest.mark.parametrize(
     "method",

--- a/tests/unit/test_middleware/test_csrf_middleware.py
+++ b/tests/unit/test_middleware/test_csrf_middleware.py
@@ -69,6 +69,19 @@ def test_csrf_successful_flow(get_handler: HTTPRouteHandler, post_handler: HTTPR
         response = client.post("/", headers={"x-csrftoken": csrf_token})
         assert response.status_code == HTTP_201_CREATED
 
+def test_csrf_httponly_flow(get_handler: HTTPRouteHandler, post_handler: HTTPRouteHandler) -> None:
+    with create_test_client(
+        route_handlers=[get_handler, post_handler], csrf_config=CSRFConfig(secret="secret", cookie_httponly=True)
+    ) as client:
+        response = client.get("/")
+        assert response.status_code == HTTP_200_OK
+
+        csrf_token: Optional[str] = response.cookies.get("csrftoken")
+        assert csrf_token is not None
+        assert "set-cookie" in response.headers
+        if csrf_token:
+          response = client.post("/" )
+          assert response.status_code == HTTP_201_CREATED
 
 @pytest.mark.parametrize(
     "method",


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

When `httponly` is `True`, it's impossible to set the header.  This fix allows this configruation to correctly validate.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
