### PR TITLE
docs: add install `advanced_alchemy` tips for serialization plugin

### DIFF
--- a/docs/tutorials/sqlalchemy/2-serialization-plugin.rst
+++ b/docs/tutorials/sqlalchemy/2-serialization-plugin.rst
@@ -5,7 +5,7 @@ Our next improvement is to leverage the
 :class:`SQLAlchemySerializationPlugin <litestar.contrib.sqlalchemy.plugins.SQLAlchemySerializationPlugin>`
 so that we can receive and return our SQLAlchemy models directly to and from our handlers.
 
-Before running the following code, you need to install the `advanced_alchemy` dependency. You can do this by running `pip install advanced_alchemy`.
+Before running the following code, you need to install the ``advanced_alchemy`` dependency. You can do this by running ``pip install advanced_alchemy``.
 
 Here's the code:
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

The import statement `from litestar.plugins.sqlalchemy import SQLAlchemySerializationPlugin` in the first code block of the document requires the `advanced_alchemy` dependency to be installed, but this dependency is not mentioned in the preceding text. This PR adds this clarification.
