### PR TITLE
fix(cli): pre parse launch arguments when cli command executed

### DIFF
--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -182,11 +182,6 @@ class LitestarExtensionGroup(LitestarGroup):
     This group class should not be used on any group besides the root ``litestar_group``.
     """
 
-    __slots__ = (
-        "_preparsed_app_dir",
-        "_preparsed_app_path",
-    )
-
     def __init__(
         self,
         name: str | None = None,
@@ -195,7 +190,10 @@ class LitestarExtensionGroup(LitestarGroup):
     ) -> None:
         """Init ``LitestarExtensionGroup``"""
         super().__init__(name=name, commands=commands, **attrs)
+
         self._prepare_done = False
+        self._preparsed_app_dir: str | None = None
+        self._preparsed_app_path: Path | None = None
 
         for entry_point in entry_points(group="litestar.commands"):
             command = entry_point.load()
@@ -233,7 +231,7 @@ class LitestarExtensionGroup(LitestarGroup):
         self._prepare(ctx)
         return ctx
 
-    def parse_args(self, ctx: Context, args: list[str]) -> None:
+    def parse_args(self, ctx: Context, args: list[str]) -> list[str]:
         """Preparse launch arguments and save app_path & app_dir to slots.
         This block is triggered in any case, but its results are only used if the --help command is invoked.
         """
@@ -248,7 +246,7 @@ class LitestarExtensionGroup(LitestarGroup):
 
         ctx.ignore_unknown_options = original_ignore_unknown_option
 
-        super().parse_args(ctx, args)
+        return super().parse_args(ctx, args)
 
     def list_commands(self, ctx: Context) -> list[str]:
         self._prepare(ctx)

--- a/tests/unit/test_cli/conftest.py
+++ b/tests/unit/test_cli/conftest.py
@@ -25,7 +25,7 @@ from . import (
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
 
-    from litestar.cli._utils import LitestarGroup
+    from litestar.cli._utils import LitestarExtensionGroup
 
 
 @pytest.fixture(autouse=True)
@@ -34,10 +34,10 @@ def reset_litestar_app_env(monkeypatch: MonkeyPatch) -> None:
 
 
 @pytest.fixture()
-def root_command() -> LitestarGroup:
+def root_command() -> LitestarExtensionGroup:
     import litestar.cli.main
 
-    return cast("LitestarGroup", importlib.reload(litestar.cli.main).litestar_group)
+    return cast("LitestarExtensionGroup", importlib.reload(litestar.cli.main).litestar_group)
 
 
 @pytest.fixture

--- a/tests/unit/test_cli/test_cli_plugin.py
+++ b/tests/unit/test_cli/test_cli_plugin.py
@@ -1,28 +1,43 @@
-import textwrap
-
 from click.testing import CliRunner
 
-from litestar.cli._utils import LitestarGroup
+from litestar.cli._utils import LitestarExtensionGroup
 from tests.unit.test_cli.conftest import CreateAppFileFixture
 
+APPLICATION_WITH_CLI_PLUGIN = """
+from litestar import Litestar
+from litestar.plugins import CLIPluginProtocol
 
-def test_basic_command(runner: CliRunner, create_app_file: CreateAppFileFixture, root_command: LitestarGroup) -> None:
-    app_file_content = textwrap.dedent(
-        """
-    from litestar import Litestar
-    from litestar.plugins import CLIPluginProtocol
+class CLIPlugin(CLIPluginProtocol):
+    def on_cli_init(self, cli):
+        @cli.command()
+        def mycommand(app: Litestar):
+            \"\"\"Description of plugin command\"\"\"
+            print(f"App is loaded: {app is not None}")
 
-    class CLIPlugin(CLIPluginProtocol):
-        def on_cli_init(self, cli):
-            @cli.command()
-            def foo(app: Litestar):
-                print(f"App is loaded: {app is not None}")
+app = Litestar(plugins=[CLIPlugin()])
+"""
 
-    app = Litestar(plugins=[CLIPlugin()])
-    """
-    )
-    app_file = create_app_file("command_test_app.py", content=app_file_content)
-    result = runner.invoke(root_command, ["--app", f"{app_file.stem}:app", "foo"])
+
+def test_basic_command(
+    runner: CliRunner,
+    create_app_file: CreateAppFileFixture,
+    root_command: LitestarExtensionGroup,
+) -> None:
+    app_file = create_app_file("command_test_app.py", content=APPLICATION_WITH_CLI_PLUGIN)
+    result = runner.invoke(root_command, ["--app", f"{app_file.stem}:app", "mycommand"])
 
     assert not result.exception
     assert "App is loaded: True" in result.output
+
+
+def test_plugin_command_appears_in_help_message(
+    runner: CliRunner,
+    create_app_file: CreateAppFileFixture,
+    root_command: LitestarExtensionGroup,
+) -> None:
+    app_file = create_app_file("command_test_app.py", content=APPLICATION_WITH_CLI_PLUGIN)
+    result = runner.invoke(root_command, ["--app", f"{app_file.stem}:app", "--help"])
+
+    assert not result.exception
+    assert "mycommand" in result.output
+    assert "Description of plugin command" in result.output


### PR DESCRIPTION
## Description

Fix #2783 

The issue was that when the `--help` command was passed, Click did not parse the others incoming arguments (e.g. `--app`), and autodiscovery feature didn't work as planned because the file containing the application was not in the default list (`AUTODISCOVERY_FILE_NAMES`). As a result, we ignored the `--app` argument and didn't loading plugins, which led to plugin commands not appearing in the list.

As a solution, I propose to override the `Group.parse_args` method to manually parse the arguments that tell us where the application is located.

## Closes
- litestar-org/litestar#2783