### PR TITLE
fix: explicit specification of arguments in FileSystemAdapter open func.

### DIFF
--- a/litestar/file_system.py
+++ b/litestar/file_system.py
@@ -113,7 +113,7 @@ class FileSystemAdapter:
                         buffering=buffering,
                     ),
                 )
-            return AsyncFile(await sync_to_thread(self.file_system.open, file, mode, buffering))  # type: ignore[arg-type]
+            return AsyncFile(await sync_to_thread(self.file_system.open, file, mode=mode, buffering=buffering))  # type: ignore[arg-type]
         except PermissionError as e:
             raise NotAuthorizedException(f"failed to open {file} due to missing permissions") from e
         except OSError as e:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
Hi there!
I have tried to plug MinIO via [create_static_files_router](https://docs.litestar.dev/2/usage/static-files.html#remote-file-systems) 

```
MinioSystem = s3fs.S3FileSystem(
    anon=False,
    key=settings.MINIO_ROOT_USER,
    secret=settings.MINIO_ROOT_PASSWORD,
    endpoint_url=settings.minio_url,
)

api_router = Router(
    path=settings.API_STR,
    route_handlers=[
        ...
        create_static_files_router(
            path="/media",
            directories=["media"],
            file_system=MinioSystem,
            resolve_symlinks=False,
        ),
    ],
)

app = Litestar(
    route_handlers=[api_router],
    ...
)
```
and after
```
curl 'http://127.0.0.1:8000/api/v1/media/avatars/4884a139-970d-4467-974c-48add111cd10.png'
```
I have recieved this error:
```
...
RuntimeError: Response content shorter than Content-Length
```
I have researched a bit and realized that s3fs.S3FileSystem._open(self, path, mode="rb", block_size=None, ...) has **block_size** parametr. In my case this parametr gets **buffering** parametr from FileSystemAdapter.open(self, file: PathType, mode: OpenBinaryMode = "rb", buffering: int = -1,) which has default value -1. This behavior breaks s3fs.S3FileSystem._open.

## Description

- explicitly specified the arguments to the FileSystemAdapter open function.
