### PR TITLE
docs: Fix casing in name of ValkeyStore

### DIFF
--- a/docs/usage/stores.rst
+++ b/docs/usage/stores.rst
@@ -35,7 +35,7 @@ Built-in stores
     A store backend by `redis <https://redis.io/>`_. It offers all the guarantees and features of Redis, making it
     suitable for almost all applications. Offers `namespacing`_.
 
-:class:`ValKeyStore <litestar.stores.valkey.ValkeyStore>`
+:class:`ValkeyStore <litestar.stores.valkey.ValkeyStore>`
     A store backed by `valkey <https://valkey.io>`_, a fork of Redis created as the result of Redis' license changes.
     Similarly to the RedisStore, it is suitable for almost all applications and supports `namespacing`_.
     At the time of writing, :class:`Valkey <valkey.asyncio.Valkey>` is equivalent to :class:`redis.asyncio.Redis`,


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

In https://docs.litestar.dev/2/usage/stores.html#built-in-stores, `ValkeyStore` is wrongly spelt `ValKeyStore`.
