### PR TITLE
docs: Add missing port to url

### DIFF
--- a/docs/tutorials/todo-app/1-accessing-the-list.rst
+++ b/docs/tutorials/todo-app/1-accessing-the-list.rst
@@ -138,7 +138,7 @@ returning a normal response, it will send a response with the HTTP status code g
 
 .. figure:: images/done-john.png
 
-    Try to access http://127.0.0.1?done=john now and you will get this error message
+    Try to access http://127.0.0.1:8000?done=john now and you will get this error message
 
 
 Now we've got that out of the way, but your code has grown to be quite complex for such


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

The URL is missing the default port so it doesn't load correctly. I added it like all the other URLs to 127.0.0.1 on the page.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
