### PR TITLE
feat: Remove starlette middleware compat

### DIFF
--- a/docs/examples/application_state/using_application_state.py
+++ b/docs/examples/application_state/using_application_state.py
@@ -16,7 +16,7 @@ def set_state_on_startup(app: Litestar) -> None:
     app.state.value = "abc123"
 
 
-def middleware_factory(*, app: "ASGIApp") -> "ASGIApp":
+def middleware_factory(app: "ASGIApp") -> "ASGIApp":
     """A middleware can access application state via `scope`."""
 
     async def my_middleware(scope: "Scope", receive: "Receive", send: "Send") -> None:

--- a/docs/release-notes/whats-new-3.rst
+++ b/docs/release-notes/whats-new-3.rst
@@ -245,6 +245,25 @@ this functionality are now required to inherit from
 :class:`~.plugins.OpenAPISchemaPlugin`.
 
 
+Dropped support for starlette middleware protocol
+-------------------------------------------------
+
+The `starlette middleware protocol <https://www.starlette.io/middleware>`_ is no longer
+supported.
+
+Only the "factory" pattern will now be supported, i.e. a callable that receives an ASGI
+callable as its only argument and returns another ASGI callable:
+
+.. code-block:: python
+
+    def middleware(app: ASGIApp) -> ASGIApp:
+        ...
+
+
+.. seealso::
+    :doc:`/usage/middleware/index`
+
+
 Removal of ``SerializationPluginProtocol``
 ------------------------------------------
 

--- a/litestar/_asgi/routing_trie/mapping.py
+++ b/litestar/_asgi/routing_trie/mapping.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
 from litestar._asgi.routing_trie.types import (
     ASGIHandlerTuple,
@@ -215,9 +215,5 @@ def build_route_middleware_stack(
             asgi_handler = AllowedHostsMiddleware(app=asgi_handler, config=app.allowed_hosts)
 
         for middleware in handler_middleware:
-            if hasattr(middleware, "__iter__"):
-                handler, kwargs = cast("tuple[Any, dict[str, Any]]", middleware)
-                asgi_handler = handler(app=asgi_handler, **kwargs)
-            else:
-                asgi_handler = middleware(app=asgi_handler)  # type: ignore[call-arg]
+            asgi_handler = middleware(asgi_handler)
     return asgi_handler

--- a/litestar/types/composite_types.py
+++ b/litestar/types/composite_types.py
@@ -22,7 +22,7 @@ __all__ = (
 
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping, MutableMapping, Sequence
+    from collections.abc import Mapping, MutableMapping, Sequence
     from os import PathLike
     from pathlib import Path
 
@@ -32,7 +32,6 @@ if TYPE_CHECKING:
     from litestar.datastructures.response_header import ResponseHeader
     from litestar.di import Provide
     from litestar.enums import ScopeType
-    from litestar.middleware.base import DefineMiddleware, MiddlewareProtocol
     from litestar.params import ParameterKwarg
 
     from .asgi_types import ASGIApp
@@ -40,7 +39,7 @@ if TYPE_CHECKING:
 
 Dependencies: TypeAlias = "Mapping[str, Union[Provide, AnyCallable]]"
 ExceptionHandlersMap: TypeAlias = "MutableMapping[Union[int, type[Exception]], ExceptionHandler]"
-Middleware: TypeAlias = "Union[Callable[..., ASGIApp], DefineMiddleware, Iterator[tuple[ASGIApp, dict[str, Any]]], type[MiddlewareProtocol]]"
+Middleware: TypeAlias = Callable[..., "ASGIApp"]
 ParametersMap: TypeAlias = "Mapping[str, ParameterKwarg]"
 PathType: TypeAlias = "Union[Path, PathLike, str]"
 ResponseCookies: TypeAlias = "Union[Sequence[Cookie], Mapping[str, str]]"

--- a/tests/unit/test_asgi/test_routing_trie/test_mapping.py
+++ b/tests/unit/test_asgi/test_routing_trie/test_mapping.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -42,36 +40,8 @@ def test_build_route_middleware_stack_with_middleware(monkeypatch: pytest.Monkey
     route = HTTPRoute(path="/", route_handlers=[handler])
     build_route_middleware_stack(app=Litestar(), route=route, route_handler=handler)
     mock_middleware.assert_called_once()
-    ((_, kw_args),) = mock_middleware.call_args_list
-    assert isinstance(kw_args["app"], ExceptionHandlerMiddleware)
 
-
-def test_build_route_middleware_stack_with_starlette_middleware(monkeypatch: pytest.MonkeyPatch) -> None:
-    # test our support for starlette's Middleware class
-    class Middleware:
-        """A Starlette ``Middleware`` class.
-
-        See https://github.com/encode/starlette/blob/23c81da94b57701eabd43f582093442e6811f81d/starlette/middleware/__init__.py#L4-L17
-        """
-
-        def __init__(self, cls: Any, **options: Any) -> None:
-            self.cls = cls
-            self.options = options
-
-        def __iter__(self) -> Iterator[Any]:
-            as_tuple = (self.cls, self.options)
-            return iter(as_tuple)
-
-    mock_middleware = MagicMock()
-    mock_middleware_arg = MagicMock()
-    del mock_middleware.__iter__
-
-    @get("/", middleware=[Middleware(mock_middleware, arg=mock_middleware_arg)])  # type: ignore[list-item]
-    async def handler() -> None:
-        pass
-
-    route = HTTPRoute(path="/", route_handlers=[handler])
-    build_route_middleware_stack(app=Litestar(), route=route, route_handler=handler)
-    ((_, kw_args),) = mock_middleware.call_args_list
-    assert isinstance(kw_args["app"], ExceptionHandlerMiddleware)
-    assert kw_args["arg"] is mock_middleware_arg
+    call_args = mock_middleware.call_args_list[0]
+    assert len(call_args.args) == 1
+    assert isinstance(call_args.args[0], ExceptionHandlerMiddleware)
+    assert not call_args.kwargs


### PR DESCRIPTION
Remove support for the starlette middleware protocol. 

This was added as a backwards compatibility fix when we transition away from the starlette dependency. 