### PR TITLE
docs: clarify WebSocket `send_websocket_stream` capabilities

### DIFF
--- a/docs/usage/websockets.rst
+++ b/docs/usage/websockets.rst
@@ -8,8 +8,10 @@ There are three ways to handle WebSockets in Litestar:
 2. :class:`~litestar.handlers.websocket_listener` and :class:`~litestar.handlers.WebsocketListener`\  :
    Reactive, event-driven WebSockets with full serialization and DTO support and support
    for a synchronous interface
-3. :class:`~litestar.handlers.websocket_stream` and :func:`~litestar.handlers.send_websocket_stream`\ :
+3. :class:`~litestar.handlers.websocket_stream`:
    Proactive, stream oriented WebSockets with full serialization and DTO support
+4. :func:`~litestar.handlers.send_websocket_stream`:
+   Proactive, stream oriented WebSockets
 
 
 The main difference between the low and high level interfaces is that, dealing with low


### PR DESCRIPTION
Docs said `send_websocket_stream` would handle serialization of arbitrary objects when it did not; Only `websocket_stream` does.