### PR TITLE
chore(build): prevent python 3.13 from installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ upgrade:       										## Upgrade all dependencies to the latest stable versio
 
 .PHONY: install
 install:
-	@uv sync
+	@uv sync --all-extras --dev --python 3.12
 
 .PHONY: clean
 clean: 												## Cleanup temporary build artifacts


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

running `make install` now will result in a broken environment because it tries to install 3.13.  

This can be removed one the 3.13 PR is merged.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
