### PR TITLE
fix: empty string being considered as the token if the token was coming from the cookies

### DIFF
--- a/litestar/security/jwt/middleware.py
+++ b/litestar/security/jwt/middleware.py
@@ -251,5 +251,6 @@ class JWTCookieAuthenticationMiddleware(JWTAuthenticationMiddleware):
         auth_header = connection.headers.get(self.auth_header) or connection.cookies.get(self.auth_cookie_key)
         if not auth_header:
             raise NotAuthorizedException("No JWT token found in request header or cookies")
-        encoded_token = auth_header.partition(" ")[-1]
+        parts = auth_header.strip().split(maxsplit=1)
+        encoded_token = parts[-1] if parts else ""
         return await self.authenticate_token(encoded_token=encoded_token, connection=connection)


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
This PR fixes the issue where an empty string was being considered as the token when the token was coming from the cookies
-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
