### PR TITLE
feat: use "path" as an error message source

### DIFF
--- a/litestar/_signature/model.py
+++ b/litestar/_signature/model.py
@@ -156,6 +156,8 @@ class SignatureModel(Struct):
                 message["source"] = "body"
             elif key in connection.query_params:
                 message["source"] = ParamType.QUERY
+            elif key in connection.path_params:
+                message["source"] = ParamType.PATH
 
             elif key in cls._fields and isinstance(cls._fields[key].kwarg_definition, ParameterKwarg):
                 if cast(ParameterKwarg, cls._fields[key].kwarg_definition).cookie:

--- a/tests/unit/test_signature/test_validation.py
+++ b/tests/unit/test_signature/test_validation.py
@@ -78,6 +78,20 @@ def test_validation_failure_raises_400() -> None:
     }
 
 
+def test_invalid_path_parameter() -> None:
+    @get("/{param:int}")
+    def test(param: Annotated[int, Parameter(le=10)]) -> None: ...
+
+    with create_test_client(route_handlers=[test]) as client:
+        response = client.get("/11")
+
+    assert response.json() == {
+        "detail": "Validation failed for GET /11",
+        "extra": [{"key": "param", "message": "Expected `int` <= 10", "source": "path"}],
+        "status_code": 400,
+    }
+
+
 def test_client_backend_error_precedence_over_server_error() -> None:
     dependencies = {
         "dep": Provide(lambda: "thirteen", sync_to_thread=False),


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Use "path" as the "source" property for an error message if the key is a path parameter

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Closes #3919 