### PR TITLE
feat: Raise exception when body parameter is annotated with non-bytes type

### DIFF
--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -599,5 +599,12 @@ class HTTPRouteHandler(BaseRouteHandler):
         if "data" in self.parsed_fn_signature.parameters and "GET" in self.http_methods:
             raise ImproperlyConfiguredException("'data' kwarg is unsupported for 'GET' request handlers")
 
+        if (body_param := self.parsed_fn_signature.parameters.get("body")) and not body_param.is_subclass_of(bytes):
+            raise ImproperlyConfiguredException(
+                f"Invalid type annotation for 'body' parameter in route handler {self}. 'body' will always receive the "
+                f"raw request body as bytes but was annotated with '{body_param.raw!r}'. If you want to receive "
+                "processed request data, use the 'data' parameter."
+            )
+
 
 route = HTTPRouteHandler

--- a/tests/unit/test_handlers/test_http_handlers/test_validations.py
+++ b/tests/unit/test_handlers/test_http_handlers/test_validations.py
@@ -159,5 +159,9 @@ def test_body_param_with_non_bytes_annotation_raises(decorator: Callable[..., An
 
 @pytest.mark.parametrize("decorator", [post, put, patch])
 def test_body_param_with_metadata_allowed(decorator: Callable[..., Any]) -> None:
-    def handler_fn(body: Annotated[str, Body(title="something")]) -> None:
+    def handler_fn(body: Annotated[bytes, Body(title="something")]) -> None:
         pass
+
+    # we expect no error here, even though the type isn't directly 'bytes' but has
+    # metadata attached to it
+    Litestar([decorator()(handler_fn)])

--- a/tests/unit/test_handlers/test_http_handlers/test_validations.py
+++ b/tests/unit/test_handlers/test_http_handlers/test_validations.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 from types import ModuleType
-from typing import Annotated, Any, Callable, Dict
+from typing import Any, Callable, Dict, List
 
 import pytest
+from typing_extensions import Annotated
 
 from litestar import HttpMethod, Litestar, WebSocket, delete, get, patch, post, put, route
 from litestar.exceptions import ImproperlyConfiguredException, ValidationException
@@ -149,7 +150,7 @@ def no_response_handler() -> {return_annotation}:
 
 @pytest.mark.parametrize("decorator", [post, put, patch])
 def test_body_param_with_non_bytes_annotation_raises(decorator: Callable[..., Any]) -> None:
-    def handler_fn(body: list[str]) -> None:
+    def handler_fn(body: List[str]) -> None:
         pass
 
     with pytest.raises(ImproperlyConfiguredException, match="Invalid type annotation for 'body' parameter"):


### PR DESCRIPTION
Add an informative error message to help users avoid the common mistake of attempting to use the `body` parameter to receive validated / structured data, by annotating it with a type such as `list[str]`, instead of `bytes`. In such a case, the user will now be instructed to use the `data` parameter instead.
