### PR TITLE
feat: Add CLI `--env-file` option

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1982,6 +1982,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "PokkaKiyo",
+      "name": "PokkaKiyo",
+      "avatar_url": "https://avatars.githubusercontent.com/u/31039465?v=4",
+      "profile": "https://github.com/PokkaKiyo",
+      "contributions": [
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1991,6 +1991,15 @@
       "contributions": [
         "test"
       ]
+    },
+    {
+      "login": "s-aleshin",
+      "name": "Sergei Aleshin",
+      "avatar_url": "https://avatars.githubusercontent.com/u/66841202?v=4",
+      "profile": "https://github.com/s-aleshin",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: dawidd6/action-download-artifact@v10
+        uses: dawidd6/action-download-artifact@v11
         with:
           workflow_conclusion: success
           run_id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact
-        uses: dawidd6/action-download-artifact@v9
+        uses: dawidd6/action-download-artifact@v10
         with:
           workflow_conclusion: success
           run_id: ${{ github.event.workflow_run.id }}

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pip install litestar
 ```
 or to include the CLI and a server (uvicorn) for running your application:
 ```shell
-pip install litestar[standard]
+pip install 'litestar[standard]'
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -599,6 +599,7 @@ see [the contribution guide](CONTRIBUTING.rst).
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Ada-lave"><img src="https://avatars.githubusercontent.com/u/113159483?v=4?s=100" width="100px;" alt="Vladislav"/><br /><sub><b>Vladislav</b></sub></a><br /><a href="https://github.com/litestar-org/litestar/commits?author=Ada-lave" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://gaitenis.id.lv"><img src="https://avatars.githubusercontent.com/u/9976861?v=4?s=100" width="100px;" alt="Edgars"/><br /><sub><b>Edgars</b></sub></a><br /><a href="https://github.com/litestar-org/litestar/commits?author=eandersons" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://jannchie.com"><img src="https://avatars.githubusercontent.com/u/29743310?v=4?s=100" width="100px;" alt="Jianqi Pan"/><br /><sub><b>Jianqi Pan</b></sub></a><br /><a href="https://github.com/litestar-org/litestar/commits?author=Jannchie" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/PokkaKiyo"><img src="https://avatars.githubusercontent.com/u/31039465?v=4?s=100" width="100px;" alt="PokkaKiyo"/><br /><sub><b>PokkaKiyo</b></sub></a><br /><a href="https://github.com/litestar-org/litestar/commits?author=PokkaKiyo" title="Tests">⚠️</a></td>
     </tr>
   </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ see [the contribution guide](CONTRIBUTING.rst).
       <td align="center" valign="top" width="14.28%"><a href="https://gaitenis.id.lv"><img src="https://avatars.githubusercontent.com/u/9976861?v=4?s=100" width="100px;" alt="Edgars"/><br /><sub><b>Edgars</b></sub></a><br /><a href="https://github.com/litestar-org/litestar/commits?author=eandersons" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://jannchie.com"><img src="https://avatars.githubusercontent.com/u/29743310?v=4?s=100" width="100px;" alt="Jianqi Pan"/><br /><sub><b>Jianqi Pan</b></sub></a><br /><a href="https://github.com/litestar-org/litestar/commits?author=Jannchie" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/PokkaKiyo"><img src="https://avatars.githubusercontent.com/u/31039465?v=4?s=100" width="100px;" alt="PokkaKiyo"/><br /><sub><b>PokkaKiyo</b></sub></a><br /><a href="https://github.com/litestar-org/litestar/commits?author=PokkaKiyo" title="Tests">⚠️</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/s-aleshin"><img src="https://avatars.githubusercontent.com/u/66841202?v=4?s=100" width="100px;" alt="Sergei Aleshin"/><br /><sub><b>Sergei Aleshin</b></sub></a><br /><a href="https://github.com/litestar-org/litestar/commits?author=s-aleshin" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/PYPI_README.md
+++ b/docs/PYPI_README.md
@@ -60,7 +60,7 @@ pip install litestar
 ```
 or to include the CLI and a server (uvicorn) for running your application:
 ```shell
-pip install litestar[standard]
+pip install 'litestar[standard]'
 ```
 
 ## Quick Start

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ intersphinx_mapping = {
     "sqlalchemy": ("https://docs.sqlalchemy.org/en/20/", None),
     "alembic": ("https://alembic.sqlalchemy.org/en/latest/", None),
     "click": ("https://click.palletsprojects.com/en/8.1.x/", None),
-    "redis": ("https://redis-py.readthedocs.io/en/stable/", None),
+    "redis": ("https://redis.readthedocs.io/en/stable/", None),
     "picologging": ("https://microsoft.github.io/picologging", None),
     "structlog": ("https://www.structlog.org/en/stable/", None),
     "tortoise": ("https://tortoise.github.io/", None),

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,37 +21,37 @@ Installation
     :icon: star
 
     `Pydantic <https://docs.pydantic.dev/latest/>`_
-        :code:`pip install litestar[pydantic]`
+        :code:`pip install 'litestar[pydantic]'`
 
     `Attrs <https://www.attrs.org>`_
-        :code:`pip install litestar[attrs]`
+        :code:`pip install 'litestar[attrs]'`
 
     :ref:`Brotli Compression Middleware <usage/middleware/builtin-middleware:brotli>`:
-        :code:`pip install litestar[brotli]`
+        :code:`pip install 'litestar[brotli]'`
 
     :ref:`Cookie Based Sessions <usage/middleware/builtin-middleware:client-side sessions>`
-        :code:`pip install litestar[cryptography]`
+        :code:`pip install 'litestar[cryptography]'`
 
     :doc:`JWT </usage/security/jwt>`
-        :code:`pip install litestar[jwt]`
+        :code:`pip install 'litestar[jwt]'`
 
     :doc:`RedisStore </usage/stores>`
-        :code:`pip install litestar[redis]`
+        :code:`pip install 'litestar[redis]'`
 
     :ref:`Picologging <usage/logging:using picologging>`
-        :code:`pip install litestar[picologging]`
+        :code:`pip install 'litestar[picologging]'`
 
     :ref:`StructLog <usage/logging:using structlog>`
-        :code:`pip install litestar[structlog]`
+        :code:`pip install 'litestar[structlog]'`
 
     :doc:`Prometheus Instrumentation </usage/metrics/prometheus>`
-        :code:`pip install litestar[prometheus]`
+        :code:`pip install 'litestar[prometheus]'`
 
     :doc:`Open Telemetry Instrumentation </usage/metrics/open-telemetry>`
-        :code:`pip install litestar[opentelemetry]`
+        :code:`pip install 'litestar[opentelemetry]'`
 
     :doc:`SQLAlchemy </usage/databases/sqlalchemy/index>`
-        :code:`pip install litestar[sqlalchemy]`
+        :code:`pip install 'litestar[sqlalchemy]'`
 
     :doc:`CLI </usage/cli>`
         .. deprecated:: 2.1.1
@@ -60,19 +60,19 @@ Installation
            If you need the optional CLI dependencies, install the ``standard`` group instead.
            **Will be removed in 3.0**
 
-        :code:`pip install litestar[cli]`
+        :code:`pip install 'litestar[cli]'`
 
     :doc:`Jinja Templating </usage/templating>`
-        :code:`pip install litestar[jinja]`
+        :code:`pip install 'litestar[jinja]'`
 
     :doc:`Mako Templating </usage/templating>`
-        :code:`pip install litestar[mako]`
+        :code:`pip install 'litestar[mako]'`
 
     Standard Installation (includes Uvicorn and Jinja2 templating):
-        :code:`pip install litestar[standard]`
+        :code:`pip install 'litestar[standard]'`
 
     All Extras:
-        :code:`pip install litestar[full]`
+        :code:`pip install 'litestar[full]'`
 
     .. note:: The full extras is not recommended because it will add a lot of unnecessary extras.
 

--- a/docs/migration/flask.rst
+++ b/docs/migration/flask.rst
@@ -293,7 +293,7 @@ Templates
 
 Flask comes with the `Jinja <https://jinja.palletsprojects.com/en/3.1.x/>`_ templating
 engine built-in. You can use Jinja with Litestar as well, but you’ll need to install it
-explicitly. You can do by installing Litestar with ``pip install litestar[jinja]``.
+explicitly. You can do by installing Litestar with ``pip install 'litestar[jinja]'``.
 In addition to Jinja, Litestar supports `Mako <https://www.makotemplates.org/>`_ and `Minijinja <https://github.com/mitsuhiko/minijinja/tree/main/minijinja-py>`_ templates as well.
 
 .. tab-set::

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -2507,7 +2507,7 @@
 
         Ensure that :exc:`MissingDependencyException` includes the correct name of the
         package to install if the package name differs from the Litestar package extra.
-        (e.g. ``pip install litestar[jinja]`` vs ``pip install jinja2``). Previously the
+        (e.g. ``pip install 'litestar[jinja]'`` vs ``pip install jinja2``). Previously the
         exception assumed the same name for both the package and package-extra name.
 
 

--- a/docs/tutorials/todo-app/0-application-basics.rst
+++ b/docs/tutorials/todo-app/0-application-basics.rst
@@ -150,7 +150,7 @@ use in order to interact with application servers like
 `uvicorn <https://www.uvicorn.org/>`_ that actually implement the HTTP protocol and
 handle it for you.
 
-If you installed Litestar with ``pip install litestar[standard]``, this will have
+If you installed Litestar with ``pip install 'litestar[standard]'``, this will have
 included *uvicorn*, as well as the Litestar CLI. The CLI provides a convenient wrapper
 around uvicorn, allowing you to easily run applications without the need for much
 configuration.

--- a/docs/usage/cli.rst
+++ b/docs/usage/cli.rst
@@ -20,7 +20,7 @@ commonly used optional dependencies.
 .. code-block:: shell
     :caption: Install the standard group
 
-    pip install litestar[standard]
+    pip install 'litestar[standard]'
 
 Once you have installed ``standard``, you will have access to the ``litestar run`` command.
 

--- a/docs/usage/cli.rst
+++ b/docs/usage/cli.rst
@@ -116,12 +116,20 @@ entries should point to a :class:`click.Command` or :class:`click.Group`:
             [project.entry-points."litestar.commands"]
             my_command = "my_litestar_plugin.cli:main"
 
-    .. tab-item:: Poetry
+    .. tab-item:: poetry
 
         .. code-block:: toml
-            :caption: Using `Poetry <https://python-poetry.org/>`_
+            :caption: Using `poetry <https://python-poetry.org/>`_
 
             [tool.poetry.plugins."litestar.commands"]
+            my_command = "my_litestar_plugin.cli:main"
+
+    .. tab-item:: uv
+
+        .. code-block:: toml
+            :caption: Using `uv <https://docs.astral.sh/uv/>`_
+
+            [project.scripts]
             my_command = "my_litestar_plugin.cli:main"
 
 Using a plugin

--- a/docs/usage/databases/sqlalchemy/plugins/sqlalchemy_plugin.rst
+++ b/docs/usage/databases/sqlalchemy/plugins/sqlalchemy_plugin.rst
@@ -20,7 +20,7 @@ Or, skip ahead to :doc:`/usage/databases/sqlalchemy/plugins/sqlalchemy_init_plug
 
 .. tip::
 
-    You can install SQLAlchemy alongside Litestar by running ``pip install litestar[sqlalchemy]``.
+    You can install SQLAlchemy alongside Litestar by running ``pip install 'litestar[sqlalchemy]'``.
 
 Example
 =======

--- a/docs/usage/metrics/open-telemetry.rst
+++ b/docs/usage/metrics/open-telemetry.rst
@@ -13,7 +13,7 @@ this package, you should first install the required dependencies:
 .. code-block:: bash
     :caption: as a Litestar extra
 
-    pip install litestar[opentelemetry]
+    pip install 'litestar[opentelemetry]'
 
 Once these requirements are satisfied, you can instrument your Litestar application by creating an instance
 of :class:`OpenTelemetryConfig <litestar.contrib.opentelemetry.OpenTelemetryConfig>` and passing the middleware it creates to

--- a/docs/usage/metrics/prometheus.rst
+++ b/docs/usage/metrics/prometheus.rst
@@ -13,7 +13,7 @@ this package, you should first install the required dependencies:
 .. code-block:: bash
     :caption: as a Litestar extra
 
-    pip install litestar[prometheus]
+    pip install 'litestar[prometheus]'
 
 Once these requirements are satisfied, you can instrument your Litestar application:
 

--- a/docs/usage/middleware/builtin-middleware.rst
+++ b/docs/usage/middleware/builtin-middleware.rst
@@ -200,7 +200,7 @@ Brotli
 ^^^^^^
 
 The `Brotli <https://pypi.org/project/Brotli>`_ package is required to run this middleware. It is available as an extras to litestar with the ``brotli``
-extra (``pip install litestar[brotli]``).
+extra (``pip install 'litestar[brotli]'``).
 
 You can enable brotli compression of responses by passing an instance of
 :class:`~litestar.config.compression.CompressionConfig` with the ``backend`` parameter set to ``"brotli"``.
@@ -326,7 +326,7 @@ which offers strong AES-CGM encryption security best practices while support coo
 .. important::
 
     ``ClientSideSessionBackend`` requires the `cryptography <https://cryptography.io/en/latest/>`_ library,
-    which can be installed together with litestar as an extra using ``pip install litestar[cryptography]``
+    which can be installed together with litestar as an extra using ``pip install 'litestar[cryptography]'``
 
 .. literalinclude:: /examples/middleware/session/cookie_backend.py
     :caption: ``cookie_backend.py``

--- a/docs/usage/openapi/schema_generation.rst
+++ b/docs/usage/openapi/schema_generation.rst
@@ -183,7 +183,7 @@ access the request instance:
    @get(path="/")
    def my_route_handler(request: Request) -> dict:
        schema = request.app.openapi_schema
-       return schema.dict()
+       return schema.to_schema()
 
 
 Customizing Pydantic model schemas

--- a/docs/usage/security/jwt.rst
+++ b/docs/usage/security/jwt.rst
@@ -9,7 +9,7 @@ packages, or simply install Litestar with the ``jwt``
 .. code-block:: shell
     :caption: Install Litestar with JWT extra
 
-    pip install litestar[jwt]
+    pip install 'litestar[jwt]'
 
 :class:`JWT Auth <.security.jwt.JWTAuth>` Backend
 -------------------------------------------------

--- a/docs/usage/templating.rst
+++ b/docs/usage/templating.rst
@@ -19,21 +19,21 @@ respective extra:
 
         .. code-block:: shell
 
-            pip install litestar[jinja]
+            pip install 'litestar[jinja]'
 
     .. tab-item:: Mako
         :sync: mako
 
         .. code-block:: shell
 
-            pip install litestar[mako]
+            pip install 'litestar[mako]'
 
     .. tab-item:: MiniJinja
         :sync: minijinja
 
         .. code-block:: shell
 
-            pip install litestar[minijinja]
+            pip install 'litestar[minijinja]'
 
 .. tip::
 

--- a/docs/usage/testing.rst
+++ b/docs/usage/testing.rst
@@ -184,28 +184,35 @@ across requests, then you might want to inject or inspect session data outside a
             .. code-block:: bash
                 :caption: Using pip
 
-                python3 -m pip install litestar[cryptography]
+                python3 -m pip install 'litestar[cryptography]'
 
         .. tab-item:: pipx
 
             .. code-block:: bash
                 :caption: Using `pipx <https://pypa.github.io/pipx/>`_
 
-                pipx install litestar[cryptography]
+                pipx install 'litestar[cryptography]'
 
         .. tab-item:: pdm
 
             .. code-block:: bash
                 :caption: Using `PDM <https://pdm.fming.dev/>`_
 
-                pdm add litestar[cryptography]
+                pdm add 'litestar[cryptography]'
 
-        .. tab-item:: Poetry
+        .. tab-item:: poetry
 
             .. code-block:: bash
-                :caption: Using `Poetry <https://python-poetry.org/>`_
+                :caption: Using `poetry <https://python-poetry.org/>`_
 
-                poetry add litestar[cryptography]
+                poetry add 'litestar[cryptography]'
+
+        .. tab-item:: uv
+
+            .. code-block:: bash
+                :caption: Using `uv <https://docs.astral.sh/uv/>`_
+
+                uv add 'litestar[cryptography]'
 
 .. tab-set::
 

--- a/litestar/_openapi/parameters.py
+++ b/litestar/_openapi/parameters.py
@@ -194,11 +194,13 @@ class ParameterFactory:
         )
 
         for field_name, field_definition in unique_handler_fields:
-            if (
-                isinstance(field_definition.kwarg_definition, DependencyKwarg)
-                and field_name not in self.dependency_providers
-            ):
+            kwarg_definition = field_definition.kwarg_definition
+            if isinstance(kwarg_definition, DependencyKwarg) and field_name not in self.dependency_providers:
                 # never document explicit dependencies
+                continue
+
+            if isinstance(kwarg_definition, ParameterKwarg) and not kwarg_definition.include_in_schema:
+                # exclude parameters that are marked as not included in the schema
                 continue
 
             if provider := self.dependency_providers.get(field_name):

--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -627,7 +627,9 @@ def isatty() -> bool:
     return sys.stdout.isatty()
 
 
-def validate_mutually_exclusive_env_options(ctx: click.Context, param: click.Option, value: Sequence[Path]) -> Sequence[Path]:
+def validate_mutually_exclusive_env_options(
+    ctx: click.Context, param: click.Option, value: Sequence[Path]
+) -> Sequence[Path]:
     if ctx.params.get("env_files") and ctx.params.get("ignore_env_files"):
         raise click.BadParameter("The options '--env-file' and '--ignore-dotenv' are mutually exclusive.")
     return value

--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import importlib
 import inspect
 import os
@@ -89,7 +88,7 @@ class LitestarEnv:
     is_app_factory: bool = False
 
     @classmethod
-    def from_env(cls, app_path: str | None, app_dir: Path | None = None) -> LitestarEnv:
+    def from_env(cls, app_path: str | None, app_dir: Path | None = None, env_file: Path | None = None) -> LitestarEnv:
         """Load environment variables.
 
         If ``python-dotenv`` is installed, use it to populate environment first
@@ -99,10 +98,16 @@ class LitestarEnv:
         if cwd_str_path not in sys.path:
             sys.path.append(cwd_str_path)
 
-        with contextlib.suppress(ImportError):
-            import dotenv
+        if env_file is not None and env_file.is_file():
+            try:
+                import dotenv
 
-            dotenv.load_dotenv()
+                dotenv.load_dotenv(env_file)
+            except ImportError as err:
+                raise LitestarCLIException(
+                    "Python-dotenv must be installed when using --env-file\nPlease install the `python-dotenv`"
+                ) from err
+
         app_path = app_path or getenv("LITESTAR_APP")
         app_name = getenv("LITESTAR_APP_NAME") or "Litestar"
         quiet_console = getenv("LITESTAR_QUIET_CONSOLE") or False

--- a/litestar/cli/main.py
+++ b/litestar/cli/main.py
@@ -26,14 +26,16 @@ __all__ = ("litestar_group",)
 )
 @click.option(
     "--env-file",
+    "env_files",
     help="Path to a .env file to load environment variables from. If not provided, environment variables won't be loaded from any .env file.",
     default=None,
     type=ClickPath(dir_okay=False, file_okay=True, path_type=Path),
     show_default=False,
+    multiple=True,
 )
 @click.pass_context
 def litestar_group(
-    ctx: click.Context, app_path: str | None, app_dir: Path | None = None, env_file: Path | None = None
+    ctx: click.Context, app_path: str | None, app_dir: Path | None = None, env_files: tuple[Path, ...] | None = None
 ) -> None:
     """Litestar CLI.
 
@@ -48,7 +50,7 @@ def litestar_group(
     'LITESTAR_APP' environment variable of the same name.
     """
     if ctx.obj is None:  # load env if env-file specified
-        ctx.obj = lambda: LitestarEnv.from_env(app_path, app_dir=app_dir, env_file=env_file)
+        ctx.obj = lambda: LitestarEnv.from_env(app_path, app_dir=app_dir, env_files=env_files)
 
 
 # add sub commands here

--- a/litestar/cli/main.py
+++ b/litestar/cli/main.py
@@ -14,7 +14,7 @@ from ._utils import LitestarEnv, LitestarExtensionGroup, validate_mutually_exclu
 from .commands import core, schema, sessions
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from typing import Sequence
 
 __all__ = ("litestar_group",)
 

--- a/litestar/cli/main.py
+++ b/litestar/cli/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 try:
     import rich_click as click
@@ -9,8 +10,11 @@ except ImportError:
 
 from click import Path as ClickPath
 
-from ._utils import LitestarEnv, LitestarExtensionGroup
+from ._utils import LitestarEnv, LitestarExtensionGroup, validate_mutually_exclusive_env_options
 from .commands import core, schema, sessions
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 __all__ = ("litestar_group",)
 
@@ -32,10 +36,22 @@ __all__ = ("litestar_group",)
     type=ClickPath(dir_okay=False, file_okay=True, path_type=Path),
     show_default=False,
     multiple=True,
+    callback=validate_mutually_exclusive_env_options,
+)
+@click.option(
+    "--ignore-env-files",
+    "ignore_env_files",
+    is_flag=True,
+    default=False,
+    callback=validate_mutually_exclusive_env_options,
 )
 @click.pass_context
 def litestar_group(
-    ctx: click.Context, app_path: str | None, app_dir: Path | None = None, env_files: tuple[Path, ...] | None = None
+    ctx: click.Context,
+    app_path: str | None,
+    app_dir: Path | None = None,
+    env_files: Sequence[Path] = (Path(".env"),),
+    ignore_env_files: bool = False,
 ) -> None:
     """Litestar CLI.
 
@@ -49,8 +65,17 @@ def litestar_group(
     ('litestar --app=<module name>.<submodule>:<app instance or factory>') or the
     'LITESTAR_APP' environment variable of the same name.
     """
-    if ctx.obj is None:  # load env if env-file specified
-        ctx.obj = lambda: LitestarEnv.from_env(app_path, app_dir=app_dir, env_files=env_files)
+    if ctx.obj is None:  # env has not been loaded yet, so we can lazy load it
+        implicit_load = not env_files
+        if ignore_env_files:
+            env_files = ()
+            implicit_load = False
+        ctx.obj = lambda: LitestarEnv.from_env(
+            app_path,
+            app_dir=app_dir,
+            env_files=env_files,
+            implicit_load=implicit_load,
+        )
 
 
 # add sub commands here

--- a/litestar/cli/main.py
+++ b/litestar/cli/main.py
@@ -31,7 +31,7 @@ __all__ = ("litestar_group",)
 @click.option(
     "--env-file",
     "env_files",
-    help="Path to a .env file to load environment variables from. If not provided, environment variables won't be loaded from any .env file.",
+    help="Path to a .env file to load environment variables from. Defaults to `./.env`",
     default=None,
     type=ClickPath(dir_okay=False, file_okay=True, path_type=Path),
     show_default=False,

--- a/litestar/cli/main.py
+++ b/litestar/cli/main.py
@@ -24,8 +24,17 @@ __all__ = ("litestar_group",)
     type=ClickPath(dir_okay=True, file_okay=False, path_type=Path),
     show_default=False,
 )
+@click.option(
+    "--env-file",
+    help="Path to a .env file to load environment variables from. If not provided, environment variables won't be loaded from any .env file.",
+    default=None,
+    type=ClickPath(dir_okay=False, file_okay=True, path_type=Path),
+    show_default=False,
+)
 @click.pass_context
-def litestar_group(ctx: click.Context, app_path: str | None, app_dir: Path | None = None) -> None:
+def litestar_group(
+    ctx: click.Context, app_path: str | None, app_dir: Path | None = None, env_file: Path | None = None
+) -> None:
     """Litestar CLI.
 
     The application to will be automatically discovered if it's in one of these
@@ -38,8 +47,8 @@ def litestar_group(ctx: click.Context, app_path: str | None, app_dir: Path | Non
     ('litestar --app=<module name>.<submodule>:<app instance or factory>') or the
     'LITESTAR_APP' environment variable of the same name.
     """
-    if ctx.obj is None:  # env has not been loaded yet, so we can lazy load it
-        ctx.obj = lambda: LitestarEnv.from_env(app_path, app_dir=app_dir)
+    if ctx.obj is None:  # load env if env-file specified
+        ctx.obj = lambda: LitestarEnv.from_env(app_path, app_dir=app_dir, env_file=env_file)
 
 
 # add sub commands here

--- a/litestar/dto/base_dto.py
+++ b/litestar/dto/base_dto.py
@@ -15,6 +15,7 @@ from litestar.dto.data_structures import DTOData
 from litestar.dto.types import RenameStrategy
 from litestar.enums import RequestEncodingType
 from litestar.exceptions.dto_exceptions import InvalidAnnotationException
+from litestar.response.base import Response
 from litestar.types.builtin_types import NoneType
 from litestar.types.composite_types import TypeEncodersMap
 from litestar.typing import FieldDefinition
@@ -229,7 +230,7 @@ class AbstractDTO(Generic[T]):
         key = "data_backend" if field_definition.name == "data" else "return_backend"
         backend = cls._dto_backends[handler_id][key]  # type: ignore[literal-required]
 
-        if backend.wrapper_attribute_name:
+        if backend.wrapper_attribute_name and not field_definition.is_subclass_of(Response):
             # The DTO has been built for a handler that has a DTO supported type wrapped in a generic type.
             #
             # The backend doesn't receive the full annotation, only the type of the attribute on the outer type that
@@ -238,7 +239,7 @@ class AbstractDTO(Generic[T]):
             # This special casing rebuilds the outer generic type annotation with the original model replaced by the DTO
             # generated transfer model type in the type arguments.
             transfer_model = backend.transfer_model_type
-            generic_args = tuple(transfer_model if a is cls.model_type else a for a in field_definition.args)
+            generic_args = tuple(transfer_model if arg is cls.model_type else arg for arg in field_definition.args)
             annotation = field_definition.safe_generic_origin[generic_args]
         else:
             annotation = backend.annotation

--- a/litestar/exceptions/base_exceptions.py
+++ b/litestar/exceptions/base_exceptions.py
@@ -44,7 +44,7 @@ class MissingDependencyException(LitestarException, ImportError):
     def __init__(self, package: str, install_package: str | None = None, extra: str | None = None) -> None:
         super().__init__(
             f"Package {package!r} is not installed but required. You can install it by running "
-            f"'pip install litestar[{extra or install_package or package}]' to install litestar with the required extra "
+            f"`pip install 'litestar[{extra or install_package or package}]'` to install litestar with the required extra "
             f"or 'pip install {install_package or package}' to install the package separately"
         )
 

--- a/litestar/params.py
+++ b/litestar/params.py
@@ -124,6 +124,11 @@ class KwargDefinition:
     Use as the key for the reference when creating a component for this type
     .. versionadded:: 2.12.0
     """
+    include_in_schema: bool = True
+    """
+    A boolean flag dictating whether this parameter should be included in the schema.
+    .. versionadded:: 2.17.0
+    """
 
     @property
     def is_constrained(self) -> bool:
@@ -201,6 +206,7 @@ def Parameter(
     title: str | None = None,
     schema_extra: dict[str, Any] | None = None,
     schema_component_key: str | None = None,
+    include_in_schema: bool = True,
 ) -> Any:
     """Create an extended parameter kwarg definition.
 
@@ -247,6 +253,7 @@ def Parameter(
             .. versionadded:: 2.8.0
         schema_component_key: Use this as the key for the reference when creating a component for this type
             .. versionadded:: 2.12.0
+        include_in_schema: A boolean flag dictating whether this parameter should be included in the schema.
     """
     return ParameterKwarg(
         annotation=annotation,
@@ -273,6 +280,7 @@ def Parameter(
         pattern=pattern,
         schema_extra=schema_extra,
         schema_component_key=schema_component_key,
+        include_in_schema=include_in_schema,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ maintainers = [
 ]
 name = "litestar"
 readme = "README.md"
-requires-python = ">=3.8,<4.0"
+requires-python = ">=3.9,<4.0"
 version = "2.16.0"
 
 [project.urls]
@@ -178,7 +178,6 @@ linting = [
 test = [
   "covdefaults",
   "pytest",
-  "pytest-asyncio<=0.24.0; python_version < \"3.9\"",
   "pytest-asyncio>0.24.0; python_version >= \"3.9\"",
   "pytest-cov",
   "pytest-lazy-fixtures",
@@ -245,7 +244,7 @@ enable_error_code = [
 ]
 packages = ["litestar", "tests"]
 plugins = ["pydantic.mypy"]
-python_version = "3.8"
+python_version = "3.9"
 
 disallow_any_generics = false
 local_partial_types = true
@@ -334,7 +333,7 @@ exclude = [
   "tests/unit/test_contrib/test_sqlalchemy.py",
 ]
 include = ["litestar", "tests"]
-pythonVersion = "3.8"
+pythonVersion = "3.9"
 reportUnnecessaryTypeIgnoreComments = true
 
 [tool.slotscheck]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ maintainers = [
 ]
 name = "litestar"
 readme = "README.md"
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.8,<4.0"
 version = "2.16.0"
 
 [project.urls]

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -136,8 +136,8 @@ def test_create_exception_response_utility_non_http_exception(media_type: MediaT
 def test_missing_dependency_exception() -> None:
     exc = MissingDependencyException("some_package")
     expected = (
-        "Package 'some_package' is not installed but required. You can install it by running 'pip install "
-        "litestar[some_package]' to install litestar with the required extra or 'pip install some_package' to install "
+        "Package 'some_package' is not installed but required. You can install it by running `pip install "
+        "'litestar[some_package]'` to install litestar with the required extra or 'pip install some_package' to install "
         "the package separately"
     )
     assert str(exc) == expected
@@ -146,8 +146,8 @@ def test_missing_dependency_exception() -> None:
 def test_missing_dependency_exception_differing_package_name() -> None:
     exc = MissingDependencyException("some_package", "install_via_this", "other-extra")
     expected = (
-        "Package 'some_package' is not installed but required. You can install it by running 'pip install "
-        "litestar[other-extra]' to install litestar with the required extra or 'pip install install_via_this' to "
+        "Package 'some_package' is not installed but required. You can install it by running `pip install "
+        "'litestar[other-extra]'` to install litestar with the required extra or 'pip install install_via_this' to "
         "install the package separately"
     )
 

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -475,3 +475,33 @@ def test_query_param_only_properties() -> None:
         "allowEmptyValue": False,
         "allowReserved": False,
     }
+
+
+def test_not_included_in_schema_parameter() -> None:
+    @get("/handler")
+    async def handler(param: Annotated[str, Parameter(include_in_schema=False)]) -> None:
+        pass
+
+    with create_test_client(handler) as client:
+        response = client.get("/schema/openapi.json")
+
+        response_json = response.json()
+        handler_schema = response_json["paths"]["/handler"]["get"]
+        assert "parameters" not in handler_schema
+
+
+def test_two_parameters_but_one_not_included_in_schema() -> None:
+    @get("/handler")
+    def handler(param1: str, param2: str = Parameter(include_in_schema=False)) -> None:
+        pass
+
+    with create_test_client(handler) as client:
+        response = client.get("/schema/openapi.json")
+
+        response_json = response.json()
+        handler_schema = response_json["paths"]["/handler"]["get"]
+        assert "parameters" in handler_schema
+
+        parameter_names = {param["name"] for param in handler_schema["parameters"]}
+        assert "param1" in parameter_names
+        assert "param2" not in parameter_names


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Add a `--env-file` flag to allow users to explicitly use .env environment variables:
- Provide custom names/paths for env files.
- Use multiple env files.
- Ignore `.env` files.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Closes #3217, #4211