### PR TITLE
chore(ci): fix the `pr_merged.yml` workflow

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -19,11 +19,8 @@ jobs:
           script: |
             const prNumber = context.payload.number
             const branch = context.baseRef
-            # TODO: `develop` no longer exists. Need a new way to determine if the
-            # change will be introduced in a major, minor, or patch release.
-            # possibly conventional commit standards in the PR title or by labels?
-            const isDevelop = branch === "develop"
-            const commentBody = `<!--closing-comment-->\nThis issue has been closed in #${prNumber}. The change will be included in the upcoming ${isDevelop ? "minor" : "patch"} release.`
+            // TODO: use semantic commits to specify the exact version, when it will be released
+            const commentBody = `<!--closing-comment-->\nThis issue has been closed in #${prNumber}. The change will be included in upcoming releases.`
 
             const query = `query($number: Int!, $owner: String!, $name: String!) { repository(owner: $owner, name: $name) {
                 pullRequest(number: $number) {


### PR DESCRIPTION
Comments in JS start with `//` and not `#` 😅 

Closes #3810 