### PR TITLE
fix: Duplicate `RateLimit-*` headers with caching

### DIFF
--- a/litestar/middleware/rate_limit.py
+++ b/litestar/middleware/rate_limit.py
@@ -109,7 +109,7 @@ class RateLimitMiddleware(AbstractMiddleware):
                 message.setdefault("headers", [])
                 headers = MutableScopeHeaders(message)
                 for key, value in self.create_response_headers(cache_object=cache_object).items():
-                    headers.add(key, value)
+                    headers[key] = value
             await send(message)
 
         return send_wrapper


### PR DESCRIPTION
Fixes https://github.com/litestar-org/litestar/issues/3625

`RateLimitMiddleware` duplicate all `RateLimit-*` headers when handler cache is enabled because it's adding new rate limit headers to the new ones, instead of just updating their values.

### Response header before
```
❯ curl -i http://localhost:8000/
HTTP/1.1 200 OK
date: Tue, 12 Nov 2024 06:50:18 GMT
server: uvicorn
content-type: text/plain; charset=utf-8
content-length: 2
ratelimit-policy: 10; w=60
ratelimit-limit: 10
ratelimit-remaining: -8
ratelimit-reset: -54
ratelimit-policy: 10; w=60
ratelimit-limit: 10
ratelimit-remaining: 0
ratelimit-reset: -49
```

### Response headers after
```
❯ curl -i http://localhost:8000/
HTTP/1.1 200 OK
date: Tue, 12 Nov 2024 06:50:18 GMT
server: uvicorn
content-type: text/plain; charset=utf-8
content-length: 2
ratelimit-policy: 10; w=60
ratelimit-limit: 10
ratelimit-remaining: 0
ratelimit-reset: -49
```