### PR TITLE
docs: fix highlighted lines in DTO usage

### DIFF
--- a/docs/usage/dto/1-abstract-dto.rst
+++ b/docs/usage/dto/1-abstract-dto.rst
@@ -190,7 +190,7 @@ handler.
 
 .. literalinclude:: /examples/data_transfer_objects/factory/dto_data_problem_statement.py
     :language: python
-    :emphasize-lines: 19,20,21,22,28
+    :emphasize-lines: 18-21,27
     :linenos:
 
 Notice that we get a ``500`` response from the handler - this is because the DTO has attempted to convert the request


### PR DESCRIPTION
Link: https://docs.litestar.dev/latest/usage/dto/1-abstract-dto.html#dto-data

It used to be like this:
<img width="792" alt="Снимок экрана 2024-10-15 в 21 52 44" src="https://github.com/user-attachments/assets/b595a8d2-895f-45ee-9aa4-9d03662d972b">

I moved all highlighted lines one line up.

