### PR TITLE
fix: possibly get httpexception.extra and httpexception.headers from class for v3

### DIFF
--- a/litestar/exceptions/http_exceptions.py
+++ b/litestar/exceptions/http_exceptions.py
@@ -15,6 +15,7 @@ from litestar.status_codes import (
     HTTP_500_INTERNAL_SERVER_ERROR,
     HTTP_503_SERVICE_UNAVAILABLE,
 )
+from litestar.types.empty import Empty, EmptyType
 
 __all__ = (
     "ClientException",
@@ -54,7 +55,7 @@ class HTTPException(LitestarException):
         detail: str = "",
         status_code: int | None = None,
         headers: dict[str, str] | None = None,
-        extra: dict[str, Any] | list[Any] | None = None,
+        extra: dict[str, Any] | list[Any] | None | EmptyType = Empty,
     ) -> None:
         """Initialize ``HTTPException``.
 
@@ -69,7 +70,7 @@ class HTTPException(LitestarException):
         """
         super().__init__(*args, detail=detail)
         self.status_code = status_code or self.status_code
-        self.extra = extra
+        self.extra = extra if extra is not Empty else getattr(self, "extra", None)
         self.headers = headers
         if not self.detail:
             self.detail = HTTPStatus(self.status_code).phrase

--- a/litestar/exceptions/http_exceptions.py
+++ b/litestar/exceptions/http_exceptions.py
@@ -44,7 +44,7 @@ class HTTPException(LitestarException):
     """Exception status code."""
     detail: str
     """Exception details or message."""
-    headers: dict[str, str] | None
+    headers: dict[str, str] | None = None
     """Headers to attach to the response."""
     extra: dict[str, Any] | list[Any] | None = None
     """An extra mapping to attach to the exception."""
@@ -54,7 +54,7 @@ class HTTPException(LitestarException):
         *args: Any,
         detail: str = "",
         status_code: int | None = None,
-        headers: dict[str, str] | None  | EmptyType = Empty,
+        headers: dict[str, str] | None | EmptyType = Empty,
         extra: dict[str, Any] | list[Any] | None | EmptyType = Empty,
     ) -> None:
         """Initialize ``HTTPException``.

--- a/litestar/exceptions/http_exceptions.py
+++ b/litestar/exceptions/http_exceptions.py
@@ -54,7 +54,7 @@ class HTTPException(LitestarException):
         *args: Any,
         detail: str = "",
         status_code: int | None = None,
-        headers: dict[str, str] | None = None,
+        headers: dict[str, str] | None  | EmptyType = Empty,
         extra: dict[str, Any] | list[Any] | None | EmptyType = Empty,
     ) -> None:
         """Initialize ``HTTPException``.
@@ -71,7 +71,7 @@ class HTTPException(LitestarException):
         super().__init__(*args, detail=detail)
         self.status_code = status_code or self.status_code
         self.extra = extra if extra is not Empty else self.extra
-        self.headers = headers
+        self.headers = headers if headers is not Empty else self.headers
         if not self.detail:
             self.detail = HTTPStatus(self.status_code).phrase
         self.args = (f"{self.status_code}: {self.detail}", *self.args)

--- a/litestar/exceptions/http_exceptions.py
+++ b/litestar/exceptions/http_exceptions.py
@@ -66,7 +66,11 @@ class HTTPException(LitestarException):
             detail: Exception details or message. Will default to args[0] if not provided.
             status_code: Exception HTTP status code.
             headers: Headers to set on the response.
+                Defaults to the class's ``headers`` if not provided.
+                Set to ``None`` explicitly to unset the default.
             extra: An extra mapping to attach to the exception.
+                Defaults to the class's ``extra`` if not provided.
+                Set to ``None`` explicitly to unset the default.
         """
         super().__init__(*args, detail=detail)
         self.status_code = status_code or self.status_code

--- a/litestar/exceptions/http_exceptions.py
+++ b/litestar/exceptions/http_exceptions.py
@@ -46,7 +46,7 @@ class HTTPException(LitestarException):
     """Exception details or message."""
     headers: dict[str, str] | None
     """Headers to attach to the response."""
-    extra: dict[str, Any] | list[Any] | None
+    extra: dict[str, Any] | list[Any] | None = None
     """An extra mapping to attach to the exception."""
 
     def __init__(
@@ -70,7 +70,7 @@ class HTTPException(LitestarException):
         """
         super().__init__(*args, detail=detail)
         self.status_code = status_code or self.status_code
-        self.extra = extra if extra is not Empty else getattr(self, "extra", None)
+        self.extra = extra if extra is not Empty else self.extra
         self.headers = headers
         if not self.detail:
             self.detail = HTTPStatus(self.status_code).phrase

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -78,10 +78,7 @@ def test_custom_http_exception_detail(detail: str) -> None:
 @pytest.mark.parametrize("ex_type", [HTTPException, CustomHTTPException])
 def test_http_exception(ex_type: type[HTTPException], status_code: int, detail: str) -> None:
     assert ex_type().status_code == HTTP_500_INTERNAL_SERVER_ERROR
-    for result in (
-        ex_type(detail, status_code=status_code),
-        ex_type(detail=detail, status_code=status_code),
-    ):
+    for result in ex_type(detail, status_code=status_code), ex_type(detail=detail, status_code=status_code):
         assert isinstance(result, LitestarException)
         assert repr(result) == f"{result.status_code} - {result.__class__.__name__} - {result.detail}"
         assert str(result) == f"{result.status_code}: {result.detail}".strip()
@@ -110,11 +107,7 @@ def test_create_exception_response_utility_litestar_http_exception(media_type: M
     assert response.status_code == HTTP_400_BAD_REQUEST
     assert response.media_type == media_type
     if media_type == MediaType.JSON:
-        assert response.content == {
-            "status_code": 400,
-            "detail": "litestar http exception",
-            "extra": ["any"],
-        }
+        assert response.content == {"status_code": 400, "detail": "litestar http exception", "extra": ["any"]}
     else:
         assert response.content == b'{"status_code":400,"detail":"litestar http exception","extra":["any"]}'
 

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -83,19 +83,14 @@ def test_http_exception(ex_type: type[HTTPException], status_code: int, detail: 
         ex_type(detail=detail, status_code=status_code),
     ):
         assert isinstance(result, LitestarException)
-        assert (
-            repr(result) == f"{result.status_code} - {result.__class__.__name__} - {result.detail}"
-        )
+        assert repr(result) == f"{result.status_code} - {result.__class__.__name__} - {result.detail}"
         assert str(result) == f"{result.status_code}: {result.detail}".strip()
 
 
 @given(detail=st.text())
 def test_improperly_configured_exception(detail: str) -> None:
     result = ImproperlyConfiguredException(detail=detail)
-    assert (
-        repr(result)
-        == f"{HTTP_500_INTERNAL_SERVER_ERROR} - {result.__class__.__name__} - {result.detail}"
-    )
+    assert repr(result) == f"{HTTP_500_INTERNAL_SERVER_ERROR} - {result.__class__.__name__} - {result.detail}"
     assert isinstance(result, HTTPException)
     assert isinstance(result, ValueError)
 
@@ -109,9 +104,7 @@ def test_validation_exception() -> None:
 
 @pytest.mark.parametrize("media_type", [MediaType.JSON, MediaType.TEXT])
 def test_create_exception_response_utility_litestar_http_exception(media_type: MediaType) -> None:
-    exc = HTTPException(
-        detail="litestar http exception", status_code=HTTP_400_BAD_REQUEST, extra=["any"]
-    )
+    exc = HTTPException(detail="litestar http exception", status_code=HTTP_400_BAD_REQUEST, extra=["any"])
     request = RequestFactory(handler_kwargs={"media_type": media_type}).get()
     response = create_exception_response(request=request, exc=exc)
     assert response.status_code == HTTP_400_BAD_REQUEST
@@ -123,10 +116,7 @@ def test_create_exception_response_utility_litestar_http_exception(media_type: M
             "extra": ["any"],
         }
     else:
-        assert (
-            response.content
-            == b'{"status_code":400,"detail":"litestar http exception","extra":["any"]}'
-        )
+        assert response.content == b'{"status_code":400,"detail":"litestar http exception","extra":["any"]}'
 
 
 @pytest.mark.parametrize("media_type", [MediaType.JSON, MediaType.TEXT])
@@ -215,10 +205,7 @@ def test_non_litestar_exception_with_detail_is_not_included() -> None:
         raise MyException()
 
     with create_test_client([handler], debug=False) as client:
-        assert (
-            client.get("/", headers={"Accept": MediaType.JSON}).json().get("detail")
-            == "Internal Server Error"
-        )
+        assert client.get("/", headers={"Accept": MediaType.JSON}).json().get("detail") == "Internal Server Error"
 
 
 def test_http_exception_with_class_var_extra() -> None:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- For HTTPException, possibly get the value for extra and headers on the class

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
- #4006 
