### PR TITLE
docs: change `sync-to-thread-info.rst` wording about `sync_to_thread`

### DIFF
--- a/docs/admonitions/sync-to-thread-info.rst
+++ b/docs/admonitions/sync-to-thread-info.rst
@@ -7,8 +7,11 @@
     running the event loop, and in turn block the whole application.
 
     To mitigate this, the ``sync_to_thread`` parameter can be set to ``True``, which
-    will result in the function being run in a thread pool. Should the function be
-    non-blocking, ``sync_to_thread`` should be set to ``False`` instead.
+    will result in the function being run in a thread pool.
+
+    If a synchronous function is non-blocking, setting ``sync_to_thread`` to ``False``
+    will tell Litestar that the user is sure about its behavior
+    and the function can be treated as non-blocking.
 
     If a synchronous function is passed, without setting an explicit ``sync_to_thread``
     value, a warning will be raised.


### PR DESCRIPTION
I failed to understand the current version, so I used https://docs.litestar.dev/2/topics/sync-vs-async.html wording with a bit more verbosity.