### PR TITLE
fix: KeyError when using 'data' kwarg in dependency functions

### DIFF
--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -349,6 +349,12 @@ class KwargsModel:
             expected_reserved_kwargs.update(dependency_kwargs_model.expected_reserved_kwargs)
             sequence_query_parameter_names.update(dependency_kwargs_model.sequence_query_parameter_names)
 
+        is_data_optional = (
+            field_definitions["data"].is_optional
+            if "data" in expected_reserved_kwargs and "data" in field_definitions
+            else False
+        )
+
         return KwargsModel(
             expected_cookie_params=expected_cookie_parameters,
             expected_dependencies=expected_dependencies,
@@ -359,7 +365,7 @@ class KwargsModel:
             expected_path_params=expected_path_parameters,
             expected_query_params=expected_query_parameters,
             expected_reserved_kwargs=expected_reserved_kwargs,
-            is_data_optional=field_definitions["data"].is_optional if "data" in expected_reserved_kwargs else False,
+            is_data_optional=is_data_optional,
             sequence_query_parameter_names=sequence_query_parameter_names,
         )
 

--- a/litestar/utils/helpers.py
+++ b/litestar/utils/helpers.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 __all__ = (
     "get_enum_string_value",
+    "get_exception_group",
     "get_name",
     "unique_name_for_scope",
     "unwrap_partial",

--- a/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
+++ b/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, cast
+from typing import Annotated, Any, Optional, cast
 
 import msgspec.json
 import pytest
@@ -16,7 +16,9 @@ from litestar import (
     put,
 )
 from litestar.datastructures.state import ImmutableState, State
+from litestar.di import Provide
 from litestar.exceptions import ImproperlyConfiguredException
+from litestar.params import Dependency
 from litestar.status_codes import (
     HTTP_200_OK,
     HTTP_201_CREATED,
@@ -284,7 +286,7 @@ def test_body(decorator: Any, http_method: Any, expected_status_code: Any) -> No
 
 
 def test_improper_use_of_state_kwarg() -> None:
-    """Test error condition of State kwarg with unexpected type.."""
+    """Test the error condition of State kwarg with an unexpected type."""
     test_path = "/bad-state"
 
     class MyController(Controller):
@@ -296,3 +298,37 @@ def test_improper_use_of_state_kwarg() -> None:
 
     with pytest.raises(ImproperlyConfiguredException):
         Litestar(route_handlers=[MyController], openapi_config=None)
+
+
+@pytest.mark.parametrize(
+    "decorator, http_method, expected_status_code",
+    [
+        (post, HttpMethod.POST, HTTP_201_CREATED),
+        (put, HttpMethod.PUT, HTTP_200_OK),
+        (patch, HttpMethod.PATCH, HTTP_200_OK),
+        (delete, HttpMethod.DELETE, HTTP_204_NO_CONTENT),
+    ],
+)
+def test_data_kwarg_in_dependency(decorator: Any, http_method: Any, expected_status_code: Any) -> None:
+    """Test that using 'data' kwarg in a dependency function doesn't raise KeyError.
+
+    This test addresses GitHub issue #4230 where using the 'data' reserved kwarg
+    in a dependency function would cause a KeyError during application initialization.
+    """
+    test_path = "/person"
+
+    async def dependency_with_data(data: DataclassPerson) -> str:
+        assert isinstance(data, DataclassPerson)
+        return f"{data.first_name} {data.last_name}"
+
+    class MyController(Controller):
+        path = test_path
+
+        @decorator(dependencies={"person_name": Provide(dependency_with_data)})
+        async def test_method(self, data: DataclassPerson, person_name: Annotated[str, Dependency()]) -> None:
+            assert data == person_instance
+            assert person_name == f"{person_instance.first_name} {person_instance.last_name}"
+
+    with create_test_client(MyController) as client:
+        response = client.request(http_method, test_path, json=msgspec.to_builtins(person_instance))
+        assert response.status_code == expected_status_code


### PR DESCRIPTION
Fixes #4230

The issue occurred when a dependency function used the 'data' reserved kwarg. The KwargsModel.create_for_signature_model method assumed that if 'data' was in expected_reserved_kwargs, it would also be present in field_definitions. However, when 'data' is used in a dependency, it gets added to expected_reserved_kwargs from the dependency but may not be present in the main handler's field_definitions.

This fix adds a safety check to ensure 'data' exists in field_definitions before attempting to access it, preventing the KeyError.

Changes:
- Modified litestar/_kwargs/kwargs_model.py line 362 to safely check for 'data' key
- Added test case to verify the fix works correctly

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4230

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
