### PR TITLE
fix(OpenAPI): Correctly handle `msgspec.Struct` tagged unions

### DIFF
--- a/litestar/_openapi/schema_generation/plugins/struct.py
+++ b/litestar/_openapi/schema_generation/plugins/struct.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Literal
 import msgspec
 from msgspec import Struct
 
-from litestar.exceptions import ImproperlyConfiguredException
 from litestar.plugins import OpenAPISchemaPlugin
 from litestar.plugins.core._msgspec import kwarg_definition_from_field
 from litestar.types.empty import Empty
@@ -55,10 +54,8 @@ class StructSchemaPlugin(OpenAPISchemaPlugin):
         # have any type annotation associated with them, so we create a FieldDefinition
         # manually
         if struct_info.tag_field:
-            if not (tag := struct_info.tag):
-                raise ImproperlyConfiguredException()
             # using a Literal here will set these as a const in the schema
-            property_fields[struct_info.tag_field] = FieldDefinition.from_annotation(Literal[tag])  # pyright: ignore
+            property_fields[struct_info.tag_field] = FieldDefinition.from_annotation(Literal[struct_info.tag])  # pyright: ignore
             required.append(struct_info.tag_field)
 
         return schema_creator.create_component_schema(

--- a/litestar/_openapi/schema_generation/plugins/struct.py
+++ b/litestar/_openapi/schema_generation/plugins/struct.py
@@ -58,7 +58,7 @@ class StructSchemaPlugin(OpenAPISchemaPlugin):
             if not (tag := struct_info.tag):
                 raise ImproperlyConfiguredException()
             # using a Literal here will set these as a const in the schema
-            property_fields[struct_info.tag_field] = FieldDefinition.from_annotation(Literal[tag])
+            property_fields[struct_info.tag_field] = FieldDefinition.from_annotation(Literal[tag])  # pyright: ignore
             required.append(struct_info.tag_field)
 
         return schema_creator.create_component_schema(

--- a/litestar/_openapi/schema_generation/plugins/struct.py
+++ b/litestar/_openapi/schema_generation/plugins/struct.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import msgspec
 from msgspec import Struct
 
+from litestar.exceptions import ImproperlyConfiguredException
 from litestar.plugins import OpenAPISchemaPlugin
 from litestar.plugins.core._msgspec import kwarg_definition_from_field
 from litestar.types.empty import Empty
@@ -20,10 +21,11 @@ class StructSchemaPlugin(OpenAPISchemaPlugin):
     def is_plugin_supported_field(self, field_definition: FieldDefinition) -> bool:
         return not field_definition.is_union and field_definition.is_subclass_of(Struct)
 
-    def to_openapi_schema(self, field_definition: FieldDefinition, schema_creator: SchemaCreator) -> Schema:
-        def is_field_required(field: msgspec.inspect.Field) -> bool:
-            return field.required or field.default_factory is Empty
+    @staticmethod
+    def _is_field_required(field: msgspec.inspect.Field) -> bool:
+        return field.required or field.default_factory is Empty
 
+    def to_openapi_schema(self, field_definition: FieldDefinition, schema_creator: SchemaCreator) -> Schema:
         type_hints = field_definition.get_type_hints(include_extras=True, resolve_generics=True)
         struct_info: msgspec.inspect.StructType = msgspec.inspect.type_info(field_definition.type_)  # type: ignore[assignment]
         struct_fields = struct_info.fields
@@ -41,14 +43,26 @@ class StructSchemaPlugin(OpenAPISchemaPlugin):
                 **field_definition_kwargs,
             )
 
+        required = [
+            field.encode_name
+            for field in struct_fields
+            if self._is_field_required(field=field) and not is_optional_union(type_hints[field.name])
+        ]
+
+        # Support tagged unions: https://jcristharif.com/msgspec/structs.html#tagged-unions
+        # These structs contain a tag_field and a tag. Since these fields are added
+        # dynamically, they are not present within the regular struct fields and don't
+        # have any type annotation associated with them, so we create a FieldDefinition
+        # manually
+        if struct_info.tag_field:
+            if not (tag := struct_info.tag):
+                raise ImproperlyConfiguredException()
+            # using a Literal here will set these as a const in the schema
+            property_fields[struct_info.tag_field] = FieldDefinition.from_annotation(Literal[tag])
+            required.append(struct_info.tag_field)
+
         return schema_creator.create_component_schema(
             field_definition,
-            required=sorted(
-                [
-                    field.encode_name
-                    for field in struct_fields
-                    if is_field_required(field=field) and not is_optional_union(type_hints[field.name])
-                ]
-            ),
+            required=sorted(required),
             property_fields=property_fields,
         )

--- a/tests/unit/test_contrib/test_msgspec.py
+++ b/tests/unit/test_contrib/test_msgspec.py
@@ -135,21 +135,61 @@ def test_msgspec_dto_annotated_dto_field() -> None:
 
 
 def test_tag_field_included_in_schema() -> None:
-    class Model(Struct, tag_field="foo", tag="bar"):
+    # default tag field, default tag value
+    class Model(Struct, tag=True):
         regular_field: str
 
-    @post("/", signature_types=[Model])
-    def handler(data: Model) -> Model:
-        return data
+    # default tag field, custom tag value
+    class Model2(Struct, tag=2):
+        regular_field: str
 
-    assert Litestar([handler]).openapi_schema.components.schemas[
-        "test_tag_field_included_in_schema.Model"
-    ].to_schema() == {
+    # custom tag field, custom tag value
+    class Model3(Struct, tag_field="foo", tag="bar"):
+        regular_field: str
+
+    @post("/1")
+    def handler(data: Model) -> None:
+        return None
+
+    @post("/2")
+    def handler_2(data: Model2) -> None:
+        return None
+
+    @post("/3")
+    def handler_3(data: Model3) -> None:
+        return None
+
+    components = Litestar(
+        [handler, handler_2, handler_3],
+        signature_types=[Model, Model2, Model3],
+    ).openapi_schema.components.to_schema()["schemas"]
+
+    assert components["test_tag_field_included_in_schema.Model"] == {
+        "properties": {
+            "regular_field": {"type": "string"},
+            "type": {"type": "string", "const": "Model"},
+        },
+        "type": "object",
+        "required": ["regular_field", "type"],
+        "title": "Model",
+    }
+
+    assert components["test_tag_field_included_in_schema.Model2"] == {
+        "properties": {
+            "regular_field": {"type": "string"},
+            "type": {"type": "integer", "const": 2},
+        },
+        "type": "object",
+        "required": ["regular_field", "type"],
+        "title": "Model2",
+    }
+
+    assert components["test_tag_field_included_in_schema.Model3"] == {
         "properties": {
             "regular_field": {"type": "string"},
             "foo": {"type": "string", "const": "bar"},
         },
         "type": "object",
         "required": ["foo", "regular_field"],
-        "title": "Model",
+        "title": "Model3",
     }


### PR DESCRIPTION
Fix a bug where we would not include the struct fields implicitly generated by msgspec for its [tagged union](https://jcristharif.com/msgspec/structs.html#tagged-unions) support.

The change consists of an addition to the OpenAPI plugin where the tagged field will be added as a `const` to the schema.

Fix #3659.

