### PR TITLE
fix(typing): Correctly handle `typing_extensions.TypeAliasType` on `typing-extensions>4.13.0` (fix #4088)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,30 @@ jobs:
       - name: Report success or fail
         run: exit ${{ needs.test.result == 'success' && '0' || '1' }}
 
+  test_typing_extensions:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        typing-extensions: ["4.12.1", "4.13.1"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pytho
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.6.12"
+          enable-cache: true
+
+      - name: Test
+        run: uv run --with="typing-extensions==${{ matrix.typing-extensions }}" -- python -m pytest tests/unit/test_typing.py
+
+
   test_integration:
     name: Test server integration
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up pytho
+      - name: Set up python
         uses: actions/setup-python@v5
         with:
           python-version: 3.13

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.4"
+          version: "0.6.12"
           enable-cache: true
 
       - name: Install dependencies

--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -22,12 +22,21 @@ from typing_extensions import (
     NotRequired,
     Required,
     Self,
-    TypeAliasType,
     get_args,
     get_origin,
     get_type_hints,
     is_typeddict,
 )
+from typing_extensions import (
+    TypeAliasType as TeTypeAliasType,
+)
+
+try:
+    from typing import TypeAliasType
+
+    TypeAliasTypes = (TypeAliasType, TeTypeAliasType)
+except ImportError:
+    TypeAliasTypes = (TeTypeAliasType,)
 
 from litestar.exceptions import ImproperlyConfiguredException, LitestarWarning
 from litestar.params import BodyKwarg, DependencyKwarg, KwargDefinition, ParameterKwarg
@@ -272,7 +281,7 @@ class FieldDefinition:
     @property
     def is_type_alias_type(self) -> bool:
         """Whether the annotation is a ``TypeAliasType``"""
-        return isinstance(self.annotation, TypeAliasType)
+        return isinstance(self.annotation, TypeAliasTypes)
 
     @property
     def is_type_var(self) -> bool:

--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -32,11 +32,11 @@ from typing_extensions import (
 )
 
 try:
-    from typing import TypeAliasType
+    from typing import TypeAliasType  # type: ignore[attr-defined]
 
     TypeAliasTypes = (TypeAliasType, TeTypeAliasType)
 except ImportError:
-    TypeAliasTypes = (TeTypeAliasType,)
+    TypeAliasTypes = (TeTypeAliasType,)  # type: ignore[assignment]
 
 from litestar.exceptions import ImproperlyConfiguredException, LitestarWarning
 from litestar.params import BodyKwarg, DependencyKwarg, KwargDefinition, ParameterKwarg

--- a/tests/unit/test_typing.py
+++ b/tests/unit/test_typing.py
@@ -18,7 +18,7 @@ from typing_extensions import (
 )
 
 try:
-    from typing import TypeAliasType
+    from typing import TypeAliasType  # type: ignore[attr-defined]
 except ImportError:
     TypeAliasType = TeTypeAliasType
 
@@ -479,8 +479,8 @@ def test_warn_default_inside_kwarg_definition_and_default_empty() -> None:
 @pytest.mark.parametrize(
     "annotation",
     [
-        pytest.param(TypeAliasType("IntAlias", int), id="typing.TypeAliasType"),
-        pytest.param(TeTypeAliasType("IntAlias", int), id="typing_extensions.TypeAliasType"),
+        pytest.param(TypeAliasType("IntAlias", int), id="typing.TypeAliasType"),  # pyright: ignore
+        pytest.param(TeTypeAliasType("IntAlias", int), id="typing_extensions.TypeAliasType"),  # pyright: ignore
     ],
 )
 def test_is_type_alias_type(annotation: Any) -> None:

--- a/tests/unit/test_typing.py
+++ b/tests/unit/test_typing.py
@@ -484,9 +484,6 @@ def test_warn_default_inside_kwarg_definition_and_default_empty() -> None:
     ],
 )
 def test_is_type_alias_type(annotation: Any) -> None:
-    from importlib.metadata import version
-
-    assert version("typing_extensions") == "4.13.0"
     field_definition = FieldDefinition.from_annotation(annotation)
     assert field_definition.is_type_alias_type
 

--- a/tests/unit/test_typing.py
+++ b/tests/unit/test_typing.py
@@ -6,7 +6,21 @@ from typing import Any, ForwardRef, Generic, List, Optional, Tuple, TypeVar, Uni
 
 import msgspec
 import pytest
-from typing_extensions import Annotated, NotRequired, Required, TypeAliasType, TypedDict, get_type_hints
+from typing_extensions import (
+    Annotated,
+    NotRequired,
+    Required,
+    TypedDict,
+    get_type_hints,
+)
+from typing_extensions import (
+    TypeAliasType as TeTypeAliasType,
+)
+
+try:
+    from typing import TypeAliasType
+except ImportError:
+    TypeAliasType = TeTypeAliasType
 
 from litestar import get
 from litestar.exceptions import LitestarWarning
@@ -462,8 +476,18 @@ def test_warn_default_inside_kwarg_definition_and_default_empty() -> None:
     assert "Deprecated default value specification" in str(record.message)
 
 
-def test_is_type_alias_type() -> None:
-    field_definition = FieldDefinition.from_annotation(TypeAliasType("IntAlias", int))  # pyright: ignore
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        pytest.param(TypeAliasType("IntAlias", int), id="typing.TypeAliasType"),
+        pytest.param(TeTypeAliasType("IntAlias", int), id="typing_extensions.TypeAliasType"),
+    ],
+)
+def test_is_type_alias_type(annotation: Any) -> None:
+    from importlib.metadata import version
+
+    assert version("typing_extensions") == "4.13.0"
+    field_definition = FieldDefinition.from_annotation(annotation)
     assert field_definition.is_type_alias_type
 
 


### PR DESCRIPTION
- Fix #4088 by handling the diverging `TypeAliasType` introduced in typing-extensions `4.13.0`; This type is no longer backwards compatible, as it is a distinct new type from `typing.TypeAliasType`. We need to check for both types now
- Add a new test job to the CI to test against known diverging versions of `typing-extensions`