### PR TITLE
fix(docs): improve text color for dark theme in mermaid diagrams

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -33,3 +33,7 @@ html[data-theme="dark"] .mermaid svg {
   background-color: white;
   padding: 1em;
 }
+
+html[data-theme="dark"] .mermaid svg p {
+  color: black;
+}


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Changed mermaid diagrams text color for dark theme to black

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
#3950 