### PR TITLE
chore: tune up skips for codespell to avoid false positives

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,8 +193,8 @@ build-backend = "hatchling.build"
 requires = ["hatchling"]
 
 [tool.codespell]
-ignore-words-list = "selectin, documen"
-skip = 'uv.lock,docs/examples/contrib/sqlalchemy/us_state_lookup.json'
+ignore-words-list = "documen,parma,re-using,re-used,selectin"
+skip = 'uv.lock,us_state_lookup.json'
 
 [tool.coverage.run]
 concurrency = ["multiprocessing", "thread"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,7 @@ requires = ["hatchling"]
 [tool.codespell]
 ignore-words-list = "documen,re-using,re-used,selectin"
 ignore-regex = "\\bParma\\b"
-skip = 'uv.lock,us_state_lookup.json'
+skip = 'uv.lock,docs/examples/contrib/sqlalchemy/us_state_lookup.json,us_state_lookup.json'
 
 [tool.coverage.run]
 concurrency = ["multiprocessing", "thread"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,8 @@ build-backend = "hatchling.build"
 requires = ["hatchling"]
 
 [tool.codespell]
-ignore-words-list = "documen,parma,re-using,re-used,selectin"
+ignore-words-list = "documen,re-using,re-used,selectin"
+ignore-regex = "\\bParma\\b"
 skip = 'uv.lock,us_state_lookup.json'
 
 [tool.coverage.run]


### PR DESCRIPTION
ATM running  codespell  would find some "re-use*" words (could be fixed as well), and parma name.  Also the .json might have been moved from original location so I decided just to go by its base name.

Without this, looks like:

```shell
❯ codespell
./README.md:421: Parma ==> Param
./README.md:421: Parma ==> Param
./docs/examples/contrib/sqlalchemy/sqlalchemy_repository_extension.py:41: re-used ==> reused
./docs/examples/contrib/sqlalchemy/us_state_lookup.json:144: ND ==> AND, 2ND
./docs/release-notes/changelog.rst:2879: re-using ==> reusing
./docs/usage/stores.rst:267: re-using ==> reusing
❯ codespell --version
2.4.1
```