### PR TITLE
fix(openapi): wrong annotation passed to FieldDefinition (DTO)

### DIFF
--- a/litestar/dto/base_dto.py
+++ b/litestar/dto/base_dto.py
@@ -15,6 +15,7 @@ from litestar.dto.data_structures import DTOData
 from litestar.dto.types import RenameStrategy
 from litestar.enums import RequestEncodingType
 from litestar.exceptions.dto_exceptions import InvalidAnnotationException
+from litestar.response.base import Response
 from litestar.types.builtin_types import NoneType
 from litestar.types.composite_types import TypeEncodersMap
 from litestar.typing import FieldDefinition
@@ -229,7 +230,7 @@ class AbstractDTO(Generic[T]):
         key = "data_backend" if field_definition.name == "data" else "return_backend"
         backend = cls._dto_backends[handler_id][key]  # type: ignore[literal-required]
 
-        if backend.wrapper_attribute_name:
+        if backend.wrapper_attribute_name and not field_definition.is_subclass_of(Response):
             # The DTO has been built for a handler that has a DTO supported type wrapped in a generic type.
             #
             # The backend doesn't receive the full annotation, only the type of the attribute on the outer type that
@@ -238,7 +239,7 @@ class AbstractDTO(Generic[T]):
             # This special casing rebuilds the outer generic type annotation with the original model replaced by the DTO
             # generated transfer model type in the type arguments.
             transfer_model = backend.transfer_model_type
-            generic_args = tuple(transfer_model if a is cls.model_type else a for a in field_definition.args)
+            generic_args = tuple(transfer_model if arg is cls.model_type else arg for arg in field_definition.args)
             annotation = field_definition.safe_generic_origin[generic_args]
         else:
             annotation = backend.annotation

--- a/tests/unit/test_dto/test_factory/test_integration.py
+++ b/tests/unit/test_dto/test_factory/test_integration.py
@@ -1044,7 +1044,7 @@ async def get_items() -> Response[List[Item]]:
 app = Litestar(route_handlers=[get_items])
 """)
 
-    openapi = module.app.openapi_schema
+    openapi = cast("Litestar", module.app).openapi_schema
     schema = openapi.components.schemas["GetItemsItemResponseBody"]
     assert not_none(schema.properties).keys() == {"id", "name"}
 

--- a/tests/unit/test_dto/test_factory/test_integration.py
+++ b/tests/unit/test_dto/test_factory/test_integration.py
@@ -697,6 +697,11 @@ def test_dto_response_wrapped_scalar_return_type(use_experimental_dto_backend: b
         response = client.get("/")
         assert response.json() == {"name": "John"}
 
+        schema_response = client.get("/schema/openapi.json")
+        schemas = list(schema_response.json()["components"]["schemas"].values())
+        assert len(schemas) == 1
+        assert schemas[0]["title"] == "HandlerPaginatedUserResponseBody"
+
 
 def test_dto_response_wrapped_collection_return_type(use_experimental_dto_backend: bool) -> None:
     @get(
@@ -712,6 +717,11 @@ def test_dto_response_wrapped_collection_return_type(use_experimental_dto_backen
     with create_test_client(handler) as client:
         response = client.get("/")
         assert response.json() == [{"name": "John"}, {"name": "Jane"}]
+
+        schema_response = client.get("/schema/openapi.json")
+        schemas = list(schema_response.json()["components"]["schemas"].values())
+        assert len(schemas) == 1
+        assert schemas[0]["title"] == "HandlerPaginatedUserResponseBody"
 
 
 def test_schema_required_fields_with_msgspec_dto(use_experimental_dto_backend: bool) -> None:


### PR DESCRIPTION
## Description

Fix #3888

Fixed an issue involving incorrect annotations being passed to `FieldDefinition` when handling `Response` class. 
However, I'm not entirely satisfied with this solution. I'd be happy for any suggestions for alternative approaches.

## Closes
- litestar-org/litestar#3888