### PR TITLE
docs: Make the spelling of "modelling" consistent

### DIFF
--- a/docs/tutorials/repository-tutorial/01-modelling-and-features.rst
+++ b/docs/tutorials/repository-tutorial/01-modelling-and-features.rst
@@ -1,14 +1,14 @@
-Introduction to Database Modeling and Repository Features
----------------------------------------------------------
+Introduction to Database Modelling and Repository Features
+----------------------------------------------------------
 In this tutorial, we will cover the integrated repository features in Litestar, starting
-with database modeling using the included SQLAlchemy declarative model helpers. These
+with database modelling using the included SQLAlchemy declarative model helpers. These
 are a series of classes and mixins that incorporate commonly used functions/column types
 to make working with models easier.
 
 .. tip:: The full code for this tutorial can be found below in the :ref:`Full Code <01-repo-full-code>` section.
 
-Modeling
---------
+Modelling
+---------
 
 We'll begin by modelling the entities and relationships between authors and books.
 We'll start by creating the ``Author`` table, utilizing the

--- a/docs/tutorials/repository-tutorial/02-repository-introduction.rst
+++ b/docs/tutorials/repository-tutorial/02-repository-introduction.rst
@@ -1,6 +1,6 @@
 Interacting with repositories
 -----------------------------
-Now that we've covered the modeling basics, we are able to create our first repository
+Now that we've covered the modelling basics, we are able to create our first repository
 class.  The repository classes include all of the standard CRUD operations as well as a
 few advanced features such as pagination, filtering and bulk operations.
 

--- a/docs/tutorials/repository-tutorial/index.rst
+++ b/docs/tutorials/repository-tutorial/index.rst
@@ -17,7 +17,7 @@ databases a breeze. Lets get started!
 .. toctree::
     :hidden:
 
-    01-modeling-and-features
+    01-modelling-and-features
     02-repository-introduction
     03-repository-controller
     04-repository-other

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -309,8 +309,8 @@ class Litestar(Router):
             security: A sequence of dicts that will be added to the schema of all route handlers in the application.
                 See
                 :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>` for details.
-            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modeling.
-            signature_types: A sequence of types for use in forward reference resolution during signature modeling.
+            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
+            signature_types: A sequence of types for use in forward reference resolution during signature modelling.
                 These types will be added to the signature namespace using their ``__name__`` attribute.
             state: An optional :class:`State <.datastructures.State>` for application state.
             static_files_config: A sequence of :class:`StaticFilesConfig <.static_files.StaticFilesConfig>`

--- a/litestar/config/app.py
+++ b/litestar/config/app.py
@@ -193,9 +193,9 @@ class AppConfig:
     :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>` for details.
     """
     signature_namespace: dict[str, Any] = field(default_factory=dict)
-    """A mapping of names to types for use in forward reference resolution during signature modeling."""
+    """A mapping of names to types for use in forward reference resolution during signature modelling."""
     signature_types: list[Any] = field(default_factory=list)
-    """A sequence of types for use in forward reference resolution during signature modeling.
+    """A sequence of types for use in forward reference resolution during signature modelling.
 
     These types will be added to the signature namespace using their ``__name__`` attribute.
     """

--- a/litestar/controller.py
+++ b/litestar/controller.py
@@ -159,9 +159,9 @@ class Controller:
     security: Sequence[SecurityRequirement] | None
     """A sequence of dictionaries that to the schema of all route handlers under the controller."""
     signature_namespace: dict[str, Any]
-    """A mapping of names to types for use in forward reference resolution during signature modeling."""
+    """A mapping of names to types for use in forward reference resolution during signature modelling."""
     signature_types: Sequence[Any]
-    """A sequence of types for use in forward reference resolution during signature modeling.
+    """A sequence of types for use in forward reference resolution during signature modelling.
 
     These types will be added to the signature namespace using their ``__name__`` attribute.
     """

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -113,7 +113,7 @@ class BaseRouteHandler:
                 outbound response data.
             signature_namespace: A mapping of names to types for use in forward reference resolution during signature
                 modelling.
-            signature_types: A sequence of types for use in forward reference resolution during signature modeling.
+            signature_types: A sequence of types for use in forward reference resolution during signature modelling.
                 These types will be added to the signature namespace using their ``__name__`` attribute.
             type_decoders: A sequence of tuples, each composed of a predicate testing for type identity and a msgspec hook for deserialization.
             type_encoders: A mapping of types to callables that transform them into types supported for serialization.

--- a/litestar/router.py
+++ b/litestar/router.py
@@ -160,8 +160,8 @@ class Router:
             security: A sequence of dicts that will be added to the schema of all route handlers in the application.
                 See :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>`
                 for details.
-            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modeling.
-            signature_types: A sequence of types for use in forward reference resolution during signature modeling.
+            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
+            signature_types: A sequence of types for use in forward reference resolution during signature modelling.
                 These types will be added to the signature namespace using their ``__name__`` attribute.
             tags: A sequence of string tags that will be appended to the schema of all route handlers under the
                 application.

--- a/litestar/testing/helpers.py
+++ b/litestar/testing/helpers.py
@@ -222,8 +222,8 @@ def create_test_client(
         security: A sequence of dicts that will be added to the schema of all route handlers in the application.
             See
             :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>` for details.
-        signature_namespace: A mapping of names to types for use in forward reference resolution during signature modeling.
-        signature_types: A sequence of types for use in forward reference resolution during signature modeling.
+        signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
+        signature_types: A sequence of types for use in forward reference resolution during signature modelling.
             These types will be added to the signature namespace using their ``__name__`` attribute.
         state: An optional :class:`State <.datastructures.State>` for application state.
         static_files_config: A sequence of :class:`StaticFilesConfig <.static_files.StaticFilesConfig>`
@@ -483,8 +483,8 @@ def create_async_test_client(
         security: A sequence of dicts that will be added to the schema of all route handlers in the application.
             See
             :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>` for details.
-        signature_namespace: A mapping of names to types for use in forward reference resolution during signature modeling.
-        signature_types: A sequence of types for use in forward reference resolution during signature modeling.
+        signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
+        signature_types: A sequence of types for use in forward reference resolution during signature modelling.
             These types will be added to the signature namespace using their ``__name__`` attribute.
         state: An optional :class:`State <.datastructures.State>` for application state.
         static_files_config: A sequence of :class:`StaticFilesConfig <.static_files.StaticFilesConfig>`


### PR DESCRIPTION
By submitting this pull request, I agree to:

- [x] follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md);
- [x] follow Litestar's [contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md);
- [x] follow the PSF's [Code of Conduct](https://www.python.org/psf/conduct/).

## Description

Occurrences of "modeling" were replaced with "modelling".
Previously both "modeling" and "modelling" were used.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Not applicable.