### PR TITLE
docs: Update `Offset Pagination With SQLAlchemy` example

### DIFF
--- a/docs/examples/pagination/using_offset_pagination_with_sqlalchemy.py
+++ b/docs/examples/pagination/using_offset_pagination_with_sqlalchemy.py
@@ -25,13 +25,13 @@ class PersonOffsetPaginator(AbstractAsyncOffsetPaginator[Person]):
         return cast("int", await self.async_session.scalar(select(func.count(Person.id))))
 
     async def get_items(self, limit: int, offset: int) -> list[Person]:
-        people: ScalarResult = await self.async_session.scalars(select(Person).slice(offset, limit))
+        people: ScalarResult = await self.async_session.scalars(select(Person).slice(offset, offset + limit))
         return list(people.all())
 
 
 # Create a route handler. The handler will receive two query parameters - 'limit' and 'offset', which is passed
 # to the paginator instance. Also create a dependency 'paginator' which will be injected into the handler.
-@get("/people", dependencies={"paginator": Provide(PersonOffsetPaginator)})
+@get("/people", dependencies={"paginator": Provide(PersonOffsetPaginator, sync_to_thread=False)})
 async def people_handler(paginator: PersonOffsetPaginator, limit: int, offset: int) -> OffsetPagination[Person]:
     return await paginator(limit=limit, offset=offset)
 


### PR DESCRIPTION
Add missing `sync_to_thread=False` argument
Also fixed the `slice` method arguments

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

`slice` context
```python
# sqlalchemy/sql/util.py
# start=1, stop=3
limit_clause = _offset_or_limit_clause(stop - start)
```
```sql
# sqlite
select * from person limit -2 offset 3;
-- ...

# postgres
select * from person limit -2 offset 3;
-- LIMIT must not be negative
```

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
https://github.com/litestar-org/litestar/issues/4141
