### PR TITLE
fix: check for default headers before appending to cors header failures

### DIFF
--- a/litestar/middleware/_internal/cors.py
+++ b/litestar/middleware/_internal/cors.py
@@ -50,7 +50,11 @@ class CORSMiddleware(AbstractMiddleware):
             )
             await asgi_response(scope, receive, send)
         elif origin:
-            await self.app(scope, receive, self.send_wrapper(send=send, origin=origin, has_cookie="cookie" in headers))
+            await self.app(
+                scope,
+                receive,
+                self.send_wrapper(send=send, origin=origin, has_cookie="cookie" in headers),
+            )
         else:
             await self.app(scope, receive, send)
 
@@ -113,7 +117,13 @@ class CORSMiddleware(AbstractMiddleware):
                 response_headers["Access-Control-Allow-Headers"] = ", ".join(
                     sorted(set(pre_flight_requested_headers) | DEFAULT_ALLOWED_CORS_HEADERS)  # pyright: ignore
                 )
-            elif any(header.lower() not in self.config.allow_headers for header in pre_flight_requested_headers):
+            elif any(
+                header.lower()
+                not in set(self.config.allow_headers).union(
+                    default_header.lower() for default_header in DEFAULT_ALLOWED_CORS_HEADERS
+                )
+                for header in pre_flight_requested_headers
+            ):
                 failures.append("headers")
 
         return (

--- a/litestar/middleware/_internal/cors.py
+++ b/litestar/middleware/_internal/cors.py
@@ -113,14 +113,12 @@ class CORSMiddleware(AbstractMiddleware):
                 response_headers["Access-Control-Allow-Headers"] = ", ".join(
                     sorted(set(pre_flight_requested_headers) | DEFAULT_ALLOWED_CORS_HEADERS)  # pyright: ignore
                 )
-            elif any(
-                header.lower()
-                not in set(self.config.allow_headers).union(
+            else:
+                all_allowed_headers = set(self.config.allow_headers).union(
                     default_header.lower() for default_header in DEFAULT_ALLOWED_CORS_HEADERS
                 )
-                for header in pre_flight_requested_headers
-            ):
-                failures.append("headers")
+                if any(header.lower() not in all_allowed_headers for header in pre_flight_requested_headers):
+                    failures.append("headers")
 
         return (
             Response(

--- a/litestar/middleware/_internal/cors.py
+++ b/litestar/middleware/_internal/cors.py
@@ -50,11 +50,7 @@ class CORSMiddleware(AbstractMiddleware):
             )
             await asgi_response(scope, receive, send)
         elif origin:
-            await self.app(
-                scope,
-                receive,
-                self.send_wrapper(send=send, origin=origin, has_cookie="cookie" in headers),
-            )
+            await self.app(scope, receive, self.send_wrapper(send=send, origin=origin, has_cookie="cookie" in headers))
         else:
             await self.app(scope, receive, send)
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Some clients sometimes apparently (AFAIK needlessly) check OPTIONS even if they only have CORS-safelisted headers to ask about; I ran into this with [Dio](https://pub.dev/packages/dio). I see no reason to allow I guess?

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
