### PR TITLE
docs(readme): Remove reference to `litestar-pg-redis-docker`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,11 @@ app = Litestar(route_handlers=[hello_world])
 <details>
 <summary>Pre-built Example Apps</summary>
 
-- [litestar-pg-redis-docker](https://github.com/litestar-org/litestar-pg-redis-docker): In addition to Litestar, this
-  demonstrates a pattern of application modularity, SQLAlchemy 2.0 ORM, Redis cache connectivity, and more. Like all
-  Litestar projects, this application is open to contributions, big and small.
-- [litestar-fullstack](https://github.com/litestar-org/litestar-fullstack): A reference application that contains most of the boilerplate required for a web application.
-  It features a Litestar app configured with best practices, SQLAlchemy 2.0 and SAQ, a frontend integrated with Vitejs and Jinja2 templates, Docker, and more.
 - [litestar-hello-world](https://github.com/litestar-org/litestar-hello-world): A bare-minimum application setup. Great
 for testing and POC work.
+- [litestar-fullstack](https://github.com/litestar-org/litestar-fullstack): A reference application that contains most of the boilerplate required for a web application.
+  It features a Litestar app configured with best practices, SQLAlchemy 2.0 and SAQ, a frontend integrated with Vitejs and Jinja2 templates, Docker, and more. Like all
+  Litestar projects, this application is open to contributions, big and small.
 </details>
 
 ## Sponsors

--- a/docs/PYPI_README.md
+++ b/docs/PYPI_README.md
@@ -103,13 +103,11 @@ app = Litestar(route_handlers=[hello_world])
 <details>
 <summary>Pre-built Example Apps</summary>
 
-- [litestar-pg-redis-docker](https://github.com/litestar-org/litestar-pg-redis-docker): In addition to Litestar, this
-  demonstrates a pattern of application modularity, SQLAlchemy 2.0 ORM, Redis cache connectivity, and more. Like all
-  Litestar projects, this application is open to contributions, big and small.
-- [litestar-fullstack](https://github.com/litestar-org/litestar-fullstack): A reference application that contains most of the boilerplate required for a web application.
-  It features a Litestar app configured with best practices, SQLAlchemy 2.0 and SAQ, a frontend integrated with Vitejs and Jinja2 templates, Docker, and more.
 - [litestar-hello-world](https://github.com/litestar-org/litestar-hello-world): A bare-minimum application setup. Great
 for testing and POC work.
+- [litestar-fullstack](https://github.com/litestar-org/litestar-fullstack): A reference application that contains most of the boilerplate required for a web application.
+  It features a Litestar app configured with best practices, SQLAlchemy 2.0 and SAQ, a frontend integrated with Vitejs and Jinja2 templates, Docker, and more. Like all
+  Litestar projects, this application is open to contributions, big and small.
 </details>
 
 ## Sponsors


### PR DESCRIPTION
## Description

- Remove reference to `litestar-pg-redis-docker`
- Reorder the repos so that the easier example is at the top
- `docs/PYPI_README.md` generated from pre-commit

## Closes
Closes #3773
