### PR TITLE
chore: don't rebuild docs from scratch when using make docs-serve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ docs-clean: 										## Dump the existing built docs
 	@rm -rf docs/_build
 	@echo "=> Removed existing documentation build assets"
 
-docs-serve: docs-clean 								## Serve the docs locally
+docs-serve:  								## Serve the docs locally
 	@echo "=> Serving documentation"
 	uv run sphinx-autobuild docs docs/_build/ -j auto --watch litestar --watch docs --watch tests --watch CONTRIBUTING.rst --port 8002
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

The docs take quite a long time to build from scratch (>1m on my old pre-Apple Silicon macbook air). After the initial build, they build quickly, so long as the `_build` dir isn't removed. I tend to kill then re-run sphinx-autobuild pretty often, so this ends up saving a lot of time

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
