### PR TITLE
docs: fix "DTO Factory and PATCH requests" section

### DIFF
--- a/docs/examples/data_transfer_objects/factory/patch_requests.py
+++ b/docs/examples/data_transfer_objects/factory/patch_requests.py
@@ -20,17 +20,16 @@ class PatchDTO(DataclassDTO[Person]):
     config = DTOConfig(exclude={"id"}, partial=True)
 
 
+peter_uuid = UUID("f32ff2ce-e32f-4537-9dc0-26e7599f1380")
 database = {
-    UUID("f32ff2ce-e32f-4537-9dc0-26e7599f1380"): Person(
-        id=UUID("f32ff2ce-e32f-4537-9dc0-26e7599f1380"), name="Peter", age=40
-    )
+    peter_uuid: Person(id=peter_uuid, name="Peter", age=40)
 }
 
 
 @patch("/person/{person_id:uuid}", dto=PatchDTO, return_dto=None, sync_to_thread=False)
 def update_person(person_id: UUID, data: DTOData[Person]) -> Person:
-    """Create a person."""
-    return data.update_instance(database.get(person_id))
+    """Partially update a person."""
+    return data.update_instance(database[person_id])
 
 
 app = Litestar(route_handlers=[update_person])

--- a/docs/usage/dto/1-abstract-dto.rst
+++ b/docs/usage/dto/1-abstract-dto.rst
@@ -251,17 +251,17 @@ attributes in the client payload, which requires some special handling internall
 
 .. literalinclude:: /examples/data_transfer_objects/factory/patch_requests.py
     :language: python
-    :emphasize-lines: 7,21,32,34
+    :emphasize-lines: 7,20,29,30,32
     :linenos:
 
-The ``PatchDTO`` class is defined for the Person class. The ``config`` attribute of ``PatchDTO`` is set to exclude the
-id field, preventing clients from setting it when updating a person, and the ``partial`` attribute is set to ``True``,
+The ``PatchDTO`` class is defined for the ``Person`` class. The ``config`` attribute of ``PatchDTO`` is set to exclude the
+``id`` field, preventing clients from setting it when updating a person, and the ``partial`` attribute is set to ``True``,
 which allows the DTO to accept a subset of the model attributes.
 
 Inside the handler, the :meth:`DTOData.update_instance <litestar.dto.data_structures.DTOData.update_instance>` method is called
 to update the instance of ``Person`` before returning it.
 
-In our request, we set only the ``name`` property of the ``Person``, from ``"Peter"`` to ``"Peter Pan"`` and received
+In our request, we update only the ``name`` property of the ``Person``, from ``"Peter"`` to ``"Peter Pan"`` and receive
 the full object - with the modified name - back in the response.
 
 Implicit Private Fields


### PR DESCRIPTION
Link: https://docs.litestar.dev/latest/usage/dto/1-abstract-dto.html#dto-factory-and-patch-requests

Highlight used to be:
<img width="791" alt="Снимок экрана 2024-10-16 в 18 59 34" src="https://github.com/user-attachments/assets/a00fdf8d-e3b1-405a-b8c9-7bf10e3cab08">

I've also modified the example code a bit to be more readable.
And I fixed a type checking bug. `.get` cannot be used in `.update_instance`, since `None` is not handled.