### PR TITLE
feat(dto-schema-name): add `__schema_name__` to dto base

### DIFF
--- a/litestar/_openapi/datastructures.py
+++ b/litestar/_openapi/datastructures.py
@@ -136,8 +136,7 @@ class SchemaRegistry:
         key = _get_normalized_schema_key(field)
         if key not in self._schema_key_map:
             return None
-
-        if (existing_type := self._component_type_map[key]) != field:
+        if (existing_type := self._component_type_map[key]) != field and f"{field.raw!r}" != f"{existing_type.raw!r}":
             # TODO: This should check for strict equality, e.g. changes in type metadata
             # However, this is currently not possible to do without breaking things, as
             # we allow to define metadata on a type annotation in one place to be used

--- a/litestar/dto/_backend.py
+++ b/litestar/dto/_backend.py
@@ -113,7 +113,8 @@ class DTOBackend:
             rename_fields=self.dto_factory.config.rename_fields,
         )
         self.transfer_model_type = self.create_transfer_model_type(
-            model_name=model_type.__name__, field_definitions=self.parsed_field_definitions, 
+            model_name=model_type.__name__,
+            field_definitions=self.parsed_field_definitions,
         )
         self.dto_data_type: type[DTOData] | None = None
 

--- a/litestar/dto/_backend.py
+++ b/litestar/dto/_backend.py
@@ -113,7 +113,7 @@ class DTOBackend:
             rename_fields=self.dto_factory.config.rename_fields,
         )
         self.transfer_model_type = self.create_transfer_model_type(
-            model_name=model_type.__name__, field_definitions=self.parsed_field_definitions
+            model_name=model_type.__name__, field_definitions=self.parsed_field_definitions, 
         )
         self.dto_data_type: type[DTOData] | None = None
 
@@ -207,7 +207,7 @@ class DTOBackend:
         Returns:
             A ``BackendT`` class.
         """
-        struct_name = self._create_transfer_model_name(model_name)
+        struct_name = self.dto_factory.__schema_name__ or self._create_transfer_model_name(model_name)
 
         struct = _create_struct_for_field_definitions(
             model_name=struct_name,

--- a/litestar/dto/_backend.py
+++ b/litestar/dto/_backend.py
@@ -113,8 +113,7 @@ class DTOBackend:
             rename_fields=self.dto_factory.config.rename_fields,
         )
         self.transfer_model_type = self.create_transfer_model_type(
-            model_name=model_type.__name__,
-            field_definitions=self.parsed_field_definitions,
+            model_name=model_type.__name__, field_definitions=self.parsed_field_definitions
         )
         self.dto_data_type: type[DTOData] | None = None
 

--- a/litestar/dto/base_dto.py
+++ b/litestar/dto/base_dto.py
@@ -52,6 +52,7 @@ class AbstractDTO(Generic[T]):
     """If ``annotation`` is an iterable, this is the inner type, otherwise will be the same as ``annotation``."""
 
     _dto_backends: ClassVar[dict[str, _BackendDict]] = {}
+    __schema_name__ = None
 
     def __init__(self, asgi_connection: ASGIConnection) -> None:
         """Create an AbstractDTOFactory type.

--- a/litestar/dto/base_dto.py
+++ b/litestar/dto/base_dto.py
@@ -52,7 +52,7 @@ class AbstractDTO(Generic[T]):
     """If ``annotation`` is an iterable, this is the inner type, otherwise will be the same as ``annotation``."""
 
     _dto_backends: ClassVar[dict[str, _BackendDict]] = {}
-    __schema_name__ = None
+    __schema_name__: ClassVar[None | str] = None
 
     def __init__(self, asgi_connection: ASGIConnection) -> None:
         """Create an AbstractDTOFactory type.


### PR DESCRIPTION


<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- resolved #3427

I really like this project. I even immediately used it to rewrite my FastAPI-based project.

Especially, it provides DTOs that make it easy to reduce repetitive boilerplate code.

In the current implementation, the DTO generates a `Struct` for each Response and Request in the backend, which is generally fine. However, this leads to countless repetitive similar definitions in the OpenAPI schema. When I use OpenAPI to generate an SDK, these class names are used for model type definitions, which complicates development due to their differences—unlike with FastAPI, which doesn’t have this issue.

Currently, I find myself unable to specify the `__schema_name__` for DTOs, although `PydanticDTO` has similar functionality.

After reading the source code, it seems not particularly difficult to allow specifying a schema_name. I have added `__schema_name__` to the `AbstractDTO` class and prioritized using this as the model class name.

When generating the schema, it should also allow schemas like classes to be redefined (perhaps it should skip redefinition, but I haven’t figured out how to do that yet.)

In any case, I believe this PR can solve my problem.

---

I have already tested the effect in my own project, and it looks good. It introduces almost no complexity; you just need to add a single line for `__schema_name__`.

```py
class TagDTO(MixedDTO[Tag]):
    __schema_name__ = "TagPublic"
    config = DTOConfig(rename_strategy="camel")
```

before:

![image](https://github.com/user-attachments/assets/4f9339f2-d659-4343-8d8b-3b3753fd56ea)

after:

![image](https://github.com/user-attachments/assets/c7f99bb9-bc11-4204-9463-ab22ad78b594)

