### PR TITLE
fix: docs[ReceiveRoutePlugin] documentation

### DIFF
--- a/docs/usage/plugins/index.rst
+++ b/docs/usage/plugins/index.rst
@@ -149,4 +149,4 @@ The following example shows a simple plugin that logs information about each rou
 
     class RouteLoggerPlugin(ReceiveRoutePlugin):
         def receive_route(self, route: BaseRoute) -> None:
-            print(f"Route registered: {route.path} [{', '.join(route.http_methods)}]")
+            print(f"Route registered: {route.path} [{', '.join(route.methods)}]")


### PR DESCRIPTION
## Description

Fixed a documentation error: updated `route.http_methods` to the correct attribute `route.methods` when logging registered routes.

before:

```py
    from litestar.plugins import ReceiveRoutePlugin
    from litestar.routes import BaseRoute

    class RouteLoggerPlugin(ReceiveRoutePlugin):
        def receive_route(self, route: BaseRoute) -> None:
            print(f"Route registered: {route.path} [{', '.join(route.http_methods)}]")
```

after:

```py
print(f"Route registered: {route.path} [{', '.join(route.methods)}]")
```