### PR TITLE
ci: Add aggregate test step to allow for dynamic test matrix jobs to be requried checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,19 @@ jobs:
       coverage: ${{ (matrix.python-version == '3.12' || matrix.python-version == '3.8') }}
       python-version: ${{ matrix.python-version }}
 
+  # add an aggregate step here to check if any of the steps of the matrix 'test' job
+  # failed. this allows us to have dynamic or diverging steps in the matrix, while still
+  # being able to mark the 'test' step as a required check for a PR to be considered
+  # mergeable, without having to specify each individual matrix item.
+  test_success:
+    needs: test
+    # ensure this step always runs
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report success or fail
+        run: exit ${{ needs.test.result == 'success' && '0' || '1' }}
+
   test_integration:
     name: Test server integration
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add an 'aggregate' step that fails if one of the matrix jobs from the `test` job fail, so we can target this aggregate job as "required check" instead of the individual matrix jobs. 

This allows us to e.g. have a `3.8` matrix job on one branch but not on the other, while still making the run fail if any of the matrix jobs fails.