### PR TITLE
docs: fix typos in `sqlalchemy` examples

### DIFF
--- a/docs/examples/contrib/sqlalchemy/sqlalchemy_async_repository.py
+++ b/docs/examples/contrib/sqlalchemy/sqlalchemy_async_repository.py
@@ -34,8 +34,8 @@ class BaseModel(_BaseModel):
     model_config = {"from_attributes": True}
 
 
-# the SQLAlchemy base includes a declarative model for you to use in your models.
-# The `Base` class includes a `UUID` based primary key (`id`)
+# The SQLAlchemy base includes a declarative model for you to use in your models.
+# The `UUIDBase` class includes a `UUID` based primary key (`id`)
 class AuthorModel(base.UUIDBase):
     # we can optionally provide the table name instead of auto-generating it
     __tablename__ = "author"  #  type: ignore[assignment]
@@ -44,9 +44,9 @@ class AuthorModel(base.UUIDBase):
     books: Mapped[list[BookModel]] = relationship(back_populates="author", lazy="noload")
 
 
-# The `AuditBase` class includes the same UUID` based primary key (`id`) and 2
-# additional columns: `created` and `updated`. `created` is a timestamp of when the
-# record created, and `updated` is the last time the record was modified.
+# The `UUIDAuditBase` class includes the same UUID` based primary key (`id`) and 2
+# additional columns: `created_at` and `updated_at`. `created_at` is a timestamp of when the
+# record created, and `updated_at` is the last time the record was modified.
 class BookModel(base.UUIDAuditBase):
     __tablename__ = "book"  #  type: ignore[assignment]
     title: Mapped[str]

--- a/docs/examples/contrib/sqlalchemy/sqlalchemy_declarative_models.py
+++ b/docs/examples/contrib/sqlalchemy/sqlalchemy_declarative_models.py
@@ -14,15 +14,15 @@ from litestar.contrib.sqlalchemy.base import UUIDAuditBase, UUIDBase
 from litestar.contrib.sqlalchemy.plugins import AsyncSessionConfig, SQLAlchemyAsyncConfig, SQLAlchemyPlugin
 
 
-# the SQLAlchemy base includes a declarative model for you to use in your models.
-# The `Base` class includes a `UUID` based primary key (`id`)
+# The SQLAlchemy base includes a declarative model for you to use in your models.
+# The `UUIDBase` class includes a `UUID` based primary key (`id`)
 class Author(UUIDBase):
     name: Mapped[str]
     dob: Mapped[date]
     books: Mapped[List[Book]] = relationship(back_populates="author", lazy="selectin")
 
 
-# The `AuditBase` class includes the same UUID` based primary key (`id`) and 2
+# The `UUIDAuditBase` class includes the same UUID` based primary key (`id`) and 2
 # additional columns: `created_at` and `updated_at`. `created_at` is a timestamp of when the
 # record created, and `updated_at` is the last time the record was modified.
 class Book(UUIDAuditBase):

--- a/docs/examples/contrib/sqlalchemy/sqlalchemy_repository_extension.py
+++ b/docs/examples/contrib/sqlalchemy/sqlalchemy_repository_extension.py
@@ -96,9 +96,9 @@ class SQLAlchemyAsyncSlugRepository(SQLAlchemyAsyncRepository[ModelT]):
         return await self.get_one_or_none(slug=slug) is None
 
 
-# The `AuditBase` class includes the same UUID` based primary key (`id`) and 2
-# additional columns: `created` and `updated`. `created` is a timestamp of when the
-# record created, and `updated` is the last time the record was modified.
+# The `UUIDAuditBase` class includes the same UUID` based primary key (`id`) and 2
+# additional columns: `created_at` and `updated_at`. `created_at` is a timestamp of when the
+# record created, and `updated_at` is the last time the record was modified.
 class BlogPost(UUIDAuditBase, SlugKey):
     title: Mapped[str]
     content: Mapped[str]

--- a/docs/examples/contrib/sqlalchemy/sqlalchemy_sync_repository.py
+++ b/docs/examples/contrib/sqlalchemy/sqlalchemy_sync_repository.py
@@ -30,8 +30,8 @@ class BaseModel(_BaseModel):
     model_config = {"from_attributes": True}
 
 
-# the SQLAlchemy base includes a declarative model for you to use in your models.
-# The `Base` class includes a `UUID` based primary key (`id`)
+# The SQLAlchemy base includes a declarative model for you to use in your models.
+# The `UUIDBase` class includes a `UUID` based primary key (`id`)
 class AuthorModel(UUIDBase):
     # we can optionally provide the table name instead of auto-generating it
     __tablename__ = "author"  #  type: ignore[assignment]
@@ -40,9 +40,9 @@ class AuthorModel(UUIDBase):
     books: Mapped[list[BookModel]] = relationship(back_populates="author", lazy="noload")
 
 
-# The `AuditBase` class includes the same UUID` based primary key (`id`) and 2
-# additional columns: `created` and `updated`. `created` is a timestamp of when the
-# record created, and `updated` is the last time the record was modified.
+# The `UUIDAuditBase` class includes the same UUID` based primary key (`id`) and 2
+# additional columns: `created_at` and `updated_at`. `created_at` is a timestamp of when the
+# record created, and `updated_at` is the last time the record was modified.
 class BookModel(UUIDAuditBase):
     __tablename__ = "book"  #  type: ignore[assignment]
     title: Mapped[str]


### PR DESCRIPTION
I've noticed this here: https://docs.litestar.dev/latest/usage/databases/sqlalchemy/models_and_repository.html#basic-controller-integration

<img width="1082" alt="Снимок экрана 2024-10-14 в 20 57 32" src="https://github.com/user-attachments/assets/d357d59f-b76a-4765-8aca-46f1c0a1c219">
