### PR TITLE
chore(mypy): enable more mypy codes

### DIFF
--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any, Collection, Iterable
 
 from litestar.constants import (
     HTTP_RESPONSE_BODY,
@@ -273,7 +273,7 @@ class LoggingMiddlewareConfig:
     """Log message to prepend when logging a request."""
     response_log_message: str = field(default="HTTP Response")
     """Log message to prepend when logging a response."""
-    request_log_fields: Iterable[RequestExtractorField] = field(
+    request_log_fields: Collection[RequestExtractorField] = field(
         default=(
             "path",
             "method",
@@ -292,7 +292,7 @@ class LoggingMiddlewareConfig:
             Thus, re-arranging the log-message is as simple as changing the iterable.
         -  To turn off logging of requests, use and empty iterable.
     """
-    response_log_fields: Iterable[ResponseExtractorField] = field(
+    response_log_fields: Collection[ResponseExtractorField] = field(
         default=(
             "status_code",
             "cookies",

--- a/litestar/testing/websocket_test_session.py
+++ b/litestar/testing/websocket_test_session.py
@@ -78,7 +78,7 @@ class WebSocketTestSession:
         async def send(message: WebSocketSendMessage) -> None:
             if message["type"] == "websocket.accept":
                 headers = message.get("headers", [])
-                if headers:
+                if headers:  # type: ignore[truthy-iterable]
                     headers_list = list(self.scope["headers"])
                     headers_list.extend(headers)
                     self.scope["headers"] = headers_list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,11 +243,16 @@ xfail_strict = true
 [tool.mypy]
 packages = ["litestar", "tests"]
 plugins = ["pydantic.mypy"]
+enable_error_code = [
+  "truthy-iterable",
+  "unused-awaitable",
+  "ignore-without-code",
+  "redundant-self",
+]
 python_version = "3.8"
 
 disallow_any_generics = false
 disallow_untyped_decorators = true
-enable_error_code = "ignore-without-code"
 implicit_reexport = false
 show_error_codes = true
 strict = true
@@ -256,6 +261,7 @@ warn_return_any = true
 warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
+local_partial_types = true
 
 [[tool.mypy.overrides]]
 ignore_errors = true


### PR DESCRIPTION
I've enabled more mypy codes:
- `local_partial_types` is needed for compat between `mypy` and `dmypy`
- `truthy-iterable` guards us from this problem:

```python
>>> class I:
...     def __iter__(self):
...         return iter([])
...         
>>> bool(I())
True
```

We had this problem in three places:

```
» pdm run mypy
litestar/middleware/logging.py:106: error: Member "response_log_fields" has type "Iterable[Literal['status_code', 'headers', 'body', 'cookies']]" which can always be true in boolean context. Consider using "Collection[Literal['status_code', 'headers', 'body', 'cookies']]" instead.  [truthy-iterable]
litestar/middleware/logging.py:109: error: Member "request_log_fields" has type "Iterable[Literal['path', 'method', 'content_type', 'headers', 'cookies', 'query', 'path_params', 'body', 'scheme', 'client']]" which can always be true in boolean context. Consider using "Collection[Literal['path', 'method', 'content_type', 'headers', 'cookies', 'query', 'path_params', 'body', 'scheme', 'client']]" instead.  [truthy-iterable]
litestar/testing/websocket_test_session.py:81: error: "headers" has type "Iterable[Tuple[bytes, bytes]]" which can always be true in boolean context. Consider using "Collection[Tuple[bytes, bytes]]" instead.  [truthy-iterable]
Found 3 errors in 2 files (checked 758 source files)
```

So, I fixes all of them. `response_log_fields` and `request_log_fields` where indeed not just `Iterable`s but `Collection`s

The other one I just ignored, because it is a test code.

- `unused-awaitable` has 0 cases
- `redundant-self` has 0 cases

Docs on error codes: https://mypy.readthedocs.io/en/stable/error_code_list2.html
Docs on `local_partial_types`: https://mypy.readthedocs.io/en/stable/config_file.html#confval-local_partial_types