### PR TITLE
docs: fix incorrect parameter name in docstring

### DIFF
--- a/litestar/middleware/base.py
+++ b/litestar/middleware/base.py
@@ -190,7 +190,7 @@ class ASGIMiddleware(abc.ABC):
 
         class MyMiddleware(ASGIMiddleware):
             scopes = (ScopeType.HTTP,)
-            exclude = ("/not/this/path",)
+            exclude_path_pattern = ("/not/this/path",)
             exclude_opt_key = "exclude_my_middleware"
 
             def __init__(self, my_logger: Logger) -> None:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
Fixes a small documentation error in the AGIMiddleware class for the exclude_path_pattern parameter
-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
