### PR TITLE
fix(prometheus): fix path template for routes without path parameters

### DIFF
--- a/litestar/_asgi/routing_trie/traversal.py
+++ b/litestar/_asgi/routing_trie/traversal.py
@@ -134,7 +134,7 @@ def parse_path_to_route(
     try:
         if path in plain_routes:
             asgi_app, handler = parse_node_handlers(node=root_node.children[path], method=method)
-            return asgi_app, handler, path, {}, root_node.path_template
+            return asgi_app, handler, path, {}, path
 
         if mount_paths_regex and (match := mount_paths_regex.match(path)):
             mount_path = path[: match.end()]

--- a/tests/examples/test_contrib/prometheus/test_prometheus_exporter_example.py
+++ b/tests/examples/test_contrib/prometheus/test_prometheus_exporter_example.py
@@ -20,7 +20,6 @@ def clear_collectors() -> None:
 @pytest.mark.parametrize(
     "group_path, route_path, route_template, expected_path",
     [
-        (True, "/test", "test", "/test"),
         (True, "/test/litestar", "test/litestar", "/test/litestar"),
         (False, "/test/litestar", "test/litestar", "/test/litestar"),
         (True, "/test/litestar", "test/{name:str}", "/test/{name}"),

--- a/tests/examples/test_contrib/prometheus/test_prometheus_exporter_example.py
+++ b/tests/examples/test_contrib/prometheus/test_prometheus_exporter_example.py
@@ -20,7 +20,9 @@ def clear_collectors() -> None:
 @pytest.mark.parametrize(
     "group_path, route_path, route_template, expected_path",
     [
-        (True, "/test/litestar", "test/{name:str}", "/test/{name}"),
+        (True, "/test", "test", "/test"),
+        (True, "/test/litestar", "test/litestar", "/test/litestar"),
+        (False, "/test/litestar", "test/litestar", "/test/litestar"),
         (True, "/test/litestar", "test/{name:str}", "/test/{name}"),
         (False, "/test/litestar", "test/{name:str}", "/test/litestar"),
         (


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

When `PrometheusConfig.group_path=True` the metrics exporter response content ignores all paths with no path parameters.

- Example for path `/test/litestar` when `group_path=True`

    > litestar_request_duration_seconds_bucket{app_name="litestar",le="0.075",method="GET",path="",status_code="200"} 1.0

- Example for path `/test/litestar` when `group_path=False`

    > litestar_request_duration_seconds_bucket{app_name="litestar",le="2.5",method="GET",path="/test/litestar",status_code="200"} 1.0

So, when the path has no params return the actual path as template so Prometheus can use it when `group_path=True`.

### QA
Added more test cases to cover this case.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

## Closes
-->
