### PR TITLE
fix(docs):  build v2 docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - v3.0
       - v2
 
 env:
@@ -43,10 +42,6 @@ jobs:
       - name: Build docs (main branch)
         run: uv run python tools/build_docs.py docs-build --version main
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
-      - name: Build docs (v3.0 branch)
-        run: uv run python tools/build_docs.py docs-build --version 3-dev
-        if: github.event_name == 'push' && github.ref == 'refs/heads/v3.0'
 
       - name: Build docs (v2 branch)
         run: uv run python tools/build_docs.py docs-build --version 2

--- a/docs/_static/versioning.js
+++ b/docs/_static/versioning.js
@@ -22,7 +22,7 @@ const addVersionWarning = (currentVersion, latestVersion) => {
   container.id = "version-warning";
 
   const isPreviewVersion = (version) => {
-        const previewVersions = ['dev', 'develop', 'main', '3-dev'];
+        const previewVersions = ['dev', 'develop', 'main'];
         return previewVersions.includes(version) || parseInt(version) > parseInt(latestVersion);
     };
 

--- a/docs/_static/versions.json
+++ b/docs/_static/versions.json
@@ -1,1 +1,1 @@
-{ "versions": ["1", "2", "main", "3-dev"], "latest": "2" }
+{ "versions": ["1", "2", "main"], "latest": "2" }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -305,8 +305,7 @@ html_context = {
     "current_version": release,  # Use the detected version
     "versions": [  # TODO(provinzkraut): this needs to use versions.json but im not 100% on how to do this yet
         ("latest", "/latest"),
-        ("development", "/main"),
-        ("v3 (preview)", "/3-dev"),
+        ("v3 (development)", "/main"),
         ("v2", "/2"),
         ("v1", "/1"),
     ],


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

I think when merging v3 into main and then release 2.17 there is some mixup, we don't necessarily build v2 docs and we still have the v3 branch build.. this is assuming it will fix the current issues on https://docs.litestar.dev/latest/

I checked out a v2 branch and brought it back to right before we merged in v3 into main, then added it to the build steps, munged the versions config... 🤞🏼