### PR TITLE
fix: remove deprecated `litestar.contrib.attrs` import

### DIFF
--- a/litestar/app.py
+++ b/litestar/app.py
@@ -563,7 +563,7 @@ class Litestar(Router):
             if not pydantic_plugin_found and not pydantic_serialization_plugin_found:
                 plugins.append(PydanticDIPlugin())
         with suppress(MissingDependencyException):
-            from litestar.contrib.attrs import AttrsSchemaPlugin
+            from litestar.plugins.attrs import AttrsSchemaPlugin
 
             pre_configured = any(isinstance(plugin, AttrsSchemaPlugin) for plugin in plugins)
             if not pre_configured:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

`litestar.contrib.attrs` was moved to `litestar.plugins.attrswas` in https://github.com/litestar-org/litestar/pull/3862 but still being used in code and gives warnings


<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
