### PR TITLE
docs(v3): fix build error

### DIFF
--- a/litestar/openapi/spec/security_requirement.py
+++ b/litestar/openapi/spec/security_requirement.py
@@ -1,4 +1,4 @@
-from typing import TypeAlias
+from typing_extensions import TypeAlias
 
 SecurityRequirement: TypeAlias = "dict[str, list[str]]"
 """Lists the required security schemes to execute this operation. The name used for each property MUST correspond to a

--- a/litestar/openapi/spec/security_requirement.py
+++ b/litestar/openapi/spec/security_requirement.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
+from typing import TypeAlias
 
-SecurityRequirement = dict[str, list[str]]
+SecurityRequirement: TypeAlias = "dict[str, list[str]]"
 """Lists the required security schemes to execute this operation. The name used for each property MUST correspond to a
 security scheme declared in the.
 


### PR DESCRIPTION
Finally found the source of the mysterious

```
docstring of builtins.dict:3: ERROR: Unexpected indentation.
docstring of builtins.dict:4: WARNING: Block quote ends without a blank line; unexpected unindent.
docstring of builtins.dict:7: ERROR: Unexpected indentation.
docstring of builtins.dict:9: WARNING: Inline strong start-string without end-string.
```

Still no idea *why* that suddenly is an issue but :woman_shrugging: 