### PR TITLE
fix(revert): `httponly` correction in CSRFMiddleware

### DIFF
--- a/litestar/middleware/csrf.py
+++ b/litestar/middleware/csrf.py
@@ -118,9 +118,6 @@ class CSRFMiddleware(MiddlewareProtocol):
             form = await request.form()
             existing_csrf_token = form.get("_csrf_token", None)
 
-        if not existing_csrf_token and self.config.cookie_httponly:
-            existing_csrf_token = csrf_cookie
-
         connection_state = ScopeState.from_scope(scope)
         if request.method in self.config.safe_methods:
             token = connection_state.csrf_token = csrf_cookie or generate_csrf_token(secret=self.config.secret)

--- a/tests/unit/test_middleware/test_csrf_middleware.py
+++ b/tests/unit/test_middleware/test_csrf_middleware.py
@@ -70,21 +70,6 @@ def test_csrf_successful_flow(get_handler: HTTPRouteHandler, post_handler: HTTPR
         assert response.status_code == HTTP_201_CREATED
 
 
-def test_csrf_httponly_flow(get_handler: HTTPRouteHandler, post_handler: HTTPRouteHandler) -> None:
-    with create_test_client(
-        route_handlers=[get_handler, post_handler], csrf_config=CSRFConfig(secret="secret", cookie_httponly=True)
-    ) as client:
-        response = client.get("/")
-        assert response.status_code == HTTP_200_OK
-
-        csrf_token: Optional[str] = response.cookies.get("csrftoken")
-        assert csrf_token is not None
-        assert "set-cookie" in response.headers
-        if csrf_token:
-            response = client.post("/")
-            assert response.status_code == HTTP_201_CREATED
-
-
 @pytest.mark.parametrize(
     "method",
     ["POST", "PUT", "DELETE", "PATCH"],


### PR DESCRIPTION
Reverts litestar-org/litestar#3739

This is an incorrect usage of the protocol.  The correct approach is to embed the csrf token within the form or template itself, so that it can be attached to the header.