### PR TITLE
fix(compression middleware): Fix resource handling

### DIFF
--- a/litestar/middleware/compression/middleware.py
+++ b/litestar/middleware/compression/middleware.py
@@ -131,6 +131,11 @@ class CompressionMiddleware(AbstractMiddleware):
             if initial_message is not None and value_or_default(connection_state.is_cached, False):
                 await send(initial_message)
                 await send(message)
+                facade.close()
+                return
+
+            if initial_message and message["type"] == "http.disconnect":
+                facade.close()
                 return
 
             if initial_message and message["type"] == "http.response.body":

--- a/litestar/middleware/compression/middleware.py
+++ b/litestar/middleware/compression/middleware.py
@@ -175,6 +175,7 @@ class CompressionMiddleware(AbstractMiddleware):
                         await send(message)
 
                     else:
+                        facade.close()
                         await send(initial_message)
                         await send(message)
 

--- a/tests/unit/test_middleware/test_compression_middleware.py
+++ b/tests/unit/test_middleware/test_compression_middleware.py
@@ -196,6 +196,8 @@ async def test_compression_streaming_response_emitted_messages(
     # second body message with more_body=True will be empty if zlib buffers output and is not flushed
     await wrapped_send(HTTPResponseBodyEvent(type="http.response.body", body=b"abc", more_body=True))
     assert mock.mock_calls[-1].args[0]["body"]
+    # send a more_body=False
+    await wrapped_send(HTTPResponseBodyEvent(type="http.response.body", body=b"", more_body=False))
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_middleware/test_compression_middleware.py
+++ b/tests/unit/test_middleware/test_compression_middleware.py
@@ -196,7 +196,7 @@ async def test_compression_streaming_response_emitted_messages(
     # second body message with more_body=True will be empty if zlib buffers output and is not flushed
     await wrapped_send(HTTPResponseBodyEvent(type="http.response.body", body=b"abc", more_body=True))
     assert mock.mock_calls[-1].args[0]["body"]
-    # send a more_body=False
+    # send a more_body=False so resources close properly
     await wrapped_send(HTTPResponseBodyEvent(type="http.response.body", body=b"", more_body=False))
 
 


### PR DESCRIPTION
Fix a few cases where we didn't close resources in the right order, leading to either "unclosed resource" or "I/O on closed file" warnings