### PR TITLE
docs: fix `redis` inventory

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ intersphinx_mapping = {
     "sqlalchemy": ("https://docs.sqlalchemy.org/en/20/", None),
     "alembic": ("https://alembic.sqlalchemy.org/en/latest/", None),
     "click": ("https://click.palletsprojects.com/en/8.1.x/", None),
-    "redis": ("https://redis-py.readthedocs.io/en/stable/", None),
+    "redis": ("https://redis.readthedocs.io/en/stable/", None),
     "picologging": ("https://microsoft.github.io/picologging", None),
     "structlog": ("https://www.structlog.org/en/stable/", None),
     "tortoise": ("https://tortoise.github.io/", None),


### PR DESCRIPTION
It was renamed: https://redis.readthedocs.io/en/stable/

See link with failed job: https://github.com/litestar-org/litestar/actions/runs/15672088433/job/44152557512
