### PR TITLE
fix(ci): Pin PDM version for 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
         name: Set up PDM
         with:
           python-version: "3.8"
+          version: "2.20.1"
           allow-python-prereleases: false
           cache: true
           cache-dependency-path: |
@@ -70,6 +71,7 @@ jobs:
         name: Set up PDM
         with:
           python-version: "3.8"
+          version: "2.20.1"
           allow-python-prereleases: false
           cache: true
           cache-dependency-path: |
@@ -95,6 +97,7 @@ jobs:
         name: Set up PDM
         with:
           python-version: "3.8"
+          version: "2.20.1"
           allow-python-prereleases: false
           cache: true
           cache-dependency-path: |


### PR DESCRIPTION
Latest version for PDM dropped support for 3.8, pinning 3.8 matrices to the latest PDM version that supports it.

[`ERROR: Ignored the following versions that require a different python version: 2.21.0 Requires-Python >=3.9`](https://github.com/litestar-org/litestar/actions/runs/12017810790/job/33553416399?pr=3525)