### PR TITLE
fix(DI): Ensure dependencies are cleaned up when exception occurrs during cleanup 

### DIFF
--- a/docs/usage/dependency-injection.rst
+++ b/docs/usage/dependency-injection.rst
@@ -153,9 +153,9 @@ and committing otherwise.
 .. admonition:: Best Practice
     :class: tip
 
-    You should always wrap `yield` in a `try`/`finally` block, regardless of whether you
-    want to handle exceptions, to ensure that the cleanup code is run even when exceptions
-    occurred:
+    You should always wrap ``yield`` in a ``try``/``finally`` block, regardless of
+    whether you want to handle exceptions, to ensure that the cleanup code is run even
+    when exceptions occurred:
 
     .. code-block:: python
 
@@ -168,9 +168,19 @@ and committing otherwise.
 
 .. attention::
 
-   Do not re-raise exceptions within the dependency. Exceptions caught within these
-   dependencies will still be handled by the regular mechanisms without an explicit
-   re-raise
+    Do not re-raise exceptions within the dependency. Exceptions caught within these
+    dependencies will still be handled by the regular mechanisms without an explicit
+    re-raise
+
+
+.. important::
+
+    Exceptions raised during the cleanup step of a dependency will be re-raised in an
+    :exc:`ExceptionGroup` (for Python versions < 3.11, the
+    `exceptiongroup <https://github.com/agronholm/exceptiongroup>`_ will be used). This
+    happens after all dependencies have been cleaned up, so exceptions raised during
+    cleanup of one dependencies do not affect the cleanup of other dependencies.
+
 
 
 Dependency keyword arguments

--- a/litestar/_kwargs/cleanup.py
+++ b/litestar/_kwargs/cleanup.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from contextlib import AbstractAsyncContextManager
 from inspect import Traceback, isasyncgen
+from types import TracebackType
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Generator
 
+import exceptiongroup
 from anyio import create_task_group
 
 from litestar.utils import ensure_async_callable
@@ -15,7 +18,7 @@ if TYPE_CHECKING:
     from litestar.types import AnyGenerator
 
 
-class DependencyCleanupGroup:
+class DependencyCleanupGroup(AbstractAsyncContextManager):
     """Wrapper for generator based dependencies.
 
     Simplify cleanup by wrapping :func:`next` / :func:`anext` calls and providing facilities to
@@ -45,7 +48,7 @@ class DependencyCleanupGroup:
             None
         """
         if self._closed:
-            raise RuntimeError("Cannot call cleanup on a closed DependencyCleanupGroup")
+            raise RuntimeError("Cannot call .add on a closed DependencyCleanupGroup")
         self._generators.append(generator)
 
     @staticmethod
@@ -62,7 +65,18 @@ class DependencyCleanupGroup:
 
         return ensure_async_callable(wrapped)
 
-    async def cleanup(self) -> None:
+    async def close(self, exc: BaseException | None = None) -> None:
+        if self._closed:
+            raise RuntimeError("Cannot call cleanup on a closed DependencyCleanupGroup")
+
+        self._closed = True
+
+        if exc is None:
+            await self._cleanup()
+        else:
+            await self._throw(exc)
+
+    async def _cleanup(self) -> None:
         """Execute cleanup by calling :func:`next` / :func:`anext` on all generators.
 
         If there are multiple generators to be called, they will be executed in a :class:`anyio.TaskGroup`.
@@ -70,10 +84,6 @@ class DependencyCleanupGroup:
         Returns:
             None
         """
-        if self._closed:
-            raise RuntimeError("Cannot call cleanup on a closed DependencyCleanupGroup")
-
-        self._closed = True
 
         if not self._generators:
             return
@@ -95,18 +105,18 @@ class DependencyCleanupGroup:
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
-        exc_tb: Traceback | None,
+        exc_tb: TracebackType | None,
     ) -> None:
         """If an exception was raised within the contextmanager block, throw it into all generators."""
-        if exc_val:
-            await self.throw(exc_val)
+        await self.close(exc_val)
 
-    async def throw(self, exc: BaseException) -> None:
+    async def _throw(self, exc: BaseException) -> None:
         """Throw an exception in all generators sequentially.
 
         Args:
             exc: Exception to throw
         """
+        exceptions = []
         for gen in self._generators:
             try:
                 if isasyncgen(gen):
@@ -115,3 +125,12 @@ class DependencyCleanupGroup:
                     gen.throw(exc)  # type: ignore[union-attr]
             except (StopIteration, StopAsyncIteration):
                 continue
+            except Exception as cleanup_exc:  # noqa: BLE001
+                if cleanup_exc is not exc:
+                    exceptions.append(cleanup_exc)
+
+        if exceptions:
+            raise exceptiongroup.ExceptionGroup(
+                "Exceptions occurred during cleanup of dependencies",
+                exceptions,
+            ) from exc

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -134,9 +134,9 @@ class HTTPRoute(BaseRoute):
             scope=scope, request=request, parameter_model=parameter_model, route_handler=route_handler
         )
 
-    async def _call_handler_function(
+    async def _call_handler_function(  # type: ignore[return]
         self, scope: Scope, request: Request, parameter_model: KwargsModel, route_handler: HTTPRouteHandler
-    ) -> ASGIApp:
+    ) -> ASGIApp:  # pyright: ignore[reportGeneralTypeIssues]
         """Call the before request handlers, retrieve any data required for the route handler, and call the route
         handler's ``to_response`` method.
 
@@ -152,6 +152,8 @@ class HTTPRoute(BaseRoute):
         # 'DependencyCleanupGroup' to enter and exit
         stack = contextlib.AsyncExitStack()
 
+        # mypy cannot infer that 'stack' never swallows exceptions, therefore it thinks
+        # this method is potentially missing a 'return' statement
         async with stack:
             if not response_data:
                 parsed_kwargs: dict[str, Any] = {}
@@ -179,11 +181,7 @@ class HTTPRoute(BaseRoute):
                     else await route_handler.fn(**parsed_kwargs)
                 )
 
-            response: ASGIApp = await route_handler.to_response(
-                app=scope["litestar_app"], data=response_data, request=request
-            )
-
-        return response
+            return await route_handler.to_response(app=scope["litestar_app"], data=response_data, request=request)
 
     @staticmethod
     async def _get_cached_response(request: Request, route_handler: HTTPRouteHandler) -> ASGIApp | None:

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from itertools import chain
 from typing import TYPE_CHECKING, Any
 
@@ -17,7 +18,6 @@ from litestar.utils.scope.state import ScopeState
 
 if TYPE_CHECKING:
     from litestar._kwargs import KwargsModel
-    from litestar._kwargs.cleanup import DependencyCleanupGroup
     from litestar.connection import Request
     from litestar.types import ASGIApp, HTTPScope, Method, Receive, Scope, Send
 
@@ -144,62 +144,46 @@ class HTTPRoute(BaseRoute):
         it tries to pass it to an appropriate exception handler - if defined.
         """
         response_data: Any = None
-        cleanup_group: DependencyCleanupGroup | None = None
 
         if before_request_handler := route_handler.resolve_before_request():
             response_data = await before_request_handler(request)
 
-        if not response_data:
-            response_data, cleanup_group = await self._get_response_data(
-                route_handler=route_handler, parameter_model=parameter_model, request=request
-            )
+        # create and enter an AsyncExit stack as we may or may not have a
+        # 'DependencyCleanupGroup' to enter and exit
+        stack = contextlib.AsyncExitStack()
 
-        response: ASGIApp = await route_handler.to_response(
-            app=scope["litestar_app"], data=response_data, request=request
-        )
+        async with stack:
+            if not response_data:
+                parsed_kwargs: dict[str, Any] = {}
 
-        if cleanup_group:
-            await cleanup_group.cleanup()
+                if parameter_model.has_kwargs and route_handler.signature_model:
+                    try:
+                        kwargs = await parameter_model.to_kwargs(connection=request)
+                    except SerializationException as e:
+                        raise ClientException(str(e)) from e
 
-        return response
+                    if kwargs.get("data") is Empty:
+                        del kwargs["data"]
 
-    @staticmethod
-    async def _get_response_data(
-        route_handler: HTTPRouteHandler, parameter_model: KwargsModel, request: Request
-    ) -> tuple[Any, DependencyCleanupGroup | None]:
-        """Determine what kwargs are required for the given route handler's ``fn`` and calls it."""
-        parsed_kwargs: dict[str, Any] = {}
-        cleanup_group: DependencyCleanupGroup | None = None
+                    if parameter_model.dependency_batches:
+                        cleanup_group = await parameter_model.resolve_dependencies(request, kwargs)
+                        await stack.enter_async_context(cleanup_group)
 
-        if parameter_model.has_kwargs and route_handler.signature_model:
-            try:
-                kwargs = await parameter_model.to_kwargs(connection=request)
-            except SerializationException as e:
-                raise ClientException(str(e)) from e
+                    parsed_kwargs = route_handler.signature_model.parse_values_from_connection_kwargs(
+                        connection=request, kwargs=kwargs
+                    )
 
-            if kwargs.get("data") is Empty:
-                del kwargs["data"]
-
-            if parameter_model.dependency_batches:
-                cleanup_group = await parameter_model.resolve_dependencies(request, kwargs)
-
-            parsed_kwargs = route_handler.signature_model.parse_values_from_connection_kwargs(
-                connection=request, kwargs=kwargs
-            )
-
-        if cleanup_group:
-            async with cleanup_group:
-                data = (
+                response_data = (
                     route_handler.fn(**parsed_kwargs)
                     if route_handler.has_sync_callable
                     else await route_handler.fn(**parsed_kwargs)
                 )
-        elif route_handler.has_sync_callable:
-            data = route_handler.fn(**parsed_kwargs)
-        else:
-            data = await route_handler.fn(**parsed_kwargs)
 
-        return data, cleanup_group
+            response: ASGIApp = await route_handler.to_response(
+                app=scope["litestar_app"], data=response_data, request=request
+            )
+
+        return response
 
     @staticmethod
     async def _get_cached_response(request: Request, route_handler: HTTPRouteHandler) -> ASGIApp | None:

--- a/litestar/routes/websocket.py
+++ b/litestar/routes/websocket.py
@@ -81,6 +81,5 @@ class WebSocketRoute(BaseRoute):
         if cleanup_group:
             async with cleanup_group:
                 await self.route_handler.fn(**parsed_kwargs)
-            await cleanup_group.cleanup()
         else:
             await self.route_handler.fn(**parsed_kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
   "rich>=13.0.0",
   "rich-click",
   "multipart>=1.2.0",
+  "exceptiongroup>=1.2.2; python_version < \"3.11\"",
   # default litestar plugins
   "litestar-htmx>=0.4.0",
 ]
@@ -397,8 +398,6 @@ lint.select = [
   "W",   # pycodestyle - warning
   "YTT", # flake8-2020
 ]
-
-line-length = 120
 lint.ignore = [
   "A003",    # flake8-builtins - class attribute {name} is shadowing a python builtin
   "B010",    # flake8-bugbear - do not call setattr with a constant attribute value
@@ -419,6 +418,8 @@ lint.ignore = [
   "ISC001",  # Ruff formatter incompatible
   "CPY001",  # ruff - copyright notice at the top of the file
 ]
+
+line-length = 120
 src = ["litestar", "tests", "docs/examples"]
 target-version = "py38"
 

--- a/tests/unit/test_kwargs/test_cleanup_group.py
+++ b/tests/unit/test_kwargs/test_cleanup_group.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import sys
 from typing import AsyncGenerator, Generator
 from unittest.mock import MagicMock
 
-import exceptiongroup
+if sys.version_info < (3, 11):
+    from exceptiongroup import ExceptionGroup
+
 import pytest
 
 from litestar._kwargs.cleanup import DependencyCleanupGroup
@@ -105,7 +108,7 @@ async def test_exception_during_close(
     await async_next(gen_2)
     group = DependencyCleanupGroup([gen_1, gen_2])
 
-    with pytest.raises(exceptiongroup.ExceptionGroup) as exc:
+    with pytest.raises(ExceptionGroup) as exc:
         await group.close(exit_exception)
 
     assert exc.value.exceptions == (gen_exc,)

--- a/tests/unit/test_kwargs/test_cleanup_group.py
+++ b/tests/unit/test_kwargs/test_cleanup_group.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from typing import AsyncGenerator, Generator
 from unittest.mock import MagicMock
 
+import exceptiongroup
 import pytest
 
 from litestar._kwargs.cleanup import DependencyCleanupGroup
@@ -20,8 +23,10 @@ def async_cleanup_mock() -> MagicMock:
 @pytest.fixture
 def generator(cleanup_mock: MagicMock) -> Generator[str, None, None]:
     def func() -> Generator[str, None, None]:
-        yield "hello"
-        cleanup_mock()
+        try:
+            yield "hello"
+        finally:
+            cleanup_mock()
 
     return func()
 
@@ -29,8 +34,10 @@ def generator(cleanup_mock: MagicMock) -> Generator[str, None, None]:
 @pytest.fixture
 def async_generator(async_cleanup_mock: MagicMock) -> AsyncGenerator[str, None]:
     async def func() -> AsyncGenerator[str, None]:
-        yield "world"
-        async_cleanup_mock()
+        try:
+            yield "world"
+        finally:
+            async_cleanup_mock()
 
     return func()
 
@@ -47,13 +54,13 @@ async def test_cleanup(generator: Generator[str, None, None], cleanup_mock: Magi
     next(generator)
     group = DependencyCleanupGroup([generator])
 
-    await group.cleanup()
+    await group.close()
 
     cleanup_mock.assert_called_once()
     assert group._closed
 
 
-async def test_cleanup_multiple(
+async def test_cleanup_throw_multiple_exceptions(
     generator: Generator[str, None, None],
     async_generator: AsyncGenerator[str, None],
     cleanup_mock: MagicMock,
@@ -61,9 +68,47 @@ async def test_cleanup_multiple(
 ) -> None:
     next(generator)
     await async_next(async_generator)
+
     group = DependencyCleanupGroup([generator, async_generator])
 
-    await group.cleanup()
+    await group.close(ValueError())
+
+    cleanup_mock.assert_called_once()
+    async_cleanup_mock.assert_called_once()
+    assert group._closed
+
+
+@pytest.mark.parametrize("exit_exception", (None, ValueError()))
+async def test_exception_during_close(
+    cleanup_mock: MagicMock,
+    async_cleanup_mock: MagicMock,
+    exit_exception: Exception | None,
+) -> None:
+    gen_exc = ValueError()
+
+    def gen_fn() -> Generator[None, None, None]:
+        try:
+            yield
+        finally:
+            cleanup_mock()
+            raise gen_exc  # raise an exception here
+
+    async def async_gen_fn() -> AsyncGenerator[None, None]:
+        try:
+            yield
+        finally:
+            async_cleanup_mock()  # we expect this to be called still
+
+    gen_1 = gen_fn()
+    gen_2 = async_gen_fn()
+    next(gen_1)
+    await async_next(gen_2)
+    group = DependencyCleanupGroup([gen_1, gen_2])
+
+    with pytest.raises(exceptiongroup.ExceptionGroup) as exc:
+        await group.close(exit_exception)
+
+    assert exc.value.exceptions == (gen_exc,)
 
     cleanup_mock.assert_called_once()
     async_cleanup_mock.assert_called_once()
@@ -74,9 +119,9 @@ async def test_cleanup_on_closed_raises(generator: Generator[str, None, None]) -
     next(generator)
     group = DependencyCleanupGroup([generator])
 
-    await group.cleanup()
+    await group.close()
     with pytest.raises(RuntimeError):
-        await group.cleanup()
+        await group.close()
 
 
 async def test_add_on_closed_raises(
@@ -85,7 +130,7 @@ async def test_add_on_closed_raises(
     next(generator)
     group = DependencyCleanupGroup([generator])
 
-    await group.cleanup()
+    await group.close()
 
     with pytest.raises(RuntimeError):
         group.add(async_generator)

--- a/tests/unit/test_kwargs/test_generator_dependencies.py
+++ b/tests/unit/test_kwargs/test_generator_dependencies.py
@@ -1,10 +1,11 @@
-from typing import AsyncGenerator, Callable, Dict, Generator
+from typing import Any, AsyncGenerator, Callable, Dict, Generator
 from unittest.mock import MagicMock
 
 import pytest
 from pytest import FixtureRequest
 
-from litestar import WebSocket, get, websocket
+from litestar import Response, WebSocket, get, websocket
+from litestar.response.base import ASGIResponse
 from litestar.testing import create_test_client
 
 
@@ -219,3 +220,32 @@ def test_generator_dependency_nested_error_during_cleanup(
         finally_mock.assert_called_once()
         exception_mock.assert_called_once()
         cleanup_mock_no_raise.assert_called_once()
+
+
+def test_exception_on_response_thrown_into_generators() -> None:
+    counter = 0
+
+    async def dependency() -> AsyncGenerator[int, None]:
+        nonlocal counter
+        counter += 1
+        try:
+            yield counter
+        finally:
+            counter -= 1
+
+    class CustomResponse(Response[str]):
+        def to_asgi_response(
+            self,
+            *args: Any,
+            **kwargs: Any,
+        ) -> ASGIResponse:
+            raise Exception("foo")
+
+    @get("/", dependencies={"dep": dependency})
+    def handler(dep: int) -> CustomResponse:
+        return CustomResponse("")
+
+    with create_test_client(route_handlers=[handler]) as client:
+        res = client.get("/")
+        assert res.status_code == 500
+        assert counter == 0

--- a/uv.lock
+++ b/uv.lock
@@ -2,11 +2,13 @@ version = 1
 revision = 1
 requires-python = ">=3.8, <4.0"
 resolution-markers = [
-    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.9' and python_full_version < '3.11' and sys_platform != 'win32'",
     "python_full_version < '3.9' and sys_platform != 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.9' and python_full_version < '3.11' and sys_platform == 'win32'",
     "python_full_version < '3.9' and sys_platform == 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'win32'",
 ]
@@ -112,10 +114,12 @@ name = "anyio"
 version = "4.8.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.9' and python_full_version < '3.11' and sys_platform != 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.9' and python_full_version < '3.11' and sys_platform == 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'win32'",
 ]
 dependencies = [
@@ -1964,6 +1968,7 @@ requires-dist = [
     { name = "cryptography", marker = "extra == 'jwt'" },
     { name = "email-validator", marker = "extra == 'pydantic'" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.2.2" },
     { name = "fast-query-parsers", marker = "extra == 'standard'", specifier = ">=1.0.2" },
     { name = "httpx", specifier = ">=0.22" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
@@ -2345,10 +2350,12 @@ name = "msgspec"
 version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.9' and python_full_version < '3.11' and sys_platform != 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.9' and python_full_version < '3.11' and sys_platform == 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/9b/95d8ce458462b8b71b8a70fa94563b2498b89933689f3a7b8911edfae3d7/msgspec-0.19.0.tar.gz", hash = "sha256:604037e7cd475345848116e89c553aa9a233259733ab51986ac924ab1b976f8e", size = 216934 }
@@ -3341,10 +3348,12 @@ name = "pytest-asyncio"
 version = "0.25.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.9' and python_full_version < '3.11' and sys_platform != 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'linux'",
     "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version >= '3.9' and python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.9' and python_full_version < '3.11' and sys_platform == 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'win32'",
 ]
 dependencies = [
@@ -4119,7 +4128,7 @@ name = "taskgroup"
 version = "0.0.0a4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.13'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/40/02753c40fa30dfdde7567c1daeefbf957dcf8c99e6534a80afb438adf07e/taskgroup-0.0.0a4.tar.gz", hash = "sha256:eb08902d221e27661950f2a0320ddf3f939f579279996f81fe30779bca3a159c", size = 8553 }
 wheels = [


### PR DESCRIPTION
Fix a bug where a dependencies' cleanup was not guaranteed to be called would not be called if an exception was thrown:

- Late during ASGI response rendering
- During cleanup of another dependency when recovering from an exception

<hr>

Refactor the code such that:

- Exceptions are always caught and thrown into dependencies as long as the dependencies are alive
- If the handler raises an exception and during dependency cleanup other exceptions are raised, the sub-exceptions are grouped into an `ExceptionGroup`. This behaviour is now equivalent to regular dependency cleanup