### PR TITLE
feat: v3 - Move `litestar-htmx` to a package extra

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -65,6 +65,9 @@ Installation
     :ref:`Polyfactory to generate OpenAPI examples <usage/openapi/schema_generation:Generating examples>`
         :code:`pip install litestar[structlog]`
 
+    :doc:`HTMX plugin </usage/htmx>`
+        :code:`pip install litestar[htmx]`
+
     Standard Installation (includes Uvicorn and Jinja2 templating):
         :code:`pip install litestar[standard]`
 

--- a/docs/release-notes/whats-new-3.rst
+++ b/docs/release-notes/whats-new-3.rst
@@ -289,3 +289,10 @@ This does not change any behaviour, as this parameter was previously ignored.
 The `polyfactory <https://polyfactory.litestar.dev/>`_ library is not included by
 default anymore, and has been moved to the ``litestar[polyfactory]`` package extra. It
 is also included in ``litestar[full]``.
+
+
+``litestar-htmx`` package removed from default dependencies
+-----------------------------------------------------------
+
+The `litestar-htmx <https://github.com/litestar-org/litestar-htmx/>`_ package powering
+the :doc:`HTMX plugin </usage/htmx>` has been moved to the ``litestar[htmx]`` extra.

--- a/docs/usage/htmx.rst
+++ b/docs/usage/htmx.rst
@@ -8,10 +8,13 @@ HTMX is a JavaScript library that gives you access to AJAX, CSS Transitions, Web
 This section assumes that you have prior knowledge of HTMX.
 If you want to learn HTMX, we recommend consulting their `official tutorial <https://htmx.org/docs>`_.
 
+
 HTMXPlugin
 ------------
 
 a Litestar plugin ``HTMXPlugin`` is available to easily configure the default request class for all Litestar routes.
+
+It can be installed via the ``litestar[htmx]`` package extra.
 
 .. code-block:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,6 @@ dependencies = [
   "rich>=13.0.0",
   "rich-click",
   "multipart>=1.2.0",
-  # default litestar plugins
-  "litestar-htmx>=0.4.0",
 ]
 description = "Litestar - A production-ready, highly performant, extensible ASGI API Framework"
 keywords = ["api", "rest", "asgi", "litestar", "starlite"]
@@ -82,8 +80,8 @@ brotli = ["brotli"]
 cli = ["jsbeautifier", "uvicorn[standard]", "uvloop>=0.18.0; sys_platform != 'win32'"]
 cryptography = ["cryptography"]
 full = [
-  "litestar[annotated-types,attrs,brotli,cli,cryptography,jinja,jwt,mako,minijinja,opentelemetry,piccolo,polyfactory,picologging,prometheus,pydantic,redis,sqlalchemy,standard,structlog,valkey]; python_version < \"3.13\"",
-  "litestar[annotated-types,attrs,brotli,cli,cryptography,jinja,jwt,mako,minijinja,opentelemetry,piccolo,polyfactory,prometheus,pydantic,redis,sqlalchemy,standard,structlog,valkey]; python_version >= \"3.13\"",
+  "litestar[annotated-types,attrs,brotli,cli,cryptography,jinja,jwt,mako,minijinja,opentelemetry,piccolo,polyfactory,picologging,prometheus,pydantic,redis,sqlalchemy,standard,structlog,valkey,htmx]; python_version < \"3.13\"",
+  "litestar[annotated-types,attrs,brotli,cli,cryptography,jinja,jwt,mako,minijinja,opentelemetry,piccolo,polyfactory,prometheus,pydantic,redis,sqlalchemy,standard,structlog,valkey,htmx]; python_version >= \"3.13\"",
 ]
 jinja = ["jinja2>=3.1.2"]
 jwt = ["cryptography", "pyjwt>=2.9.0"]
@@ -110,6 +108,7 @@ standard = [
 structlog = ["structlog"]
 valkey = ["valkey[libvalkey]>=6.0.2"]
 polyfactory = ["polyfactory>=2.6.3"]
+htmx = ["litestar-htmx>=0.4.0"]
 
 [project.scripts]
 litestar = "litestar.__main__:run_cli"

--- a/uv.lock
+++ b/uv.lock
@@ -1595,7 +1595,6 @@ dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "httpx" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
-    { name = "litestar-htmx" },
     { name = "msgspec" },
     { name = "multidict" },
     { name = "multipart" },
@@ -1633,6 +1632,7 @@ full = [
     { name = "fast-query-parsers" },
     { name = "jinja2" },
     { name = "jsbeautifier" },
+    { name = "litestar-htmx" },
     { name = "mako" },
     { name = "minijinja" },
     { name = "opentelemetry-instrumentation-asgi" },
@@ -1648,6 +1648,9 @@ full = [
     { name = "uvicorn", extra = ["standard"] },
     { name = "uvloop", marker = "sys_platform != 'win32'" },
     { name = "valkey", extra = ["libvalkey"] },
+]
+htmx = [
+    { name = "litestar-htmx" },
 ]
 jinja = [
     { name = "jinja2" },
@@ -1784,9 +1787,9 @@ requires-dist = [
     { name = "jinja2", marker = "extra == 'standard'" },
     { name = "jsbeautifier", marker = "extra == 'cli'" },
     { name = "jsbeautifier", marker = "extra == 'standard'" },
-    { name = "litestar", extras = ["annotated-types", "attrs", "brotli", "cli", "cryptography", "jinja", "jwt", "mako", "minijinja", "opentelemetry", "piccolo", "polyfactory", "picologging", "prometheus", "pydantic", "redis", "sqlalchemy", "standard", "structlog", "valkey"], marker = "python_full_version < '3.13' and extra == 'full'" },
-    { name = "litestar", extras = ["annotated-types", "attrs", "brotli", "cli", "cryptography", "jinja", "jwt", "mako", "minijinja", "opentelemetry", "piccolo", "polyfactory", "prometheus", "pydantic", "redis", "sqlalchemy", "standard", "structlog", "valkey"], marker = "python_full_version >= '3.13' and extra == 'full'" },
-    { name = "litestar-htmx", specifier = ">=0.4.0" },
+    { name = "litestar", extras = ["annotated-types", "attrs", "brotli", "cli", "cryptography", "jinja", "jwt", "mako", "minijinja", "opentelemetry", "piccolo", "polyfactory", "picologging", "prometheus", "pydantic", "redis", "sqlalchemy", "standard", "structlog", "valkey", "htmx"], marker = "python_full_version < '3.13' and extra == 'full'" },
+    { name = "litestar", extras = ["annotated-types", "attrs", "brotli", "cli", "cryptography", "jinja", "jwt", "mako", "minijinja", "opentelemetry", "piccolo", "polyfactory", "prometheus", "pydantic", "redis", "sqlalchemy", "standard", "structlog", "valkey", "htmx"], marker = "python_full_version >= '3.13' and extra == 'full'" },
+    { name = "litestar-htmx", marker = "extra == 'htmx'", specifier = ">=0.4.0" },
     { name = "mako", marker = "extra == 'mako'", specifier = ">=1.2.4" },
     { name = "minijinja", marker = "extra == 'minijinja'", specifier = ">=1.0.0" },
     { name = "msgspec", specifier = ">=0.19.0" },
@@ -1812,7 +1815,7 @@ requires-dist = [
     { name = "uvloop", marker = "sys_platform != 'win32' and extra == 'standard'", specifier = ">=0.18.0" },
     { name = "valkey", extras = ["libvalkey"], marker = "extra == 'valkey'", specifier = ">=6.0.2" },
 ]
-provides-extras = ["annotated-types", "attrs", "brotli", "cli", "cryptography", "full", "jinja", "jwt", "mako", "minijinja", "opentelemetry", "piccolo", "picologging", "prometheus", "pydantic", "redis", "sqlalchemy", "standard", "structlog", "valkey", "polyfactory"]
+provides-extras = ["annotated-types", "attrs", "brotli", "cli", "cryptography", "full", "jinja", "jwt", "mako", "minijinja", "opentelemetry", "piccolo", "picologging", "prometheus", "pydantic", "redis", "sqlalchemy", "standard", "structlog", "valkey", "polyfactory", "htmx"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Move `litestar-htmx` from a default dependency to the `litestar[htmx]` extra.