### PR TITLE
fix(testing): subprocess client raises exc when fails to start

### DIFF
--- a/tests/unit/test_testing/test_sub_client/test_subprocess_client.py
+++ b/tests/unit/test_testing/test_sub_client/test_subprocess_client.py
@@ -12,23 +12,42 @@ import httpx_sse
 import pytest
 
 from litestar.testing import subprocess_async_client, subprocess_sync_client
+from litestar.testing.client.subprocess_client import StartupError, run_app
 
 if sys.platform == "win32":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 ROOT = pathlib.Path(__file__).parent
+APP = "demo:app"
 
 
 @pytest.fixture(name="async_client")
 async def fx_async_client() -> AsyncIterator[httpx.AsyncClient]:
-    async with subprocess_async_client(workdir=ROOT, app="demo:app") as client:
+    async with subprocess_async_client(workdir=ROOT, app=APP) as client:
         yield client
 
 
 @pytest.fixture(name="sync_client")
 def fx_sync_client() -> Iterator[httpx.Client]:
-    with subprocess_sync_client(workdir=ROOT, app="demo:app") as client:
+    with subprocess_sync_client(workdir=ROOT, app=APP) as client:
         yield client
+
+
+async def test_run_app() -> None:
+    """Ensure that method returns application url if started successfully"""
+    with run_app(workdir=ROOT, app=APP) as url:
+        assert isinstance(url, str)
+        assert url.startswith("http://127.0.0.1:")
+
+
+async def test_run_app_exception() -> None:
+    """
+    Ensure that method throws a StartupError if the application fails to start.
+    To simulate this, we set retry_count=0, so that we don't check if the application has started.
+    """
+    with pytest.raises(StartupError):
+        with run_app(workdir=ROOT, app=APP, retry_count=0):
+            ...
 
 
 async def test_subprocess_async_client(async_client: httpx.AsyncClient) -> None:


### PR DESCRIPTION
## Description

Fix #4021 
- Added two new parameters to `run_app` method: `retry_count` and `retry_timeout`
- `run_app` now throws `StartupError` if application doesn't start on time

## Closes
- litestar-org/litestar#4021