### PR TITLE
fix: LifespanHandler memory stream cleanup

### DIFF
--- a/litestar/testing/client/async_client.py
+++ b/litestar/testing/client/async_client.py
@@ -86,6 +86,7 @@ class AsyncTestClient(AsyncClient, BaseTestClient, Generic[T]):  # type: ignore[
         async with AsyncExitStack() as stack:
             self.blocking_portal = portal = stack.enter_context(self.portal())
             self.lifespan_handler = LifeSpanHandler(client=self)
+            stack.enter_context(self.lifespan_handler)
 
             @stack.callback
             def reset_portal() -> None:

--- a/litestar/testing/client/sync_client.py
+++ b/litestar/testing/client/sync_client.py
@@ -87,6 +87,7 @@ class TestClient(Client, BaseTestClient, Generic[T]):  # type: ignore[misc]
         with ExitStack() as stack:
             self.blocking_portal = portal = stack.enter_context(self.portal())
             self.lifespan_handler = LifeSpanHandler(client=self)
+            stack.enter_context(self.lifespan_handler)
 
             @stack.callback
             def reset_portal() -> None:

--- a/litestar/testing/life_span_handler.py
+++ b/litestar/testing/life_span_handler.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
-import contextlib
-import threading
 import warnings
 from math import inf
 from typing import TYPE_CHECKING, Generic, Optional, TypeVar, cast
 
-import anyio
 from anyio import create_memory_object_stream
 from anyio.streams.stapled import StapledObjectStream
 
 from litestar.testing.client.base import BaseTestClient
-from litestar.utils import warn_deprecation
 
 if TYPE_CHECKING:
     from litestar.types import (

--- a/litestar/testing/life_span_handler.py
+++ b/litestar/testing/life_span_handler.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import contextlib
+import threading
+import warnings
 from math import inf
 from typing import TYPE_CHECKING, Generic, Optional, TypeVar, cast
 
+import anyio
 from anyio import create_memory_object_stream
 from anyio.streams.stapled import StapledObjectStream
 
 from litestar.testing.client.base import BaseTestClient
+from litestar.utils import warn_deprecation
 
 if TYPE_CHECKING:
     from litestar.types import (
@@ -20,24 +25,64 @@ T = TypeVar("T", bound=BaseTestClient)
 
 
 class LifeSpanHandler(Generic[T]):
-    __slots__ = "stream_send", "stream_receive", "client", "task"
+    __slots__ = (
+        "stream_send",
+        "stream_receive",
+        "client",
+        "task",
+        "_startup_done",
+    )
 
     def __init__(self, client: T) -> None:
         self.client = client
         self.stream_send = StapledObjectStream[Optional["LifeSpanSendMessage"]](*create_memory_object_stream(inf))  # type: ignore[arg-type]
         self.stream_receive = StapledObjectStream["LifeSpanReceiveMessage"](*create_memory_object_stream(inf))  # type: ignore[arg-type]
+        self._startup_done = False
 
+    def _ensure_setup(self, is_safe: bool = False):
+        if self._startup_done:
+            return
+
+        if not is_safe:
+            warnings.warn(
+                "LifeSpanHandler used with implicit startup; Use LifeSpanHandler as a context manager instead. "
+                "Implicit startup will be deprecated in version 3.0.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+
+        self._startup_done = True
         with self.client.portal() as portal:
             self.task = portal.start_task_soon(self.lifespan)
             portal.call(self.wait_startup)
 
+    def _teardown(self):
+        with self.client.portal() as portal:
+            portal.call(self.stream_send.aclose)
+            portal.call(self.stream_receive.aclose)
+
+    def __enter__(self) -> LifeSpanHandler:
+        try:
+            self._ensure_setup()
+        except Exception as exc:
+            self._teardown()
+            raise exc
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._teardown()
+
     async def receive(self) -> LifeSpanSendMessage:
+        self._ensure_setup()
+
         message = await self.stream_send.receive()
         if message is None:
             self.task.result()
         return cast("LifeSpanSendMessage", message)
 
     async def wait_startup(self) -> None:
+        self._ensure_setup()
+
         event: LifeSpanStartupEvent = {"type": "lifespan.startup"}
         await self.stream_receive.send(event)
 
@@ -54,6 +99,8 @@ class LifeSpanHandler(Generic[T]):
             await self.receive()
 
     async def wait_shutdown(self) -> None:
+        self._ensure_setup()
+
         async with self.stream_send:
             lifespan_shutdown_event: LifeSpanShutdownEvent = {"type": "lifespan.shutdown"}
             await self.stream_receive.send(lifespan_shutdown_event)
@@ -71,6 +118,8 @@ class LifeSpanHandler(Generic[T]):
                 await self.receive()
 
     async def lifespan(self) -> None:
+        self._ensure_setup()
+
         scope = {"type": "lifespan"}
         try:
             await self.client.app(scope, self.stream_receive.receive, self.stream_send.send)

--- a/litestar/testing/life_span_handler.py
+++ b/litestar/testing/life_span_handler.py
@@ -52,21 +52,21 @@ class LifeSpanHandler(Generic[T]):
             self.task = portal.start_task_soon(self.lifespan)
             portal.call(self.wait_startup)
 
-    def _teardown(self):
+    def close(self):
         with self.client.portal() as portal:
             portal.call(self.stream_send.aclose)
             portal.call(self.stream_receive.aclose)
 
     def __enter__(self) -> LifeSpanHandler:
         try:
-            self._ensure_setup()
+            self._ensure_setup(is_safe=True)
         except Exception as exc:
-            self._teardown()
+            self.close()
             raise exc
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self._teardown()
+        self.close()
 
     async def receive(self) -> LifeSpanSendMessage:
         self._ensure_setup()

--- a/tests/unit/test_testing/test_lifespan_handler.py
+++ b/tests/unit/test_testing/test_lifespan_handler.py
@@ -4,13 +4,16 @@ from litestar.testing import TestClient
 from litestar.testing.life_span_handler import LifeSpanHandler
 from litestar.types import Receive, Scope, Send
 
+pytestmark = pytest.mark.filterwarnings("default")
+
 
 async def test_wait_startup_invalid_event() -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         await send({"type": "lifespan.startup.something_unexpected"})  # type: ignore[typeddict-item]
 
     with pytest.raises(RuntimeError, match="Received unexpected ASGI message type"):
-        LifeSpanHandler(TestClient(app))
+        with LifeSpanHandler(TestClient(app)):
+            pass
 
 
 async def test_wait_shutdown_invalid_event() -> None:
@@ -18,7 +21,7 @@ async def test_wait_shutdown_invalid_event() -> None:
         await send({"type": "lifespan.startup.complete"})  # type: ignore[typeddict-item]
         await send({"type": "lifespan.shutdown.something_unexpected"})  # type: ignore[typeddict-item]
 
-    handler = LifeSpanHandler(TestClient(app))
+    with LifeSpanHandler(TestClient(app)) as handler:
 
-    with pytest.raises(RuntimeError, match="Received unexpected ASGI message type"):
-        await handler.wait_shutdown()
+        with pytest.raises(RuntimeError, match="Received unexpected ASGI message type"):
+            await handler.wait_shutdown()

--- a/tests/unit/test_testing/test_lifespan_handler.py
+++ b/tests/unit/test_testing/test_lifespan_handler.py
@@ -24,3 +24,14 @@ async def test_wait_shutdown_invalid_event() -> None:
     with LifeSpanHandler(TestClient(app)) as handler:
         with pytest.raises(RuntimeError, match="Received unexpected ASGI message type"):
             await handler.wait_shutdown()
+
+
+async def test_implicit_startup() -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "lifespan.startup.complete"})  # type: ignore[typeddict-item]
+        await send({"type": "lifespan.shutdown.complete"})  # type: ignore[typeddict-item]
+
+    with pytest.warns(DeprecationWarning):
+        handler = LifeSpanHandler(TestClient(app))
+        await handler.wait_shutdown()
+        handler.close()

--- a/tests/unit/test_testing/test_lifespan_handler.py
+++ b/tests/unit/test_testing/test_lifespan_handler.py
@@ -22,6 +22,5 @@ async def test_wait_shutdown_invalid_event() -> None:
         await send({"type": "lifespan.shutdown.something_unexpected"})  # type: ignore[typeddict-item]
 
     with LifeSpanHandler(TestClient(app)) as handler:
-
         with pytest.raises(RuntimeError, match="Received unexpected ASGI message type"):
             await handler.wait_shutdown()


### PR DESCRIPTION
Fix a dangling anyio stream in `LifespanHandler`.

Closes #3834.