### PR TITLE
docs: add line check to code-blocks with `blacken-docs`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,13 @@ repos:
     rev: "v1.0.0"
     hooks:
       - id: sphinx-lint
+  - repo: https://github.com/adamchainz/blacken-docs
+    rev: "1.19.1"
+    hooks:
+      - id: blacken-docs
+        args: ["-l=80", "--check"]
+        additional_dependencies:
+        - black==22.12.0
   - repo: local
     hooks:
       - id: pypi-readme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,7 @@ linting = [
   "types-pyyaml",
   "types-redis",
   "types-psutil",
+  "blacken-docs",
 ]
 test = [
   "covdefaults",

--- a/uv.lock
+++ b/uv.lock
@@ -405,6 +405,41 @@ wheels = [
 ]
 
 [[package]]
+name = "blacken-docs"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9' and sys_platform != 'win32'",
+    "python_full_version < '3.9' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "black", marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/a9/99fe0283575297466df65eb54873a892f0db5fd24459abef4c2691db883a/blacken_docs-1.18.0.tar.gz", hash = "sha256:47bed628679d008a8eb55d112df950582e68d0f57615223929e366348d935444", size = 14743 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/7e/532f6c8b81346c2337c54b0e16f49f2968d86b0c535d6318b3f21f3ff4cf/blacken_docs-1.18.0-py3-none-any.whl", hash = "sha256:64f592246784131e9f84dad1db397f44eeddc77fdf01726bab920a3f00a3815c", size = 8243 },
+]
+
+[[package]]
+name = "blacken-docs"
+version = "1.19.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "black", marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/a2/772f95006335a59837b415b8b3b38a7c5f2606060d6336ee111521af563e/blacken_docs-1.19.1.tar.gz", hash = "sha256:3cf7a10f5b87886683e3ab07a0dc17de41425f3d21e2948e59f1c6079c45b328", size = 14918 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/1b/166bd46537f9d7832d856ddf3b5cc2ef9761a2cb4b31c83c245dd8987c11/blacken_docs-1.19.1-py3-none-any.whl", hash = "sha256:73c3dee042a28f2d4f7df6e2c340869d6ced9704f6174d035d9b6199567f890d", size = 8280 },
+]
+
+[[package]]
 name = "brotli"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1927,6 +1962,8 @@ docs = [
 ]
 linting = [
     { name = "asyncpg-stubs" },
+    { name = "blacken-docs", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "blacken-docs", version = "1.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "codecov-cli" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -2040,6 +2077,7 @@ docs = [
 ]
 linting = [
     { name = "asyncpg-stubs" },
+    { name = "blacken-docs" },
     { name = "codecov-cli" },
     { name = "mypy" },
     { name = "pre-commit" },


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Hi! 

I added `blacken-docs` for checking code-blocks in docs as dep and also put it to `pre-commit` so it can be running through `make lint`. But during work got several questions:

`blacken-docs` using black, so code-blocks check are not only for line-length. Here is a output result:
```
docs/migration/flask.rst:276: code block parse error Cannot parse: 4:0:  app = Litestar(route_handlers=[
docs/usage/cli.rst: Requires a rewrite.
litestar/security/session_auth/auth.py: Requires a rewrite.
docs/migration/fastapi.rst: Requires a rewrite.
docs/usage/middleware/builtin-middleware.rst: Requires a rewrite.
litestar/middleware/session/base.py: Requires a rewrite.
docs/usage/security/abstract-authentication-middleware.rst: Requires a rewrite.
docs/usage/routing/overview.rst: Requires a rewrite.
docs/index.rst: Requires a rewrite.
docs/usage/middleware/creating-middleware.rst: Requires a rewrite.
docs/PYPI_README.md: Requires a rewrite.
docs/usage/testing.rst: Requires a rewrite.
docs/usage/responses.rst: Requires a rewrite.
docs/usage/htmx.rst: Requires a rewrite.
docs/usage/routing/handlers.rst:393: code block parse error Cannot parse: 1:8: handler instance and paths
docs/usage/logging.rst: Requires a rewrite.
docs/usage/dependency-injection.rst: Requires a rewrite.
docs/usage/security/excluding-and-including-endpoints.rst: Requires a rewrite.
litestar/utils/signature.py: Requires a rewrite.
docs/usage/applications.rst: Requires a rewrite.
docs/release-notes/whats-new-2.rst: Requires a rewrite.
docs/usage/templating.rst: Requires a rewrite.
docs/usage/events.rst: Requires a rewrite.
litestar/datastructures/state.py: Requires a rewrite.
docs/usage/metrics/open-telemetry.rst: Requires a rewrite.
README.md: Requires a rewrite.
docs/release-notes/changelog.rst:803: code block parse error Cannot parse: 1:25: from litestar.middlewares
docs/usage/openapi/schema_generation.rst: Requires a rewrite.
```
Should I run through and fix it?

Second, as mention in issue, it should checking only docs, but in docs may be auto generated code blocks from src docstrings (like here `litestar/datastructures/state.py`). Should we include checks for not only docs?   

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Resolve 
#3211 

