### PR TITLE
fix: ignore platform/version specific `trio` failures

### DIFF
--- a/tests/unit/test_concurrency.py
+++ b/tests/unit/test_concurrency.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from typing import Generator
 from unittest.mock import AsyncMock
@@ -37,6 +38,7 @@ def test_sync_to_thread_asyncio() -> None:
     assert loop.run_until_complete(sync_to_thread(func)) == 1
 
 
+@pytest.mark.xfail(sys.platform == "win32", reason="Trio has issues with thread handling on Windows")
 def test_sync_to_thread_trio() -> None:
     assert trio.run(sync_to_thread, func) == 1
 
@@ -78,6 +80,7 @@ def test_set_asyncio_executor_from_running_loop_raises() -> None:
     assert get_asyncio_executor() is None
 
 
+@pytest.mark.xfail(sys.platform == "win32", reason="Trio has issues with thread handling on Windows")
 def test_trio_uses_limiter(mocker: MockerFixture) -> None:
     limiter = trio.CapacityLimiter(10)
     mocker.patch("litestar.concurrency.get_trio_capacity_limiter", return_value=limiter)
@@ -88,6 +91,7 @@ def test_trio_uses_limiter(mocker: MockerFixture) -> None:
     assert mock_run_sync.call_args_list[0].kwargs["limiter"] is limiter
 
 
+@pytest.mark.xfail(sys.platform == "win32", reason="Trio has issues with thread handling on Windows")
 def test_set_trio_capacity_limiter_from_async_context_raises() -> None:
     async def main() -> None:
         set_trio_capacity_limiter(trio.CapacityLimiter(1))


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This PR temporarily ignores failures related to `trio` and specific `anyio` versions on Windows platforms.

[Here](https://github.com/litestar-org/litestar/actions/runs/12613952703/job/35152354906#step:7:313) is an example of the related error

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
