### PR TITLE
docs: use transparent bg for mermaid

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,6 +73,8 @@ napoleon_use_admonition_for_notes = True
 napoleon_use_admonition_for_references = False
 napoleon_attr_annotations = True
 
+mermaid_params = ['--backgroundColor', 'transparent']
+
 autoclass_content = "class"
 autodoc_class_signature = "separated"
 autodoc_default_options = {"special-members": "__init__", "show-inheritance": True, "members": True}


### PR DESCRIPTION
This will remove white backgroud from graphs.

Before:
![изображение](https://github.com/user-attachments/assets/b06416de-7bc9-4bf6-8896-8fd4a220421a)

Refs https://github.com/litestar-org/litestar/pull/3963

