### PR TITLE
docs: fix API reference for `asgi_types` scopes

### DIFF
--- a/docs/reference/types.rst
+++ b/docs/reference/types.rst
@@ -1,7 +1,7 @@
 types
 =====
 
-.. py:currentmodule:: litestar.types
+.. module:: litestar.types
 
 
 
@@ -58,15 +58,15 @@ ASGI Application Parameters
 ASGI Scopes
 ~~~~~~~~~~~~
 
-.. autodata:: litestar.types.ASGIVersion
+.. autoclass:: litestar.types.ASGIVersion
 
-.. autodata:: litestar.types.BaseScope
+.. autoclass:: litestar.types.BaseScope
 
-.. autodata:: litestar.types.HTTPScope
+.. autoclass:: litestar.types.HTTPScope
 
-.. autodata:: litestar.types.LifeSpanScope
+.. autoclass:: litestar.types.LifeSpanScope
 
-.. autodata:: litestar.types.WebSocketScope
+.. autoclass:: litestar.types.WebSocketScope
 
 
 ASGI Events


### PR DESCRIPTION
It used to be:
<img width="1087" alt="Снимок экрана 2024-10-18 в 13 49 35" src="https://github.com/user-attachments/assets/5c063e31-2e35-441f-968a-14e279c4f8b2">

After my change:
<img width="1102" alt="Снимок экрана 2024-10-18 в 13 53 28" src="https://github.com/user-attachments/assets/5e8a69ce-bad6-4e7a-bb3e-e6948aa5547a">

Note that we still don't expose `asgi_types` module as an implementation detail.
