### PR TITLE
feat: Add star theme to rich-click CLI

### DIFF
--- a/litestar/cli/__init__.py
+++ b/litestar/cli/__init__.py
@@ -7,6 +7,7 @@ from importlib.util import find_spec
 if find_spec("rich_click") is not None:  # pragma: no cover
     import rich_click
 
+    rich_click.rich_click.THEME = "star-box"  # pyright: ignore
     rich_click.rich_click.USE_RICH_MARKUP = True
     rich_click.rich_click.USE_MARKDOWN = False
     rich_click.rich_click.SHOW_ARGUMENTS = True


### PR DESCRIPTION
## Description

In rich-click 1.9.0, we are adding themes. https://ewels.github.io/rich-click/1.9/documentation/themes/

Also, litestar appears to one of if not the largest user of rich-click.

As a thank you for using us and to cross-promote other great open source libraries, we added an ANSI-color theme to rich-click 1.9.0 with litestar's colors (primary yellow with blue accent), simply called `star`.

This implementation is also backwards compatible with previous rich-click versions.

I tested that this works by cloning the `litestar` repo and running:

```shell
uv pip install -U "rich-click>=1.9.0"
litestar --help
litestar run --help
```

## Formats

rich-click 1.9.0 also implements different formats for themes.

The big question I have is which of the five formats you prefer. Currently I have it set to `box` but we have 5 choices:

### `rich_click.rich_click.THEME = "star-box"`

Current rich-click format

<img width="3358" height="1832" alt="image" src="https://github.com/user-attachments/assets/8ff9dc8b-07f4-4b75-885e-2259dea53371" />

### `rich_click.rich_click.THEME = "star-slim"`

Classic CLI look

<img width="3358" height="1832" alt="image" src="https://github.com/user-attachments/assets/224365ac-6206-4a6f-b46d-d79007463c97" />

### `rich_click.rich_click.THEME = "star-modern"`

<img width="3358" height="1832" alt="image" src="https://github.com/user-attachments/assets/512ad41e-cee6-4c89-a031-33ed323d224a" />

### `rich_click.rich_click.THEME = "star-nu"`

Compact but legible

<img width="3358" height="1832" alt="image" src="https://github.com/user-attachments/assets/e9e91e30-6ee1-48f5-8c4b-ba5f930f181f" />

### `rich_click.rich_click.THEME = "star-robo"`

Boxes but more spacious

<img width="3358" height="1832" alt="image" src="https://github.com/user-attachments/assets/4d1d64c1-a45b-4e09-b2dd-fccd2d3e2df5" />

## Changes to / critiques of style?

If you are interested in doing this, but have any concerns about the style such as colors, etc., let me know and we can make adjustments!

One more note, we do reference "Litestar" in the help text for this theme; we describe it as the "Litestar theme". I don't expect this to cause any issues w/r/t copyright or trademark, but let me know if it does and we can remove that mention.

## Closes

#4262