### PR TITLE
feat: v3 - Make `polyfactory` an optional dependency

### DIFF
--- a/docs/examples/openapi/generating_examples.py
+++ b/docs/examples/openapi/generating_examples.py
@@ -1,0 +1,10 @@
+from litestar import Litestar
+from litestar.openapi.config import OpenAPIConfig
+
+app = Litestar(
+    openapi_config=OpenAPIConfig(
+        title="My API",
+        version="0.1.0",
+        create_examples=True,
+    ),
+)

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -62,6 +62,9 @@ Installation
     :doc:`Mako Templating </usage/templating>`
         :code:`pip install litestar[mako]`
 
+    :ref:`Polyfactory to generate OpenAPI examples <usage/openapi/schema_generation:Generating examples>`
+        :code:`pip install litestar[structlog]`
+
     Standard Installation (includes Uvicorn and Jinja2 templating):
         :code:`pip install litestar[standard]`
 

--- a/docs/release-notes/whats-new-3.rst
+++ b/docs/release-notes/whats-new-3.rst
@@ -281,3 +281,11 @@ The unsupported ``body`` parameter of :class:`~.ASGIStreamingResponse`
 and :class:`.ASGIFileResponse` has been removed.
 
 This does not change any behaviour, as this parameter was previously ignored.
+
+
+``polyfactory`` package removed from default dependencies
+----------------------------------------------------------
+
+The `polyfactory <https://polyfactory.litestar.dev/>`_ library is not included by
+default anymore, and has been moved to the ``litestar[polyfactory]`` package extra. It
+is also included in ``litestar[full]``.

--- a/docs/usage/openapi/schema_generation.rst
+++ b/docs/usage/openapi/schema_generation.rst
@@ -319,3 +319,17 @@ The above example will result in an OpenAPI schema object that looks like this:
    converter. To work around this, Litestar will honor an `alias` field provided to the
    `dataclass.field <https://docs.python.org/3/library/dataclasses.html#dataclasses.field>`_ metadata
    when generating the field name in the schema.
+
+
+Generating examples
+-------------------
+
+Litestar can automatically generate examples for the ``example`` section of a schema.
+To enable this feature, you'll need to have the
+`polyfactory <https://polyfactory.litestar.dev/>`_ library installed, which is included
+as a package extra under ``litestar[polyfactory`` and ``litestar[full]``.
+
+Once installed, you can turn on example generation via the OpenAPI config:
+
+.. literalinclude:: /examples/openapi/customize_pydantic_model_name.py
+    :language: python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
   "importlib-metadata; python_version < \"3.10\"",
   "msgspec>=0.19.0",
   "multidict>=6.0.2",
-  "polyfactory>=2.6.3",
   "pyyaml",
   "typing-extensions",
   "click",
@@ -83,8 +82,8 @@ brotli = ["brotli"]
 cli = ["jsbeautifier", "uvicorn[standard]", "uvloop>=0.18.0; sys_platform != 'win32'"]
 cryptography = ["cryptography"]
 full = [
-  "litestar[annotated-types,attrs,brotli,cli,cryptography,jinja,jwt,mako,minijinja,opentelemetry,piccolo,picologging,prometheus,pydantic,redis,sqlalchemy,standard,structlog,valkey]; python_version < \"3.13\"",
-  "litestar[annotated-types,attrs,brotli,cli,cryptography,jinja,jwt,mako,minijinja,opentelemetry,piccolo,prometheus,pydantic,redis,sqlalchemy,standard,structlog,valkey]; python_version >= \"3.13\"",
+  "litestar[annotated-types,attrs,brotli,cli,cryptography,jinja,jwt,mako,minijinja,opentelemetry,piccolo,polyfactory,picologging,prometheus,pydantic,redis,sqlalchemy,standard,structlog,valkey]; python_version < \"3.13\"",
+  "litestar[annotated-types,attrs,brotli,cli,cryptography,jinja,jwt,mako,minijinja,opentelemetry,piccolo,polyfactory,prometheus,pydantic,redis,sqlalchemy,standard,structlog,valkey]; python_version >= \"3.13\"",
 ]
 jinja = ["jinja2>=3.1.2"]
 jwt = ["cryptography", "pyjwt>=2.9.0"]
@@ -110,6 +109,7 @@ standard = [
 ]
 structlog = ["structlog"]
 valkey = ["valkey[libvalkey]>=6.0.2"]
+polyfactory = ["polyfactory>=2.6.3"]
 
 [project.scripts]
 litestar = "litestar.__main__:run_cli"

--- a/uv.lock
+++ b/uv.lock
@@ -354,18 +354,6 @@ wheels = [
 ]
 
 [[package]]
-name = "blacken-docs"
-version = "1.18.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "black" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/12/a9/99fe0283575297466df65eb54873a892f0db5fd24459abef4c2691db883a/blacken_docs-1.18.0.tar.gz", hash = "sha256:47bed628679d008a8eb55d112df950582e68d0f57615223929e366348d935444", size = 14743 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/7e/532f6c8b81346c2337c54b0e16f49f2968d86b0c535d6318b3f21f3ff4cf/blacken_docs-1.18.0-py3-none-any.whl", hash = "sha256:64f592246784131e9f84dad1db397f44eeddc77fdf01726bab920a3f00a3815c", size = 8243 },
-]
-
-[[package]]
 name = "brotli"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1611,7 +1599,6 @@ dependencies = [
     { name = "msgspec" },
     { name = "multidict" },
     { name = "multipart" },
-    { name = "polyfactory" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "rich-click" },
@@ -1651,6 +1638,7 @@ full = [
     { name = "opentelemetry-instrumentation-asgi" },
     { name = "piccolo" },
     { name = "picologging", marker = "python_full_version < '3.13'" },
+    { name = "polyfactory" },
     { name = "prometheus-client" },
     { name = "pydantic" },
     { name = "pydantic-extra-types" },
@@ -1682,6 +1670,9 @@ piccolo = [
 ]
 picologging = [
     { name = "picologging", marker = "python_full_version < '3.13'" },
+]
+polyfactory = [
+    { name = "polyfactory" },
 ]
 prometheus = [
     { name = "prometheus-client" },
@@ -1793,8 +1784,8 @@ requires-dist = [
     { name = "jinja2", marker = "extra == 'standard'" },
     { name = "jsbeautifier", marker = "extra == 'cli'" },
     { name = "jsbeautifier", marker = "extra == 'standard'" },
-    { name = "litestar", extras = ["annotated-types", "attrs", "brotli", "cli", "cryptography", "jinja", "jwt", "mako", "minijinja", "opentelemetry", "piccolo", "picologging", "prometheus", "pydantic", "redis", "sqlalchemy", "standard", "structlog", "valkey"], marker = "python_full_version < '3.13' and extra == 'full'" },
-    { name = "litestar", extras = ["annotated-types", "attrs", "brotli", "cli", "cryptography", "jinja", "jwt", "mako", "minijinja", "opentelemetry", "piccolo", "prometheus", "pydantic", "redis", "sqlalchemy", "standard", "structlog", "valkey"], marker = "python_full_version >= '3.13' and extra == 'full'" },
+    { name = "litestar", extras = ["annotated-types", "attrs", "brotli", "cli", "cryptography", "jinja", "jwt", "mako", "minijinja", "opentelemetry", "piccolo", "polyfactory", "picologging", "prometheus", "pydantic", "redis", "sqlalchemy", "standard", "structlog", "valkey"], marker = "python_full_version < '3.13' and extra == 'full'" },
+    { name = "litestar", extras = ["annotated-types", "attrs", "brotli", "cli", "cryptography", "jinja", "jwt", "mako", "minijinja", "opentelemetry", "piccolo", "polyfactory", "prometheus", "pydantic", "redis", "sqlalchemy", "standard", "structlog", "valkey"], marker = "python_full_version >= '3.13' and extra == 'full'" },
     { name = "litestar-htmx", specifier = ">=0.4.0" },
     { name = "mako", marker = "extra == 'mako'", specifier = ">=1.2.4" },
     { name = "minijinja", marker = "extra == 'minijinja'", specifier = ">=1.0.0" },
@@ -1804,7 +1795,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-asgi", marker = "extra == 'opentelemetry'" },
     { name = "piccolo", marker = "extra == 'piccolo'" },
     { name = "picologging", marker = "python_full_version < '3.13' and extra == 'picologging'" },
-    { name = "polyfactory", specifier = ">=2.6.3" },
+    { name = "polyfactory", marker = "extra == 'polyfactory'", specifier = ">=2.6.3" },
     { name = "prometheus-client", marker = "extra == 'prometheus'" },
     { name = "pydantic", marker = "extra == 'pydantic'" },
     { name = "pydantic-extra-types", marker = "extra == 'pydantic'" },
@@ -1821,7 +1812,7 @@ requires-dist = [
     { name = "uvloop", marker = "sys_platform != 'win32' and extra == 'standard'", specifier = ">=0.18.0" },
     { name = "valkey", extras = ["libvalkey"], marker = "extra == 'valkey'", specifier = ">=6.0.2" },
 ]
-provides-extras = ["annotated-types", "attrs", "brotli", "cli", "cryptography", "full", "jinja", "jwt", "mako", "minijinja", "opentelemetry", "piccolo", "picologging", "prometheus", "pydantic", "redis", "valkey", "sqlalchemy", "standard", "structlog"]
+provides-extras = ["annotated-types", "attrs", "brotli", "cli", "cryptography", "full", "jinja", "jwt", "mako", "minijinja", "opentelemetry", "piccolo", "picologging", "prometheus", "pydantic", "redis", "sqlalchemy", "standard", "structlog", "valkey", "polyfactory"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1898,9 +1889,8 @@ wheels = [
 [[package]]
 name = "litestar-sphinx-theme"
 version = "0.3.1"
-source = { git = "https://github.com/litestar-org/litestar-sphinx-theme.git?rev=v3#e5f1df5af973eafafbc683e56d0f5762b2e0c315" }
+source = { git = "https://github.com/litestar-org/litestar-sphinx-theme.git?rev=v3#3a2dd24bdb6484c1c0da1116043586ec22a32962" }
 dependencies = [
-    { name = "blacken-docs" },
     { name = "shibuya" },
     { name = "sphinx-autobuild" },
     { name = "sphinx-copybutton" },


### PR DESCRIPTION
Move `polyfactory` from the default dependencies to `polyfactory` extra. It is not used by default anymore and hidden behind an OpenAPI config flag.