### PR TITLE
chore(mypy): enable `possibly-undefined` error code

### DIFF
--- a/litestar/contrib/sqlalchemy/__init__.py
+++ b/litestar/contrib/sqlalchemy/__init__.py
@@ -29,6 +29,10 @@ def __getattr__(attr_name: str) -> object:
             )
 
             value = globals()[attr_name] = getattr(exceptions, attr_name)
+
+        else:  # pragma: no cover
+            raise RuntimeError(f"Unhandled module attribute: {attr_name!r}")
+
         warn_deprecation(
             deprecated_name=f"litestar.contrib.sqlalchemy.{attr_name}",
             version="2.12",

--- a/litestar/contrib/sqlalchemy/repository/__init__.py
+++ b/litestar/contrib/sqlalchemy/repository/__init__.py
@@ -30,6 +30,9 @@ def __getattr__(attr_name: str) -> object:
                 wrap_sqlalchemy_exception,  # type: ignore[import-not-found] # pyright: ignore[reportMissingImport]
             )
 
+        else:  # pragma: no cover
+            raise RuntimeError(f"Unhandled module attribute: {attr_name!r}")
+
         value = globals()[attr_name] = locals()[attr_name]
         warn_deprecation(
             deprecated_name=f"litestar.contrib.sqlalchemy.repository.{attr_name}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,6 +247,7 @@ enable_error_code = [
   "truthy-iterable",
   "unused-awaitable",
   "ignore-without-code",
+  "possibly-undefined",
   "redundant-self",
 ]
 python_version = "3.8"


### PR DESCRIPTION
Docs: https://mypy.readthedocs.io/en/stable/error_code_list2.html#warn-about-variables-that-are-defined-only-in-some-execution-paths-possibly-undefined

Why did I make the code change?
- We handle all names defined in `__all__` via `if` and `elif` branches
- If we somehow forget to handle a name in the future (before this module is removed), it will raise an error
- Users should not be affected by the change
- It will be removed in 3.0 with the warning
- Now mypy is happy :)