### PR TITLE
feat(core): Cancel handler functions / responses when client disconnects

### DIFF
--- a/litestar/exceptions/base_exceptions.py
+++ b/litestar/exceptions/base_exceptions.py
@@ -55,3 +55,7 @@ class SerializationException(LitestarException):
 
 class LitestarWarning(UserWarning):
     """Base class for Litestar warnings"""
+
+
+class ClientDisconnect(LitestarException):
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ dependencies = [
   "rich-click",
   "multipart>=1.2.0",
   # default litestar plugins
-  "litestar-htmx>=0.4.0"
+  "litestar-htmx>=0.4.0",
+  "exceptiongroup>=1.2.2",
 ]
 description = "Litestar - A production-ready, highly performant, extensible ASGI API Framework"
 keywords = ["api", "rest", "asgi", "litestar", "starlite"]
@@ -413,8 +414,6 @@ lint.select = [
   "W", # pycodestyle - warning
   "YTT", # flake8-2020
 ]
-
-line-length = 120
 lint.ignore = [
   "A003", # flake8-builtins - class attribute {name} is shadowing a python builtin
   "B010", # flake8-bugbear - do not call setattr with a constant attribute value
@@ -435,6 +434,8 @@ lint.ignore = [
   "ISC001", # Ruff formatter incompatible
   "CPY001", # ruff - copyright notice at the top of the file
 ]
+
+line-length = 120
 src = ["litestar", "tests", "docs/examples"]
 target-version = "py38"
 

--- a/tests/unit/test_connection/test_request.py
+++ b/tests/unit/test_connection/test_request.py
@@ -20,6 +20,7 @@ from litestar.exceptions import (
     LitestarWarning,
     SerializationException,
 )
+from litestar.exceptions.base_exceptions import ClientDisconnect
 from litestar.middleware import MiddlewareProtocol
 from litestar.response.base import ASGIResponse
 from litestar.serialization import encode_json, encode_msgpack
@@ -382,7 +383,7 @@ def test_request_without_setting_receive(create_scope: Callable[..., Scope]) -> 
 
 
 async def test_request_disconnect(create_scope: Callable[..., Scope]) -> None:
-    """If a client disconnect occurs while reading request body then InternalServerException should be raised."""
+    """If a client disconnect occurs while reading request body then ClientDisconnect should be raised."""
 
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         request = Request[Any, Any, State](scope, receive)
@@ -391,7 +392,7 @@ async def test_request_disconnect(create_scope: Callable[..., Scope]) -> None:
     async def receiver() -> dict[str, str]:
         return {"type": "http.disconnect"}
 
-    with pytest.raises(InternalServerException):
+    with pytest.raises(ClientDisconnect):
         await app(
             create_scope(type="http", route_handler=_route_handler, method="POST", path="/"),
             receiver,  # type: ignore[arg-type]

--- a/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
+++ b/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
@@ -72,7 +72,6 @@ person_instance = DataclassPersonFactory.build()
         (post, HttpMethod.POST, HTTP_201_CREATED),
         (put, HttpMethod.PUT, HTTP_200_OK),
         (patch, HttpMethod.PATCH, HTTP_200_OK),
-        (delete, HttpMethod.DELETE, HTTP_204_NO_CONTENT),
     ],
 )
 def test_data_using_model(decorator: Any, http_method: Any, expected_status_code: Any) -> None:
@@ -96,7 +95,6 @@ def test_data_using_model(decorator: Any, http_method: Any, expected_status_code
         (post, HttpMethod.POST, HTTP_201_CREATED),
         (put, HttpMethod.PUT, HTTP_200_OK),
         (patch, HttpMethod.PATCH, HTTP_200_OK),
-        (delete, HttpMethod.DELETE, HTTP_204_NO_CONTENT),
     ],
 )
 def test_data_using_list_of_models(decorator: Any, http_method: Any, expected_status_code: Any) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,11 +1,13 @@
 version = 1
 requires-python = ">=3.8, <4.0"
 resolution-markers = [
-    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.9' and python_full_version < '3.11' and sys_platform != 'win32'",
     "python_full_version < '3.9' and sys_platform != 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.9' and python_full_version < '3.11' and sys_platform == 'win32'",
     "python_full_version < '3.9' and sys_platform == 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'win32'",
 ]
@@ -111,10 +113,12 @@ name = "anyio"
 version = "4.8.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.9' and python_full_version < '3.11' and sys_platform != 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.9' and python_full_version < '3.11' and sys_platform == 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'win32'",
 ]
 dependencies = [
@@ -1780,7 +1784,7 @@ dependencies = [
     { name = "anyio", version = "4.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "anyio", version = "4.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "click" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup" },
     { name = "httpx" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "importlib-resources", marker = "python_full_version < '3.9'" },
@@ -1962,6 +1966,7 @@ requires-dist = [
     { name = "cryptography", marker = "extra == 'cryptography'" },
     { name = "cryptography", marker = "extra == 'jwt'" },
     { name = "email-validator", marker = "extra == 'pydantic'" },
+    { name = "exceptiongroup", specifier = ">=1.2.2" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "fast-query-parsers", marker = "extra == 'standard'", specifier = ">=1.0.2" },
     { name = "httpx", specifier = ">=0.22" },
@@ -2343,10 +2348,12 @@ name = "msgspec"
 version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.9' and python_full_version < '3.11' and sys_platform != 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.9' and python_full_version < '3.11' and sys_platform == 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/9b/95d8ce458462b8b71b8a70fa94563b2498b89933689f3a7b8911edfae3d7/msgspec-0.19.0.tar.gz", hash = "sha256:604037e7cd475345848116e89c553aa9a233259733ab51986ac924ab1b976f8e", size = 216934 }
@@ -3339,10 +3346,12 @@ name = "pytest-asyncio"
 version = "0.25.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.9' and python_full_version < '3.11' and sys_platform != 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.9' and python_full_version < '3.11' and sys_platform == 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'win32'",
 ]
 dependencies = [
@@ -4117,7 +4126,7 @@ name = "taskgroup"
 version = "0.0.0a4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.13'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/40/02753c40fa30dfdde7567c1daeefbf957dcf8c99e6534a80afb438adf07e/taskgroup-0.0.0a4.tar.gz", hash = "sha256:eb08902d221e27661950f2a0320ddf3f939f579279996f81fe30779bca3a159c", size = 8553 }
 wheels = [


### PR DESCRIPTION
poc for listening for early client disconnects and cancelling handler functions / responses in progress.

<hr>

I currently consider this not viable, since it imposes a 50% performance penalty when looking at throughput of a simple plaintext benchmark. This is due to the overhead introduced by running the response cycle in an `anyio.TaskGroup`, which is considerable. There is a pure asyncio solution, which is a bit more performant, but overhead is still in the same ballpark.

<hr>

This also surfaces some flaws in how we're handling static files, which is what's causing most of the test failures, and would need to be addressed.

<hr>

### Open questions

- Should background tasks be cancelled?
- Should background tasks run if the response hasn't finished due to the client disconnecting?

