### PR TITLE
docs: Replace contrib with plugins in example code

### DIFF
--- a/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_init_plugin.py
+++ b/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_init_plugin.py
@@ -6,12 +6,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, get, post, put
-from litestar.contrib.sqlalchemy.plugins import (
+from litestar.exceptions import ClientException, NotFoundException
+from litestar.plugins.sqlalchemy import (
     SQLAlchemyAsyncConfig,
     SQLAlchemyInitPlugin,
     SQLAlchemySerializationPlugin,
 )
-from litestar.exceptions import ClientException, NotFoundException
 from litestar.status_codes import HTTP_409_CONFLICT
 
 
@@ -36,7 +36,7 @@ async def provide_transaction(db_session: AsyncSession) -> AsyncGenerator[AsyncS
         ) from exc
 
 
-async def get_todo_by_title(todo_name, session: AsyncSession) -> TodoItem:
+async def get_todo_by_title(todo_name: str, session: AsyncSession) -> TodoItem:
     query = select(TodoItem).where(TodoItem.title == todo_name)
     result = await session.execute(query)
     try:
@@ -51,7 +51,7 @@ async def get_todo_list(done: Optional[bool], session: AsyncSession) -> List[Tod
         query = query.where(TodoItem.done.is_(done))
 
     result = await session.execute(query)
-    return result.scalars().all()
+    return list(result.scalars().all())
 
 
 @get("/")

--- a/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_plugin.py
+++ b/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_plugin.py
@@ -6,8 +6,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, get, post, put
-from litestar.contrib.sqlalchemy.plugins import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
 from litestar.exceptions import ClientException, NotFoundException
+from litestar.plugins.sqlalchemy import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
 from litestar.status_codes import HTTP_409_CONFLICT
 
 
@@ -32,7 +32,7 @@ async def provide_transaction(db_session: AsyncSession) -> AsyncGenerator[AsyncS
         ) from exc
 
 
-async def get_todo_by_title(todo_name, session: AsyncSession) -> TodoItem:
+async def get_todo_by_title(todo_name: str, session: AsyncSession) -> TodoItem:
     query = select(TodoItem).where(TodoItem.title == todo_name)
     result = await session.execute(query)
     try:
@@ -47,7 +47,7 @@ async def get_todo_list(done: Optional[bool], session: AsyncSession) -> List[Tod
         query = query.where(TodoItem.done.is_(done))
 
     result = await session.execute(query)
-    return result.scalars().all()
+    return list(result.scalars().all())
 
 
 @get("/")

--- a/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_serialization_plugin.py
+++ b/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_serialization_plugin.py
@@ -7,9 +7,9 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, get, post, put
-from litestar.contrib.sqlalchemy.plugins import SQLAlchemySerializationPlugin
 from litestar.datastructures import State
 from litestar.exceptions import ClientException, NotFoundException
+from litestar.plugins.sqlalchemy import SQLAlchemySerializationPlugin
 from litestar.status_codes import HTTP_409_CONFLICT
 
 
@@ -54,7 +54,7 @@ async def provide_transaction(state: State) -> AsyncGenerator[AsyncSession, None
             ) from exc
 
 
-async def get_todo_by_title(todo_name, session: AsyncSession) -> TodoItem:
+async def get_todo_by_title(todo_name: str, session: AsyncSession) -> TodoItem:
     query = select(TodoItem).where(TodoItem.title == todo_name)
     result = await session.execute(query)
     try:
@@ -69,7 +69,7 @@ async def get_todo_list(done: Optional[bool], session: AsyncSession) -> List[Tod
         query = query.where(TodoItem.done.is_(done))
 
     result = await session.execute(query)
-    return result.scalars().all()
+    return list(result.scalars().all())
 
 
 @get("/")

--- a/docs/examples/contrib/sqlalchemy/sqlalchemy_repository_bulk_operations.py
+++ b/docs/examples/contrib/sqlalchemy/sqlalchemy_repository_bulk_operations.py
@@ -6,22 +6,21 @@ from rich import get_console
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Mapped, Session, sessionmaker
 
-from litestar.contrib.sqlalchemy.base import UUIDBase
-from litestar.contrib.sqlalchemy.repository import SQLAlchemySyncRepository
+from litestar.plugins.sqlalchemy import base, repository
 from litestar.repository.filters import LimitOffset
 
 here = Path(__file__).parent
 console = get_console()
 
 
-class USState(UUIDBase):
+class USState(base.UUIDBase):
     # you can optionally override the generated table name by manually setting it.
     __tablename__ = "us_state_lookup"  # type: ignore[assignment]
     abbreviation: Mapped[str]
     name: Mapped[str]
 
 
-class USStateRepository(SQLAlchemySyncRepository[USState]):
+class USStateRepository(repository.SQLAlchemySyncRepository[USState]):
     """US State repository."""
 
     model_type = USState

--- a/docs/examples/contrib/sqlalchemy/sqlalchemy_repository_crud.py
+++ b/docs/examples/contrib/sqlalchemy/sqlalchemy_repository_crud.py
@@ -10,21 +10,20 @@ from rich import get_console
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.orm import Mapped
 
-from litestar.contrib.sqlalchemy.base import UUIDBase
-from litestar.contrib.sqlalchemy.repository import SQLAlchemyAsyncRepository
+from litestar.plugins.sqlalchemy import base, repository
 
 console = get_console()
 
 
 # the SQLAlchemy base includes a declarative model for you to use in your models.
 # The `Base` class includes a `UUID` based primary key (`id`)
-class Author(UUIDBase):
+class Author(base.UUIDBase):
     name: Mapped[str]
     dob: Mapped[date]
     dod: Mapped[date | None]
 
 
-class AuthorRepository(SQLAlchemyAsyncRepository[Author]):
+class AuthorRepository(repository.SQLAlchemyAsyncRepository[Author]):
     """Author repository."""
 
     model_type = Author
@@ -88,7 +87,7 @@ async def get_author_if_exists(id: UUID) -> Author | None:
 async def run_script() -> None:
     """Load data from a fixture."""
     async with engine.begin() as conn:
-        await conn.run_sync(UUIDBase.metadata.create_all)
+        await conn.run_sync(base.UUIDBase.metadata.create_all)
 
     # 1) create a new Author record.
     console.print("1) Adding a new record")

--- a/docs/examples/contrib/sqlalchemy/sqlalchemy_repository_extension.py
+++ b/docs/examples/contrib/sqlalchemy/sqlalchemy_repository_extension.py
@@ -13,10 +13,14 @@ from sqlalchemy.orm import Mapped, declarative_mixin, mapped_column
 from sqlalchemy.types import String
 
 from litestar import Litestar, get, post
-from litestar.contrib.sqlalchemy.base import UUIDAuditBase
-from litestar.contrib.sqlalchemy.plugins import AsyncSessionConfig, SQLAlchemyAsyncConfig, SQLAlchemyInitPlugin
-from litestar.contrib.sqlalchemy.repository import ModelT, SQLAlchemyAsyncRepository
 from litestar.di import Provide
+from litestar.plugins.sqlalchemy import (
+    AsyncSessionConfig,
+    SQLAlchemyAsyncConfig,
+    SQLAlchemyInitPlugin,
+    base,
+    repository,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -39,7 +43,7 @@ class SlugKey:
 
 
 # this class can be re-used with any model that has the `SlugKey` Mixin
-class SQLAlchemyAsyncSlugRepository(SQLAlchemyAsyncRepository[ModelT]):
+class SQLAlchemyAsyncSlugRepository(repository.SQLAlchemyAsyncRepository[repository.ModelT]):
     """Extends the repository to include slug model features.."""
 
     async def get_available_slug(
@@ -99,7 +103,7 @@ class SQLAlchemyAsyncSlugRepository(SQLAlchemyAsyncRepository[ModelT]):
 # The `UUIDAuditBase` class includes the same UUID` based primary key (`id`) and 2
 # additional columns: `created_at` and `updated_at`. `created_at` is a timestamp of when the
 # record created, and `updated_at` is the last time the record was modified.
-class BlogPost(UUIDAuditBase, SlugKey):
+class BlogPost(base.UUIDAuditBase, SlugKey):
     title: Mapped[str]
     content: Mapped[str]
 
@@ -140,7 +144,7 @@ sqlalchemy_plugin = SQLAlchemyInitPlugin(config=sqlalchemy_config)
 async def on_startup() -> None:
     """Initializes the database."""
     async with sqlalchemy_config.get_engine().begin() as conn:
-        await conn.run_sync(UUIDAuditBase.metadata.create_all)
+        await conn.run_sync(base.UUIDAuditBase.metadata.create_all)
 
 
 @get(path="/")

--- a/docs/examples/contrib/sqlalchemy/sqlalchemy_sync_repository.py
+++ b/docs/examples/contrib/sqlalchemy/sqlalchemy_sync_repository.py
@@ -10,14 +10,17 @@ from sqlalchemy import ForeignKey, select
 from sqlalchemy.orm import Mapped, mapped_column, relationship, selectinload
 
 from litestar import Litestar, get
-from litestar.contrib.sqlalchemy import SQLAlchemyInitPlugin, SQLAlchemySyncConfig
-from litestar.contrib.sqlalchemy.base import UUIDAuditBase, UUIDBase
-from litestar.contrib.sqlalchemy.repository import SQLAlchemySyncRepository
 from litestar.controller import Controller
 from litestar.di import Provide
 from litestar.handlers.http_handlers.decorators import delete, patch, post
 from litestar.pagination import OffsetPagination
 from litestar.params import Parameter
+from litestar.plugins.sqlalchemy import (
+    SQLAlchemyInitPlugin,
+    SQLAlchemySyncConfig,
+    base,
+    repository,
+)
 from litestar.repository.filters import LimitOffset
 
 if TYPE_CHECKING:
@@ -32,7 +35,7 @@ class BaseModel(_BaseModel):
 
 # The SQLAlchemy base includes a declarative model for you to use in your models.
 # The `UUIDBase` class includes a `UUID` based primary key (`id`)
-class AuthorModel(UUIDBase):
+class AuthorModel(base.UUIDBase):
     # we can optionally provide the table name instead of auto-generating it
     __tablename__ = "author"  #  type: ignore[assignment]
     name: Mapped[str]
@@ -43,7 +46,7 @@ class AuthorModel(UUIDBase):
 # The `UUIDAuditBase` class includes the same UUID` based primary key (`id`) and 2
 # additional columns: `created_at` and `updated_at`. `created_at` is a timestamp of when the
 # record created, and `updated_at` is the last time the record was modified.
-class BookModel(UUIDAuditBase):
+class BookModel(base.UUIDAuditBase):
     __tablename__ = "book"  #  type: ignore[assignment]
     title: Mapped[str]
     author_id: Mapped[UUID] = mapped_column(ForeignKey("author.id"))
@@ -69,7 +72,7 @@ class AuthorUpdate(BaseModel):
     dob: date | None = None
 
 
-class AuthorRepository(SQLAlchemySyncRepository[AuthorModel]):
+class AuthorRepository(repository.SQLAlchemySyncRepository[AuthorModel]):
     """Author repository."""
 
     model_type = AuthorModel
@@ -206,7 +209,7 @@ sqlalchemy_plugin = SQLAlchemyInitPlugin(config=sqlalchemy_config)
 def on_startup() -> None:
     """Initializes the database."""
     with sqlalchemy_config.get_engine().begin() as conn:
-        UUIDBase.metadata.create_all(conn)
+        base.UUIDBase.metadata.create_all(conn)
 
 
 app = Litestar(

--- a/docs/examples/data_transfer_objects/factory/my_lib.py
+++ b/docs/examples/data_transfer_objects/factory/my_lib.py
@@ -4,10 +4,10 @@ from typing import Any
 
 from sqlalchemy.orm import DeclarativeBase
 
-from litestar.contrib.sqlalchemy.base import CommonTableAttributes, UUIDPrimaryKey, create_registry
+from litestar.plugins.sqlalchemy import base, mixins
 
 
-class _Base(CommonTableAttributes, UUIDPrimaryKey, DeclarativeBase):
+class _Base(base.CommonTableAttributes, mixins.UUIDPrimaryKey, DeclarativeBase):
     """Fake base SQLAlchemy model for typing purposes."""
 
 
@@ -16,5 +16,9 @@ Base: _Base
 
 def __getattr__(name: str) -> Any:
     if name == "Base":
-        return type("Base", (CommonTableAttributes, UUIDPrimaryKey, DeclarativeBase), {"registry": create_registry()})
+        return type(
+            "Base",
+            (base.CommonTableAttributes, mixins.UUIDPrimaryKey, DeclarativeBase),
+            {"registry": base.create_registry()},
+        )
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/docs/examples/pagination/using_offset_pagination_with_sqlalchemy.py
+++ b/docs/examples/pagination/using_offset_pagination_with_sqlalchemy.py
@@ -4,17 +4,16 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Mapped
 
 from litestar import Litestar, get
-from litestar.contrib.sqlalchemy.base import UUIDBase
-from litestar.contrib.sqlalchemy.plugins import SQLAlchemyAsyncConfig, SQLAlchemyInitPlugin
 from litestar.di import Provide
 from litestar.pagination import AbstractAsyncOffsetPaginator, OffsetPagination
+from litestar.plugins.sqlalchemy import SQLAlchemyAsyncConfig, SQLAlchemyInitPlugin, base
 
 if TYPE_CHECKING:
     from sqlalchemy.engine.result import ScalarResult
     from sqlalchemy.ext.asyncio import AsyncSession
 
 
-class Person(UUIDBase):
+class Person(base.UUIDBase):
     name: Mapped[str]
 
 
@@ -46,7 +45,7 @@ sqlalchemy_plugin = SQLAlchemyInitPlugin(config=sqlalchemy_config)
 async def on_startup() -> None:
     """Initializes the database."""
     async with sqlalchemy_config.get_engine().begin() as conn:
-        await conn.run_sync(UUIDBase.metadata.create_all)
+        await conn.run_sync(base.UUIDBase.metadata.create_all)
 
 
 app = Litestar(route_handlers=[people_handler], on_startup=[on_startup], plugins=[sqlalchemy_plugin])

--- a/docs/examples/plugins/sqlalchemy/configure.py
+++ b/docs/examples/plugins/sqlalchemy/configure.py
@@ -1,4 +1,4 @@
-from litestar.contrib.sqlalchemy.plugins import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
+from litestar.plugins.sqlalchemy import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
 
 sqlalchemy_config = SQLAlchemyAsyncConfig(connection_string="sqlite+aiosqlite:///test.sqlite")
 plugin = SQLAlchemyPlugin(config=sqlalchemy_config)

--- a/docs/examples/plugins/sqlalchemy/modelling.py
+++ b/docs/examples/plugins/sqlalchemy/modelling.py
@@ -1,8 +1,8 @@
 from sqlalchemy.orm import Mapped
 
-from litestar.contrib.sqlalchemy.base import UUIDBase
+from litestar.plugins.sqlalchemy import base
 
 
-class TodoItem(UUIDBase):
+class TodoItem(base.UUIDBase):
     title: Mapped[str]
     done: Mapped[bool]

--- a/docs/examples/plugins/sqlalchemy_init_plugin/sqlalchemy_async.py
+++ b/docs/examples/plugins/sqlalchemy_init_plugin/sqlalchemy_async.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import text
 
 from litestar import Litestar, get
-from litestar.contrib.sqlalchemy.plugins import SQLAlchemyAsyncConfig, SQLAlchemyInitPlugin
+from litestar.plugins.sqlalchemy import SQLAlchemyAsyncConfig, SQLAlchemyInitPlugin
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession

--- a/docs/examples/plugins/sqlalchemy_init_plugin/sqlalchemy_sync.py
+++ b/docs/examples/plugins/sqlalchemy_init_plugin/sqlalchemy_sync.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import text
 
 from litestar import Litestar, get
-from litestar.contrib.sqlalchemy.plugins import SQLAlchemyInitPlugin, SQLAlchemySyncConfig
+from litestar.plugins.sqlalchemy import SQLAlchemyInitPlugin, SQLAlchemySyncConfig
 
 if TYPE_CHECKING:
     from sqlalchemy import Engine

--- a/docs/tutorials/repository-tutorial/02-repository-introduction.rst
+++ b/docs/tutorials/repository-tutorial/02-repository-introduction.rst
@@ -146,7 +146,7 @@ conditions. This pattern can be extended and adjusted to meet your needs.
 .. literalinclude:: /examples/contrib/sqlalchemy/sqlalchemy_repository_bulk_operations.py
     :language: python
     :caption: ``app.py``
-    :lines: 37-55
+    :lines: 1-3, 34-54
     :linenos:
 
 You can review the JSON source file here:
@@ -171,7 +171,7 @@ performance when working with larger data sets.
 .. literalinclude:: /examples/contrib/sqlalchemy/sqlalchemy_repository_bulk_operations.py
     :language: python
     :caption: ``app.py``
-    :lines: 66-71
+    :lines: 5-11, 13, 14-16, 18-26, 27-33, 55-70
     :linenos:
 
 Paginated Data Selection
@@ -185,7 +185,7 @@ repository.
 .. literalinclude:: /examples/contrib/sqlalchemy/sqlalchemy_repository_bulk_operations.py
     :language: python
     :caption: ``app.py``
-    :lines: 73-75
+    :lines: 10, 55-56, 72-74
     :linenos:
 
 Bulk Delete
@@ -198,7 +198,7 @@ executing row-by-row.
 .. literalinclude:: /examples/contrib/sqlalchemy/sqlalchemy_repository_bulk_operations.py
     :language: python
     :caption: ``app.py``
-    :lines: 77-79
+    :lines: 76-78
     :linenos:
 
 Counts
@@ -209,7 +209,7 @@ Finally, we'll demonstrate how to count the number of records remaining in the d
 .. literalinclude:: /examples/contrib/sqlalchemy/sqlalchemy_repository_bulk_operations.py
     :language: python
     :caption: ``app.py``
-    :lines: 81-83
+    :lines: 80-82
     :linenos:
 
 Now that we have demonstrated how to interact with the repository objects outside of a

--- a/docs/tutorials/repository-tutorial/04-repository-other.rst
+++ b/docs/tutorials/repository-tutorial/04-repository-other.rst
@@ -1,5 +1,6 @@
 Adding Additional Features to the Repository
 --------------------------------------------
+
 While most of the functionality you need is built into the repository, there are still
 cases where you need to add in additional functionality. Let's explore ways that we
 can add functionality on top of the repository pattern.
@@ -8,10 +9,11 @@ can add functionality on top of the repository pattern.
 
 Slug Fields
 -----------
+
 .. literalinclude:: /examples/contrib/sqlalchemy/sqlalchemy_repository_extension.py
     :language: python
     :caption: ``app.py``
-    :lines: 12, 33-40, 101-106
+    :lines: 10-23, 33-34, 37-42, 101-102, 106-108
     :linenos:
 
 In this example, we are using a ``BlogPost`` model to hold blog post titles and
@@ -32,7 +34,7 @@ to have the slugified value of "follow-the-yellow-brick-road".
 .. literalinclude:: /examples/contrib/sqlalchemy/sqlalchemy_repository_extension.py
     :language: python
     :caption: ``app.py``
-    :lines: 43-98
+    :lines: 1-8, 14-23, 43-44, 46-100
     :linenos:
 
 Since the ``BlogPost.title`` field is not marked as unique, this means that we'll have
@@ -42,7 +44,7 @@ a random set of digits are appended to the end of the slug to make it unique.
 .. literalinclude:: /examples/contrib/sqlalchemy/sqlalchemy_repository_extension.py
     :language: python
     :caption: ``app.py``
-    :lines: 171-173
+    :lines: 1-23, 27-32, 101-102, 106-126, 170-180
     :linenos:
 
 We are all set to use this in our routes now.  First, we'll convert our incoming
@@ -64,5 +66,5 @@ Full Code
     .. literalinclude:: /examples/contrib/sqlalchemy/sqlalchemy_repository_extension.py
         :language: python
         :caption: ``app.py``
-        :lines: 12, 33-40, 101-106, 43-98, 171-173
+        :emphasize-lines: 12, 37-42, 106-108, 177
         :linenos:

--- a/docs/tutorials/sqlalchemy/2-serialization-plugin.rst
+++ b/docs/tutorials/sqlalchemy/2-serialization-plugin.rst
@@ -10,7 +10,7 @@ Here's the code:
 .. literalinclude:: /examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_serialization_plugin.py
     :language: python
     :linenos:
-    :emphasize-lines: 11,76-77,82-83,88,90-91,98
+    :emphasize-lines: 12, 75-77, 80-83, 86-91, 98
 
 We've simply imported the plugin and added it to our app's plugins list, and now we can receive and return our
 SQLAlchemy data models directly to and from our handler.
@@ -30,14 +30,14 @@ Once more, let's compare the sets of application handlers before and after our r
         .. literalinclude:: /examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_serialization_plugin.py
             :language: python
             :linenos:
-            :lines: 75-99
+            :lines: 1-13, 73-99
 
    .. tab-item:: Before
 
         .. literalinclude:: /examples/contrib/sqlalchemy/plugins/tutorial/full_app_no_plugins.py
             :language: python
             :linenos:
-            :lines: 69-100
+            :lines: 1-12, 67-100
 
 Very nice! But, we can do better.
 

--- a/docs/tutorials/sqlalchemy/3-init-plugin.rst
+++ b/docs/tutorials/sqlalchemy/3-init-plugin.rst
@@ -19,7 +19,7 @@ Here's the updated code:
 .. literalinclude:: /examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_init_plugin.py
     :language: python
     :linenos:
-    :emphasize-lines: 11,30,78-79,87
+    :emphasize-lines: 12, 28, 76-78, 85
 
 The most notable difference is that we no longer need the ``db_connection()`` lifespan context manager - the plugin
 handles this for us. It also handles the creation of the tables in our database if we supply our metadata and

--- a/docs/tutorials/sqlalchemy/4-final-touches-and-recap.rst
+++ b/docs/tutorials/sqlalchemy/4-final-touches-and-recap.rst
@@ -13,7 +13,7 @@ Here is our final application:
 .. literalinclude:: /examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_plugin.py
     :language: python
     :linenos:
-    :emphasize-lines: 11,83
+    :emphasize-lines: 10, 82
 
 Recap
 =====
@@ -27,7 +27,7 @@ In the final application ``TodoItem`` is defined, representing a TODO item. It e
 .. literalinclude:: /examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_plugin.py
     :language: python
     :linenos:
-    :lines: 13-23
+    :lines: 1-6, 12-21
 
 Next, we define a dependency that centralizes our database transaction management and error handling. This dependency
 depends on the ``db_session`` dependency, which is provided by the SQLAlchemy plugin, and is made available to our
@@ -36,21 +36,21 @@ handlers via the ``transaction`` argument:
 .. literalinclude:: /examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_plugin.py
     :language: python
     :linenos:
-    :lines: 25-33
+    :lines: 1-11, 22-32
 
 We also define a couple of utility functions, that help us to retrieve our TODO items from the database:
 
 .. literalinclude:: /examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_plugin.py
     :language: python
     :linenos:
-    :lines: 35-52
+    :lines: 1-11, 33-50
 
 We define our route handlers, which are the interface through which TODO items can be created, retrieved and updated:
 
 .. literalinclude:: /examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_plugin.py
     :language: python
     :linenos:
-    :lines: 54-70
+    :lines: 1-11, 51-69
 
 Finally, we define our application, using the
 :class:`SQLAlchemyPlugin <litestar.contrib.sqlalchemy.plugins.SQLAlchemyPlugin>` to configure SQLAlchemy and manage the
@@ -59,7 +59,7 @@ engine and session lifecycle, and register our ``transaction`` dependency.
 .. literalinclude:: /examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_plugin.py
     :language: python
     :linenos:
-    :lines: 80-83
+    :lines: 1-11, 78-83
 
 .. seealso::
 


### PR DESCRIPTION
By submitting this pull request, I agree to:
- [x] follow Litestar's [Code of Conduct](/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] follow Litestar's [contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- [x] follow the PSFs's [Code of Conduct](https://www.python.org/psf/conduct/)

## Description

Changes in example code were made to use `litestar.plugins.sqlalchemy` instead of `litestar.contrib.sqlalchemy` as the latter is being depreciated.
Documentation files where the changed files were referenced were updated as well to adjust the referenced lines because:

- amount of lines in the import section were changed in some referenced files that were updated;
- they already were off.

Additionally imports and other relevant parts were included in code example blocks so it could be easily seen what is imported from where.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Closes

Not applicable.