### PR TITLE
feat(DTO): Add custom attribute accessor callable

### DIFF
--- a/litestar/dto/_backend.py
+++ b/litestar/dto/_backend.py
@@ -9,6 +9,7 @@ from typing import (
     TYPE_CHECKING,
     AbstractSet,
     Any,
+    Callable,
     ClassVar,
     Collection,
     Final,
@@ -65,6 +66,7 @@ class CompositeTypeHandler(Protocol):
 class DTOBackend:
     __slots__ = (
         "annotation",
+        "attribute_accessor",
         "dto_data_type",
         "dto_factory",
         "field_definition",
@@ -105,6 +107,7 @@ class DTOBackend:
         self.handler_id: Final[str] = handler_id
         self.model_type: Final[type[Any]] = model_type
         self.wrapper_attribute_name: Final[str | None] = wrapper_attribute_name
+        self.attribute_accessor = dto_factory.attribute_accessor
 
         self.parsed_field_definitions = self.parse_model(
             model_type=model_type,
@@ -279,6 +282,7 @@ class DTOBackend:
                     field_definitions=self.parsed_field_definitions,
                     field_definition=self.field_definition,
                     is_data_field=self.is_data_field,
+                    attribute_accessor=self.attribute_accessor,
                 ),
             )
         return self.transfer_data_from_builtins(self.parse_builtins(builtins, asgi_connection))
@@ -298,6 +302,7 @@ class DTOBackend:
             field_definitions=self.parsed_field_definitions,
             field_definition=self.field_definition,
             is_data_field=self.is_data_field,
+            attribute_accessor=self.attribute_accessor,
         )
 
     def populate_data_from_raw(self, raw: bytes, asgi_connection: ASGIConnection) -> Any:
@@ -319,6 +324,7 @@ class DTOBackend:
                     field_definitions=self.parsed_field_definitions,
                     field_definition=self.field_definition,
                     is_data_field=self.is_data_field,
+                    attribute_accessor=self.attribute_accessor,
                 ),
             )
         return _transfer_data(
@@ -327,6 +333,7 @@ class DTOBackend:
             field_definitions=self.parsed_field_definitions,
             field_definition=self.field_definition,
             is_data_field=self.is_data_field,
+            attribute_accessor=self.attribute_accessor,
         )
 
     def encode_data(self, data: Any) -> LitestarEncodableType:
@@ -341,10 +348,11 @@ class DTOBackend:
         if self.wrapper_attribute_name:
             wrapped_transfer = _transfer_data(
                 destination_type=self.transfer_model_type,
-                source_data=getattr(data, self.wrapper_attribute_name),
+                source_data=self.attribute_accessor(data, self.wrapper_attribute_name),
                 field_definitions=self.parsed_field_definitions,
                 field_definition=self.field_definition,
                 is_data_field=self.is_data_field,
+                attribute_accessor=self.attribute_accessor,
             )
             setattr(
                 data,
@@ -361,6 +369,7 @@ class DTOBackend:
                 field_definitions=self.parsed_field_definitions,
                 field_definition=self.field_definition,
                 is_data_field=self.is_data_field,
+                attribute_accessor=self.attribute_accessor,
             ),
         )
 
@@ -567,6 +576,7 @@ def _transfer_data(
     field_definitions: tuple[TransferDTOFieldDefinition, ...],
     field_definition: FieldDefinition,
     is_data_field: bool,
+    attribute_accessor: Callable[[object, str], Any],
 ) -> Any:
     """Create instance or iterable of instances of ``destination_type``.
 
@@ -576,6 +586,7 @@ def _transfer_data(
         field_definitions: model field definitions.
         field_definition: the parsed type that represents the handler annotation for which the DTO is being applied.
         is_data_field: whether the DTO is being applied to a ``data`` field.
+        attribute_accessor: 'getattr'-like function to access attributes on the data source
 
     Returns:
         Data parsed into ``destination_type``.
@@ -589,6 +600,7 @@ def _transfer_data(
                     field_definitions=field_definitions,
                     field_definition=field_definition.inner_types[0],
                     is_data_field=is_data_field,
+                    attribute_accessor=attribute_accessor,
                 )
                 for item in source_data
             )
@@ -601,6 +613,7 @@ def _transfer_data(
                     field_definitions=field_definitions,
                     field_definition=field_definition.inner_types[1],
                     is_data_field=is_data_field,
+                    attribute_accessor=attribute_accessor,
                 ),
             )
             for key, value in source_data.items()  # type: ignore[union-attr]
@@ -611,6 +624,7 @@ def _transfer_data(
         source_instance=source_data,
         field_definitions=field_definitions,
         is_data_field=is_data_field,
+        attribute_accessor=attribute_accessor,
     )
 
 
@@ -619,6 +633,7 @@ def _transfer_instance_data(
     source_instance: Any,
     field_definitions: tuple[TransferDTOFieldDefinition, ...],
     is_data_field: bool,
+    attribute_accessor: Callable[[object, str], Any],
 ) -> Any:
     """Create instance of ``destination_type`` with data from ``source_instance``.
 
@@ -627,6 +642,7 @@ def _transfer_instance_data(
         source_instance: primitive data that has been parsed and validated via the backend.
         field_definitions: model field definitions.
         is_data_field: whether the given field is a 'data' kwarg field.
+        attribute_accessor: 'getattr'-like function to access attributes on the data source
 
     Returns:
         Data parsed into ``model_type``.
@@ -648,7 +664,7 @@ def _transfer_instance_data(
         source_value = (
             source_instance[field_definition.name]
             if isinstance(source_instance, Mapping)
-            else getattr(source_instance, field_definition.name)
+            else attribute_accessor(source_instance, field_definition.name)
         )
 
         if field_definition.is_partial and is_data_field and source_value is UNSET:
@@ -659,6 +675,7 @@ def _transfer_instance_data(
             transfer_type=transfer_type,
             nested_as_dict=destination_type is dict,
             is_data_field=is_data_field,
+            attribute_accessor=attribute_accessor,
         )
 
     return destination_type(**unstructured_data)
@@ -669,6 +686,7 @@ def _transfer_type_data(
     transfer_type: TransferType,
     nested_as_dict: bool,
     is_data_field: bool,
+    attribute_accessor: Callable[[object, str], Any],
 ) -> Any:
     if isinstance(transfer_type, SimpleType) and transfer_type.nested_field_info:
         if nested_as_dict:
@@ -683,6 +701,7 @@ def _transfer_type_data(
             source_instance=source_value,
             field_definitions=transfer_type.nested_field_info.field_definitions,
             is_data_field=is_data_field,
+            attribute_accessor=attribute_accessor,
         )
 
     if isinstance(transfer_type, UnionType) and transfer_type.has_nested:
@@ -690,6 +709,7 @@ def _transfer_type_data(
             transfer_type=transfer_type,
             source_value=source_value,
             is_data_field=is_data_field,
+            attribute_accessor=attribute_accessor,
         )
 
     if isinstance(transfer_type, CollectionType):
@@ -700,6 +720,7 @@ def _transfer_type_data(
                     transfer_type=transfer_type.inner_type,
                     nested_as_dict=False,
                     is_data_field=is_data_field,
+                    attribute_accessor=attribute_accessor,
                 )
                 for item in source_value
             )
@@ -716,6 +737,7 @@ def _transfer_type_data(
                         transfer_type=transfer_type.value_type,
                         nested_as_dict=False,
                         is_data_field=is_data_field,
+                        attribute_accessor=attribute_accessor,
                     ),
                 )
                 for key, value in source_value.items()
@@ -730,6 +752,7 @@ def _transfer_nested_union_type_data(
     transfer_type: UnionType,
     source_value: Any,
     is_data_field: bool,
+    attribute_accessor: Callable[[object, str], Any],
 ) -> Any:
     for inner_type in transfer_type.inner_types:
         if isinstance(inner_type, CompositeType):
@@ -746,6 +769,7 @@ def _transfer_nested_union_type_data(
                 source_instance=source_value,
                 field_definitions=inner_type.nested_field_info.field_definitions,
                 is_data_field=is_data_field,
+                attribute_accessor=attribute_accessor,
             )
     return source_value
 

--- a/litestar/dto/_codegen_backend.py
+++ b/litestar/dto/_codegen_backend.py
@@ -46,8 +46,6 @@ __all__ = ("DTOCodegenBackend",)
 class DTOCodegenBackend(DTOBackend):
     __slots__ = (
         "_encode_data",
-        "_transfer_data_from_builtins",
-        "_transfer_data_from_builtins_with_overrides",
         "_transfer_to_dict",
         "_transfer_to_model_type",
     )
@@ -88,14 +86,6 @@ class DTOCodegenBackend(DTOBackend):
             destination_type=self.model_type,
             field_definition=self.field_definition,
         )
-        self._transfer_data_from_builtins = self._create_transfer_data_fn(
-            destination_type=self.model_type,
-            field_definition=self.field_definition,
-        )
-        self._transfer_data_from_builtins_with_overrides = self._create_transfer_data_fn(
-            destination_type=self.model_type,
-            field_definition=self.field_definition,
-        )
         self._encode_data = self._create_transfer_data_fn(
             destination_type=self.transfer_model_type,
             field_definition=self.field_definition,
@@ -127,7 +117,7 @@ class DTOCodegenBackend(DTOBackend):
         Returns:
             Instance or collection of ``model_type`` instances.
         """
-        return self._transfer_data_from_builtins(builtins)
+        return self._transfer_to_model_type(builtins)
 
     def populate_data_from_raw(self, raw: bytes, asgi_connection: ASGIConnection) -> Any:
         """Parse raw bytes into instance of `model_type`.
@@ -182,6 +172,7 @@ class DTOCodegenBackend(DTOBackend):
             field_definitions=self.parsed_field_definitions,
             is_data_field=self.is_data_field,
             field_definition=field_definition,
+            attribute_accessor=self.attribute_accessor,
         )
 
 
@@ -190,12 +181,22 @@ class FieldAccessManager(Protocol):
 
 
 class TransferFunctionFactory:
-    def __init__(self, is_data_field: bool, nested_as_dict: bool) -> None:
+    def __init__(
+        self,
+        is_data_field: bool,
+        nested_as_dict: bool,
+        attribute_accessor: Callable[[object, str], Any],
+    ) -> None:
+        self.attribute_accessor = attribute_accessor
         self.is_data_field = is_data_field
         self._fn_locals: dict[str, Any] = {
             "Mapping": Mapping,
             "UNSET": UNSET,
         }
+        if attribute_accessor is not getattr:
+            self.attribute_accessor_name: str | None = self._add_to_fn_globals("__getattr_impl", attribute_accessor)
+        else:
+            self.attribute_accessor_name = None
         self._indentation = 1
         self._body = ""
         self.names: set[str] = set()
@@ -213,7 +214,10 @@ class TransferFunctionFactory:
         return unique_name
 
     def _make_function(
-        self, source_value_name: str, return_value_name: str, fn_name: str = "func"
+        self,
+        source_value_name: str,
+        return_value_name: str,
+        fn_name: str = "func",
     ) -> Callable[[Any], Any]:
         """Wrap the current body contents in a function definition and turn it into a callable object"""
         source = f"def {fn_name}({source_value_name}):\n{self._body} return {return_value_name}"
@@ -287,7 +291,10 @@ class TransferFunctionFactory:
         within this context can use this expression to access the desired value.
         """
 
-        value_expr = f"{source_name}.{field_name}"
+        if self.attribute_accessor_name:
+            value_expr = f"{self.attribute_accessor_name}({source_name}, '{field_name}')"
+        else:
+            value_expr = f"{source_name}.{field_name}"
 
         # if we expect an optional attribute it's faster to check with hasattr
         if expect_optional:
@@ -305,8 +312,13 @@ class TransferFunctionFactory:
         field_definitions: tuple[TransferDTOFieldDefinition, ...],
         destination_type: type[Any],
         is_data_field: bool,
+        attribute_accessor: Callable[[object, str], Any],
     ) -> Callable[[Any], Any]:
-        factory = cls(is_data_field=is_data_field, nested_as_dict=destination_type is dict)
+        factory = cls(
+            is_data_field=is_data_field,
+            nested_as_dict=destination_type is dict,
+            attribute_accessor=attribute_accessor,
+        )
         tmp_return_type_name = factory._create_local_name("tmp_return_type")
         source_instance_name = factory._create_local_name("source_instance")
         destination_type_name = factory._add_to_fn_globals("destination_type", destination_type)
@@ -324,8 +336,13 @@ class TransferFunctionFactory:
         cls,
         transfer_type: TransferType,
         is_data_field: bool,
+        attribute_accessor: Callable[[object, str], Any],
     ) -> Callable[[Any], Any]:
-        factory = cls(is_data_field=is_data_field, nested_as_dict=False)
+        factory = cls(
+            is_data_field=is_data_field,
+            nested_as_dict=False,
+            attribute_accessor=attribute_accessor,
+        )
         tmp_return_type_name = factory._create_local_name("tmp_return_type")
         source_value_name = factory._create_local_name("source_value")
         factory._create_transfer_type_data_body(
@@ -339,15 +356,18 @@ class TransferFunctionFactory:
     @classmethod
     def create_transfer_data(
         cls,
+        *,
         destination_type: type[Any],
         field_definitions: tuple[TransferDTOFieldDefinition, ...],
         is_data_field: bool,
         field_definition: FieldDefinition | None = None,
+        attribute_accessor: Callable[[object, str], Any],
     ) -> Callable[[Any], Any]:
         if field_definition and field_definition.is_non_string_collection:
             factory = cls(
                 is_data_field=is_data_field,
                 nested_as_dict=False,
+                attribute_accessor=attribute_accessor,
             )
             source_value_name = factory._create_local_name("source_value")
             return_value_name = factory._create_local_name("tmp_return_value")
@@ -364,6 +384,7 @@ class TransferFunctionFactory:
             destination_type=destination_type,
             field_definitions=field_definitions,
             is_data_field=is_data_field,
+            attribute_accessor=attribute_accessor,
         )
 
     def _create_transfer_data_body_nested(
@@ -380,6 +401,7 @@ class TransferFunctionFactory:
             destination_type=destination_type,
             field_definition=field_definition.inner_types[0],
             field_definitions=field_definitions,
+            attribute_accessor=self.attribute_accessor,
         )
         transfer_func_name = self._add_to_fn_globals("transfer_data", transfer_func)
         if field_definition.is_mapping:
@@ -511,7 +533,9 @@ class TransferFunctionFactory:
             origin_name = self._add_to_fn_globals("origin", transfer_type.field_definition.instantiable_origin)
             if transfer_type.has_nested:
                 transfer_type_data_fn = TransferFunctionFactory.create_transfer_type_data(
-                    is_data_field=self.is_data_field, transfer_type=transfer_type.inner_type
+                    is_data_field=self.is_data_field,
+                    transfer_type=transfer_type.inner_type,
+                    attribute_accessor=self.attribute_accessor,
                 )
                 transfer_type_data_name = self._add_to_fn_globals("transfer_type_data", transfer_type_data_fn)
                 self._add_stmt(
@@ -526,7 +550,9 @@ class TransferFunctionFactory:
             origin_name = self._add_to_fn_globals("origin", transfer_type.field_definition.instantiable_origin)
             if transfer_type.has_nested:
                 transfer_type_data_fn = TransferFunctionFactory.create_transfer_type_data(
-                    is_data_field=self.is_data_field, transfer_type=transfer_type.value_type
+                    is_data_field=self.is_data_field,
+                    transfer_type=transfer_type.value_type,
+                    attribute_accessor=self.attribute_accessor,
                 )
                 transfer_type_data_name = self._add_to_fn_globals("transfer_type_data", transfer_type_data_fn)
                 self._add_stmt(

--- a/litestar/dto/base_dto.py
+++ b/litestar/dto/base_dto.py
@@ -4,7 +4,7 @@ import dataclasses
 import typing
 from abc import abstractmethod
 from inspect import getmodule
-from typing import TYPE_CHECKING, Collection, Generic, TypeVar
+from typing import TYPE_CHECKING, Callable, Collection, Generic, TypeVar
 
 from typing_extensions import NotRequired, TypedDict, get_type_hints
 
@@ -50,6 +50,8 @@ class AbstractDTO(Generic[T]):
     """Config objects to define properties of the DTO."""
     model_type: type[T]
     """If ``annotation`` is an iterable, this is the inner type, otherwise will be the same as ``annotation``."""
+    attribute_accessor: Callable[[object, str], Any] = getattr
+    """:func:`getattr` like callable to access attributes on the data source"""
 
     _dto_backends: ClassVar[dict[str, _BackendDict]] = {}
 

--- a/tests/unit/test_dto/test_factory/test_backends/test_backends.py
+++ b/tests/unit/test_dto/test_factory/test_backends/test_backends.py
@@ -1,6 +1,7 @@
 # ruff: noqa: UP006,UP007
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass, field
 from types import ModuleType
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional
@@ -13,6 +14,7 @@ from litestar import Litestar, Request, get, post
 from litestar._openapi.schema_generation import SchemaCreator
 from litestar.dto import DataclassDTO, DTOConfig, DTOField
 from litestar.dto._backend import DTOBackend, _create_struct_field_meta_for_field_definition
+from litestar.dto._codegen_backend import DTOCodegenBackend
 from litestar.dto._types import CollectionType, SimpleType, TransferDTOFieldDefinition
 from litestar.dto.data_structures import DTOFieldDefinition
 from litestar.enums import MediaType
@@ -334,7 +336,7 @@ def test_transfer_only_touches_included_attributes(backend_cls: type[DTOBackend]
         bar: str = ""
 
     class Factory(DataclassDTO):
-        config = DTOConfig(include={"excluded"})
+        config = DTOConfig(include={"id"})
 
     backend = backend_cls(
         handler_id="test",
@@ -349,6 +351,64 @@ def test_transfer_only_touches_included_attributes(backend_cls: type[DTOBackend]
 
     backend.encode_data(Foo(id="1"))
     assert mock.call_count == 0
+
+
+def test_custom_attribute_accessor(backend_cls: type[DTOBackend]) -> None:
+    mock = MagicMock()
+
+    @dataclass()
+    class Foo:
+        id: str
+        bar: str = ""
+
+    def my_getattr(obj: object, attr: str) -> Any:
+        mock(attr)
+        return getattr(obj, attr)
+
+    class MyDataclassDTO(DataclassDTO):
+        attribute_accessor = my_getattr
+
+    class Factory(MyDataclassDTO):
+        config = DTOConfig(include={"id"})
+
+    backend = backend_cls(
+        handler_id="test",
+        dto_factory=Factory,
+        field_definition=TransferDTOFieldDefinition.from_annotation(Foo),
+        model_type=Foo,
+        wrapper_attribute_name=None,
+        is_data_field=False,
+    )
+
+    backend.encode_data(Foo(id="1"))
+    mock.assert_called_once_with("id")
+
+
+@pytest.mark.xfail()
+def test_codegen_attribute_accessor_not_used_when_default() -> None:
+    @dataclass()
+    class Foo:
+        id: str
+
+    class Factory(DataclassDTO):
+        config = DTOConfig(include={"id"})
+
+    backend = DTOCodegenBackend(
+        handler_id="test",
+        dto_factory=Factory,
+        field_definition=TransferDTOFieldDefinition.from_annotation(Foo),
+        model_type=Foo,
+        wrapper_attribute_name=None,
+        is_data_field=False,
+    )
+
+    to_model_source = inspect.getsource(backend._transfer_to_model_type)
+    encode_source = inspect.getsource(backend._encode_data)
+
+    assert ".id" in to_model_source
+    assert ".id" in encode_source
+    assert "__getattr_impl" not in to_model_source
+    assert "__getattr_impl" not in encode_source
 
 
 def test_parse_model_nested_exclude(create_module: Callable[[str], ModuleType], backend_cls: type[DTOBackend]) -> None:

--- a/tests/unit/test_dto/test_factory/test_backends/test_backends.py
+++ b/tests/unit/test_dto/test_factory/test_backends/test_backends.py
@@ -384,14 +384,17 @@ def test_custom_attribute_accessor(backend_cls: type[DTOBackend]) -> None:
     mock.assert_called_once_with("id")
 
 
-@pytest.mark.xfail()
 def test_codegen_attribute_accessor_not_used_when_default() -> None:
+    # when no custom 'attribute_accessor' is used, we expect the logic to be skipped
+    # entirely, and plain 'obj.value' attribute access to be performed, as this is more
+    # performant than using the default 'getattr'
+
     @dataclass()
     class Foo:
-        id: str
+        some_field: str
 
     class Factory(DataclassDTO):
-        config = DTOConfig(include={"id"})
+        config = DTOConfig()
 
     backend = DTOCodegenBackend(
         handler_id="test",
@@ -405,8 +408,8 @@ def test_codegen_attribute_accessor_not_used_when_default() -> None:
     to_model_source = inspect.getsource(backend._transfer_to_model_type)
     encode_source = inspect.getsource(backend._encode_data)
 
-    assert ".id" in to_model_source
-    assert ".id" in encode_source
+    assert ".some_field" in to_model_source
+    assert ".some_field" in encode_source
     assert "__getattr_impl" not in to_model_source
     assert "__getattr_impl" not in encode_source
 


### PR DESCRIPTION
Add a new `attribute_accessor` property to `AbstractDTO`, which can be used by both the codegen and functional backend to access attributes on an object.

This can be useful to implement DTOs for types that do not adhere to the plain protocol of `obj.data_field` or need to add additional checks, e.g. using `obj.related_field.all()` on a Django model to access related objects, while ensuring no I/O occurs.