### PR TITLE
chore(mypy): enable `truthy-bool` error code

### DIFF
--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -485,7 +485,7 @@ class SchemaCreator:
         if field_definition.is_non_string_sequence or field_definition.is_non_string_iterable:
             # filters out ellipsis from tuple[int, ...] type annotations
             inner_types = (f for f in field_definition.inner_types if f.annotation is not Ellipsis)
-            items = list(map(self.for_field_definition, inner_types or ()))
+            items = list(map(self.for_field_definition, inner_types))
 
             return Schema(
                 type=OpenAPIType.ARRAY,

--- a/litestar/_openapi/typescript_converter/converter.py
+++ b/litestar/_openapi/typescript_converter/converter.py
@@ -264,7 +264,7 @@ def convert_openapi_to_typescript(openapi_schema: OpenAPI, namespace: str = "API
     """
     if not openapi_schema.paths:  # pragma: no cover
         raise ValueError("OpenAPI schema has no paths")
-    if not openapi_schema.components:  # pragma: no cover
+    if not openapi_schema.components:  # type: ignore[truthy-bool]  # pragma: no cover
         raise ValueError("OpenAPI schema has no components")
 
     operations: list[TypeScriptNamespace] = []

--- a/litestar/security/base.py
+++ b/litestar/security/base.py
@@ -89,7 +89,7 @@ class AbstractSecurityConfig(ABC, Generic[UserType, AuthType]):
             app_config.openapi_config = copy(app_config.openapi_config)
             if isinstance(app_config.openapi_config.components, list):
                 app_config.openapi_config.components.append(self.openapi_components)
-            elif app_config.openapi_config.components:
+            elif app_config.openapi_config.components:  # type: ignore[truthy-bool]
                 app_config.openapi_config.components = [self.openapi_components, app_config.openapi_config.components]
             else:
                 app_config.openapi_config.components = [self.openapi_components]

--- a/litestar/security/base.py
+++ b/litestar/security/base.py
@@ -89,10 +89,8 @@ class AbstractSecurityConfig(ABC, Generic[UserType, AuthType]):
             app_config.openapi_config = copy(app_config.openapi_config)
             if isinstance(app_config.openapi_config.components, list):
                 app_config.openapi_config.components.append(self.openapi_components)
-            elif app_config.openapi_config.components:  # type: ignore[truthy-bool]
-                app_config.openapi_config.components = [self.openapi_components, app_config.openapi_config.components]
             else:
-                app_config.openapi_config.components = [self.openapi_components]
+                app_config.openapi_config.components = [self.openapi_components, app_config.openapi_config.components]
 
             if isinstance(app_config.openapi_config.security, list):
                 app_config.openapi_config.security.append(self.security_requirement)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,6 +247,7 @@ xfail_strict = true
 packages = ["litestar", "tests"]
 plugins = ["pydantic.mypy"]
 enable_error_code = [
+  "truthy-bool",
   "truthy-iterable",
   "unused-awaitable",
   "ignore-without-code",
@@ -256,20 +257,18 @@ enable_error_code = [
 python_version = "3.8"
 
 disallow_any_generics = false
-disallow_untyped_decorators = true
-implicit_reexport = false
 show_error_codes = true
 strict = true
-warn_redundant_casts = true
-warn_return_any = true
 warn_unreachable = true
-warn_unused_configs = true
-warn_unused_ignores = true
 local_partial_types = true
 
 [[tool.mypy.overrides]]
 ignore_errors = true
 module = ["tests.examples.*", "tests.docker_service_fixtures"]
+
+[[tool.mypy.overrides]]
+module = ["tests.*"]
+disable_error_code = ["truthy-bool"]
 
 [[tool.mypy.overrides]]
 disallow_untyped_decorators = false


### PR DESCRIPTION
Docs: https://mypy.readthedocs.io/en/stable/error_code_list2.html#check-that-expression-is-not-implicitly-true-in-boolean-context-truthy-bool

I am using `# type: ignore[truthy-bool]` for `.components` check, because I see that it is treated specially for some reason (like `pragma: no cover`). Is this correct?

I also removed configs that are part of the `--strict` flag from settings.