### PR TITLE
feat: OpenAPI plugins send CSRF request header

### DIFF
--- a/litestar/openapi/plugins.py
+++ b/litestar/openapi/plugins.py
@@ -32,6 +32,7 @@ _default_style = "<style>body { margin: 0; padding: 0 }</style>"
 
 
 def _get_cookie_value_or_undefined(cookie_name: str) -> str:
+    """Javascript code as a string to get the value of a cookie by name or undefined."""
     return f"document.cookie.split('; ').find((row) => row.startsWith('{cookie_name}='))?.split('=')[1];"
 
 

--- a/tests/unit/test_openapi/test_plugins.py
+++ b/tests/unit/test_openapi/test_plugins.py
@@ -1,0 +1,39 @@
+from litestar import Litestar
+from litestar.config.csrf import CSRFConfig
+from litestar.openapi.config import OpenAPIConfig
+from litestar.openapi.plugins import RapidocRenderPlugin, SwaggerRenderPlugin
+from litestar.testing import TestClient
+
+
+def test_rapidoc_csrf() -> None:
+    app = Litestar(
+        csrf_config=CSRFConfig(secret="litestar"),
+        openapi_config=OpenAPIConfig(
+            title="Litestar Example",
+            version="0.0.1",
+            render_plugins=[RapidocRenderPlugin()],
+        ),
+    )
+
+    with TestClient(app=app) as client:
+        resp = client.get("/schema/rapidoc")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "text/html; charset=utf-8"
+        assert ".addEventListener('before-try'," in resp.text
+
+
+def test_swagger_ui_csrf() -> None:
+    app = Litestar(
+        csrf_config=CSRFConfig(secret="litestar"),
+        openapi_config=OpenAPIConfig(
+            title="Litestar Example",
+            version="0.0.1",
+            render_plugins=[SwaggerRenderPlugin()],
+        ),
+    )
+
+    with TestClient(app=app) as client:
+        resp = client.get("/schema/swagger")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "text/html; charset=utf-8"
+        assert "requestInterceptor:" in resp.text


### PR DESCRIPTION
Supported OpenAPI UI clients will extract the CSRF cookie value and attach it to the request headers if CSRF is enabled on the application.

- [x] Swagger
- [x] RapiDoc
- [ ] Scalar
- [ ] Redoc
- [ ] Stoplight Elements

Scalar (https://github.com/scalar/scalar/discussions/2810), Redoc and (Stoplight) Elements does not seem to support interceptors or some other mechanism to achieve this.

Currently it also sends the header on "safe" methods but for both currently supported UI clients (Swagger and RapiDoc) it's possible to limit this to "unsafe" methods only, if required.