### PR TITLE
feat: allow weak references to Router and Litestar instances (#4186)

### DIFF
--- a/litestar/router.py
+++ b/litestar/router.py
@@ -51,6 +51,7 @@ class Router:
     """
 
     __slots__ = (
+        "__weakref__",
         "after_request",
         "after_response",
         "before_request",


### PR DESCRIPTION
## Description

Adds `__weakref__` slot to `Router`, and thus also to `Litestar`, allowing weak references to be created for objects of these types.

## Closes

Closes #4186.
