### PR TITLE
feat(openapi): add option to exclude parameter from schema

### DIFF
--- a/litestar/_openapi/parameters.py
+++ b/litestar/_openapi/parameters.py
@@ -194,11 +194,13 @@ class ParameterFactory:
         )
 
         for field_name, field_definition in unique_handler_fields:
-            if (
-                isinstance(field_definition.kwarg_definition, DependencyKwarg)
-                and field_name not in self.dependency_providers
-            ):
+            kwarg_definition = field_definition.kwarg_definition
+            if isinstance(kwarg_definition, DependencyKwarg) and field_name not in self.dependency_providers:
                 # never document explicit dependencies
+                continue
+
+            if isinstance(kwarg_definition, ParameterKwarg) and not kwarg_definition.include_in_schema:
+                # exclude parameters that are marked as not included in the schema
                 continue
 
             if provider := self.dependency_providers.get(field_name):

--- a/litestar/params.py
+++ b/litestar/params.py
@@ -124,7 +124,7 @@ class KwargDefinition:
     Use as the key for the reference when creating a component for this type
     .. versionadded:: 2.12.0
     """
-    include_in_schema: bool = field(default=True)
+    include_in_schema: bool = True
     """A boolean flag dictating whether this parameter should be included in the schema."""
 
     @property

--- a/litestar/params.py
+++ b/litestar/params.py
@@ -125,7 +125,10 @@ class KwargDefinition:
     .. versionadded:: 2.12.0
     """
     include_in_schema: bool = True
-    """A boolean flag dictating whether this parameter should be included in the schema."""
+    """A boolean flag dictating whether this parameter should be included in the schema.
+    
+    .. versionadded:: 2.17.0
+    """
 
     @property
     def is_constrained(self) -> bool:

--- a/litestar/params.py
+++ b/litestar/params.py
@@ -125,8 +125,8 @@ class KwargDefinition:
     .. versionadded:: 2.12.0
     """
     include_in_schema: bool = True
-    """A boolean flag dictating whether this parameter should be included in the schema.
-    
+    """
+    A boolean flag dictating whether this parameter should be included in the schema.
     .. versionadded:: 2.17.0
     """
 

--- a/litestar/params.py
+++ b/litestar/params.py
@@ -124,6 +124,8 @@ class KwargDefinition:
     Use as the key for the reference when creating a component for this type
     .. versionadded:: 2.12.0
     """
+    include_in_schema: bool = field(default=True)
+    """A boolean flag dictating whether this parameter should be included in the schema."""
 
     @property
     def is_constrained(self) -> bool:
@@ -201,6 +203,7 @@ def Parameter(
     title: str | None = None,
     schema_extra: dict[str, Any] | None = None,
     schema_component_key: str | None = None,
+    include_in_schema: bool = True,
 ) -> Any:
     """Create an extended parameter kwarg definition.
 
@@ -247,6 +250,7 @@ def Parameter(
             .. versionadded:: 2.8.0
         schema_component_key: Use this as the key for the reference when creating a component for this type
             .. versionadded:: 2.12.0
+        include_in_schema: A boolean flag dictating whether this parameter should be included in the schema.
     """
     return ParameterKwarg(
         annotation=annotation,
@@ -273,6 +277,7 @@ def Parameter(
         pattern=pattern,
         schema_extra=schema_extra,
         schema_component_key=schema_component_key,
+        include_in_schema=include_in_schema,
     )
 
 

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -487,7 +487,7 @@ def test_not_included_in_schema_parameter() -> None:
 
         response_json = response.json()
         handler_schema = response_json["paths"]["/handler"]["get"]
-        assert "parameters" in handler_schema
+        assert "parameters" not in handler_schema
 
 
 def test_two_parameters_but_one_not_included_in_schema() -> None:


### PR DESCRIPTION
## Description

I've added additional argument to `KwargsDefinition` that allows excluding a parameter from OpenAPI schema.
This change is backward-compatible and I've also verified that it should merge smoothly with v3.

## Closes
- litestar-org/litestar#4173
