### PR TITLE
feat(log): disable stack trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ from litestar import Litestar, get
 
 
 @get("/")
-def hello_world() -> dict[str, str]:
+async def hello_world() -> dict[str, str]:
     """Keeping the tradition alive with hello world."""
     return {"hello": "world"}
 

--- a/docs/PYPI_README.md
+++ b/docs/PYPI_README.md
@@ -66,7 +66,7 @@ from litestar import Litestar, get
 
 
 @get("/")
-def hello_world() -> dict[str, str]:
+async def hello_world() -> dict[str, str]:
     """Keeping the tradition alive with hello world."""
     return {"hello": "world"}
 

--- a/docs/usage/logging.rst
+++ b/docs/usage/logging.rst
@@ -43,8 +43,8 @@ Application and request level loggers can be configured using the :class:`~lites
 Controlling Exception Logging
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-While ``log_exceptions`` controls when exceptions are logged, sometimes you may want to suppress stack traces for specific 
-exception types or HTTP status codes. The ``disable_stack_trace`` parameter allows you to specify a set of exception types 
+While ``log_exceptions`` controls when exceptions are logged, sometimes you may want to suppress stack traces for specific
+exception types or HTTP status codes. The ``disable_stack_trace`` parameter allows you to specify a set of exception types
 or status codes that should not generate stack traces in logs:
 
 .. code-block:: python

--- a/docs/usage/logging.rst
+++ b/docs/usage/logging.rst
@@ -40,6 +40,27 @@ Application and request level loggers can be configured using the :class:`~lites
     Exceptions won't be logged by default, except in debug mode. Make sure to use ``log_exceptions="always"`` as in the
     example above to log exceptions if you need it.
 
+Controlling Exception Logging
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+While ``log_exceptions`` controls when exceptions are logged, sometimes you may want to suppress stack traces for specific 
+exception types or HTTP status codes. The ``disable_stack_trace`` parameter allows you to specify a set of exception types 
+or status codes that should not generate stack traces in logs:
+
+.. code-block:: python
+
+   from litestar import Litestar
+   from litestar.logging import LoggingConfig
+
+   # Don't log stack traces for 404 errors and ValueError exceptions
+   logging_config = LoggingConfig(
+       debug=True,
+       disable_stack_trace={404, ValueError},
+   )
+
+   app = Litestar(logging_config=logging_config)
+
+This is particularly useful for common exceptions that you expect in normal operation and don't need detailed stack traces for.
 
 Using Python standard library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/litestar/logging/config.py
+++ b/litestar/logging/config.py
@@ -167,6 +167,8 @@ class BaseLoggingConfig(ABC):
     """
     exception_logging_handler: ExceptionLoggingHandler | None
     """Handler function for logging exceptions."""
+    disable_stack_trace: list[int]
+    """List of http status codes to disable stack trace logging for."""
 
     @abstractmethod
     def configure(self) -> GetLogger:
@@ -244,6 +246,8 @@ class LoggingConfig(BaseLoggingConfig):
     """Should the root logger be configured, defaults to True for ease of configuration."""
     log_exceptions: Literal["always", "debug", "never"] = field(default="debug")
     """Should exceptions be logged, defaults to log exceptions when 'app.debug == True'"""
+    disable_stack_trace: list[int] = field(default_factory=list)
+    """List of http status codes to disable stack trace logging for."""
     traceback_line_limit: int = field(default=-1)
     """Max number of lines to print for exception traceback.
 
@@ -476,6 +480,8 @@ class StructLoggingConfig(BaseLoggingConfig):
     """Whether to cache the logger configuration and reuse."""
     log_exceptions: Literal["always", "debug", "never"] = field(default="debug")
     """Should exceptions be logged, defaults to log exceptions when 'app.debug == True'"""
+    disable_stack_trace: list[int] = field(default_factory=list)
+    """List of http status codes to disable stack trace logging for."""
     traceback_line_limit: int = field(default=-1)
     """Max number of lines to print for exception traceback.
 

--- a/litestar/logging/config.py
+++ b/litestar/logging/config.py
@@ -168,7 +168,7 @@ class BaseLoggingConfig(ABC):
     exception_logging_handler: ExceptionLoggingHandler | None
     """Handler function for logging exceptions."""
     disable_stack_trace: set[Union[int, type[Exception]]]  # noqa: UP007
-    """List of http status codes to disable stack trace logging for."""
+    """Set of http status codes and exceptions to disable stack trace logging for."""
 
     @abstractmethod
     def configure(self) -> GetLogger:
@@ -247,7 +247,7 @@ class LoggingConfig(BaseLoggingConfig):
     log_exceptions: Literal["always", "debug", "never"] = field(default="debug")
     """Should exceptions be logged, defaults to log exceptions when 'app.debug == True'"""
     disable_stack_trace: set[Union[int, type[Exception]]] = field(default_factory=set)  # noqa: UP007
-    """List of http status codes to disable stack trace logging for."""
+    """Set of http status codes and exceptions to disable stack trace logging for."""
     traceback_line_limit: int = field(default=-1)
     """Max number of lines to print for exception traceback.
 
@@ -289,6 +289,7 @@ class LoggingConfig(BaseLoggingConfig):
             "log_exceptions",
             "propagate",
             "traceback_line_limit",
+            "disable_stack_trace",
         }
 
         if not self.configure_root_logger:
@@ -481,7 +482,7 @@ class StructLoggingConfig(BaseLoggingConfig):
     log_exceptions: Literal["always", "debug", "never"] = field(default="debug")
     """Should exceptions be logged, defaults to log exceptions when 'app.debug == True'"""
     disable_stack_trace: set[Union[int, type[Exception]]] = field(default_factory=set)  # noqa: UP007
-    """List of http status codes to disable stack trace logging for."""
+    """Set of http status codes and exceptions to disable stack trace logging for."""
     traceback_line_limit: int = field(default=-1)
     """Max number of lines to print for exception traceback.
 
@@ -542,6 +543,7 @@ class StructLoggingConfig(BaseLoggingConfig):
                     "traceback_line_limit",
                     "exception_logging_handler",
                     "pretty_print_tty",
+                    "disable_stack_trace",
                 )
             }
         )

--- a/litestar/logging/config.py
+++ b/litestar/logging/config.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, fields
 from importlib.util import find_spec
 from logging import INFO
-from typing import TYPE_CHECKING, Any, Callable, Literal, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, Union, cast
 
 from litestar.exceptions import ImproperlyConfiguredException, MissingDependencyException
 from litestar.serialization.msgspec_hooks import _msgspec_json_encoder
@@ -167,7 +167,7 @@ class BaseLoggingConfig(ABC):
     """
     exception_logging_handler: ExceptionLoggingHandler | None
     """Handler function for logging exceptions."""
-    disable_stack_trace: list[int]
+    disable_stack_trace: set[Union[int, type[Exception]]]  # noqa: UP007
     """List of http status codes to disable stack trace logging for."""
 
     @abstractmethod
@@ -246,7 +246,7 @@ class LoggingConfig(BaseLoggingConfig):
     """Should the root logger be configured, defaults to True for ease of configuration."""
     log_exceptions: Literal["always", "debug", "never"] = field(default="debug")
     """Should exceptions be logged, defaults to log exceptions when 'app.debug == True'"""
-    disable_stack_trace: list[int] = field(default_factory=list)
+    disable_stack_trace: set[Union[int, type[Exception]]] = field(default_factory=set)  # noqa: UP007
     """List of http status codes to disable stack trace logging for."""
     traceback_line_limit: int = field(default=-1)
     """Max number of lines to print for exception traceback.
@@ -480,7 +480,7 @@ class StructLoggingConfig(BaseLoggingConfig):
     """Whether to cache the logger configuration and reuse."""
     log_exceptions: Literal["always", "debug", "never"] = field(default="debug")
     """Should exceptions be logged, defaults to log exceptions when 'app.debug == True'"""
-    disable_stack_trace: list[int] = field(default_factory=list)
+    disable_stack_trace: set[Union[int, type[Exception]]] = field(default_factory=set)  # noqa: UP007
     """List of http status codes to disable stack trace logging for."""
     traceback_line_limit: int = field(default=-1)
     """Max number of lines to print for exception traceback.

--- a/litestar/middleware/_internal/exceptions/middleware.py
+++ b/litestar/middleware/_internal/exceptions/middleware.py
@@ -260,8 +260,8 @@ class ExceptionHandlerMiddleware:
         exception_type = exc[0]
 
         exception_status = None
-        if hasattr(exc[1], "status_code"):
-            exception_status = exc[1].status_code  # type: ignore[attr-defined]
+        if hasattr(exception_type, "status_code"):
+            exception_status = exception_type.status_code  # type: ignore[attr-defined]
 
         check_value = exception_status if exception_status is not None else exception_type
 

--- a/litestar/middleware/_internal/exceptions/middleware.py
+++ b/litestar/middleware/_internal/exceptions/middleware.py
@@ -258,10 +258,10 @@ class ExceptionHandlerMiddleware:
             None
         """
         exc = exc_info()
-        status_code = HTTP_500_INTERNAL_SERVER_ERROR
+        exception_type = exc[0]
 
-        with contextlib.suppress(Exception):
-            status_code = exc[1].__class__.status_code  # type: ignore[attr-defined]
+        with contextlib.suppress(AttributeError):
+            exception_type = exc[0].status_code  # type: ignore[attr-defined]
 
         if (
             (
@@ -269,6 +269,6 @@ class ExceptionHandlerMiddleware:
                 or (logging_config.log_exceptions == "debug" and self._get_debug_scope(scope))
             )
             and logging_config.exception_logging_handler
-            and status_code not in logging_config.disable_stack_trace
+            and exception_type not in logging_config.disable_stack_trace
         ):
             logging_config.exception_logging_handler(logger, scope, format_exception(*exc))

--- a/litestar/middleware/_internal/exceptions/middleware.py
+++ b/litestar/middleware/_internal/exceptions/middleware.py
@@ -260,8 +260,8 @@ class ExceptionHandlerMiddleware:
         exception_type = exc[0]
 
         exception_status = None
-        if hasattr(exception_type, "status_code"):
-            exception_status = exception_type.status_code  # type: ignore[attr-defined]
+        if exception_type is not None and hasattr(exception_type, "status_code"):
+            exception_status = exception_type.status_code
 
         check_value = exception_status if exception_status is not None else exception_type
 

--- a/tests/unit/test_logging/test_logging_config.py
+++ b/tests/unit/test_logging/test_logging_config.py
@@ -5,14 +5,14 @@ import time
 from importlib.util import find_spec
 from logging.handlers import QueueHandler
 from queue import Queue
-from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Union, cast
-from unittest.mock import patch
+from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Set, Type, Union, cast
+from unittest.mock import MagicMock, patch
 
 import pytest
 from _pytest.logging import LogCaptureHandler, _LiveLoggingNullHandler
 
 from litestar import Request, get
-from litestar.exceptions import ImproperlyConfiguredException
+from litestar.exceptions import HTTPException, ImproperlyConfiguredException, NotFoundException
 from litestar.logging.config import (
     LoggingConfig,
     _get_default_handlers,
@@ -543,3 +543,45 @@ def test_traceback_line_limit_deprecation(traceback_line_limit: int, expected_wa
     with patch("litestar.logging.config.warn_deprecation") as mock_warning_deprecation:
         LoggingConfig(traceback_line_limit=traceback_line_limit)
         assert mock_warning_deprecation.called is expected_warning_deprecation_called
+
+
+@pytest.mark.parametrize(
+    "disable_stack_trace, exception_to_raise, handler_called",
+    [
+        # will log the stack trace
+        [set(), HTTPException, True],
+        [set(), ValueError, True],
+        [{400}, HTTPException, True],
+        [{NameError}, ValueError, True],
+        [{400, NameError}, ValueError, True],
+        # will not log the stack trace
+        [{NotFoundException}, HTTPException, False],
+        [{404}, HTTPException, False],
+        [{ValueError}, ValueError, False],
+        [{400, ValueError}, ValueError, False],
+        [{404, NameError}, HTTPException, False],
+    ],
+)
+def test_disable_stack_trace(
+    disable_stack_trace: Set[Union[int, Type[Exception]]],
+    exception_to_raise: Exception,
+    handler_called: bool,
+) -> None:
+    mock_handler = MagicMock()
+
+    logging_config = LoggingConfig(disable_stack_trace=disable_stack_trace, exception_logging_handler=mock_handler)
+
+    @get("/error")
+    async def error_route() -> None:
+        raise exception_to_raise
+
+    with create_test_client([error_route], logging_config=logging_config, debug=True) as client:
+        if exception_to_raise is not HTTPException:
+            _ = client.get("/error")
+        else:
+            _ = client.get("/404-error")
+
+        if handler_called:
+            assert mock_handler.called, "Exception logging handler should have been called"
+        else:
+            assert not mock_handler.called, "Exception logging handler should not have been called"

--- a/tests/unit/test_logging/test_logging_config.py
+++ b/tests/unit/test_logging/test_logging_config.py
@@ -564,7 +564,7 @@ def test_traceback_line_limit_deprecation(traceback_line_limit: int, expected_wa
 )
 def test_disable_stack_trace(
     disable_stack_trace: Set[Union[int, Type[Exception]]],
-    exception_to_raise: Exception,
+    exception_to_raise: Type[Exception],
     handler_called: bool,
 ) -> None:
     mock_handler = MagicMock()
@@ -576,10 +576,10 @@ def test_disable_stack_trace(
         raise exception_to_raise
 
     with create_test_client([error_route], logging_config=logging_config, debug=True) as client:
-        if exception_to_raise is not HTTPException:
-            _ = client.get("/error")
-        else:
+        if exception_to_raise is HTTPException:
             _ = client.get("/404-error")
+        else:
+            _ = client.get("/error")
 
         if handler_called:
             assert mock_handler.called, "Exception logging handler should have been called"

--- a/tests/unit/test_logging/test_structlog_config.py
+++ b/tests/unit/test_logging/test_structlog_config.py
@@ -195,7 +195,7 @@ def test_structlog_config_as_json(isatty: bool, pretty_print_tty: bool, expected
 )
 def test_structlog_disable_stack_trace(
     disable_stack_trace: Set[Union[int, Type[Exception]]],
-    exception_to_raise: Exception,
+    exception_to_raise: Type[Exception],
     handler_called: bool,
 ) -> None:
     mock_handler = MagicMock()
@@ -209,10 +209,10 @@ def test_structlog_disable_stack_trace(
         raise exception_to_raise
 
     with create_test_client([error_route], logging_config=logging_config, debug=True) as client:
-        if exception_to_raise is not HTTPException:
-            _ = client.get("/error")
-        else:
+        if exception_to_raise is HTTPException:
             _ = client.get("/404-error")
+        else:
+            _ = client.get("/error")
 
         if handler_called:
             assert mock_handler.called, "Structlog exception handler should have been called"


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

In the logger configuration, users can specify a set of status codes and exception types for which Litestar will not log the full stack trace.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
#4081 

## Example

```py
import uvicorn

from litestar import Litestar, get
from litestar.logging import LoggingConfig


@get("/")
async def index() -> str:
    return "Hello, world!"


@get("/value-error")
async def value_error() -> None:
    raise ValueError("This is a test value error.")  # not log the stack trace


@get("/name-error")
async def name_error() -> None:
    raise NameError("This is a test name error.")


app = Litestar(
    route_handlers=[index, value_error, name_error],
    debug=True,
    logging_config=LoggingConfig(
        disable_stack_trace={404, ValueError}  # disable_stack_trace: set[Union[int, type[Exception]]]
    ),
)


if __name__ == "__main__":
    uvicorn.run(app=app, port=8621)

```