### PR TITLE
fix: sign bug in rate limit middelware

### DIFF
--- a/litestar/middleware/rate_limit.py
+++ b/litestar/middleware/rate_limit.py
@@ -205,7 +205,7 @@ class RateLimitMiddleware(AbstractMiddleware):
             self.config.rate_limit_policy_header_key: f"{self.max_requests}; w={DURATION_VALUES[self.unit]}",
             self.config.rate_limit_limit_header_key: str(self.max_requests),
             self.config.rate_limit_remaining_header_key: remaining_requests,
-            self.config.rate_limit_reset_header_key: str(int(time()) - cache_object.reset),
+            self.config.rate_limit_reset_header_key: str(cache_object.reset - int(time())),
         }
 
 

--- a/litestar/middleware/rate_limit.py
+++ b/litestar/middleware/rate_limit.py
@@ -198,7 +198,7 @@ class RateLimitMiddleware(AbstractMiddleware):
             A dict of http headers.
         """
         remaining_requests = str(
-            len(cache_object.history) - self.max_requests if len(cache_object.history) <= self.max_requests else 0
+            self.max_requests - len(cache_object.history) if len(cache_object.history) <= self.max_requests else 0
         )
 
         return {

--- a/tests/unit/test_middleware/test_rate_limit_middleware.py
+++ b/tests/unit/test_middleware/test_rate_limit_middleware.py
@@ -28,33 +28,42 @@ async def test_rate_limiting(unit: DurationUnit) -> None:
     def handler() -> None:
         return None
 
-    config = RateLimitConfig(rate_limit=(unit, 1))
+    config = RateLimitConfig(rate_limit=(unit, 2))
     cache_key = "RateLimitMiddleware::testclient"
     app = Litestar(route_handlers=[handler], middleware=[config.middleware])
     store = app.stores.get("rate_limit")
 
     with travel(datetime.utcnow, tick=False) as frozen_time, TestClient(app=app) as client:
         response = client.get("/")
-        assert response.status_code == HTTP_200_OK
+
         cached_value = await store.get(cache_key)
         assert cached_value
         cache_object = CacheObject(**decode_json(value=cached_value))
         assert len(cache_object.history) == 1
 
-        assert response.headers.get(config.rate_limit_policy_header_key) == f"1; w={DURATION_VALUES[unit]}"
-        assert response.headers.get(config.rate_limit_limit_header_key) == "1"
-        assert response.headers.get(config.rate_limit_remaining_header_key) == "0"
+        assert response.status_code == HTTP_200_OK
+        assert response.headers.get(config.rate_limit_policy_header_key) == f"2; w={DURATION_VALUES[unit]}"
+        assert response.headers.get(config.rate_limit_limit_header_key) == "2"
+        assert response.headers.get(config.rate_limit_remaining_header_key) == "1"
         # Since the time is frozen, no time has passed.
-        # Hence the remaining seconds for the current quota window should be the same as the whole window length.
+        # Therefore, the remaining seconds for the current quota window should be the same as the entire window length.
         assert response.headers.get(config.rate_limit_reset_header_key) == str(DURATION_VALUES[unit])
 
-        # Move time one second before the end of the quota window
+        # Move time one second before the end of the quota window for the next request
         frozen_time.shift(DURATION_VALUES[unit] - 1)
+        response = client.get("/")
+
+        assert response.status_code == HTTP_200_OK
+        assert response.headers.get(config.rate_limit_policy_header_key) == f"2; w={DURATION_VALUES[unit]}"
+        assert response.headers.get(config.rate_limit_limit_header_key) == "2"
+        assert response.headers.get(config.rate_limit_remaining_header_key) == "0"
+        assert response.headers.get(config.rate_limit_reset_header_key) == "1"
 
         response = client.get("/")
+
         assert response.status_code == HTTP_429_TOO_MANY_REQUESTS
-        assert response.headers.get(config.rate_limit_policy_header_key) == f"1; w={DURATION_VALUES[unit]}"
-        assert response.headers.get(config.rate_limit_limit_header_key) == "1"
+        assert response.headers.get(config.rate_limit_policy_header_key) == f"2; w={DURATION_VALUES[unit]}"
+        assert response.headers.get(config.rate_limit_limit_header_key) == "2"
         assert response.headers.get(config.rate_limit_remaining_header_key) == "0"
         assert response.headers.get(config.rate_limit_reset_header_key) == "1"
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
When using the rate limit middleware, the response header fields `RateLimit-Remaining` and `RateLimit-Reset` have negative values. This branch fixes the issue.

This might be a breaking change for consumers of an API implemented with litestar.

I split the PR into four commits which might make it easier to review this PR.

Side note: Initially my commits didn't follow the conventional commits guidelines, but pre-commit didn't complain. See point 6 in https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst#workflow
Is this a bug in the pre-commit setup?

