### PR TITLE
feat: Include ReceiveRoutePlugin in base plugins

### DIFF
--- a/docs/usage/plugins/index.rst
+++ b/docs/usage/plugins/index.rst
@@ -121,3 +121,32 @@ signature (their :func:`__init__` method).
 
     flash_messages
     problem_details
+
+
+ReceiveRoutePlugin
+-----------------
+
+:class:`~litestar.plugins.ReceiveRoutePlugin` allows you to receive routes as they are registered on the application.
+This can be useful for plugins that need to perform actions based on the routes being added, such as generating
+documentation, validating route configurations, or tracking route statistics.
+
+Implementations of this plugin must define a single method:
+:meth:`receive_route(self, route: BaseRoute) -> None: <litestar.plugins.ReceiveRoutePlugin.receive_route>`
+
+The method receives a :class:`BaseRoute <litestar.routes.BaseRoute>` instance as routes are registered on the application.
+This happens during the application initialization process, after routes are created but before the application starts.
+
+Example
++++++++
+
+The following example shows a simple plugin that logs information about each route as it's registered:
+
+.. code-block:: python
+
+    from litestar.plugins import ReceiveRoutePlugin
+    from litestar.routes import BaseRoute
+    
+    class RouteLoggerPlugin(ReceiveRoutePlugin):
+        def receive_route(self, route: BaseRoute) -> None:
+            print(f"Route registered: {route.path} [{', '.join(route.http_methods)}]")
+

--- a/docs/usage/plugins/index.rst
+++ b/docs/usage/plugins/index.rst
@@ -145,8 +145,7 @@ The following example shows a simple plugin that logs information about each rou
 
     from litestar.plugins import ReceiveRoutePlugin
     from litestar.routes import BaseRoute
-    
+
     class RouteLoggerPlugin(ReceiveRoutePlugin):
         def receive_route(self, route: BaseRoute) -> None:
             print(f"Route registered: {route.path} [{', '.join(route.http_methods)}]")
-

--- a/docs/usage/plugins/index.rst
+++ b/docs/usage/plugins/index.rst
@@ -124,7 +124,7 @@ signature (their :func:`__init__` method).
 
 
 ReceiveRoutePlugin
------------------
+------------------
 
 :class:`~litestar.plugins.ReceiveRoutePlugin` allows you to receive routes as they are registered on the application.
 This can be useful for plugins that need to perform actions based on the routes being added, such as generating

--- a/litestar/plugins/__init__.py
+++ b/litestar/plugins/__init__.py
@@ -8,6 +8,7 @@ from litestar.plugins.base import (
     OpenAPISchemaPluginProtocol,
     PluginProtocol,
     PluginRegistry,
+    ReceiveRoutePlugin,
     SerializationPlugin,
     SerializationPluginProtocol,
 )
@@ -22,6 +23,7 @@ __all__ = (
     "OpenAPISchemaPluginProtocol",
     "PluginProtocol",
     "PluginRegistry",
+    "ReceiveRoutePlugin",
     "SerializationPlugin",
     "SerializationPluginProtocol",
 )

--- a/litestar/plugins/base.py
+++ b/litestar/plugins/base.py
@@ -27,6 +27,7 @@ __all__ = (
     "OpenAPISchemaPluginProtocol",
     "PluginProtocol",
     "PluginRegistry",
+    "ReceiveRoutePlugin",
     "SerializationPlugin",
     "SerializationPluginProtocol",
 )


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Adds `ReceiveRoutePlugin` to the `__all__` list to make it available for public import.

This ensures the plugin can be imported directly from the module using:
`from litestar.plugins import ReceiveRoutePlugin`


<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

