### PR TITLE
fix: patching of otel middleware to work with subclasses

### DIFF
--- a/litestar/contrib/opentelemetry/plugin.py
+++ b/litestar/contrib/opentelemetry/plugin.py
@@ -42,7 +42,7 @@ class OpenTelemetryPlugin(InitPluginProtocol):
         for middleware in middlewares:
             if (
                 isinstance(middleware, DefineMiddleware)
-                and middleware.middleware is OpenTelemetryInstrumentationMiddleware
+                and issubclass(middleware.middleware, OpenTelemetryInstrumentationMiddleware)
             ):
                 otel_middleware = middleware
             else:

--- a/litestar/contrib/opentelemetry/plugin.py
+++ b/litestar/contrib/opentelemetry/plugin.py
@@ -42,6 +42,7 @@ class OpenTelemetryPlugin(InitPluginProtocol):
         for middleware in middlewares:
             if (
                 isinstance(middleware, DefineMiddleware)
+                and isintance(middleware.middleware, type)
                 and issubclass(middleware.middleware, OpenTelemetryInstrumentationMiddleware)
             ):
                 otel_middleware = middleware

--- a/litestar/contrib/opentelemetry/plugin.py
+++ b/litestar/contrib/opentelemetry/plugin.py
@@ -42,7 +42,7 @@ class OpenTelemetryPlugin(InitPluginProtocol):
         for middleware in middlewares:
             if (
                 isinstance(middleware, DefineMiddleware)
-                and isintance(middleware.middleware, type)
+                and isinstance(middleware.middleware, type)
                 and issubclass(middleware.middleware, OpenTelemetryInstrumentationMiddleware)
             ):
                 otel_middleware = middleware


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- This should allow workarounds like OpenTelemetrySingletonMiddleware from https://github.com/litestar-org/litestar/issues/3056
to work with the patching applied in https://github.com/litestar-org/litestar/pull/3689


<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
