### PR TITLE
feat(core): new base middleware

### DIFF
--- a/docs/examples/middleware/abstract_middleware_migration_new.py
+++ b/docs/examples/middleware/abstract_middleware_migration_new.py
@@ -1,0 +1,17 @@
+import anyio
+
+from litestar import Litestar
+from litestar.middleware import ASGIMiddleware
+from litestar.types import ASGIApp, Receive, Scope, Send
+
+
+class TimeoutMiddleware(ASGIMiddleware):
+    def __init__(self, timeout: float):
+        self.timeout = timeout
+
+    async def handle(self, scope: Scope, receive: Receive, send: Send, next_app: ASGIApp) -> None:
+        with anyio.move_on_after(self.timeout):
+            await next_app(scope, receive, send)
+
+
+app = Litestar(middleware=[TimeoutMiddleware(timeout=5)])

--- a/docs/examples/middleware/abstract_middleware_migration_old.py
+++ b/docs/examples/middleware/abstract_middleware_migration_old.py
@@ -1,0 +1,32 @@
+import anyio
+
+from litestar import Litestar
+from litestar.middleware import AbstractMiddleware, DefineMiddleware
+from litestar.types import ASGIApp, Receive, Scope, Scopes, Send
+
+
+class TimeoutMiddleware(AbstractMiddleware):
+    def __init__(
+        self,
+        app: ASGIApp,
+        timeout: float,
+        exclude: str | list[str] | None = None,
+        exclude_opt_key: str | None = None,
+        scopes: Scopes | None = None,
+    ):
+        self.timeout = timeout
+        super().__init__(app=app, exclude=exclude, exclude_opt_key=exclude_opt_key, scopes=scopes)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        with anyio.move_on_after(self.timeout):
+            await self.app(scope, receive, send)
+
+
+app = Litestar(
+    middleware=[
+        DefineMiddleware(
+            TimeoutMiddleware,
+            timeout=5,
+        )
+    ]
+)

--- a/docs/examples/middleware/middleware_protocol_migration_new.py
+++ b/docs/examples/middleware/middleware_protocol_migration_new.py
@@ -1,0 +1,8 @@
+from litestar.middleware import ASGIMiddleware
+from litestar.types import ASGIApp, Receive, Scope, Send
+
+
+class MyMiddleware(ASGIMiddleware):
+    async def handle(self, scope: Scope, receive: Receive, send: Send, next_app: ASGIApp) -> None:
+        # do stuff
+        await next_app(scope, receive, send)

--- a/docs/examples/middleware/middleware_protocol_migration_old.py
+++ b/docs/examples/middleware/middleware_protocol_migration_old.py
@@ -1,0 +1,11 @@
+from litestar.middleware import MiddlewareProtocol
+from litestar.types import ASGIApp, Receive, Scope, Send
+
+
+class MyMiddleware(MiddlewareProtocol):
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # do stuff
+        await self.app(scope, receive, send)

--- a/docs/examples/middleware/request_timing.py
+++ b/docs/examples/middleware/request_timing.py
@@ -1,0 +1,22 @@
+import time
+
+from litestar.datastructures import MutableScopeHeaders
+from litestar.enums import ScopeType
+from litestar.middleware import ASGIMiddleware
+from litestar.types import ASGIApp, Message, Receive, Scope, Send
+
+
+class ProcessTimeHeader(ASGIMiddleware):
+    scopes = (ScopeType.HTTP, ScopeType.ASGI)
+
+    async def handle(self, scope: Scope, receive: Receive, send: Send, next_app: ASGIApp) -> None:
+        start_time = time.monotonic()
+
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                process_time = time.monotonic() - start_time
+                headers = MutableScopeHeaders.from_message(message=message)
+                headers["X-Process-Time"] = str(process_time)
+            await send(message)
+
+        await next_app(scope, receive, send_wrapper)

--- a/docs/examples/middleware/using_asgi_middleware.py
+++ b/docs/examples/middleware/using_asgi_middleware.py
@@ -1,0 +1,62 @@
+import anyio
+
+from litestar import Litestar, get
+from litestar.enums import ScopeType
+from litestar.exceptions import ClientException
+from litestar.middleware import ASGIMiddleware
+from litestar.types import ASGIApp, Receive, Scope, Send
+
+
+class TimeoutMiddleware(ASGIMiddleware):
+    # we can configure some things on the class level here, related to when our
+    # middleware should be applied.
+
+    # if the requests' 'scope["type"]' is not "http", the middleware will be skipped
+    scopes = (ScopeType.HTTP,)
+
+    # if the handler for a request has set an opt of 'no_timeout=True', the middleware
+    # will be skipped
+    exclude_opt_key = "no_timeout"
+
+    # the base class does not define an '__init__' method, so we're free to overwrite
+    # this, which we're making use of to add some configuration
+    def __init__(
+        self,
+        timeout: float,
+        exclude_path_pattern: str | tuple[str, ...] | None = None,
+    ) -> None:
+        self.timeout = timeout
+
+        # we can also dynamically configure the options provided by the base class on
+        # the instance level
+        self.exclude_path_pattern = exclude_path_pattern
+
+    async def handle(self, scope: Scope, receive: Receive, send: Send, next_app: ASGIApp) -> None:
+        try:
+            with anyio.fail_after(self.timeout):
+                # call the next app in the chain
+                await next_app(scope, receive, send)
+        except TimeoutError:
+            # if the request has timed out, raise an exception. since the whole
+            # application is wrapped in an exception handling middleware, it will
+            # transform this exception into a response for us
+            raise ClientException(status_code=408) from None
+
+
+@get("/", no_timeout=True)
+async def handler_with_opt_skip() -> None:
+    pass
+
+
+@get("/not-this-path")
+async def handler_with_path_skip() -> None:
+    pass
+
+
+app = Litestar(
+    route_handlers=[
+        handler_with_opt_skip,
+        handler_with_path_skip,
+    ],
+    middleware=[TimeoutMiddleware(timeout=5)],
+)

--- a/docs/usage/middleware/creating-middleware.rst
+++ b/docs/usage/middleware/creating-middleware.rst
@@ -26,6 +26,21 @@ two base classes you can use for this purpose - the :class:`~litestar.middleware
 which gives a bare-bones type, or the :class:`~litestar.middleware.base.AbstractMiddleware` that offers a
 base class with some built in functionality.
 
+Modifying Requests and Responses
+-------------------------------------
+
+Middlewares can not only be used to execute *around* other ASGI callable, they can also
+intercept and modify both incoming and outgoing data in a request / response cycle by
+"wrapping" the respective ``receive`` and ``send`` ASGI callables.
+
+The following demonstrates how to add a request timing header with a timestamp to all
+outgoing responses:
+
+.. literalinclude:: /examples/middleware/request_timing.py
+    :language: python
+
+
+
 Using MiddlewareProtocol
 ------------------------
 

--- a/docs/usage/middleware/creating-middleware.rst
+++ b/docs/usage/middleware/creating-middleware.rst
@@ -21,13 +21,20 @@ The example previously given was using a factory function, i.e.:
 
        return my_middleware
 
-While using functions is a perfectly viable approach, you can also use classes to do the same. See the next sections on
-two base classes you can use for this purpose - the :class:`~litestar.middleware.base.MiddlewareProtocol` ,
-which gives a bare-bones type, or the :class:`~litestar.middleware.base.AbstractMiddleware` that offers a
-base class with some built in functionality.
+
+Extending ``ASGIMiddleware``
+----------------------------
+
+While using functions is a perfectly viable approach, the recommended way to handle this
+is by using the :class:`~litestar.middleware.ASGIMiddleware` abstract base class, which
+also includes functionality to dynamically skip the middleware based on ASGI
+``scope["type"]``, handler ``opt`` keys or path patterns and a simple way to pass
+configuration to middlewares; It does not implement an ``__init__`` method, so
+subclasses are free to use it to customize the middleware's configuration.
+
 
 Modifying Requests and Responses
--------------------------------------
+++++++++++++++++++++++++++++++++
 
 Middlewares can not only be used to execute *around* other ASGI callable, they can also
 intercept and modify both incoming and outgoing data in a request / response cycle by
@@ -38,6 +45,48 @@ outgoing responses:
 
 .. literalinclude:: /examples/middleware/request_timing.py
     :language: python
+
+
+
+Migrating to ``ASGIMiddleware`` from ``MiddlewareProtocol`` / ``AbstractMiddleware``
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+:class:`~litestar.middleware.ASGIMiddleware` was introduced in Litestar 2.15. If you've
+been using ``MiddlewareProtocol`` / ``AbstractMiddleware`` to implement your middlewares
+before, there's a simple migration path to using ``ASGIMiddleware``.
+
+**Migrating from ``MiddlewareProtocol``**
+
+.. tab-set::
+
+    .. tab-item:: ``MiddlewareProtocol``
+
+        .. literalinclude:: /examples/middleware/middleware_protocol_migration_old.py
+            :language: python
+
+    .. tab-item:: ``ASGIMiddleware``
+
+        .. literalinclude:: /examples/middleware/middleware_protocol_migration_new.py
+            :language: python
+
+
+
+**Migrating from ``AbstractMiddleware``**
+
+.. tab-set::
+
+    .. tab-item:: ``MiddlewareProtocol``
+
+        .. literalinclude:: /examples/middleware/abstract_middleware_migration_old.py
+            :language: python
+
+    .. tab-item:: ``ASGIMiddleware``
+
+        .. literalinclude:: /examples/middleware/abstract_middleware_migration_new.py
+            :language: python
+
+
+
 
 
 
@@ -100,7 +149,7 @@ specifies:
 
 
 Responding using the MiddlewareProtocol
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
++++++++++++++++++++++++++++++++++++++++
 
 Once a middleware finishes doing whatever its doing, it should pass ``scope``, ``receive``, and ``send`` to an ASGI app
 and await it. This is what's happening in the above example with: ``await self.app(scope, receive, send)``. Let's
@@ -130,7 +179,7 @@ As you can see in the above, given some condition (``request.session`` being ``N
 :class:`~litestar.response.redirect.ASGIRedirectResponse` and then await it. Otherwise, we await ``self.app``
 
 Modifying ASGI Requests and Responses using the MiddlewareProtocol
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. important::
 

--- a/litestar/middleware/__init__.py
+++ b/litestar/middleware/__init__.py
@@ -4,11 +4,13 @@ from litestar.middleware.authentication import (
 )
 from litestar.middleware.base import (
     AbstractMiddleware,
+    ASGIMiddleware,
     DefineMiddleware,
     MiddlewareProtocol,
 )
 
 __all__ = (
+    "ASGIMiddleware",
     "AbstractAuthenticationMiddleware",
     "AbstractMiddleware",
     "AuthenticationResult",

--- a/litestar/middleware/_utils.py
+++ b/litestar/middleware/_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Pattern, Sequence
+from typing import TYPE_CHECKING, Iterable, Pattern, Sequence
 
 from litestar.exceptions import ImproperlyConfiguredException
 
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 def build_exclude_path_pattern(
     *,
-    exclude: str | list[str] | None = None,
+    exclude: str | Iterable[str] | None = None,
     middleware_cls: type | None = None,
 ) -> Pattern | None:
     """Build single path pattern from list of patterns to opt-out from middleware processing.
@@ -32,7 +32,7 @@ def build_exclude_path_pattern(
         return None
 
     try:
-        pattern = re.compile("|".join(exclude)) if isinstance(exclude, list) else re.compile(exclude)
+        pattern = re.compile("|".join(exclude)) if not isinstance(exclude, str) else re.compile(exclude)
         if pattern.match("/") and pattern.match("/982c7064-6ac7-44b7-9be5-07a2ff6d8a92"):
             # match a UUID to ensure that it matches paths greedily and not just a literal /
             warn_middleware_excluded_on_all_routes(pattern, middleware_cls=middleware_cls)

--- a/litestar/middleware/base.py
+++ b/litestar/middleware/base.py
@@ -169,6 +169,7 @@ class ASGIMiddleware(abc.ABC):
         An instance of the individual middleware's will be created *once* and used to
         build up the internal middleware stack. As such, middlewares should *not* be
         stateful, as this state will be shared across all requests.
+        Any connection-specific state should be scoped to the `handle` implementation. Not doing so would typically lead to conflicting variable reads/writes across requests, and most likely bugs.
 
     .. example::
 

--- a/litestar/middleware/base.py
+++ b/litestar/middleware/base.py
@@ -9,6 +9,7 @@ from litestar.middleware._utils import (
     build_exclude_path_pattern,
     should_bypass_middleware,
 )
+from litestar.utils.deprecation import warn_deprecation
 
 __all__ = (
     "ASGIMiddleware",
@@ -119,6 +120,14 @@ class AbstractMiddleware:
 
     @classmethod
     def __init_subclass__(cls, **kwargs: Any) -> None:
+        if not cls.__module__.startswith("litestar"):
+            warn_deprecation(
+                version="2.15",
+                deprecated_name="AbstractMiddleware",
+                kind="class",
+                alternative="litestar.middleware.ASGIMiddleware",
+            )
+
         super().__init_subclass__(**kwargs)
 
         original__call__ = cls.__call__

--- a/litestar/middleware/base.py
+++ b/litestar/middleware/base.py
@@ -166,32 +166,33 @@ class ASGIMiddleware(abc.ABC):
     to use it to customize the middleware's configuration.
 
     .. important::
-        An instance of the individual middleware's will be created *once* and used to
+        An instance of the individual middlewares will be created *once* and used to
         build up the internal middleware stack. As such, middlewares should *not* be
         stateful, as this state will be shared across all requests.
-        Any connection-specific state should be scoped to the `handle` implementation. Not doing so would typically lead to conflicting variable reads/writes across requests, and most likely bugs.
-
-    .. example::
-
-        .. code-block:: python
-
-            class MyMiddleware(ASGIMiddleware):
-                scopes = (ScopeType.HTTP,)
-                exclude = ("/not/this/path",)
-                exclude_opt_key = "exclude_my_middleware"
-
-                def __init__(self, my_logger: Logger) -> None:
-                    self.logger = logger
-
-                async def handle(
-                    self, scope: Scope, receive: Receive, send: Send, next_app: ASGIApp
-                ) -> None:
-                    self.logger.debug("Received request for path %s", scope["path"])
-                    await next_app(scope, receive, send)
-                    self.logger.debug("Processed request for path %s", scope["path"])
+        Any connection-specific state should be scoped to the `handle` implementation.
+        Not doing so would typically lead to conflicting variable reads / writes across
+        requests, and - most likely - bugs.
 
 
-            app = Litestar(..., middleware=[MyMiddleware(logger=my_logger)])
+    .. code-block:: python
+
+        class MyMiddleware(ASGIMiddleware):
+            scopes = (ScopeType.HTTP,)
+            exclude = ("/not/this/path",)
+            exclude_opt_key = "exclude_my_middleware"
+
+            def __init__(self, my_logger: Logger) -> None:
+                self.logger = logger
+
+            async def handle(
+                self, scope: Scope, receive: Receive, send: Send, next_app: ASGIApp
+            ) -> None:
+                self.logger.debug("Received request for path %s", scope["path"])
+                await next_app(scope, receive, send)
+                self.logger.debug("Processed request for path %s", scope["path"])
+
+
+        app = Litestar(..., middleware=[MyMiddleware(logger=my_logger)])
 
     .. versionadded:: 2.15
     """
@@ -214,7 +215,7 @@ class ASGIMiddleware(abc.ABC):
         async def middleware(scope: Scope, receive: Receive, send: Send) -> None:
             if should_bypass_middleware(
                 scope=scope,
-                scopes=scopes,
+                scopes=scopes,  # type: ignore[arg-type]
                 exclude_opt_key=exclude_opt_key,
                 exclude_path_pattern=exclude_pattern,
             ):

--- a/tests/unit/test_middleware/test_base_middleware.py
+++ b/tests/unit/test_middleware/test_base_middleware.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING, List, Tuple, Union
 from warnings import catch_warnings
 
 import pytest
@@ -6,13 +6,13 @@ import pytest
 from litestar import MediaType, asgi, get
 from litestar.datastructures.headers import MutableScopeHeaders
 from litestar.exceptions import LitestarWarning, ValidationException
-from litestar.middleware import AbstractMiddleware, DefineMiddleware
+from litestar.middleware import AbstractMiddleware, ASGIMiddleware, DefineMiddleware
 from litestar.response.base import ASGIResponse
 from litestar.status_codes import HTTP_400_BAD_REQUEST
 from litestar.testing import create_test_client
 
 if TYPE_CHECKING:
-    from litestar.types import Message, Receive, Scope, Send
+    from litestar.types import ASGIApp, Message, Receive, Scope, Send
 
 
 def test_custom_middleware() -> None:
@@ -166,5 +166,166 @@ def test_exclude_by_opt_key() -> None:
         return {"hello": "world"}
 
     with create_test_client(handler, middleware=[DefineMiddleware(SubclassMiddleware)]) as client:
+        response = client.get("/")
+        assert "test" not in response.headers
+
+
+def test_abstract_middleware_deprecation_warning() -> None:
+    with pytest.warns(DeprecationWarning, match="AbstractMiddleware"):
+
+        class MyMiddleware(AbstractMiddleware):
+            pass
+
+
+def test_asgi_middleware() -> None:
+    class SubclassMiddleware(ASGIMiddleware):
+        async def handle(self, scope: "Scope", receive: "Receive", send: "Send", next_app: "ASGIApp") -> None:
+            async def _send(message: "Message") -> None:
+                if message["type"] == "http.response.start":
+                    headers = MutableScopeHeaders(message)
+                    headers.add("test", str(123))
+                await send(message)
+
+            await next_app(scope, receive, _send)
+
+    @get("/")
+    def handler() -> dict:
+        return {"hello": "world"}
+
+    with create_test_client(handler, middleware=[SubclassMiddleware()]) as client:
+        response = client.get("/")
+        assert response.headers["test"] == "123"
+
+
+def test_asgi_middleware_raises_exception() -> None:
+    class SubclassMiddleware(ASGIMiddleware):
+        async def handle(self, scope: "Scope", receive: "Receive", send: "Send", next_app: "ASGIApp") -> None:
+            raise ValidationException(detail="nope")
+
+    @get("/")
+    def handler() -> dict:
+        return {"hello": "world"}
+
+    with create_test_client(handler, middleware=[SubclassMiddleware()]) as client:
+        response = client.get("/")
+        assert response.status_code == HTTP_400_BAD_REQUEST
+
+
+def test_asgi_middleware_exclude_by_pattern() -> None:
+    class SubclassMiddleware(ASGIMiddleware):
+        def __init__(self) -> None:
+            self.exclude_path_pattern = r"^/123"
+
+        async def handle(self, scope: "Scope", receive: "Receive", send: "Send", next_app: "ASGIApp") -> None:
+            async def _send(message: "Message") -> None:
+                if message["type"] == "http.response.start":
+                    headers = MutableScopeHeaders(message)
+                    headers.add("test", str(123))
+                await send(message)
+
+            await next_app(scope, receive, _send)
+
+    @get("/123")
+    def first_handler() -> dict:
+        return {"hello": "world"}
+
+    @get("/456")
+    def second_handler() -> dict:
+        return {"hello": "world"}
+
+    @asgi("/mount", is_mount=True)
+    async def handler(scope: "Scope", receive: "Receive", send: "Send") -> None:
+        response = ASGIResponse(body=b"ok", media_type=MediaType.TEXT)
+        await response(scope, receive, send)
+
+    with create_test_client([first_handler, second_handler, handler], middleware=[SubclassMiddleware()]) as client:
+        response = client.get("/123")
+        assert "test" not in response.headers
+
+        response = client.get("/456")
+        assert "test" in response.headers
+
+        response = client.get("/mount/123")
+        assert "test" in response.headers
+
+
+def test_asgi_middleware_exclude_by_pattern_tuple() -> None:
+    class SubclassMiddleware(ASGIMiddleware):
+        exclude_path_pattern = ("123", "456")
+
+        async def handle(self, scope: "Scope", receive: "Receive", send: "Send", next_app: "ASGIApp") -> None:
+            async def _send(message: "Message") -> None:
+                if message["type"] == "http.response.start":
+                    headers = MutableScopeHeaders(message)
+                    headers.add("test", str(123))
+                await send(message)
+
+            await next_app(scope, receive, _send)
+
+    @get("/123")
+    def first_handler() -> dict:
+        return {"hello": "world"}
+
+    @get("/456")
+    def second_handler() -> dict:
+        return {"hello": "world"}
+
+    @get("/789")
+    def third_handler() -> dict:
+        return {"hello": "world"}
+
+    with create_test_client(
+        [first_handler, second_handler, third_handler], middleware=[SubclassMiddleware()]
+    ) as client:
+        response = client.get("/123")
+        assert "test" not in response.headers
+        response = client.get("/456")
+        assert "test" not in response.headers
+        response = client.get("/789")
+        assert "test" in response.headers
+
+
+@pytest.mark.parametrize("excludes", ["/", ("/", "/foo"), "/*", "/.*"])
+def test_asgi_middleware_exclude_by_pattern_warns_if_exclude_all(excludes: Union[str, Tuple[str, ...]]) -> None:
+    class SubclassMiddleware(ASGIMiddleware):
+        exclude_path_pattern = excludes
+
+        async def handle(self, scope: "Scope", receive: "Receive", send: "Send", next_app: "ASGIApp") -> None:
+            await next_app(scope, receive, send)
+
+    with pytest.warns(LitestarWarning, match="Middleware 'SubclassMiddleware' exclude pattern"):
+        create_test_client(middleware=[SubclassMiddleware()])
+
+
+def test_asgi_middleware_exclude_doesnt_warn_on_non_greedy_pattern() -> None:
+    class SubclassMiddleware(ASGIMiddleware):
+        exclude_path_pattern = "^/$"
+
+        async def handle(self, scope: "Scope", receive: "Receive", send: "Send", next_app: "ASGIApp") -> None:
+            await next_app(scope, receive, send)
+
+    with catch_warnings(record=True) as warnings:
+        create_test_client(middleware=[SubclassMiddleware()])
+        assert len(warnings) == 0
+
+
+def test_asgi_middleware_exclude_by_opt_key() -> None:
+    class SubclassMiddleware(ASGIMiddleware):
+        exclude_opt_key = "exclude_route"
+
+        async def handle(self, scope: "Scope", receive: "Receive", send: "Send", next_app: "ASGIApp") -> None:
+            async def _send(message: "Message") -> None:
+                if message["type"] == "http.response.start":
+                    headers = MutableScopeHeaders(message)
+                    headers.add("test", str(123))
+                await send(message)
+
+                await next_app(scope, receive, send)
+
+    @get("/", exclude_route=True)
+    def handler() -> dict:
+        return {"hello": "world"}
+
+    with create_test_client(handler, middleware=[SubclassMiddleware()]) as client:
         response = client.get("/")
         assert "test" not in response.headers


### PR DESCRIPTION
Add a new base middleware class to facilitate easier configuration and middleware dispatching.

The new `ASGIMiddleware` features the same functionality as the `AbstractMiddleware`, but makes it easier to pass configuration directly to middleware classes without a separate configuration object, allowing to get rid of the `DefineMiddleware` pattern entirely.

<hr> 

If we are to add this, I propose we do so in v2, and migrate existing middlewares to this pattern in v3.