### PR TITLE
docs: fix typos in channels and responses

### DIFF
--- a/docs/usage/channels.rst
+++ b/docs/usage/channels.rst
@@ -316,7 +316,7 @@ There are two general methods of consuming the :term:`event stream`:
    which starts a background task, iterating over the stream, invoking a provided
    callback for every :term:`event` received
 
-Iterating over the :term:`steam <event stream>` directly is mostly useful if processing the events is the only
+Iterating over the :term:`stream <event stream>` directly is mostly useful if processing the events is the only
 concern, since :meth:`iter_events <Subscriber.iter_events>` is effectively an infinite
 loop. For all other applications, using the context manager is preferable, since it
 allows to easily run other code concurrently.

--- a/docs/usage/responses.rst
+++ b/docs/usage/responses.rst
@@ -690,7 +690,7 @@ In your iterator function you can yield integers, strings or bytes, the message 
 as the ``event_type`` if the ServerSentEvent has no ``event_type`` set, otherwise it will use the ``event_type``
 specified, and the data will be the yielded value.
 
-If you want to send a different event type, you can use a dictionary with the keys ``event_type`` and ``data`` or the :class:`ServerSentMessage <.response.ServerSentEventMessage>` class.
+If you want to send a different event type, you can use a dictionary with the keys ``event_type`` and ``data`` or the :class:`ServerSentEventMessage <.response.ServerSentEventMessage>` class.
 
 .. note::
 


### PR DESCRIPTION
- Fix simple typos
