### PR TITLE
feat(core): Streaming multipart parser

### DIFF
--- a/litestar/_kwargs/extractors.py
+++ b/litestar/_kwargs/extractors.py
@@ -340,8 +340,8 @@ async def _extract_multipart(
     connection.scope["_form"] = form_values = (  # type: ignore[typeddict-unknown-key]
         connection.scope["_form"]  # type: ignore[typeddict-item]
         if "_form" in connection.scope
-        else parse_multipart_form(
-            body=await connection.body(),
+        else await parse_multipart_form(
+            stream=connection.stream(),
             boundary=connection.content_type[-1].get("boundary", "").encode(),
             multipart_form_part_limit=multipart_form_part_limit,
             type_decoders=connection.route_handler.resolve_type_decoders(),

--- a/litestar/_multipart.py
+++ b/litestar/_multipart.py
@@ -1,41 +1,22 @@
-"""The contents of this file were adapted from sanic.
-
-MIT License
-
-Copyright (c) 2016-present Sanic Community
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
-
 from __future__ import annotations
 
 import re
 from collections import defaultdict
-from email.utils import decode_rfc2231
-from typing import TYPE_CHECKING, Any
-from urllib.parse import unquote
+from typing import TYPE_CHECKING, Any, AsyncGenerator
+
+from multipart import (  # type: ignore[import-untyped]
+    MultipartSegment,
+    ParserError,
+    ParserLimitReached,
+    PushMultipartParser,
+)
 
 from litestar.datastructures.upload_file import UploadFile
-from litestar.exceptions import ValidationException
+from litestar.exceptions import ClientException
 
-__all__ = ("parse_body", "parse_content_header", "parse_multipart_form")
+__all__ = ("parse_content_header", "parse_multipart_form")
 
+from litestar.utils.compat import async_next
 
 if TYPE_CHECKING:
     from litestar.types import TypeDecodersSequence
@@ -67,34 +48,8 @@ def parse_content_header(value: str) -> tuple[str, dict[str, str]]:
     return value.strip().lower(), options
 
 
-def parse_body(body: bytes, boundary: bytes, multipart_form_part_limit: int) -> list[bytes]:
-    """Split the body using the boundary
-        and validate the number of form parts is within the allowed limit.
-
-    Args:
-        body: The form body.
-        boundary: The boundary used to separate form components.
-        multipart_form_part_limit: The limit of allowed form components
-
-    Returns:
-        A list of form components.
-    """
-    if not (body and boundary):
-        return []
-
-    form_parts = body.split(boundary, multipart_form_part_limit + 3)[1:-1]
-
-    if len(form_parts) > multipart_form_part_limit:
-        raise ValidationException(
-            f"number of multipart components exceeds the allowed limit of {multipart_form_part_limit}, "
-            f"this potentially indicates a DoS attack"
-        )
-
-    return form_parts
-
-
-def parse_multipart_form(
-    body: bytes,
+async def parse_multipart_form(  # noqa: C901
+    stream: AsyncGenerator[bytes, None],
     boundary: bytes,
     multipart_form_part_limit: int = 1000,
     type_decoders: TypeDecodersSequence | None = None,
@@ -102,7 +57,7 @@ def parse_multipart_form(
     """Parse multipart form data.
 
     Args:
-        body: Body of the request.
+        stream: Body of the request.
         boundary: Boundary of the multipart message.
         multipart_form_part_limit: Limit of the number of parts allowed.
         type_decoders: A sequence of type decoders to use.
@@ -113,51 +68,55 @@ def parse_multipart_form(
 
     fields: defaultdict[str, list[Any]] = defaultdict(list)
 
-    for form_part in parse_body(body=body, boundary=boundary, multipart_form_part_limit=multipart_form_part_limit):
-        file_name = None
-        content_type = "text/plain"
-        content_charset = "utf-8"
-        field_name = None
-        line_index = 2
-        line_end_index = 0
-        headers: list[tuple[str, str]] = []
+    chunk = await async_next(stream, b"")
+    if not chunk:
+        return fields
 
-        while line_end_index != -1:
-            line_end_index = form_part.find(b"\r\n", line_index)
-            form_line = form_part[line_index:line_end_index].decode("utf-8")
+    try:
+        with PushMultipartParser(boundary, max_segment_count=multipart_form_part_limit) as parser:
+            segment: MultipartSegment | None = None
+            data: UploadFile | bytes = b""
+            while not parser.closed:
+                for form_part in parser.parse(chunk):
+                    if isinstance(form_part, MultipartSegment):
+                        segment = form_part
+                        if segment.filename:
+                            data = UploadFile(
+                                content_type=segment.content_type or "text/plain",
+                                filename=segment.filename,
+                                headers=dict(segment.headerlist),
+                            )
+                    elif form_part:
+                        if isinstance(data, UploadFile):
+                            await data.write(form_part)
+                        else:
+                            data += form_part
+                    else:
+                        # end of part
+                        if segment is None:
+                            # we have reached the end of a segment before we have
+                            # received a complete header segment
+                            raise ClientException("Unexpected eof in multipart/form-data")
+                        if segment.name:
+                            if isinstance(data, UploadFile):
+                                await data.seek(0)
+                                fields[segment.name].append(data)
+                            elif data:
+                                fields[segment.name].append(data.decode(segment.charset or "utf-8"))
+                            else:
+                                fields[segment.name].append(None)
 
-            if not form_line:
-                break
+                        # reset for next part
+                        data = b""
+                        segment = None
 
-            line_index = line_end_index + 2
-            colon_index = form_line.index(":")
-            current_idx = colon_index + 2
-            form_header_field = form_line[:colon_index].lower()
-            form_header_value, form_parameters = parse_content_header(form_line[current_idx:])
+                chunk = await async_next(stream, b"")
 
-            if form_header_field == "content-disposition":
-                field_name = form_parameters.get("name")
-                file_name = form_parameters.get("filename")
-
-                if file_name is None and (filename_with_asterisk := form_parameters.get("filename*")):
-                    encoding, _, value = decode_rfc2231(filename_with_asterisk)
-                    file_name = unquote(value, encoding=encoding or content_charset)
-
-            elif form_header_field == "content-type":
-                content_type = form_header_value
-                content_charset = form_parameters.get("charset", "utf-8")
-            headers.append((form_header_field, form_header_value))
-
-        if field_name:
-            post_data = form_part[line_index:-4].lstrip(b"\r\n")
-            if file_name:
-                form_file = UploadFile(
-                    content_type=content_type, filename=file_name, file_data=post_data, headers=dict(headers)
-                )
-                fields[field_name].append(form_file)
-            elif post_data:
-                fields[field_name].append(post_data.decode(content_charset))
-            else:
-                fields[field_name].append(None)
+    except ParserError as exc:
+        raise ClientException("Invalid multipart/form-data") from exc
+    except ParserLimitReached:
+        # FIXME (3.0): This should raise a '413 - Request Entity Too Large', but for
+        # backwards compatibility, we keep it as a 400 for now
+        raise ClientException("Request Entity Too Large") from None
 
     return {k: v if len(v) > 1 else v[0] for k, v in fields.items()}

--- a/litestar/_multipart.py
+++ b/litestar/_multipart.py
@@ -75,7 +75,7 @@ async def parse_multipart_form(  # noqa: C901
     try:
         with PushMultipartParser(boundary, max_segment_count=multipart_form_part_limit) as parser:
             segment: MultipartSegment | None = None
-            data: UploadFile | bytes = b""
+            data: UploadFile | bytearray = bytearray()
             while not parser.closed:
                 for form_part in parser.parse(chunk):
                     if isinstance(form_part, MultipartSegment):
@@ -90,7 +90,7 @@ async def parse_multipart_form(  # noqa: C901
                         if isinstance(data, UploadFile):
                             await data.write(form_part)
                         else:
-                            data += form_part
+                            data.extend(form_part)
                     else:
                         # end of part
                         if segment is None:
@@ -107,7 +107,7 @@ async def parse_multipart_form(  # noqa: C901
                             fields[segment.name].append(None)
 
                         # reset for next part
-                        data = b""
+                        data = bytearray()
                         segment = None
 
                 chunk = await async_next(stream, b"")

--- a/litestar/_multipart.py
+++ b/litestar/_multipart.py
@@ -97,14 +97,14 @@ async def parse_multipart_form(  # noqa: C901
                             # we have reached the end of a segment before we have
                             # received a complete header segment
                             raise ClientException("Unexpected eof in multipart/form-data")
-                        if segment.name:
-                            if isinstance(data, UploadFile):
-                                await data.seek(0)
-                                fields[segment.name].append(data)
-                            elif data:
-                                fields[segment.name].append(data.decode(segment.charset or "utf-8"))
-                            else:
-                                fields[segment.name].append(None)
+
+                        if isinstance(data, UploadFile):
+                            await data.seek(0)
+                            fields[segment.name].append(data)
+                        elif data:
+                            fields[segment.name].append(data.decode(segment.charset or "utf-8"))
+                        else:
+                            fields[segment.name].append(None)
 
                         # reset for next part
                         data = b""

--- a/litestar/connection/request.py
+++ b/litestar/connection/request.py
@@ -77,7 +77,7 @@ class Request(Generic[UserT, AuthT, StateT], ASGIConnection["HTTPRouteHandler", 
         """
         super().__init__(scope, receive, send)
         self.is_connected: bool = True
-        self._body: bytes | EmptyType = Empty
+        self._body: bytes | EmptyType = self._connection_state.body
         self._form: FormMultiDict | EmptyType = Empty
         self._json: Any = Empty
         self._msgpack: Any = Empty
@@ -264,8 +264,8 @@ class Request(Generic[UserT, AuthT, StateT], ASGIConnection["HTTPRouteHandler", 
             if (form_data := self._connection_state.form) is Empty:
                 content_type, options = self.content_type
                 if content_type == RequestEncodingType.MULTI_PART:
-                    form_data = parse_multipart_form(
-                        body=await self.body(),
+                    form_data = await parse_multipart_form(
+                        stream=self.stream(),
                         boundary=options.get("boundary", "").encode(),
                         multipart_form_part_limit=self.app.multipart_form_part_limit,
                     )

--- a/litestar/datastructures/upload_file.py
+++ b/litestar/datastructures/upload_file.py
@@ -49,7 +49,7 @@ class UploadFile:
         """
         return getattr(self.file, "_rolled", False)
 
-    async def write(self, data: bytes) -> int:
+    async def write(self, data: bytes | bytearray) -> int:
         """Proxy for data writing.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "click",
     "rich>=13.0.0",
     "rich-click",
+    "multipart@git+https://github.com/defnull/multipart.git",
     # default litestar plugins
     "litestar-htmx>=0.3.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,9 @@ dependencies = [
     "click",
     "rich>=13.0.0",
     "rich-click",
+    "multipart@git+https://github.com/defnull/multipart.git",
     # default litestar plugins
-    "litestar-htmx>=0.3.0"
+    "litestar-htmx>=0.3.0",
 ]
 description = "Litestar - A production-ready, highly performant, extensible ASGI API Framework"
 keywords = ["api", "rest", "asgi", "litestar", "starlite"]
@@ -95,7 +96,7 @@ opentelemetry = ["opentelemetry-instrumentation-asgi"]
 piccolo = ["piccolo"]
 picologging = ["picologging"]
 prometheus = ["prometheus-client"]
-pydantic = ["pydantic", "email-validator", "pydantic-extra-types"]
+pydantic = ["pydantic<2.10", "email-validator", "pydantic-extra-types"]
 redis = ["redis[hiredis]>=4.4.4"]
 sqlalchemy = ["advanced-alchemy>=0.2.2"]
 standard = ["jinja2", "jsbeautifier", "uvicorn[standard]", "uvloop>=0.18.0; sys_platform != 'win32'", "fast-query-parsers>=1.0.2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "click",
     "rich>=13.0.0",
     "rich-click",
-    "multipart@git+https://github.com/defnull/multipart.git",
+    "multipart>=1.2.0",
     # default litestar plugins
     "litestar-htmx>=0.3.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,8 @@ dependencies = [
     "click",
     "rich>=13.0.0",
     "rich-click",
-    "multipart@git+https://github.com/defnull/multipart.git",
     # default litestar plugins
-    "litestar-htmx>=0.3.0",
+    "litestar-htmx>=0.3.0"
 ]
 description = "Litestar - A production-ready, highly performant, extensible ASGI API Framework"
 keywords = ["api", "rest", "asgi", "litestar", "starlite"]
@@ -96,7 +95,7 @@ opentelemetry = ["opentelemetry-instrumentation-asgi"]
 piccolo = ["piccolo"]
 picologging = ["picologging"]
 prometheus = ["prometheus-client"]
-pydantic = ["pydantic<2.10", "email-validator", "pydantic-extra-types"]
+pydantic = ["pydantic", "email-validator", "pydantic-extra-types"]
 redis = ["redis[hiredis]>=4.4.4"]
 sqlalchemy = ["advanced-alchemy>=0.2.2"]
 standard = ["jinja2", "jsbeautifier", "uvicorn[standard]", "uvloop>=0.18.0; sys_platform != 'win32'", "fast-query-parsers>=1.0.2"]

--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -296,26 +296,6 @@ def test_multipart_request_without_charset_for_filename() -> None:
         }
 
 
-@pytest.mark.xfail
-def test_multipart_request_with_asterisks_filename() -> None:
-    with create_test_client(form_handler) as client:
-        response = client.post(
-            "/form",
-            content=(
-                # file
-                b"--a7f7ac8d4e2e437c877bb7b8d7cc549c\r\n"
-                b"Content-Disposition: form-data; name='file'; filename*=utf-8''Na%C3%AFve%20file.jpg\r\n"
-                b"Content-Type: image/jpeg\r\n\r\n"
-                b"<file content>\r\n"
-                b"--a7f7ac8d4e2e437c877bb7b8d7cc549c--\r\n"
-            ),
-            headers={"Content-Type": "multipart/form-data; boundary=a7f7ac8d4e2e437c877bb7b8d7cc549c"},
-        )
-        assert response.json() == {
-            "'file'": {"filename": "Naïve file.jpg", "content": "<file content>", "content_type": "image/jpeg"}
-        }
-
-
 def test_multipart_request_with_encoded_value() -> None:
     with create_test_client(form_handler) as client:
         response = client.post(

--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -296,6 +296,26 @@ def test_multipart_request_without_charset_for_filename() -> None:
         }
 
 
+@pytest.mark.xfail
+def test_multipart_request_with_asterisks_filename() -> None:
+    with create_test_client(form_handler) as client:
+        response = client.post(
+            "/form",
+            content=(
+                # file
+                b"--a7f7ac8d4e2e437c877bb7b8d7cc549c\r\n"
+                b"Content-Disposition: form-data; name='file'; filename*=utf-8''Na%C3%AFve%20file.jpg\r\n"
+                b"Content-Type: image/jpeg\r\n\r\n"
+                b"<file content>\r\n"
+                b"--a7f7ac8d4e2e437c877bb7b8d7cc549c--\r\n"
+            ),
+            headers={"Content-Type": "multipart/form-data; boundary=a7f7ac8d4e2e437c877bb7b8d7cc549c"},
+        )
+        assert response.json() == {
+            "'file'": {"filename": "Naïve file.jpg", "content": "<file content>", "content_type": "image/jpeg"}
+        }
+
+
 def test_multipart_request_with_encoded_value() -> None:
     with create_test_client(form_handler) as client:
         response = client.post(

--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -563,3 +563,18 @@ def test_multipart_and_url_encoded_behave_the_same(form_type) -> None:  # type: 
                 headers={"Content-Type": "multipart/form-data; boundary=1f35df74046888ceaa62d8a534a076dd"},
             )
         assert response.status_code == HTTP_201_CREATED
+
+
+def test_invalid_multipart_raises_client_error() -> None:
+    with create_test_client(form_handler) as client:
+        response = client.post(
+            "/form",
+            content=(
+                b"--20b303e711c4ab8c443184ac833ab00f\r\n"
+                b"Content-Disposition: form-data; "
+                b'name="value"\r\n\r\n'
+                b"--20b303e711c4ab8c44318833ab00f--\r\n"
+            ),
+            headers={"Content-Type": "multipart/form-data; charset=utf-8; boundary=20b303e711c4ab8c443184ac833ab00f"},
+        )
+        assert response.status_code == HTTP_400_BAD_REQUEST

--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -296,7 +296,7 @@ def test_multipart_request_without_charset_for_filename() -> None:
         }
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(reason="filename* is deprecated and should not be used according to RFC-7578")
 def test_multipart_request_with_asterisks_filename() -> None:
     with create_test_client(form_handler) as client:
         response = client.post(

--- a/uv.lock
+++ b/uv.lock
@@ -1641,6 +1641,7 @@ dependencies = [
     { name = "litestar-htmx" },
     { name = "msgspec" },
     { name = "multidict" },
+    { name = "multipart" },
     { name = "polyfactory" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -1843,6 +1844,7 @@ requires-dist = [
     { name = "minijinja", marker = "extra == 'minijinja'", specifier = ">=1.0.0" },
     { name = "msgspec", specifier = ">=0.18.2" },
     { name = "multidict", specifier = ">=6.0.2" },
+    { name = "multipart", specifier = ">=1.2.0" },
     { name = "opentelemetry-instrumentation-asgi", marker = "extra == 'opentelemetry'" },
     { name = "piccolo", marker = "extra == 'piccolo'" },
     { name = "picologging", marker = "extra == 'picologging'" },
@@ -2296,6 +2298,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/99/e82e1a275d8b1ea16d3a251474262258dbbe41c05cce0c01bceda1fc8ea5/multidict-6.1.0-cp39-cp39-win32.whl", hash = "sha256:1ca0083e80e791cffc6efce7660ad24af66c8d4079d2a750b29001b53ff59ada", size = 26421 },
     { url = "https://files.pythonhosted.org/packages/86/1c/9fa630272355af7e4446a2c7550c259f11ee422ab2d30ff90a0a71cf3d9e/multidict-6.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:aa466da5b15ccea564bdab9c89175c762bc12825f4659c11227f515cee76fa4a", size = 28791 },
     { url = "https://files.pythonhosted.org/packages/99/b7/b9e70fde2c0f0c9af4cc5277782a89b66d35948ea3369ec9f598358c3ac5/multidict-6.1.0-py3-none-any.whl", hash = "sha256:48e171e52d1c4d33888e529b999e5900356b9ae588c2f09a52dcefb158b27506", size = 10051 },
+]
+
+[[package]]
+name = "multipart"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5a/66075b21cf7622958e724c482ab9e0c150fe057b20743ec215706bf5dbac/multipart-1.2.0.tar.gz", hash = "sha256:fc9ec7177b642e07c3c360126b9c845160376e65db6fcfd04df63d58135e1e8b", size = 35932 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/49/89bdcbefe6fdb59ef67e7d6d407c88acdce7ca6441b73945f949862081c6/multipart-1.2.0-py3-none-any.whl", hash = "sha256:79ecedd8ad13e1b4888224cedcc7caee6b784cb89337b50c83ad24a09c66be0f", size = 12915 },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a streaming multipart parser via the [multipart](https://github.com/defnull/multipart) lib.

This gives us:

- Ability to stream large / larger-than-memory file uploads
- Better / more correct edge case handling
- Still good performance