### PR TITLE
fix(ci):  Github CI fail due to deprecated action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: coverage-data
+          pattern: coverage-data*
           merge-multiple: true
 
       - name: Combine coverage files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
           echo "${{ github.event.number }}" > .pr_number
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs-preview
           path: |
@@ -294,9 +294,9 @@ jobs:
       - name: Rename coverage file
         run: mv .coverage* .coverage.pydantic_v1
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: coverage-data
+          name: coverage-data-pydantic_v1-${{ inputs.python-version }}
           path: .coverage.pydantic_v1
           include-hidden-files: true
 
@@ -312,9 +312,10 @@ jobs:
           python-version: "3.12"
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: coverage-data
+          pattern: coverage-data
+          merge-multiple: true
 
       - name: Combine coverage files
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,9 +77,9 @@ jobs:
         if: inputs.coverage
         run: mv .coverage .coverage.${{ inputs.python-version }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: inputs.coverage
         with:
-          name: coverage-data
+          name: coverage-data-${{ inputs.python-version }}
           path: .coverage.${{ inputs.python-version }}
           include-hidden-files: true


### PR DESCRIPTION
Fixes #3937

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
