### PR TITLE
docs: make sure that `channels` use `finally` in all examples

### DIFF
--- a/docs/usage/channels.rst
+++ b/docs/usage/channels.rst
@@ -219,8 +219,10 @@ subscriptions need to be managed dynamically.
 .. code-block:: python
 
     subscriber = await channels.subscribe(["foo", "bar"])
-    ...  # do some stuff here
-    await channels.unsubscribe(subscriber, ["foo"])
+    try:
+        ...  # do some stuff here
+    finally:
+        await channels.unsubscribe(subscriber, ["foo"])
 
 
 Or, using the context manager


### PR DESCRIPTION
Right now this code:
<img width="795" alt="Снимок экрана 2024-10-14 в 18 20 32" src="https://github.com/user-attachments/assets/e75a6974-5232-43b8-be6a-c65269cfccc4">

Is not really correct, because in case of an exception - it will not execute `await channels.unsubscribe(subscriber, ["foo"])`, which might be unexpected.

There's a similar example above that use the correct form: 

<img width="785" alt="Снимок экрана 2024-10-14 в 18 21 35" src="https://github.com/user-attachments/assets/5cef8e7a-9917-41fd-a759-ec8da11df110">
