### PR TITLE
docs: type hint in full_app_with_session_di.py

### DIFF
--- a/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_session_di.py
+++ b/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_session_di.py
@@ -1,6 +1,6 @@
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, NoResultFound
@@ -70,7 +70,7 @@ async def get_todo_by_title(todo_name, session: AsyncSession) -> TodoItem:
         raise NotFoundException(detail=f"TODO {todo_name!r} not found") from e
 
 
-async def get_todo_list(done: Optional[bool], session: AsyncSession) -> list[TodoItem]:
+async def get_todo_list(done: Optional[bool], session: AsyncSession) -> Sequence[TodoItem]:
     query = select(TodoItem)
     if done is not None:
         query = query.where(TodoItem.done.is_(done))

--- a/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_session_di.py
+++ b/docs/examples/contrib/sqlalchemy/plugins/tutorial/full_app_with_session_di.py
@@ -1,6 +1,6 @@
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Sequence
 from contextlib import asynccontextmanager
-from typing import Any, Optional, Sequence
+from typing import Any, Optional
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, NoResultFound


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This PR fixes the type hinting error in the example code in the documentation at [1-provide-session-with-di](https://docs.litestar.dev/2/tutorials/sqlalchemy/1-provide-session-with-di.html).

In my environment (Python 3.13, Pylance), line 79 of the code before the change would prompt:

> Type "Sequence[TodoItem]" is not assignable to return type "list[TodoItem]"

Moreover, according to the context of the documentation, the `list` type hint for the return value of `get_todo_list` is not consistent with the `Sequence` used in the previous document at [0-introduction](https://docs.litestar.dev/2/tutorials/sqlalchemy/0-introduction.html).