### PR TITLE
docs: fix highlight of code example in "Providing values for nested data"

### DIFF
--- a/docs/usage/dto/1-abstract-dto.rst
+++ b/docs/usage/dto/1-abstract-dto.rst
@@ -228,7 +228,7 @@ nested model with excluded fields.
 
 .. literalinclude:: /examples/data_transfer_objects/factory/providing_values_for_nested_data.py
     :language: python
-    :emphasize-lines: 10,11,12,13,21,29,35
+    :emphasize-lines: 9-12,20,28,34
     :linenos:
 
 The double-underscore syntax ``address__id`` passed as a keyword argument to the
@@ -237,7 +237,7 @@ nested attribute. In this case, it's used to provide a value for the ``id`` attr
 within the ``Person`` instance.
 
 This is a common convention in Python for dealing with nested structures. The double underscore can be interpreted as
-"traverse through", so ``address__id`` means "traverse through address to get to id".
+"traverse through", so ``address__id`` means "traverse through address to get to its id".
 
 In the context of this script, ``create_instance(id=1, address__id=2)`` is saying "create a new ``Person`` instance from
 the client data given an id of ``1``, and supplement the client address data with an id of ``2``".


### PR DESCRIPTION
Right now: https://docs.litestar.dev/latest/usage/dto/1-abstract-dto.html#providing-values-for-nested-data

<img width="795" alt="Снимок экрана 2024-10-16 в 15 25 00" src="https://github.com/user-attachments/assets/de7d3556-f730-42ef-be85-bacff45ea1c5">

