### PR TITLE
fix(OpenAPI): constraint check logic

### DIFF
--- a/litestar/params.py
+++ b/litestar/params.py
@@ -135,7 +135,7 @@ class KwargDefinition:
     def is_constrained(self) -> bool:
         """Return True if any of the constraints are set."""
         return any(
-            attr if attr and attr is not Empty else False  # type: ignore[comparison-overlap]
+            attr is not None
             for attr in (
                 self.gt,
                 self.ge,

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -291,6 +291,7 @@ class Foo(TypedDict):
 
 def test_create_schema_from_msgspec_annotated_type() -> None:
     class Lookup(msgspec.Struct):
+        int_field: Annotated[int, msgspec.Meta(gt=0)]
         str_field: Annotated[
             str,
             msgspec.Meta(max_length=16, examples=["example"], description="description", title="title", pattern=r"\w+"),
@@ -300,12 +301,14 @@ def test_create_schema_from_msgspec_annotated_type() -> None:
 
     schema = get_schema_for_field_definition(FieldDefinition.from_kwarg(name="Lookup", annotation=Lookup))
 
+    assert schema.properties["int_field"].type == OpenAPIType.INTEGER  # type: ignore[index, union-attr]
+    assert schema.properties["int_field"].exclusive_minimum == 0  # type: ignore[index, union-attr]
     assert schema.properties["str_field"].type == OpenAPIType.STRING  # type: ignore[index, union-attr]
     assert schema.properties["str_field"].examples == ["example"]  # type: ignore[index, union-attr]
     assert schema.properties["str_field"].description == "description"  # type: ignore[index]
     assert schema.properties["str_field"].title == "title"  # type: ignore[index, union-attr]
     assert schema.properties["str_field"].max_length == 16  # type: ignore[index, union-attr]
-    assert sorted(schema.required) == sorted(["str_field", "bytes_field"])  # type: ignore[arg-type]
+    assert sorted(schema.required) == sorted(["int_field", "str_field", "bytes_field"])  # type: ignore[arg-type]
     assert schema.properties["bytes_field"].to_schema() == {  # type: ignore[index]
         "contentEncoding": "utf-8",
         "maxLength": 2,


### PR DESCRIPTION
## Description

- Adds back missing constraints to OpenAPI for simple (non-union, non-optional, non-nested) field types that specify constraints.

## Closes
Closes #3999