### PR TITLE
feat: allow route_reverse params of type uuid to be passed as str

### DIFF
--- a/litestar/app.py
+++ b/litestar/app.py
@@ -15,6 +15,7 @@ from functools import partial
 from itertools import chain
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Iterable, Mapping, Sequence, TypedDict, cast
+from uuid import UUID
 
 from litestar._asgi import ASGIRouter
 from litestar._asgi.utils import get_route_handlers, wrap_in_exception_handler
@@ -768,7 +769,9 @@ class Litestar(Router):
 
         Args:
             name: A route handler unique name.
-            **path_parameters: Actual values for path parameters in the route.
+            **path_parameters: Actual values for path parameters in the route. Parameters of type
+                `datetime`, `date`, `time`, `timedelta`, `float`, `Path`, `UUID`
+                may be passed in their string representations.
 
         Raises:
             NoRouteMatchFoundException: If route with 'name' does not exist, path parameters are missing in
@@ -781,7 +784,7 @@ class Litestar(Router):
         if handler_index is None:
             raise NoRouteMatchFoundException(f"Route {name} can not be found")
 
-        allow_str_instead = {datetime, date, time, timedelta, float, Path}
+        allow_str_instead = {datetime, date, time, timedelta, float, Path, UUID}
         routes = sorted(
             self.asgi_router.route_mapping[handler_index["identifier"]],
             key=lambda r: len(r.path_parameters),


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This allows params of type UUID to be passed as strings (e.g. their hex representation) into route_reverse (just like datetime, Path etc.). I don't know if the test is really necessary, but that is for the maintainers to decide.

Originally I intended to allow int too, but this broke about 20 tests I did not feel confident to fix them all in a reasonable amount of time.

Discussed in [#3968](https://github.com/litestar-org/litestar/issues/3968#issuecomment-2612178106)