### PR TITLE
docs: Replace expired Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ or read more about it [here](https://docs.litestar.dev/latest/benchmarks) in our
 
 ## Contributing
 
-Litestar is open to contributions big and small. You can always [join our discord](https://discord.gg/X3FJqy8d2j) server
+Litestar is open to contributions big and small. You can always [join our discord](https://discord.gg/litestar) server
 or [join our Matrix](https://matrix.to/#/#litestar:matrix.org) space
 to discuss contributions and project maintenance. For guidelines on how to contribute, please
 see [the contribution guide](CONTRIBUTING.rst).

--- a/docs/PYPI_README.md
+++ b/docs/PYPI_README.md
@@ -303,7 +303,7 @@ or read more about it [here](https://docs.litestar.dev/latest/benchmarks) in our
 
 ## Contributing
 
-Litestar is open to contributions big and small. You can always [join our discord](https://discord.gg/X3FJqy8d2j) server
+Litestar is open to contributions big and small. You can always [join our discord](https://discord.gg/litestar) server
 or [join our Matrix](https://matrix.to/#/#litestar:matrix.org) space
 to discuss contributions and project maintenance. For guidelines on how to contribute, please
 see [the contribution guide](CONTRIBUTING.rst).


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
The Discord invite link in the readme is expired.
This is also the case at https://litestar.dev header and footer, but unfortunately I didn't find where the url was sourced from (https://github.com/litestar-org/litestar.dev/blob/0854bdd6c8f9263b67cb561926641781bf291176/page/_templates/landing-page.html#L85). 

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
