### PR TITLE
docs: remove deprecated sponsor STOK

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ A **huge** thanks to our sponsors:
 
 <a href="https://github.com/scalar/scalar/?utm_source=litestar&utm_medium=website&utm_campaign=main-badge" target="_blank" title="Scalar.com - Document, Discover and Test APIs with Scalar."><img src="https://raw.githubusercontent.com/litestar-org/branding/main/assets/sponsors/scalar.svg" width="180" alt="Scalar.com"></a>
 <a href="https://telemetrysports.com/" title="Telemetry Sports - Changing the way data influences the sports experience"><img src="https://raw.githubusercontent.com/litestar-org/branding/main/assets/sponsors/telemetry-sports/unofficial-telemetry-whitebg.svg" width="150" alt="Telemetry Sports"></a>
-<a href="https://www.stok.kr/" title="Stok - Stack Up Your Assets!"><img src="https://avatars.githubusercontent.com/u/144093421?s=400&v=4" width="150" alt="Stok"></a>
 
 <a href="https://docs.litestar.dev/dev/#sponsors" class="external-link" target="_blank">Check out our sponsors in the docs</a>
 

--- a/docs/PYPI_README.md
+++ b/docs/PYPI_README.md
@@ -121,7 +121,6 @@ A **huge** thanks to our sponsors:
 
 <a href="https://github.com/scalar/scalar/?utm_source=litestar&utm_medium=website&utm_campaign=main-badge" target="_blank" title="Scalar.com - Document, Discover and Test APIs with Scalar."><img src="https://raw.githubusercontent.com/litestar-org/branding/main/assets/sponsors/scalar.svg" width="180" alt="Scalar.com"></a>
 <a href="https://telemetrysports.com/" title="Telemetry Sports - Changing the way data influences the sports experience"><img src="https://raw.githubusercontent.com/litestar-org/branding/main/assets/sponsors/telemetry-sports/unofficial-telemetry-whitebg.svg" width="150" alt="Telemetry Sports"></a>
-<a href="https://www.stok.kr/" title="Stok - Stack Up Your Assets!"><img src="https://avatars.githubusercontent.com/u/144093421?s=400&v=4" width="150" alt="Stok"></a>
 
 <a href="https://docs.litestar.dev/dev/#sponsors" class="external-link" target="_blank">Check out our sponsors in the docs</a>
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -155,12 +155,6 @@ A huge thank you to our current sponsors:
         </a>
         <p style="text-align: center;">Telemetry Sports</p>
       </div>
-      <div>
-        <a href="https://www.stok.kr/" title="Stok - Stack Up Your Assets!">
-            <img src="https://avatars.githubusercontent.com/u/144093421?s=400&v=4" alt="Stok" style="border-radius: 10px; width: auto; max-height: 150px;" />
-        </a>
-        <p style="text-align: center;">Stok</p>
-      </div>
     </div>
 
 We invite organizations and individuals to join our sponsorship program.


### PR DESCRIPTION
## Description
Remove STOK in sponsor lists of documents since STOK team is not sponsoring any more.
