### PR TITLE
fix: Safe Handling of "more_body" in ASGI Responses

### DIFF
--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -227,7 +227,7 @@ class LoggingMiddleware(AbstractMiddleware):
                 connection_state.log_context[HTTP_RESPONSE_BODY] = message
                 self.log_response(scope=scope)
 
-                if not message["more_body"]:
+                if not message.get('more_body'):
                     connection_state.log_context.clear()
 
             await send(message)

--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -227,7 +227,7 @@ class LoggingMiddleware(AbstractMiddleware):
                 connection_state.log_context[HTTP_RESPONSE_BODY] = message
                 self.log_response(scope=scope)
 
-                if not message.get('more_body'):
+                if not message.get("more_body"):
                     connection_state.log_context.clear()
 
             await send(message)

--- a/litestar/middleware/response_cache.py
+++ b/litestar/middleware/response_cache.py
@@ -49,7 +49,7 @@ class ResponseCacheMiddleware(AbstractMiddleware):
                 elif value_or_default(connection_state.do_cache, False):
                     messages.append(message)
 
-                if messages and message["type"] == HTTP_RESPONSE_BODY and not message["more_body"]:
+                if messages and message["type"] == HTTP_RESPONSE_BODY and not message.get('more_body')
                     key = (route_handler.cache_key_builder or self.config.key_builder)(Request(scope))
                     store = self.config.get_store_from_app(scope["app"])
                     await store.set(key, encode_msgpack(messages), expires_in=expires_in)

--- a/litestar/middleware/response_cache.py
+++ b/litestar/middleware/response_cache.py
@@ -49,7 +49,7 @@ class ResponseCacheMiddleware(AbstractMiddleware):
                 elif value_or_default(connection_state.do_cache, False):
                     messages.append(message)
 
-                if messages and message["type"] == HTTP_RESPONSE_BODY and not message.get('more_body'):
+                if messages and message["type"] == HTTP_RESPONSE_BODY and not message.get("more_body"):
                     key = (route_handler.cache_key_builder or self.config.key_builder)(Request(scope))
                     store = self.config.get_store_from_app(scope["app"])
                     await store.set(key, encode_msgpack(messages), expires_in=expires_in)


### PR DESCRIPTION

## Safe Access to "More Body"

I've encountered an issue in sqladmin-litestar-plugin where some ASGI frameworks (such as Starlette) do not include "more_body": false in the "http.response.body" event. According to the ASGI specification, this key should be set to False when there is no additional body content. Litestar expects "more_body" to be explicitly defined, but others might not.

This leads to failures when an ASGI framework mounted on Litestar throws error for the "more_body" key in "http.response.body". 

I have changed it to `message.get('more_body')`as @cofin suggests.