### PR TITLE
fix(channels): use `SQL` function for `psycopg`

### DIFF
--- a/litestar/channels/backends/psycopg.py
+++ b/litestar/channels/backends/psycopg.py
@@ -31,11 +31,7 @@ class PsycoPgChannelsBackend(ChannelsBackend):
                 await conn.execute(SQL("SELECT pg_notify(%s, %s);").format(Identifier(channel), dec_data))
 
     async def subscribe(self, channels: Iterable[str]) -> None:
-        channels_to_subscribe = set(channels) - self._subscribed_channels
-        if not channels_to_subscribe:
-            return
-
-        for channel in channels_to_subscribe:
+        for channel in set(channels) - self._subscribed_channels:
             await self._listener_conn.execute(SQL("LISTEN {}").format(Identifier(channel)))
 
             self._subscribed_channels.add(channel)

--- a/litestar/channels/backends/psycopg.py
+++ b/litestar/channels/backends/psycopg.py
@@ -1,19 +1,16 @@
 from __future__ import annotations
 
 from contextlib import AsyncExitStack
-from typing import AsyncGenerator, Iterable
+from typing import Any, AsyncGenerator, Iterable
 
-import psycopg
+from psycopg import AsyncConnection
+from psycopg.sql import SQL, Identifier
 
 from .base import ChannelsBackend
 
 
-def _safe_quote(ident: str) -> str:
-    return '"{}"'.format(ident.replace('"', '""'))  # sourcery skip
-
-
 class PsycoPgChannelsBackend(ChannelsBackend):
-    _listener_conn: psycopg.AsyncConnection
+    _listener_conn: AsyncConnection[Any]
 
     def __init__(self, pg_dsn: str) -> None:
         self._pg_dsn = pg_dsn
@@ -21,7 +18,7 @@ class PsycoPgChannelsBackend(ChannelsBackend):
         self._exit_stack = AsyncExitStack()
 
     async def on_startup(self) -> None:
-        self._listener_conn = await psycopg.AsyncConnection.connect(self._pg_dsn, autocommit=True)
+        self._listener_conn = await AsyncConnection[Any].connect(self._pg_dsn, autocommit=True)
         await self._exit_stack.enter_async_context(self._listener_conn)
 
     async def on_shutdown(self) -> None:
@@ -29,21 +26,23 @@ class PsycoPgChannelsBackend(ChannelsBackend):
 
     async def publish(self, data: bytes, channels: Iterable[str]) -> None:
         dec_data = data.decode("utf-8")
-        async with await psycopg.AsyncConnection.connect(self._pg_dsn) as conn:
+        async with await AsyncConnection[Any].connect(self._pg_dsn) as conn:
             for channel in channels:
-                await conn.execute("SELECT pg_notify(%s, %s);", (channel, dec_data))
+                await conn.execute(SQL("SELECT pg_notify(%s, %s);").format(Identifier(channel), dec_data))
 
     async def subscribe(self, channels: Iterable[str]) -> None:
-        for channel in set(channels) - self._subscribed_channels:
-            # can't use placeholders in LISTEN
-            await self._listener_conn.execute(f"LISTEN {_safe_quote(channel)};")  # pyright: ignore
+        channels_to_subscribe = set(channels) - self._subscribed_channels
+        if not channels_to_subscribe:
+            return
+
+        for channel in channels_to_subscribe:
+            await self._listener_conn.execute(SQL("LISTEN {}").format(Identifier(channel)))
 
             self._subscribed_channels.add(channel)
 
     async def unsubscribe(self, channels: Iterable[str]) -> None:
         for channel in channels:
-            # can't use placeholders in UNLISTEN
-            await self._listener_conn.execute(f"UNLISTEN {_safe_quote(channel)};")  # pyright: ignore
+            await self._listener_conn.execute(SQL("UNLISTEN {}").format(Identifier(channel)))
         self._subscribed_channels = self._subscribed_channels - set(channels)
 
     async def stream_events(self) -> AsyncGenerator[tuple[str, bytes], None]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,7 +298,7 @@ module = [
   "litestar.openapi.spec.base",
   "litestar.utils.helpers",
   "litestar.channels.plugin",
-  "litestar.handlers.http_handlers._utils"  
+  "litestar.handlers.http_handlers._utils"
 ]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,7 +298,7 @@ module = [
   "litestar.openapi.spec.base",
   "litestar.utils.helpers",
   "litestar.channels.plugin",
-  "litestar.handlers.http_handlers._utils"
+  "litestar.handlers.http_handlers._utils"  
 ]
 
 [[tool.mypy.overrides]]

--- a/tests/unit/test_channels/test_plugin.py
+++ b/tests/unit/test_channels/test_plugin.py
@@ -17,8 +17,7 @@ from litestar.channels.subscriber import BacklogStrategy
 from litestar.exceptions import ImproperlyConfiguredException, LitestarException
 from litestar.testing import TestClient, create_test_client
 from litestar.types.asgi_types import WebSocketMode
-
-from .util import get_from_stream
+from tests.unit.test_channels.util import get_from_stream
 
 
 @pytest.fixture(


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This PR updates the channels backend to use the native psycopg `SQL` API. 

Additionally, it preemptively fixes some new warnings from upcoming pyright and ruff changes

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
