### PR TITLE
Documentation - Fix non-existing function in "Accessing the OpenAPI schema in code" section

### DIFF
--- a/docs/usage/openapi/schema_generation.rst
+++ b/docs/usage/openapi/schema_generation.rst
@@ -183,7 +183,7 @@ access the request instance:
    @get(path="/")
    def my_route_handler(request: Request) -> dict:
        schema = request.app.openapi_schema
-       return schema.dict()
+       return schema.to_schema()
 
 
 Customizing Pydantic model schemas


### PR DESCRIPTION
This is really a very very small PR (a one-liner, lol). But since I stumvled upon it I thought I'd provide the PR to fix it.

The docs currently call .dict() but that function is not existing. It is to_schema now. 

https://docs.litestar.dev/latest/reference/openapi/spec.html#litestar.openapi.spec.BaseSchemaObject