### PR TITLE
fix: typo in exception message for ImproperlyConfiguredException

### DIFF
--- a/litestar/di.py
+++ b/litestar/di.py
@@ -54,7 +54,7 @@ class Provide:
             sync_to_thread: Run sync code in an async thread. Defaults to False.
         """
         if not callable(dependency):
-            raise ImproperlyConfiguredException("Provider dependency must a callable value")
+            raise ImproperlyConfiguredException("Provider dependency must be a callable value")
 
         is_class_dependency = isclass(dependency)
         self.has_sync_generator_dependency = isgeneratorfunction(


### PR DESCRIPTION
Corrected the exception message from "Provider dependency must a callable value" to "Provider dependency must be a callable value". This ensures clarity and proper grammar in error messages.