### PR TITLE
docs: Use "click to toggle" instead of "click to expand"

### DIFF
--- a/docs/tutorials/repository-tutorial/01-modeling-and-features.rst
+++ b/docs/tutorials/repository-tutorial/01-modeling-and-features.rst
@@ -83,7 +83,7 @@ Let's build on this as we look at the repository classes.
 Full Code
 ---------
 
-.. dropdown:: Full Code (click to expand)
+.. dropdown:: Full Code (click to toggle)
 
     .. literalinclude:: /examples/contrib/sqlalchemy/sqlalchemy_declarative_models.py
         :language: python

--- a/docs/tutorials/repository-tutorial/02-repository-introduction.rst
+++ b/docs/tutorials/repository-tutorial/02-repository-introduction.rst
@@ -221,7 +221,7 @@ functionality to a :class:`~litestar.controller.Controller`!
 Full Code
 ---------
 
-.. dropdown:: Full Code (click to expand)
+.. dropdown:: Full Code (click to toggle)
 
     .. literalinclude:: /examples/contrib/sqlalchemy/sqlalchemy_repository_crud.py
         :language: python

--- a/docs/tutorials/repository-tutorial/03-repository-controller.rst
+++ b/docs/tutorials/repository-tutorial/03-repository-controller.rst
@@ -37,7 +37,7 @@ option. This option configures the specified relationship to load via
 Next, we define the ``AuthorController``. This controller exposes five routes for
 interacting with the ``Author`` model:
 
-.. dropdown:: AuthorController (click to expand)
+.. dropdown:: ``AuthorController`` (click to toggle)
 
     .. literalinclude:: /examples/contrib/sqlalchemy/sqlalchemy_async_repository.py
         :language: python
@@ -52,7 +52,7 @@ In the above examples, we've used the asynchronous repository implementation. Ho
 Litestar also supports synchronous database drivers with an identical implementation.
 Here's a corresponding synchronous version of the previous example:
 
-.. dropdown:: Synchronous Repository (click to expand)
+.. dropdown:: Synchronous Repository (click to toggle)
 
     .. literalinclude:: /examples/contrib/sqlalchemy/sqlalchemy_sync_repository.py
         :language: python
@@ -68,7 +68,7 @@ functionality to our application.
 Full Code
 ---------
 
-.. dropdown:: Full Code (click to expand)
+.. dropdown:: Full Code (click to toggle)
 
     .. literalinclude:: /examples/contrib/sqlalchemy/sqlalchemy_async_repository.py
         :language: python

--- a/docs/tutorials/repository-tutorial/04-repository-other.rst
+++ b/docs/tutorials/repository-tutorial/04-repository-other.rst
@@ -59,7 +59,7 @@ Finally, we insert the model with the added slug.
 Full Code
 ---------
 
-.. dropdown:: Full Code (click to expand)
+.. dropdown:: Full Code (click to toggle)
 
     .. literalinclude:: /examples/contrib/sqlalchemy/sqlalchemy_repository_extension.py
         :language: python

--- a/docs/usage/channels.rst
+++ b/docs/usage/channels.rst
@@ -30,7 +30,7 @@ terminology, and the flow of data, the following glossary and flowcharts are pro
 Glossary
 ++++++++
 
-.. dropdown:: Click to expand glossary
+.. dropdown:: Click to toggle the glossary
 
     .. glossary::
 
@@ -94,7 +94,7 @@ Glossary
 Flowcharts
 ++++++++++
 
-.. dropdown:: Click to expand flowcharts
+.. dropdown:: Click to toggle flowcharts
 
     .. mermaid::
         :align: center

--- a/docs/usage/security/guards.rst
+++ b/docs/usage/security/guards.rst
@@ -25,7 +25,7 @@ We begin by creating an :class:`~enum.Enum` with two roles - ``consumer`` and ``
 
 Our ``User`` model will now look like this:
 
-.. dropdown:: Click to expand the User model
+.. dropdown:: Click to toggle the model ``User``
 
     .. code-block:: python
         :caption: User model for role based authorization
@@ -52,7 +52,7 @@ Given that the ``User`` model has a ``role`` property we can use it to authorize
 Let us create a guard that only allows admin users to access certain route handlers and then add it to a route
 handler function:
 
-.. dropdown:: Click to expand the ``admin_user_guard`` guard
+.. dropdown:: Click to toggle the guard ``admin_user_guard``
 
     .. code-block:: python
         :caption: Defining the ``admin_user_guard`` guard used to authorize certain route handlers


### PR DESCRIPTION
By submitting this pull request, I agree to:

- [x] follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md);
- [x] follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md);
- [x] follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/).

## Description

"click to expand" was replaced with "click to toggle" as the action both expands and collapses a section, thus the term "toggle" is more suitable as it works both ways.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Not applicable.