### PR TITLE
fix: (typo) changed emphasis from line 12 to 11 to highlight the correct plugin being added in tutorial

### DIFF
--- a/docs/tutorials/sqlalchemy/3-init-plugin.rst
+++ b/docs/tutorials/sqlalchemy/3-init-plugin.rst
@@ -19,7 +19,7 @@ Here's the updated code:
 .. literalinclude:: /examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_init_plugin.py
     :language: python
     :linenos:
-    :emphasize-lines: 12,30,78-79,87
+    :emphasize-lines: 11,30,78-79,87
 
 The most notable difference is that we no longer need the ``db_connection()`` lifespan context manager - the plugin
 handles this for us. It also handles the creation of the tables in our database if we supply our metadata and


### PR DESCRIPTION

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Tiny fix in line numbers to emphasise SQLAlchemyInitPlugin and not SQLAlchemySerializationPlugin is being added in this section of the tutorial. 

SQLAlchemySerializationPlugin is currently being highlighted which was the plugin shown in the previous section and is not being added here.


<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
N/A