### PR TITLE
fix: misleading error message upon ImportError with --app argument to CLI

### DIFF
--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -283,10 +283,12 @@ def _validate_app_path(app_path: str) -> tuple[ModuleType, str]:
 
     try:
         module = importlib.import_module(module_path)
-    except ImportError:
-        console.print(f"[bold red] Invalid argument passed --app {app_path!r}: Module not found")
-        sys.exit(1)
-
+    except ImportError as e:
+        if e.name == module_path:
+            console.print(f"[bold red] Invalid argument passed --app {app_path!r}: Module not found")
+            sys.exit(1)
+        else:
+            raise (e)
     return module, app_name
 
 

--- a/tests/unit/test_cli/test_cli.py
+++ b/tests/unit/test_cli/test_cli.py
@@ -114,3 +114,20 @@ def test_incorrect_app_argument(
     assert result.exit_code == 1
 
     mock.assert_not_called()
+
+
+@pytest.mark.xdist_group("cli_autodiscovery")
+def test_invalid_import_in_app_argument(
+    runner: "CliRunner", create_app_file: CreateAppFileFixture, tmp_project_dir: "Path"
+) -> None:
+    app_file = "main.py"
+
+    create_app_file(
+        file=app_file,
+        content="from something import bar\n" + CREATE_APP_FILE_CONTENT,
+    )
+
+    app_dir = str(tmp_project_dir.absolute())
+
+    result = runner.invoke(cli_command, ["--app", "main:create_app", "--app-dir", app_dir, "info"])
+    assert isinstance(result.exception, ModuleNotFoundError)


### PR DESCRIPTION
## Description

Fixes #4129 

Before this PR, if the `--app` CLI option is used, any `ImportErrors` that occur while instantiating the application are assumed to be caused by a bad `--app` argument.  This does not account for cases where the `--app` option is actually fine, but the `ImportError` arose from inside the applicaiton code, and this results in a misleading error message.

This PR adds a check on whether the exception resulted from a failure to import the module named in the `--app` option.  If the error arose while attempting some other import, it is not caught.  This is consistent with the behaviour that occurs when `--app` is not used.