### PR TITLE
docs: fix missing import in `cache` usage

### DIFF
--- a/docs/usage/caching.rst
+++ b/docs/usage/caching.rst
@@ -35,7 +35,7 @@ sentinel instead:
     :language: python
     :caption: Caching the response indefinitely by setting the :paramref:`~litestar.handlers.HTTPRouteHandler.cache`
       parameter to :class:`~litestar.config.response_cache.CACHE_FOREVER`.
-    :lines: 1, 3, 14-18
+    :lines: 1-3, 14-18
     :emphasize-lines: 5
 
 Configuration


### PR DESCRIPTION
It used to be:
<img width="794" alt="Снимок экрана 2024-10-14 в 17 21 52" src="https://github.com/user-attachments/assets/fd79d1a1-1c3c-4bcf-bdd2-8a6b668eb797">

Because the second line of https://github.com/litestar-org/litestar/blob/ad592f68aa8a76e844fee3e0f5d50101ebd9ce25/docs/examples/caching/cache.py#L2 was missing