### PR TITLE
fix(picologging): better handle unsupported environments

### DIFF
--- a/litestar/logging/config.py
+++ b/litestar/logging/config.py
@@ -292,13 +292,16 @@ class LoggingConfig(BaseLoggingConfig):
 
         if self.logging_module == "picologging":
             try:
-                from picologging import config, getLogger
+                from picologging import (  # pyright: ignore[reportMissingImports,reportGeneralTypeIssues]
+                    config,  # pyright: ignore[reportMissingImports,reportGeneralTypeIssues]
+                    getLogger,  # pyright: ignore[reportMissingImports,reportGeneralTypeIssues]
+                )
             except ImportError as e:
                 raise MissingDependencyException("picologging") from e
 
             excluded_fields.add("incremental")
         else:
-            from logging import config, getLogger  # type: ignore[no-redef, assignment]
+            from logging import config, getLogger  # type: ignore[no-redef,assignment,unused-ignore]
 
         values = {
             _field.name: getattr(self, _field.name)

--- a/litestar/logging/picologging.py
+++ b/litestar/logging/picologging.py
@@ -11,15 +11,15 @@ __all__ = ("QueueListenerHandler",)
 
 
 try:
-    import picologging  # noqa: F401
+    import picologging  # noqa: F401 # pyright: ignore[reportMissingImports]
 except ImportError as e:
     raise MissingDependencyException("picologging") from e
 
-from picologging import StreamHandler
-from picologging.handlers import QueueHandler, QueueListener
+from picologging import StreamHandler  # pyright: ignore[reportMissingImports]
+from picologging.handlers import QueueHandler, QueueListener  # pyright: ignore[reportMissingImports]
 
 
-class QueueListenerHandler(QueueHandler):
+class QueueListenerHandler(QueueHandler):  # type: ignore[misc,unused-ignore]
     """Configure queue listener and handler to support non-blocking logging configuration."""
 
     def __init__(self, handlers: list[Any] | None = None) -> None:
@@ -32,8 +32,8 @@ class QueueListenerHandler(QueueHandler):
             - Requires ``picologging`` to be installed.
         """
         super().__init__(Queue(-1))
-        handlers = resolve_handlers(handlers) if handlers else [StreamHandler()]
-        self.listener = QueueListener(self.queue, *handlers)
+        handlers = resolve_handlers(handlers) if handlers else [StreamHandler()]  # pyright: ignore[reportGeneralTypeIssues]
+        self.listener = QueueListener(self.queue, *handlers)  # pyright: ignore[reportGeneralTypeIssues]
         self.listener.start()
 
         atexit.register(self.listener.stop)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,7 +298,7 @@ module = [
   "litestar.openapi.spec.base",
   "litestar.utils.helpers",
   "litestar.channels.plugin",
-  "litestar.handlers.http_handlers._utils"  
+  "litestar.handlers.http_handlers._utils"
 ]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,21 +31,21 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "anyio>=3",
-    "httpx>=0.22",
-    "exceptiongroup; python_version < \"3.11\"",
-    "importlib-metadata; python_version < \"3.10\"",
-    "importlib-resources>=5.12.0; python_version < \"3.9\"",
-    "msgspec>=0.18.2",
-    "multidict>=6.0.2",
-    "polyfactory>=2.6.3",
-    "pyyaml",
-    "typing-extensions",
-    "click",
-    "rich>=13.0.0",
-    "rich-click",
-    "multipart>=1.2.0",
-    # default litestar plugins
+  "anyio>=3",
+  "httpx>=0.22",
+  "exceptiongroup; python_version < \"3.11\"",
+  "importlib-metadata; python_version < \"3.10\"",
+  "importlib-resources>=5.12.0; python_version < \"3.9\"",
+  "msgspec>=0.18.2",
+  "multidict>=6.0.2",
+  "polyfactory>=2.6.3",
+  "pyyaml",
+  "typing-extensions",
+  "click",
+  "rich>=13.0.0",
+  "rich-click",
+  "multipart>=1.2.0",
+  # default litestar plugins
     "litestar-htmx>=0.4.0"
 ]
 description = "Litestar - A production-ready, highly performant, extensible ASGI API Framework"
@@ -140,16 +140,16 @@ dev = [
 ]
 
 docs = [
-    "sphinx>=7.1.2",
-    "sphinx-autobuild>=2021.3.14",
-    "sphinx-copybutton>=0.5.2",
-    "sphinx-toolbox>=3.5.0",
-    "sphinx-design>=0.5.0",
-    "sphinx-click>=4.4.0",
-    "sphinxcontrib-mermaid>=0.9.2",
-    "auto-pytabs[sphinx]>=0.5.0",
-    "litestar-sphinx-theme @ git+https://github.com/litestar-org/litestar-sphinx-theme.git",
-    "sphinx-paramlinks>=0.6.0",
+  "sphinx>=7.1.2",
+  "sphinx-autobuild>=2021.3.14",
+  "sphinx-copybutton>=0.5.2",
+  "sphinx-toolbox>=3.5.0",
+  "sphinx-design>=0.5.0",
+  "sphinx-click>=4.4.0",
+  "sphinxcontrib-mermaid>=0.9.2",
+  "auto-pytabs[sphinx]>=0.5.0",
+  "litestar-sphinx-theme @ git+https://github.com/litestar-org/litestar-sphinx-theme.git",
+  "sphinx-paramlinks>=0.6.0",
 ]
 linting = [
   "ruff>=0.2.1",
@@ -257,6 +257,10 @@ module = ["tests.*"]
 disable_error_code = ["truthy-bool"]
 
 [[tool.mypy.overrides]]
+disable_error_code = ["assignment"]
+module = ["tests.unit.test_logging.*"]
+
+[[tool.mypy.overrides]]
 disallow_untyped_decorators = false
 module = ["tests.unit.test_kwargs.test_reserved_kwargs_injection"]
 
@@ -290,10 +294,11 @@ module = [
   "litestar.plugins.pydantic.*",
   "tests.unit.test_contrib.test_sqlalchemy",
   "tests.unit.test_contrib.test_pydantic.*",
+  "tests.unit.test_logging.test_logging_config",
   "litestar.openapi.spec.base",
   "litestar.utils.helpers",
   "litestar.channels.plugin",
-  "litestar.handlers.http_handlers._utils"
+  "litestar.handlers.http_handlers._utils"  
 ]
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
…3.13, etc.)

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Picologging does not currently support Python 3.13.  This change proactively adds updates to ensure tests work when picologging is not supported in the python environment.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
