### PR TITLE
fix: Fix #4035 - incorrect deprecation warning issued when subclassing middlewares

### DIFF
--- a/litestar/middleware/base.py
+++ b/litestar/middleware/base.py
@@ -120,7 +120,10 @@ class AbstractMiddleware:
 
     @classmethod
     def __init_subclass__(cls, **kwargs: Any) -> None:
-        if not cls.__module__.startswith("litestar"):
+        if not any(c.__module__.startswith("litestar") and c is not AbstractMiddleware for c in cls.mro()):
+            # we don't want to warn about usage of 'AbstractMiddleware' if users aren't
+            # directly subclassing it, i.e. they're subclassing another Litestar
+            # middleware which itself subclasses 'AbstractMiddleware'
             warn_deprecation(
                 version="2.15",
                 deprecated_name="AbstractMiddleware",


### PR DESCRIPTION
Fix a bug introduced in #3996 that would incorrectly issue a deprecation warning if a user subclassed a Litestar built-in middleware which itself subclasses `AbstractMiddleware`.

Fix consists of checking the mro to ensure we're only warning if the subclass has `AbstractMiddleware` as a direct ancestor within the user code.

Fix #4035