### PR TITLE
chore: remove unnecessary flags from install command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ upgrade:       										## Upgrade all dependencies to the latest stable versio
 
 .PHONY: install
 install:
-	@uv sync --all-extras --dev --python 3.12
+	@uv sync --python 3.12
 
 .PHONY: clean
 clean: 												## Cleanup temporary build artifacts


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Remove `--all-extras --dev`, as they're redundant with the default-groups defined here https://github.com/litestar-org/litestar/blob/518af0dda4e1fea75755147fee2a90dee778e121/pyproject.toml#L125

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
