### PR TITLE
docs: fix typo in dependency_validation_error

### DIFF
--- a/docs/examples/dependency_injection/dependency_validation_error.py
+++ b/docs/examples/dependency_injection/dependency_validation_error.py
@@ -11,7 +11,7 @@ async def provide_str() -> str:
 
 @get("/", dependencies={"injected": Provide(provide_str)}, sync_to_thread=False)
 def hello_world(injected: int) -> Dict[str, Any]:
-    """Handler expects and `int`, but we've provided a `str`."""
+    """Handler expects an `int`, but we've provided a `str`."""
     return {"hello": injected}
 
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
This PR fixes a typo in docs/examples/dependency_injection/dependency_validation_error.py
-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
