### PR TITLE
fix: normalize openapi server url

### DIFF
--- a/litestar/openapi/spec/server.py
+++ b/litestar/openapi/spec/server.py
@@ -36,4 +36,5 @@ class Server(BaseSchemaObject):
 
     def __post_init__(self) -> None:
         """Normalize the url."""
-        self.url = normalize_path(self.url)
+        if self.url.startswith("http") is False:
+            self.url = normalize_path(self.url)

--- a/litestar/openapi/spec/server.py
+++ b/litestar/openapi/spec/server.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from litestar.openapi.spec.base import BaseSchemaObject
+from litestar.utils import normalize_path
 
 if TYPE_CHECKING:
     from litestar.openapi.spec.server_variable import ServerVariable
@@ -32,3 +33,7 @@ class Server(BaseSchemaObject):
 
     variables: dict[str, ServerVariable] | None = None
     """A map between a variable name and its value. The value is used for substitution in the server's URL template."""
+
+    def __post_init__(self) -> None:
+        """Normalize the url."""
+        self.url = normalize_path(self.url)


### PR DESCRIPTION
## Description
If we specify a server URL in `OpenAPIConfig` without a leading `/`, the schema generates incorrect paths.
Example:
```python
from __future__ import annotations
from litestar import Litestar, get
from litestar.openapi import OpenAPIConfig
from litestar.openapi.spec import Server

@get("/")
async def test() -> dict:
    return {}

@get("/test")
async def test1() -> dict:
    return {}

app = Litestar(
    route_handlers=[test, test1],
    openapi_config=OpenAPIConfig(
        title="Litestar",
        version="1.0.0",
        servers=[Server(url="api/v3")],
    )
)
```
![image](https://github.com/user-attachments/assets/1563f81f-675a-41fb-b148-a04ee169a613)

As a solution, I decided to use `from litestar.utils import normalize_path` to normalize the server URLs.
