### PR TITLE
Remove excluded pydantic field  from open api response

### DIFF
--- a/litestar/_openapi/datastructures.py
+++ b/litestar/_openapi/datastructures.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Iterator, Sequence, _GenericAlias  # type: ignore[attr-defined]
 
 from litestar.exceptions import ImproperlyConfiguredException
@@ -246,3 +247,10 @@ class OpenAPIContext:
                 f"please ensure the value of 'operation_id' is either not set or unique for {operation_id}"
             )
         self.operation_ids.add(operation_id)
+
+
+@dataclass
+class SchemaContext:
+    """Context data for schema creator."""
+
+    is_response: bool = field(default=False)

--- a/litestar/_openapi/responses.py
+++ b/litestar/_openapi/responses.py
@@ -8,6 +8,7 @@ from http import HTTPStatus
 from operator import attrgetter
 from typing import TYPE_CHECKING, Any, Iterator
 
+from litestar._openapi.datastructures import SchemaContext
 from litestar._openapi.schema_generation import SchemaCreator
 from litestar._openapi.schema_generation.utils import get_formatted_examples
 from litestar.enums import MediaType
@@ -76,7 +77,9 @@ class ResponseFactory:
         self.context = context
         self.route_handler = route_handler
         self.field_definition = route_handler.parsed_fn_signature.return_type
-        self.schema_creator = SchemaCreator.from_openapi_context(context, prefer_alias=False)
+        self.schema_creator = SchemaCreator.from_openapi_context(
+            context, prefer_alias=False, schema_context=SchemaContext(is_response=True)
+        )
 
     def create_responses(self, raises_validation_error: bool) -> Responses | None:
         """Create the schema for responses, if any.
@@ -146,7 +149,6 @@ class ResponseFactory:
                     media_type = media_type or MediaType.JSON
                 else:
                     field_def = self.field_definition
-
                 result = self.schema_creator.for_field_definition(field_def)
 
             schema = (

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -33,7 +33,7 @@ from uuid import UUID
 
 from typing_extensions import Self, get_args
 
-from litestar._openapi.datastructures import SchemaRegistry
+from litestar._openapi.datastructures import SchemaContext, SchemaRegistry
 from litestar._openapi.schema_generation.constrained_fields import (
     create_date_constrained_field_schema,
     create_numerical_constrained_field_schema,
@@ -230,7 +230,7 @@ def create_schema_for_annotation(annotation: Any) -> Schema:
 
 
 class SchemaCreator:
-    __slots__ = ("generate_examples", "plugins", "prefer_alias", "schema_registry")
+    __slots__ = ("generate_examples", "plugins", "prefer_alias", "schema_context", "schema_registry")
 
     def __init__(
         self,
@@ -238,6 +238,7 @@ class SchemaCreator:
         plugins: Iterable[OpenAPISchemaPluginProtocol] | None = None,
         prefer_alias: bool = True,
         schema_registry: SchemaRegistry | None = None,
+        schema_context: SchemaContext | None = None,
     ) -> None:
         """Instantiate a SchemaCreator.
 
@@ -246,11 +247,13 @@ class SchemaCreator:
             plugins: A list of plugins.
             prefer_alias: Whether to prefer the alias name for the schema.
             schema_registry: A SchemaRegistry instance.
+            schema_context: A context information for generated schema
         """
         self.generate_examples = generate_examples
         self.plugins = plugins if plugins is not None else []
         self.prefer_alias = prefer_alias
         self.schema_registry = schema_registry or SchemaRegistry()
+        self.schema_context = schema_context or SchemaContext()
 
     @classmethod
     def from_openapi_context(cls, context: OpenAPIContext, prefer_alias: bool = True, **kwargs: Any) -> Self:

--- a/litestar/plugins/pydantic/utils.py
+++ b/litestar/plugins/pydantic/utils.py
@@ -14,7 +14,12 @@ from litestar.openapi.spec import Example
 from litestar.params import KwargDefinition, ParameterKwarg
 from litestar.types import Empty
 from litestar.typing import FieldDefinition
-from litestar.utils import deprecated, is_class_and_subclass, is_generic, is_undefined_sentinel
+from litestar.utils import (
+    deprecated,
+    is_class_and_subclass,
+    is_generic,
+    is_undefined_sentinel,
+)
 from litestar.utils.typing import (
     _substitute_typevars,
     get_origin_or_inner_type,
@@ -448,10 +453,10 @@ def get_model_info(
     }
 
     if is_v2_model:
-        # extract the annotations from the FieldInfo. This allows us to skip fields
-        # which have been marked as private
-        # if there's a default factory, we wrap the field in 'Optional', to signal
-        # that it is not required
+        # extract the annotations from the FieldInfo.
+        # This allows us to skip fields which have been marked as private
+        # if there's a default factory, we wrap the field in 'Optional',
+        #  to signal that it is not required
         model_annotations = {
             k: Optional[field_info.annotation] if field_info.default_factory else field_info.annotation  # type: ignore[union-attr]
             for k, field_info in model_fields.items()
@@ -466,10 +471,12 @@ def get_model_info(
 
     if is_generic_model:
         # if the model is generic, resolve the type variables. We pass in the
-        # already extracted annotations, to keep the logic of respecting private
-        # fields consistent with the above
+        # already extracted annotations, to keep the logic of respecting
+        # private fields consistent with the above
         model_annotations = pydantic_get_type_hints_with_generics_resolved(
-            annotation, model_annotations=model_annotations, include_extras=True
+            annotation,
+            model_annotations=model_annotations,
+            include_extras=True,
         )
 
     create_field_definition: _CreateFieldDefinition = (
@@ -481,11 +488,12 @@ def get_model_info(
             field_annotation=model_annotations[k],
             name=field_info.alias if field_info.alias and prefer_alias else k,
             default=Empty
-            if is_undefined_sentinel(field_info.default) or is_pydantic_undefined(field_info.default)
+            if (is_undefined_sentinel(field_info.default) or is_pydantic_undefined(field_info.default))
             else field_info.default,
             field_info=field_info,
         )
         for k, field_info in model_fields.items()
+        if bool(field_info.exclude) is False
     }
 
     computed_field_definitions = create_field_definitions_for_computed_fields(


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

If we use a Pedantic model to type the response of a request, the fields marked as 'exclude' are displayed in the Open API schema, even though they won't be present after serialization.

Example:
```python
from litestar import Litestar, get
from pydantic import BaseModel, Field
from pprint import pprint


class Model(BaseModel):
    """Model."""

    name: str
    age: int
    exclude_field: str = Field(exclude=True)


@get("/")
def test() -> Model:
    return Model(name="David", age=25, exclude_field="man")


app = Litestar(route_handlers=[test])


pprint(app.openapi_schema.to_schema())
```

Result:
```
{'components': {'schemas': {'Model': {'properties': {'age': {'type': 'integer'},
                                                     'exclude_field': {'type': 'string'},
                                                     'name': {'type': 'string'}},
                                      'required': ['age',
                                                   'exclude_field',
                                                   'name'],
                                      'title': 'Model',
                                      'type': 'object'}}},
 'info': {'title': 'Litestar API', 'version': '1.0.0'},
 'openapi': '3.1.0',
 'paths': {'/': {'get': {'deprecated': False,
                         'operationId': 'Test',
                         'responses': {'200': {'content': {'application/json': {'schema': {'$ref': '#/components/schemas/Model'}}},
                                               'description': 'Request '
                                                              'fulfilled, '
                                                              'document '
                                                              'follows',
                                               'headers': {}}},
                         'summary': 'Test'}}},
 'servers': [{'url': '/'}]}
```

To prevent this, I created a attribute called `schema_context` on the `SchemaCreator` object, in which I pass the request context to determine if the current schema is a response; if so, we filter out the fields by the `exclude` attribute.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
