### PR TITLE
docs: improve github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -1,8 +1,11 @@
 name: "Bug Report"
 description: Create an issue for a bug.
 title: "Bug: <title>"
-labels: ["Bug :bug:", "Triage Required"]
-projects: ["litestar-org/16"]
+labels:
+  - "Bug :bug:"
+  - "Triage Required"
+projects:
+  - "litestar-org/16"
 body:
   - type: textarea
     id: description
@@ -24,11 +27,17 @@ body:
     id: mcve
     attributes:
       label: "MCVE"
-      description: "Please provide a minimal, complete, and verifiable example of the issue."
-      value: |
-        ```py
-        # Your MCVE code here
-        ```
+      description: >-
+        Please provide a minimal, complete, and verifiable example of the issue.
+        This will be automatically formatted into code, so no need for backticks.
+      placeholder: |
+        from litestar import Litestar, get
+
+        @get("/")
+        def hello_world() -> str:
+            return "hello world"
+
+        app = Litestar(route_handlers=[hello_world])
       render: python
     validations:
       required: false
@@ -42,7 +51,6 @@ body:
         2. Click on '....'
         3. Scroll down to '....'
         4. See error
-      render: bash
     validations:
       required: false
   - type: textarea
@@ -50,20 +58,20 @@ body:
     attributes:
       label: "Screenshots"
       description: If applicable, add screenshots to help explain your problem.
-      value: |
-        "![SCREENSHOT_DESCRIPTION](SCREENSHOT_LINK.png)"
-      render: bash
+      placeholder: Drag-and-drop images up add them directly or use Markdown to embed external images.
     validations:
       required: false
   - type: textarea
     id: logs
     attributes:
       label: "Logs"
-      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-      render: bash
+      description: >-
+        Please copy and paste any relevant log output.
+        This will be automatically formatted into code, so no need for backticks.
+      render: text
     validations:
       required: false
-  - type: textarea
+  - type: input
     id: version
     attributes:
       label: "Litestar Version"

--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -71,7 +71,7 @@ body:
       render: text
     validations:
       required: false
-  - type: input
+  - type: textarea
     id: version
     attributes:
       label: "Litestar Version"

--- a/.github/ISSUE_TEMPLATE/DOCS.yml
+++ b/.github/ISSUE_TEMPLATE/DOCS.yml
@@ -1,8 +1,10 @@
 name: "Documentation Update"
 description: Create an issue for documentation changes
 title: "Docs: <title>"
-labels: ["Documentation :books:"]
-projects: ["litestar-org/16"]
+labels:
+  - "Documentation :books:"
+projects:
+  - "litestar-org/16"
 body:
   - type: textarea
     id: summary

--- a/.github/ISSUE_TEMPLATE/REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/REQUEST.yml
@@ -1,8 +1,10 @@
 name: "Feature Request"
 description: Create an issue for a new feature request
 title: "Enhancement: <title>"
-labels: ["Enhancement"]
-projects: ["litestar-org/16"]
+labels:
+  - "Enhancement"
+projects:
+  - "litestar-org/16"
 body:
   - type: textarea
     id: summary


### PR DESCRIPTION
## Description

This simple pull request improves GitHub issues templates, as the BUG.yaml was quite frustating when I created #4016

Before:
![Screenshot 2025-02-19 at 18 23 03](https://github.com/user-attachments/assets/f244b7fc-5fee-43e5-a005-8bb3e019c43a)

After:
![Screenshot 2025-02-19 at 18 12 18](https://github.com/user-attachments/assets/106586c0-429b-4668-821c-a72ba1b58ca5)


Summary of changes:

- Changed image upload textarea to a WYSIWYG to allow hosting images on GitHub instead of forcing raw markdown.
- To ensure consistency in the, changed JSON lists to YAML lists.
- Improved descriptions and placeholders

