### PR TITLE
fix(typing): always unwrap `TypeAliasType`s

### DIFF
--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -52,6 +52,7 @@ from litestar.plugins import OpenAPISchemaPlugin
 from litestar.types import Empty
 from litestar.types.builtin_types import NoneType
 from litestar.typing import FieldDefinition
+from litestar.utils import deprecated
 from litestar.utils.helpers import get_name
 from litestar.utils.predicates import (
     is_class_and_subclass,
@@ -309,8 +310,6 @@ class SchemaCreator:
 
         if field_definition.is_new_type:
             result = self.for_new_type(field_definition)
-        elif field_definition.is_type_alias_type:
-            result = self.for_type_alias_type(field_definition)
         elif plugin_for_annotation := self.get_plugin_for(field_definition):
             result = self.for_plugin(field_definition, plugin_for_annotation)
         elif _should_create_literal_schema(field_definition):
@@ -353,6 +352,7 @@ class SchemaCreator:
             )
         )
 
+    @deprecated(version="2.15", removal_in="3.0", info="TypeAliasType is supported natively")
     def for_type_alias_type(self, field_definition: FieldDefinition) -> Schema | Reference:
         return self.for_field_definition(
             FieldDefinition.from_kwarg(

--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -272,7 +272,7 @@ class FieldDefinition:
     @property
     def is_type_alias_type(self) -> bool:
         """Whether the annotation is a ``TypeAliasType``"""
-        return isinstance(self.annotation, TypeAliasType)
+        return TypeAliasType in self.type_wrappers
 
     @property
     def is_type_var(self) -> bool:

--- a/tests/unit/test_typing.py
+++ b/tests/unit/test_typing.py
@@ -12,6 +12,7 @@ from litestar import get
 from litestar.exceptions import LitestarWarning
 from litestar.params import DependencyKwarg, KwargDefinition, Parameter, ParameterKwarg
 from litestar.typing import FieldDefinition
+from litestar.utils.typing import unwrap_annotation
 from tests.unit.test_utils.test_signature import T, _check_field_definition, field_definition_int, test_type_hints
 
 
@@ -465,6 +466,7 @@ def test_warn_default_inside_kwarg_definition_and_default_empty() -> None:
 def test_is_type_alias_type() -> None:
     field_definition = FieldDefinition.from_annotation(TypeAliasType("IntAlias", int))  # pyright: ignore
     assert field_definition.is_type_alias_type
+    assert field_definition.annotation == int
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="type keyword not available before 3.12")
@@ -474,3 +476,34 @@ def test_unwrap_type_alias_type_keyword() -> None:
     annotation = ctx["IntAlias"]
     field_definition = FieldDefinition.from_annotation(annotation)
     assert field_definition.is_type_alias_type
+    assert field_definition.annotation == int
+
+
+def test_unwrap_annotation_type_alias_type() -> None:
+    annotation, metadata, wrappers = unwrap_annotation(TypeAliasType("SomeAlias", int))
+    assert annotation == int
+    assert not metadata
+    assert TypeAliasType in wrappers
+
+
+NestedAlias = TypeAliasType("Outer", Union[Annotated[int, "meta"], list["Outer"]])
+
+
+@pytest.mark.parametrize(
+    "annotation, expected_meta, expected_type",
+    [
+        (Annotated[TypeAliasType("SomeAlias", int), "meta"], ("meta",), int),
+        (TypeAliasType("SomeAlias", TypeAliasType("InnerAlias", int)), (), int),
+        (TypeAliasType("SomeAlias", Annotated[int, "meta"]), ("meta",), int),
+        (TypeAliasType("SomeAlias", Annotated[TypeAliasType("InnerAlias", int), "meta"]), ("meta",), int),
+        (Annotated[TypeAliasType("SomeAlias", Annotated[int, "inner meta"]), "meta"], ("meta", "inner meta"), int),
+        (NestedAlias, ("meta",), NestedAlias),
+    ],
+)
+def test_unwrap_annotation_type_alias_type_nested(
+    annotation: Any, expected_meta: tuple[str, ...], expected_type: Any
+) -> None:
+    annotation, metadata, wrappers = unwrap_annotation(annotation)
+    assert annotation == expected_type
+    assert metadata == expected_meta
+    assert TypeAliasType in wrappers

--- a/tests/unit/test_typing.py
+++ b/tests/unit/test_typing.py
@@ -483,7 +483,7 @@ def type_kw_or(src: str) -> Any:
     if sys.version_info < (3, 12):
         return None
 
-    ctx: dict[str, Any] = {}
+    ctx: dict[str, Any] = {}  # type: ignore[unreachable]
 
     exec(src, ctx, None)
     return ctx["Alias"]
@@ -506,7 +506,7 @@ def test_unwrap_annotation_type_alias_type(annotation: Any) -> None:
     assert TypeAliasType in wrappers
 
 
-NestedAlias = TypeAliasType("Outer", Union[Annotated[int, "meta"], list["Outer"]])  # noqa: F821
+NestedAlias = TypeAliasType("NestedAlias", Union[Annotated[int, "meta"], List["NestedAlias"]])  # type: ignore[misc]
 
 
 @pytest.mark.parametrize(
@@ -530,7 +530,7 @@ def test_unwrap_annotation_type_alias_type_nested(
 
 
 def test_unwrap_annotation_type_alias_type_nested_with_type_kw() -> None:
-    annotation = Annotated[type_kw_or("type Alias = int"), "meta"]
+    annotation = Annotated[type_kw_or("type Alias = int"), "meta"]  # type: ignore[valid-type]
     unwrapped, metadata, wrappers = unwrap_annotation(annotation)
     assert unwrapped == int
     assert metadata == ("meta",)


### PR DESCRIPTION
While fixing #3912 I noticed we only unwrap these partially. However, I am not sure if unwrapping them *at all* is proper, because of a particular edge case: They can be self-referential. This is used e.g. in `pydantic.JsonType`.

`SelfReferential = TypeAliasType("Outer", Union[Annotated[int, "meta"], list["Outer"]])`

This type can be understood by e.g. mypy, but is hard to parse for our typing system since we want to extract the metadata from the `Annotated`, but need to keep the outer `TypeAliasType`, so the self-referencing works in later stages (e.g. Pydantic).

I'm not entirely sure how we should best handle this, as our typing system has fundamentally different requirements than that of the 3rd party tools we rely on. 

Divergences in how self-referential types are treated by these tools further complicates things.

For example, this is fine in Pydantic:

```python
import pydantic

type Foo = int | list[Foo]

class SomeModel(pydantic.BaseModel):
    a: Foo

SomeModel.model_validate_json('{"a": 1}')
```

But msgspec raises a `RecursionError`:

```python
import msgspec

type Foo = int | list[Foo]

class SomeStruct(msgspec.Struct):
    a: Foo

msgspec.json.decode('{"a": 1}', type=SomeStruct)
```

<hr>

Not really sure yet how to proceed, I'll have to think about this a bit. I'd be happy about some input though @litestar-org/members