### PR TITLE
feat: add scalar configuration

### DIFF
--- a/litestar/openapi/datastructures.py
+++ b/litestar/openapi/datastructures.py
@@ -27,3 +27,11 @@ class ResponseSpec:
     """Response media type."""
     examples: list[Example] | None = field(default=None)
     """A list of Example models."""
+
+
+@dataclass
+class ScalarConfig:
+    """The config for Scalar from https://github.com/scalar/scalar/blob/main/documentation/configuration.md"""
+
+    show_sidebar: bool = field(default=True)
+    """Whether the sidebar should be shown."""

--- a/litestar/openapi/datastructures.py
+++ b/litestar/openapi/datastructures.py
@@ -27,11 +27,3 @@ class ResponseSpec:
     """Response media type."""
     examples: list[Example] | None = field(default=None)
     """A list of Example models."""
-
-
-@dataclass
-class ScalarConfig:
-    """The config for Scalar from https://github.com/scalar/scalar/blob/main/documentation/configuration.md"""
-
-    show_sidebar: bool = field(default=True)
-    """Whether the sidebar should be shown."""

--- a/litestar/openapi/plugins.py
+++ b/litestar/openapi/plugins.py
@@ -1,24 +1,25 @@
 from __future__ import annotations
 
+import json
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Sequence
 from dataclasses import asdict
+from typing import TYPE_CHECKING, Any, Sequence
 
 import msgspec
 import yaml
-import json
 
 from litestar.constants import OPENAPI_JSON_HANDLER_NAME
+from litestar.dto._backend import _camelize
 from litestar.enums import MediaType, OpenAPIMediaType
 from litestar.handlers import get
-from litestar.openapi.datastructures import ScalarConfig
 from litestar.serialization import encode_json, get_serializer
-from litestar.dto._backend import _camelize
 
 if TYPE_CHECKING:
     from litestar.config.csrf import CSRFConfig
     from litestar.connection import Request
+    from litestar.openapi.datastructures import ScalarConfig
     from litestar.router import Router
+
 
 __all__ = (
     "OpenAPIRenderPlugin",
@@ -380,6 +381,8 @@ class ScalarRenderPlugin(OpenAPIRenderPlugin):
             css_url: Download url for the Scalar CSS bundle.
                 If not provided, the Litestar-provided CSS will be used.
             path: Path to serve the OpenAPI UI at.
+            config: Scalar configuration.
+                If not provided the default Scalar configuration will be used.
             **kwargs: Additional arguments to pass to the base class.
         """
         self.js_url = js_url or f"https://cdn.jsdelivr.net/npm/@scalar/api-reference@{version}"

--- a/litestar/openapi/plugins.py
+++ b/litestar/openapi/plugins.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Sequence
 
@@ -436,7 +435,7 @@ class ScalarRenderPlugin(OpenAPIRenderPlugin):
             return ""
         return f"""
                 <script>
-                  document.getElementById('api-reference').dataset.configuration = '{json.dumps(self.options)}'
+                  document.getElementById('api-reference').dataset.configuration = '{msgspec.json.encode(self.options).decode()}'
                 </script>
                 """
 

--- a/tests/unit/test_openapi/test_plugins.py
+++ b/tests/unit/test_openapi/test_plugins.py
@@ -1,7 +1,9 @@
+import pytest
+
 from litestar import Litestar
 from litestar.config.csrf import CSRFConfig
 from litestar.openapi.config import OpenAPIConfig
-from litestar.openapi.plugins import RapidocRenderPlugin, SwaggerRenderPlugin
+from litestar.openapi.plugins import RapidocRenderPlugin, ScalarRenderPlugin, SwaggerRenderPlugin
 from litestar.testing import TestClient
 
 rapidoc_fragment = ".addEventListener('before-try',"
@@ -60,3 +62,30 @@ def test_plugins_csrf_httponly() -> None:
         resp = client.get("/schema/swagger")
         assert resp.status_code == 200
         assert swagger_fragment not in resp.text
+
+
+@pytest.mark.parametrize(
+    "scalar_config",
+    [
+        {"showSidebar": False},
+    ],
+)
+@pytest.mark.parametrize(
+    "expected_config_render",
+    [
+        "document.getElementById('api-reference').dataset.configuration = '{\"showSidebar\":false}'",
+    ],
+)
+def test_openapi_scalar_options(scalar_config, expected_config_render) -> None:
+    app = Litestar(
+        openapi_config=OpenAPIConfig(
+            title="Litestar Example",
+            version="0.0.1",
+            render_plugins=[ScalarRenderPlugin(options=scalar_config)],
+        )
+    )
+
+    with TestClient(app=app) as client:
+        resp = client.get("/schema/scalar")
+        assert resp.status_code == 200
+        assert expected_config_render in resp.text

--- a/tests/unit/test_openapi/test_plugins.py
+++ b/tests/unit/test_openapi/test_plugins.py
@@ -76,7 +76,7 @@ def test_plugins_csrf_httponly() -> None:
         "document.getElementById('api-reference').dataset.configuration = '{\"showSidebar\":false}'",
     ],
 )
-def test_openapi_scalar_options(scalar_config, expected_config_render) -> None:
+def test_openapi_scalar_options(scalar_config: dict, expected_config_render: str) -> None:
     app = Litestar(
         openapi_config=OpenAPIConfig(
             title="Litestar Example",


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Hello! I'm currently work on adding scalar configuration and during work got some questions:
 
- I start adding config params from [here](https://github.com/scalar/scalar/blob/main/documentation/configuration.md), but not sure about including every param. What should we add?
- Here is MRE for how to work with configuration:
```python
from litestar import Litestar, get
from litestar.openapi.config import OpenAPIConfig
from litestar.openapi.datastructures import ScalarConfig
from litestar.openapi.plugins import ScalarRenderPlugin

scalar_plugin = ScalarRenderPlugin(version="1.19.5", config=ScalarConfig(show_sidebar=False))

@get("/")
async def hello_world() -> dict[str, str]:
    """Keeping the tradition alive with hello world."""
    return {"hello": "world"}

app = Litestar(
    route_handlers=[hello_world],
    openapi_config=OpenAPIConfig(
        title="Litestar Example",
        description="Example of Litestar with Scalar OpenAPI docs",
        version="0.0.1",
        render_plugins=[scalar_plugin],
        path="/docs",
    ),
)
```
I'm not sure about config `dataclass` object location. Maybe it must be somewhere else?
- The config could change with changing Scalar version and we have `version` arg in `ScalarRenderPlugin`. So should we somehow detect difference?

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
#3951 
