### PR TITLE
fix(ASGI mounts): Prevent accidental scope overrides by mounted ASGI apps

### DIFF
--- a/docs/examples/application_hooks/after_exception_hook.py
+++ b/docs/examples/application_hooks/after_exception_hook.py
@@ -19,7 +19,7 @@ def my_handler() -> None:
 
 async def after_exception_handler(exc: Exception, scope: "Scope") -> None:
     """Hook function that will be invoked after each exception."""
-    state = scope["app"].state
+    state = Litestar.from_scope(scope).state
     if not hasattr(state, "error_count"):
         state.error_count = 1
     else:

--- a/docs/examples/application_hooks/before_send_hook.py
+++ b/docs/examples/application_hooks/before_send_hook.py
@@ -24,7 +24,7 @@ async def before_send_hook_handler(message: Message, scope: Scope) -> None:
     """
     if message["type"] == "http.response.start":
         headers = MutableScopeHeaders.from_message(message=message)
-        headers["My Header"] = scope["app"].state.message
+        headers["My Header"] = Litestar.from_scope(scope).state.message
 
 
 def on_startup(app: Litestar) -> None:

--- a/docs/examples/application_state/using_application_state.py
+++ b/docs/examples/application_state/using_application_state.py
@@ -20,7 +20,7 @@ def middleware_factory(*, app: "ASGIApp") -> "ASGIApp":
     """A middleware can access application state via `scope`."""
 
     async def my_middleware(scope: "Scope", receive: "Receive", send: "Send") -> None:
-        state = scope["app"].state
+        state = Litestar.from_scope(scope).state
         logger.info("state value in middleware: %s", state.value)
         await app(scope, receive, send)
 

--- a/docs/examples/routing/mount_custom_app.py
+++ b/docs/examples/routing/mount_custom_app.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from litestar.types import Receive, Scope, Send
 
 
-@asgi("/some/sub-path", is_mount=True)
+@asgi("/some/sub-path", is_mount=True, copy_scope=True)
 async def my_asgi_app(scope: "Scope", receive: "Receive", send: "Send") -> None:
     """
     Args:

--- a/docs/examples/routing/mounting_starlette_app.py
+++ b/docs/examples/routing/mounting_starlette_app.py
@@ -15,7 +15,7 @@ async def index(request: "Request") -> JSONResponse:
     return JSONResponse({"forwarded_path": request.url.path})
 
 
-starlette_app = asgi(path="/some/sub-path", is_mount=True)(
+starlette_app = asgi(path="/some/sub-path", is_mount=True, copy_scope=True)(
     Starlette(
         routes=[
             Route("/", index),

--- a/docs/usage/applications.rst
+++ b/docs/usage/applications.rst
@@ -110,10 +110,10 @@ is accessible.
 :ref:`reserved keyword arguments <usage/routing/handlers:"reserved" keyword arguments>`.
 
 It is important to understand in this context that the application instance is injected into the ASGI ``scope`` mapping
-for each connection (i.e. request or websocket connection) as ``scope["app"]``. This makes the application
-accessible wherever the scope mapping is available, e.g. in middleware, on :class:`~.connection.request.Request` and
-:class:`~.connection.websocket.WebSocket` instances (accessible as ``request.app`` / ``socket.app``), and many
-other places.
+for each connection (i.e. request or websocket connection) as ``scope["litestar_app"]``, and can be retrieved using
+:meth:`~litestar.Litestar.from_scope`. This makes the application accessible wherever the scope mapping is available,
+e.g. in middleware, on :class:`~.connection.request.Request` and :class:`~.connection.websocket.WebSocket` instances
+(accessible as ``request.app`` / ``socket.app``), and many other places.
 
 Therefore, :paramref:`~.app.Litestar.state` offers an easy way to share contextual data between disparate parts
 of the application, as seen below:

--- a/docs/usage/applications.rst
+++ b/docs/usage/applications.rst
@@ -111,7 +111,7 @@ is accessible.
 
 It is important to understand in this context that the application instance is injected into the ASGI ``scope`` mapping
 for each connection (i.e. request or websocket connection) as ``scope["litestar_app"]``, and can be retrieved using
-:meth:`~litestar.Litestar.from_scope`. This makes the application accessible wherever the scope mapping is available,
+:meth:`~.Litestar.from_scope`. This makes the application accessible wherever the scope mapping is available,
 e.g. in middleware, on :class:`~.connection.request.Request` and :class:`~.connection.websocket.WebSocket` instances
 (accessible as ``request.app`` / ``socket.app``), and many other places.
 

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -610,9 +610,14 @@ class Litestar(Router):
             await self.asgi_router.lifespan(receive=receive, send=send)  # type: ignore[arg-type]
             return
 
-        scope["app"] = self
+        scope["app"] = scope["litestar_app"] = self
         scope.setdefault("state", {})
         await self.asgi_handler(scope, receive, self._wrap_send(send=send, scope=scope))  # type: ignore[arg-type]
+
+    @classmethod
+    def from_scope(cls, scope: Scope) -> Litestar:
+        """Retrieve the Litestar application from the current ASGI scope"""
+        return scope["litestar_app"]
 
     async def _call_lifespan_hook(self, hook: LifespanHook) -> None:
         ret = hook(self) if inspect.signature(hook).parameters else hook()  # type: ignore[call-arg]

--- a/litestar/connection/base.py
+++ b/litestar/connection/base.py
@@ -100,7 +100,7 @@ class ASGIConnection(Generic[HandlerT, UserT, AuthT, StateT]):
         Returns:
             The :class:`Litestar <litestar.app.Litestar>` application instance
         """
-        return self.scope["app"]
+        return self.scope["litestar_app"]
 
     @property
     def route_handler(self) -> HandlerT:
@@ -321,7 +321,7 @@ class ASGIConnection(Generic[HandlerT, UserT, AuthT, StateT]):
         Returns:
             A string representing the absolute url of the route handler.
         """
-        litestar_instance = self.scope["app"]
+        litestar_instance = self.scope["litestar_app"]
         url_path = litestar_instance.route_reverse(name, **path_parameters)
 
         return make_absolute_url(url_path, self.base_url)
@@ -339,7 +339,7 @@ class ASGIConnection(Generic[HandlerT, UserT, AuthT, StateT]):
         Returns:
             A string representing absolute url to the asset.
         """
-        litestar_instance = self.scope["app"]
+        litestar_instance = self.scope["litestar_app"]
         url_path = litestar_instance.url_for_static_asset(name, file_path)
 
         return make_absolute_url(url_path, self.base_url)

--- a/litestar/middleware/_internal/cors.py
+++ b/litestar/middleware/_internal/cors.py
@@ -44,7 +44,7 @@ class CORSMiddleware(AbstractMiddleware):
         origin = headers.get("origin")
 
         if scope["type"] == ScopeType.HTTP and scope["method"] == HttpMethod.OPTIONS and origin:
-            request = scope["app"].request_class(scope=scope, receive=receive, send=send)
+            request = scope["litestar_app"].request_class(scope=scope, receive=receive, send=send)
             asgi_response = self._create_preflight_response(origin=origin, request_headers=headers).to_asgi_response(
                 app=None, request=request
             )

--- a/litestar/middleware/_internal/exceptions/middleware.py
+++ b/litestar/middleware/_internal/exceptions/middleware.py
@@ -135,7 +135,7 @@ class ExceptionHandlerMiddleware:
 
     @staticmethod
     def _get_debug_scope(scope: Scope) -> bool:
-        return scope["app"].debug
+        return scope["litestar_app"].debug
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI-callable.
@@ -161,7 +161,7 @@ class ExceptionHandlerMiddleware:
             if scope_state.response_started:
                 raise LitestarException("Exception caught after response started") from e
 
-            litestar_app = scope["app"]
+            litestar_app = scope["litestar_app"]
 
             if litestar_app.logging_config and (logger := litestar_app.logger):
                 self.handle_exception_logging(logger=logger, logging_config=litestar_app.logging_config, scope=scope)

--- a/litestar/middleware/csrf.py
+++ b/litestar/middleware/csrf.py
@@ -106,7 +106,7 @@ class CSRFMiddleware(MiddlewareProtocol):
             await self.app(scope, receive, send)
             return
 
-        request: Request[Any, Any, Any] = scope["app"].request_class(scope=scope, receive=receive)
+        request: Request[Any, Any, Any] = scope["litestar_app"].request_class(scope=scope, receive=receive)
         content_type, _ = request.content_type
         csrf_cookie = request.cookies.get(self.config.cookie_name)
         existing_csrf_token = request.headers.get(self.config.header_name)

--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -100,7 +100,7 @@ class LoggingMiddleware(AbstractMiddleware):
             None
         """
         if not hasattr(self, "logger"):
-            self.logger = scope["app"].get_logger(self.config.logger_name)
+            self.logger = scope["litestar_app"].get_logger(self.config.logger_name)
             self.is_struct_logger = structlog_installed and repr(self.logger).startswith("<BoundLoggerLazyProxy")
 
         if self.config.response_log_fields:
@@ -121,7 +121,7 @@ class LoggingMiddleware(AbstractMiddleware):
         Returns:
             None
         """
-        extracted_data = await self.extract_request_data(request=scope["app"].request_class(scope, receive))
+        extracted_data = await self.extract_request_data(request=scope["litestar_app"].request_class(scope, receive))
         self.log_message(values=extracted_data)
 
     def log_response(self, scope: Scope) -> None:

--- a/litestar/middleware/rate_limit.py
+++ b/litestar/middleware/rate_limit.py
@@ -67,7 +67,7 @@ class RateLimitMiddleware(AbstractMiddleware):
         Returns:
             None
         """
-        app = scope["app"]
+        app = scope["litestar_app"]
         request: Request[Any, Any, Any] = app.request_class(scope)
         store = self.config.get_store_from_app(app)
         if await self.should_check_request(request=request):

--- a/litestar/middleware/response_cache.py
+++ b/litestar/middleware/response_cache.py
@@ -51,7 +51,7 @@ class ResponseCacheMiddleware(AbstractMiddleware):
 
                 if messages and message["type"] == HTTP_RESPONSE_BODY and not message.get("more_body"):
                     key = (route_handler.cache_key_builder or self.config.key_builder)(Request(scope))
-                    store = self.config.get_store_from_app(scope["app"])
+                    store = self.config.get_store_from_app(scope["litestar_app"])
                     await store.set(key, encode_msgpack(messages), expires_in=expires_in)
             await send(message)
 

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -154,7 +154,9 @@ class HTTPRoute(BaseRoute):
                 route_handler=route_handler, parameter_model=parameter_model, request=request
             )
 
-        response: ASGIApp = await route_handler.to_response(app=scope["app"], data=response_data, request=request)
+        response: ASGIApp = await route_handler.to_response(
+            app=scope["litestar_app"], data=response_data, request=request
+        )
 
         if cleanup_group:
             await cleanup_group.cleanup()

--- a/litestar/testing/client/base.py
+++ b/litestar/testing/client/base.py
@@ -54,6 +54,7 @@ def fake_asgi_connection(app: ASGIApp, cookies: dict[str, str]) -> ASGIConnectio
         "http_version": "1.1",
         "extensions": {"http.response.template": {}},
         "app": app,  # type: ignore[typeddict-item]
+        "litestar_app": app,
         "state": {},
         "path_params": {},
         "route_handler": None,

--- a/litestar/testing/request_factory.py
+++ b/litestar/testing/request_factory.py
@@ -75,7 +75,7 @@ class RequestFactory:
         """Initialize ``RequestFactory``
 
         Args:
-             app: An instance of :class:`Litestar <litestar.app.Litestar>` to set as ``request.scope["app"]``.
+             app: An instance of :class:`Litestar <litestar.app.Litestar>` to set as ``request.scope["litestar_app"]``.
              server: The server's domain.
              port: The server's port.
              root_path: Root path for the server.
@@ -175,6 +175,7 @@ class RequestFactory:
             path=path,
             headers=[],
             app=self.app,
+            litestar_app=self.app,
             session=session,
             user=user,
             auth=auth,

--- a/litestar/types/asgi_types.py
+++ b/litestar/types/asgi_types.py
@@ -124,7 +124,8 @@ class HeaderScope(TypedDict):
 class BaseScope(HeaderScope):
     """Base ASGI-scope."""
 
-    app: Litestar
+    app: Litestar  # deprecated
+    litestar_app: Litestar
     asgi: ASGIVersion
     auth: Any
     client: tuple[str, int] | None

--- a/litestar/utils/scope/__init__.py
+++ b/litestar/utils/scope/__init__.py
@@ -24,7 +24,7 @@ def get_serializer_from_scope(scope: Scope) -> Serializer:
         A serializer function
     """
     route_handler = scope["route_handler"]
-    app = scope["app"]
+    app = scope["litestar_app"]
 
     if hasattr(route_handler, "resolve_type_encoders"):
         type_encoders = route_handler.resolve_type_encoders()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,6 +211,7 @@ def create_scope() -> Callable[..., Scope]:
     ) -> Scope:
         scope = {
             "app": app,
+            "litestar_app": app,
             "asgi": asgi or {"spec_version": "2.0", "version": "3.0"},
             "auth": auth,
             "type": type,

--- a/tests/unit/test_handlers/test_asgi_handlers/test_handle_asgi.py
+++ b/tests/unit/test_handlers/test_asgi_handlers/test_handle_asgi.py
@@ -1,9 +1,14 @@
-from litestar import Controller, MediaType, asgi
+from unittest.mock import MagicMock
+
+import pytest
+
+from litestar import Controller, Litestar, MediaType, asgi
 from litestar.enums import ScopeType
+from litestar.exceptions import LitestarWarning
 from litestar.response.base import ASGIResponse
 from litestar.status_codes import HTTP_200_OK
 from litestar.testing import create_test_client
-from litestar.types import Receive, Scope, Send
+from litestar.types import ASGIApp, Receive, Scope, Send
 
 
 def test_handle_asgi() -> None:
@@ -51,3 +56,37 @@ def test_asgi_signature_namespace() -> None:
         response = client.get("/asgi")
         assert response.status_code == HTTP_200_OK
         assert response.text == "/asgi"
+
+
+def test_copy_scope_not_set_warns_on_modification() -> None:
+    @asgi(is_mount=True)
+    async def handler(scope: "Scope", receive: "Receive", send: "Send") -> None:
+        scope["foo"] = ""  # type: ignore[typeddict-unknown-key]
+        await ASGIResponse()(scope, receive, send)
+
+    with create_test_client([handler]) as client:
+        with pytest.warns(LitestarWarning, match="modified 'scope' with 'copy_scope' set to 'None'"):
+            response = client.get("/")
+        assert response.status_code == HTTP_200_OK
+
+
+@pytest.mark.parametrize("copy_scope, expected_value", [(True, None), (False, "foo")])
+def test_copy_scope(copy_scope: bool, expected_value: "str | None") -> None:
+    mock = MagicMock()
+
+    def middleware_factory(app: Litestar) -> ASGIApp:
+        async def middleware(scope: "Scope", receive: "Receive", send: "Send") -> None:
+            await app(scope, receive, send)
+            mock(scope.get("foo"))
+
+        return middleware
+
+    @asgi(is_mount=True, copy_scope=copy_scope)
+    async def handler(scope: "Scope", receive: "Receive", send: "Send") -> None:
+        scope["foo"] = "foo"  # type: ignore[typeddict-unknown-key]
+        await ASGIResponse()(scope, receive, send)
+
+    with create_test_client([handler], middleware=[middleware_factory]) as client:
+        client.get("/")
+
+    mock.assert_called_once_with(expected_value)


### PR DESCRIPTION
When mounting ASGI apps, there's no guarantee they won't overwrite some key in the `scope` that we rely on, e.g. `scope["app"]`, which is what caused #3934.

To prevent this, I've implemented two things:

1. Do not store the Litestar instance under the generic `app` key, but the more specific `litestar_app` key. I've also added a `Litestar.from_scope` method, which can be used to safely access the current app from the sope
2. Added a new parameter `copy_scope` to the ASGI route handler, which, when set to `True` will copy the scope before calling into the mounted ASGI app. This should make things behave more as expected, since it truly give the called app its own environment without causing any side-effects. Since this change might break some things, I've left it with a default of `None`, which does not copy the scope, but will issue a warning if the mounted app modified it, enabling users to decide how to deal with that situation

Fixes #3934