### PR TITLE
docs: add `uv` examples to the docs

### DIFF
--- a/docs/usage/cli.rst
+++ b/docs/usage/cli.rst
@@ -116,12 +116,20 @@ entries should point to a :class:`click.Command` or :class:`click.Group`:
             [project.entry-points."litestar.commands"]
             my_command = "my_litestar_plugin.cli:main"
 
-    .. tab-item:: Poetry
+    .. tab-item:: poetry
 
         .. code-block:: toml
-            :caption: Using `Poetry <https://python-poetry.org/>`_
+            :caption: Using `poetry <https://python-poetry.org/>`_
 
             [tool.poetry.plugins."litestar.commands"]
+            my_command = "my_litestar_plugin.cli:main"
+
+    .. tab-item:: uv
+
+        .. code-block:: toml
+            :caption: Using `uv <https://docs.astral.sh/uv/>`_
+
+            [project.scripts]
             my_command = "my_litestar_plugin.cli:main"
 
 Using a plugin

--- a/docs/usage/testing.rst
+++ b/docs/usage/testing.rst
@@ -184,28 +184,35 @@ across requests, then you might want to inject or inspect session data outside a
             .. code-block:: bash
                 :caption: Using pip
 
-                python3 -m pip install litestar[cryptography]
+                python3 -m pip install 'litestar[cryptography]'
 
         .. tab-item:: pipx
 
             .. code-block:: bash
                 :caption: Using `pipx <https://pypa.github.io/pipx/>`_
 
-                pipx install litestar[cryptography]
+                pipx install 'litestar[cryptography]'
 
         .. tab-item:: pdm
 
             .. code-block:: bash
                 :caption: Using `PDM <https://pdm.fming.dev/>`_
 
-                pdm add litestar[cryptography]
+                pdm add 'litestar[cryptography]'
 
-        .. tab-item:: Poetry
+        .. tab-item:: poetry
 
             .. code-block:: bash
-                :caption: Using `Poetry <https://python-poetry.org/>`_
+                :caption: Using `poetry <https://python-poetry.org/>`_
 
-                poetry add litestar[cryptography]
+                poetry add 'litestar[cryptography]'
+
+        .. tab-item:: uv
+
+            .. code-block:: bash
+                :caption: Using `uv <https://docs.astral.sh/uv/>`_
+
+                uv add 'litestar[cryptography]'
 
 .. tab-set::
 


### PR DESCRIPTION
Notes:
- I used `poetry` instead of `Poetry` for consistency with other names
- I added `'` where needed, because `python3 -m pip install litestar[cryptography]` generates `zsh: no matches found: litestar[cryptography]` on `bash` and `zsh` (not sure about others)
- `uv` examples are added, since `uv` is really popular now