### PR TITLE
docs: Use the article "an" for words beginning with SQL

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -3638,7 +3638,7 @@
         Fix the behaviour of DTOs such that they will no longer access fields that have
         been included. This behaviour would previously cause issues when these
         attributes were either costly or impossible to access (e.g. lazy loaded
-        relationships of a SQLAlchemy model).
+        relationships of an SQLAlchemy model).
 
     .. change:: DTO | Regression: ``DTOData.create_instance`` ignores renaming
         :type: bugfix
@@ -4176,7 +4176,7 @@
         :type: feature
         :pr: 1852
 
-        Replace the nondescript :exc:`KeyError` raised when a SQLAlchemy DTO is
+        Replace the nondescript :exc:`KeyError` raised when an SQLAlchemy DTO is
         constructed from a model that is missing a type annotation for an included
         column with an :exc:`ImproperlyConfiguredException`, including an explicit error
         message, pointing at the potential cause.
@@ -5126,7 +5126,7 @@
         SQLAlchemy 1 support has been dropped.
 
         .. note::
-            If you rely on SQLAlchemy 1, you can stick to Starlite *1.51* for now. In the future, a SQLAlchemy 1 plugin
+            If you rely on SQLAlchemy 1, you can stick to Starlite *1.51* for now. In the future, an SQLAlchemy 1 plugin
             may be released as a standalone package.
 
     .. change:: Fix inconsistent parsing of unix timestamp between Pydantic and cattrs
@@ -5442,7 +5442,7 @@
 
         Add a a ``repository`` module to ``contrib``, providing abstract base classes
         to implement the repository pattern. Also added was the ``contrib.repository.sqlalchemy``
-        module, implementing a SQLAlchemy repository, offering hand-tuned abstractions
+        module, implementing an SQLAlchemy repository, offering hand-tuned abstractions
         over commonly used tasks, such as handling of object sessions, inserting,
         updating and upserting individual models or collections.
 

--- a/docs/usage/databases/sqlalchemy/plugins/sqlalchemy_serialization_plugin.rst
+++ b/docs/usage/databases/sqlalchemy/plugins/sqlalchemy_serialization_plugin.rst
@@ -27,7 +27,7 @@ How it works
 ============
 
 The plugin works by defining a :class:`SQLAlchemyDTO <advanced_alchemy.extensions.litestar.dto.SQLAlchemyDTO>` class for each
-handler ``data`` or return annotation that is a SQLAlchemy model, or collection of SQLAlchemy models, that isn't
+handler ``data`` or return annotation that is an SQLAlchemy model, or a collection of SQLAlchemy models, that isn't
 otherwise managed by an explicitly defined DTO class.
 
 The following two examples are functionally equivalent:

--- a/docs/usage/dto/1-abstract-dto.rst
+++ b/docs/usage/dto/1-abstract-dto.rst
@@ -17,13 +17,13 @@ Using DTO Factories
 -------------------
 
 DTO factories are used to create DTOs for use with a particular data modelling library. The following example creates
-a DTO for use with a SQLAlchemy model:
+a DTO for use with an SQLAlchemy model:
 
 .. literalinclude:: /examples/data_transfer_objects/factory/simple_dto_factory_example.py
-    :caption: A SQLAlchemy model DTO
+    :caption: An SQLAlchemy model DTO
     :language: python
 
-Here we see that a SQLAlchemy model is used as both the ``data`` and return annotation for the handler, and while
+Here we see that an SQLAlchemy model is used as both the ``data`` and return annotation for the handler, and while
 Litestar does not natively support encoding/decoding to/from SQLAlchemy models, through
 :class:`SQLAlchemyDTO <advanced_alchemy.extensions.litestar.dto.SQLAlchemyDTO>` we can do this.
 


### PR DESCRIPTION
By submitting this pull request, I agree to:

- [x] follow Litestar's [Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md);
- [x] follow Litestar's [contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md);
- [x] follow the PSFs's [Code of Conduct](https://www.python.org/psf/conduct/).

## Description

Article "a" was replaced with "an" for words beginning with "SQL" as the pronunciation of SQL starts with a vowel sound: /ˌɛsˌkjuˈɛl/ (S-Q-L). Previously both "a SQL*" and "an SQL*" were used.
That is, if project authors do not prefer the alternative pronunciation /ˈsiːkwəl/ ("sequel"), in which case the existing occurrences of "an SQL*" should be replaced with "a SQL*".

For reference:

- <https://www.scribbr.com/commonly-confused-words/a-vs-an/#acronyms>
- <https://en.wikipedia.org/wiki/SQL>

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Not applicable.