### PR TITLE
fix(routing): Ensure a `MethodNotAllowedException` exception during routing properly sets `Allow` header 

### DIFF
--- a/litestar/_asgi/routing_trie/traversal.py
+++ b/litestar/_asgi/routing_trie/traversal.py
@@ -81,7 +81,10 @@ def parse_node_handlers(
     if node.is_asgi:
         return node.asgi_handlers["asgi"]
     if method:
-        return node.asgi_handlers[method]
+        try:
+            return node.asgi_handlers[method]
+        except KeyError as e:
+            raise MethodNotAllowedException(headers={"allowed": ", ".join(node.asgi_handlers.keys())}) from e
     return node.asgi_handlers["websocket"]
 
 
@@ -170,7 +173,5 @@ def parse_path_to_route(
             parsed_path_parameters,
             node.path_template,
         )
-    except KeyError as e:
-        raise MethodNotAllowedException() from e
     except ValueError as e:
         raise NotFoundException() from e

--- a/tests/e2e/test_routing/test_path_resolution.py
+++ b/tests/e2e/test_routing/test_path_resolution.py
@@ -161,6 +161,7 @@ async def test_http_route_raises_for_unsupported_method(anyio_backend: str) -> N
     with create_test_client(route_handlers=[my_get_handler, my_post_handler]) as client:
         response = client.delete("/")
         assert response.status_code == HTTP_405_METHOD_NOT_ALLOWED
+        assert response.headers.get("allowed", "") == "GET, POST, OPTIONS"
 
 
 def test_path_order() -> None:


### PR DESCRIPTION
`MethodNotAllowedException` exceptions raised during routing did not include the [`Allow`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Allow) header, which must be present in a `405 Method Not Allowed` response.

Fixes #4277.

