### PR TITLE
feat(Pydantic): honor hide_input_in_errors in throwing validation exceptions

### DIFF
--- a/litestar/contrib/pydantic/pydantic_init_plugin.py
+++ b/litestar/contrib/pydantic/pydantic_init_plugin.py
@@ -51,7 +51,12 @@ def _dec_pydantic_v2(model_type: type[pydantic_v2.BaseModel], value: Any, strict
     try:
         return model_type.model_validate(value, strict=strict)
     except pydantic_v2.ValidationError as e:
-        raise ExtendedMsgSpecValidationError(errors=cast("list[dict[str, Any]]", e.errors())) from e
+        hide_input = False
+        if isinstance(model_config := getattr(model_type, "model_config", None), dict):
+            hide_input = bool(model_config.get("hide_input_in_errors"))
+        raise ExtendedMsgSpecValidationError(
+            errors=cast("list[dict[str, Any]]", e.errors(include_input=not hide_input))
+        ) from e
 
 
 def _dec_pydantic_uuid(

--- a/litestar/contrib/pydantic/pydantic_init_plugin.py
+++ b/litestar/contrib/pydantic/pydantic_init_plugin.py
@@ -33,8 +33,12 @@ except ImportError:
 
 
 if TYPE_CHECKING:
+    import pydantic as pydantic_v2_mandatory
+
     from litestar.config.app import AppConfig
     from litestar.types.serialization import PydanticV1FieldsListType, PydanticV2FieldsListType
+else:
+    pydantic_v2_mandatory = pydantic_v2
 
 
 T = TypeVar("T")
@@ -47,13 +51,13 @@ def _dec_pydantic_v1(model_type: type[pydantic_v1.BaseModel], value: Any) -> pyd
         raise ExtendedMsgSpecValidationError(errors=cast("list[dict[str, Any]]", e.errors())) from e
 
 
-def _dec_pydantic_v2(model_type: type[pydantic_v2.BaseModel], value: Any, strict: bool) -> pydantic_v2.BaseModel:  # pyright: ignore[reportInvalidTypeForm]
+def _dec_pydantic_v2(
+    model_type: type[pydantic_v2_mandatory.BaseModel], value: Any, strict: bool
+) -> pydantic_v2_mandatory.BaseModel:
     try:
         return model_type.model_validate(value, strict=strict)
-    except pydantic_v2.ValidationError as e:
-        hide_input = False
-        if isinstance(model_config := getattr(model_type, "model_config", None), dict):
-            hide_input = bool(model_config.get("hide_input_in_errors"))
+    except pydantic_v2_mandatory.ValidationError as e:
+        hide_input = model_type.model_config.get("hide_input_in_errors", False)
         raise ExtendedMsgSpecValidationError(
             errors=cast("list[dict[str, Any]]", e.errors(include_input=not hide_input))
         ) from e


### PR DESCRIPTION
## Description

Pydantic's `BaseModel` supports configuration to hide data values when throwing exceptions, via setting `hide_input_in_errors` -- see https://docs.pydantic.dev/2.0/api/config/#pydantic.config.ConfigDict.hide_input_in_errors and https://docs.pydantic.dev/latest/usage/model_config/#hide-input-in-errors (the value is also in 2.0, but not linkable in the non-`latest` version of the documentation build).

At present, Litestar does not honor this configuration when generating exceptions for validation errors, which can lead to sensitive data leaking into logs.