### PR TITLE
fix(openapi): support prefixItems for tuple schema

### DIFF
--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -476,10 +476,6 @@ class SchemaCreator:
                     type=OpenAPIType.ARRAY,
                     prefix_items=[self.for_field_definition(f) for f in inner_types],
                 )
-                return Schema(
-                    type=OpenAPIType.ARRAY,
-                    prefix_items=[self.for_field_definition(f) for f in inner_types],
-                )
 
             # Handle other sequence types normally
             items = list(map(self.for_field_definition, inner_types))

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -468,14 +468,14 @@ class SchemaCreator:
 
         if field_definition.is_non_string_sequence or field_definition.is_non_string_iterable:
             # filters out ellipsis from tuple[int, ...] type annotations
-            inner_types = [f for f in field_definition.inner_types if f.annotation is not Ellipsis]
+            inner_types = tuple(f for f in field_definition.inner_types if f.annotation is not Ellipsis)
 
             # Handle tuple elements using prefixItems
-            if (
-                (field_definition.annotation is tuple or get_origin_or_inner_type(field_definition.annotation) is tuple)
-                and inner_types
-                and all(f.annotation is not Ellipsis for f in field_definition.inner_types)
-            ):
+            if (field_definition.origin is tuple) and inner_types == field_definition.inner_types:
+                return Schema(
+                    type=OpenAPIType.ARRAY,
+                    prefix_items=[self.for_field_definition(f) for f in inner_types],
+                )
                 return Schema(
                     type=OpenAPIType.ARRAY,
                     prefix_items=[self.for_field_definition(f) for f in inner_types],

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -468,7 +468,20 @@ class SchemaCreator:
 
         if field_definition.is_non_string_sequence or field_definition.is_non_string_iterable:
             # filters out ellipsis from tuple[int, ...] type annotations
-            inner_types = (f for f in field_definition.inner_types if f.annotation is not Ellipsis)
+            inner_types = [f for f in field_definition.inner_types if f.annotation is not Ellipsis]
+
+            # Handle tuple elements using prefixItems
+            if (
+                (field_definition.annotation is tuple or get_origin_or_inner_type(field_definition.annotation) is tuple)
+                and inner_types
+                and all(f.annotation is not Ellipsis for f in field_definition.inner_types)
+            ):
+                return Schema(
+                    type=OpenAPIType.ARRAY,
+                    prefix_items=[self.for_field_definition(f) for f in inner_types],
+                )
+
+            # Handle other sequence types normally
             items = list(map(self.for_field_definition, inner_types))
 
             return Schema(

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -469,7 +469,23 @@ def test_schema_tuple_with_union() -> None:
 
 def test_schema_tuple() -> None:
     schema = get_schema_for_field_definition(FieldDefinition.from_annotation(Tuple[int, str]))
-    assert schema.prefix_items == [Schema(type=OpenAPIType.INTEGER), Schema(type=OpenAPIType.STRING)]
+    assert schema == Schema(
+        prefix_items=[Schema(type=OpenAPIType.INTEGER), Schema(type=OpenAPIType.STRING)],
+        type=OpenAPIType.ARRAY,
+    )
+
+
+def test_schema_optional_tuple() -> None:
+    schema = get_schema_for_field_definition(FieldDefinition.from_annotation(Optional[Tuple[int, str]]))
+    assert schema == Schema(
+        one_of=[
+            Schema(
+                prefix_items=[Schema(type=OpenAPIType.INTEGER), Schema(type=OpenAPIType.STRING)],
+                type=OpenAPIType.ARRAY,
+            ),
+            Schema(type=OpenAPIType.NULL),
+        ],
+    )
 
 
 def test_optional_enum() -> None:

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -461,11 +461,15 @@ def test_schema_generation_with_ellipsis() -> None:
 
 def test_schema_tuple_with_union() -> None:
     schema = get_schema_for_field_definition(FieldDefinition.from_annotation(Tuple[int, Union[int, str]]))
-    assert isinstance(schema.items, Schema)
-    assert schema.items.one_of == [
+    assert schema.prefix_items == [
         Schema(type=OpenAPIType.INTEGER),
         Schema(one_of=[Schema(type=OpenAPIType.INTEGER), Schema(type=OpenAPIType.STRING)]),
     ]
+
+
+def test_schema_tuple() -> None:
+    schema = get_schema_for_field_definition(FieldDefinition.from_annotation(Tuple[int, str]))
+    assert schema.prefix_items == [Schema(type=OpenAPIType.INTEGER), Schema(type=OpenAPIType.STRING)]
 
 
 def test_optional_enum() -> None:


### PR DESCRIPTION
- resolved #4130 

The previous implementation incorrectly treated Python tuples as arrays with items of a single, uniform type.

This change utilizes prefixItems (OpenAPI 3.1+) to correctly specify the type for each element at its specific position when the field is a tuple. This results in a more accurate and modern OpenAPI schema that precisely reflects the Python tuple structure.

Additionally:

- Adjusted assertions in `test_schema_tuple_with_union` as the original expectations seemed incorrect with the proper schema generation.
- Added a new test case `test_schema_tuple`.