### PR TITLE
docs: add graphql documentation

### DIFF
--- a/docs/usage/graphql.rst
+++ b/docs/usage/graphql.rst
@@ -1,7 +1,7 @@
 Graphql
 #######
 
-Litestar does not support ``graphql`` out of the box. This can be done through third party packages. 
+Litestar does not support ``graphql`` out of the box. This can be done through third party packages.
 
 .. note::
     Currently the only library that supports Litestar is `Strawberry <https://strawberry.rocks/docs/integrations/litestar#litestar>`_.

--- a/docs/usage/graphql.rst
+++ b/docs/usage/graphql.rst
@@ -1,7 +1,7 @@
 Graphql
 #######
 
-Litestar does not support ``graphql`` out of the box. This can be done throught third party packages. 
+Litestar does not support ``graphql`` out of the box. This can be done through third party packages. 
 
 .. note::
     Currently the only library that supports Litestar is `Strawberry <https://strawberry.rocks/docs/integrations/litestar#litestar>`_.

--- a/docs/usage/graphql.rst
+++ b/docs/usage/graphql.rst
@@ -1,0 +1,8 @@
+Graphql
+#######
+
+Litestar does not support ``graphql`` out of the box. This can be done throught third party packages. 
+
+.. note::
+    Currently the only library that supports Litestar is `Strawberry <https://strawberry.rocks/docs/integrations/litestar#litestar>`_.
+    Check the official `Graphql <https://graphql.org/community/tools-and-libraries/?tags=python>`_  documentation to learn more about other graphql libraries.

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -16,6 +16,7 @@ Usage
     dto/index
     events
     exceptions
+    graphql
     htmx
     lifecycle-hooks
     logging


### PR DESCRIPTION
## Description
Added documentation about the usage of `graphql` in Litestar using [Strawberry](https://strawberry.rocks).

## Closes
#3317

## Follow up
#3719
