### PR TITLE
feat!: Remove deprecated plugin properties

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -24,3 +24,17 @@
         .. seealso::
             :ref:`usage/testing:Test Clients`
             :ref:`usage/testing:Deciding which test client to use`
+
+    .. change:: Remove deprecated plugin properties from ``Litestar``
+        :type: feature
+        :breaking:
+
+        Remove deprecated ``<plugin_type>_plugins`` properties from :class:`Litestar`.
+
+        ===================================  ===================================
+        Removed                              Use instead
+        ===================================  ===================================
+        ``Litestar.openapi_schema_plugins``  ``Litestar.plugins.openapi_schema``
+        ``Litestar.cli_plugins``             ``Litestar.plugins.cli``
+        ``Litestar.serialization_plugins``   ``Litestar.serialization.cli``
+        ===================================  ===================================

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -45,17 +45,15 @@ from litestar.openapi.config import OpenAPIConfig
 from litestar.plugins import (
     CLIPlugin,
     InitPluginProtocol,
-    OpenAPISchemaPlugin,
     PluginProtocol,
     PluginRegistry,
-    SerializationPlugin,
 )
 from litestar.router import Router
 from litestar.routes import ASGIRoute, HTTPRoute, WebSocketRoute
 from litestar.stores.registry import StoreRegistry
 from litestar.types import Empty, TypeDecodersSequence
 from litestar.types.internal_types import PathParameterDefinition, RouteHandlerMapItem, TemplateConfigType
-from litestar.utils import deprecated, ensure_async_callable, join_paths, unique
+from litestar.utils import ensure_async_callable, join_paths, unique
 from litestar.utils.dataclass import extract_dataclass_items
 from litestar.utils.predicates import is_async_callable, is_class_and_subclass
 from litestar.utils.warnings import warn_pdb_on_exception
@@ -528,21 +526,6 @@ class Litestar(Router):
         except ImportError:
             pass
         return config
-
-    @property
-    @deprecated(version="2.0", alternative="Litestar.plugins.cli", kind="property")
-    def cli_plugins(self) -> list[CLIPlugin]:
-        return list(self.plugins.cli)
-
-    @property
-    @deprecated(version="2.0", alternative="Litestar.plugins.openapi", kind="property")
-    def openapi_schema_plugins(self) -> list[OpenAPISchemaPlugin]:
-        return list(self.plugins.openapi)
-
-    @property
-    @deprecated(version="2.0", alternative="Litestar.plugins.serialization", kind="property")
-    def serialization_plugins(self) -> list[SerializationPlugin]:
-        return list(self.plugins.serialization)
 
     @staticmethod
     def _get_default_plugins(plugins: list[PluginProtocol]) -> list[PluginProtocol]:

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -15,7 +15,6 @@ from pytest import MonkeyPatch
 from litestar import Litestar, MediaType, Request, Response, get
 from litestar.config.app import AppConfig, ExperimentalFeatures
 from litestar.config.response_cache import ResponseCacheConfig
-from litestar.contrib.sqlalchemy.plugins import SQLAlchemySerializationPlugin
 from litestar.datastructures import MutableScopeHeaders, State
 from litestar.events.emitter import SimpleEventEmitter
 from litestar.exceptions import (
@@ -370,18 +369,6 @@ def test_registering_route_handler_generates_openapi_docs() -> None:
     app.register(get("/path2")(fn))
     assert app.openapi_schema.paths.get("/path1")
     assert app.openapi_schema.paths.get("/path2")
-
-
-def test_plugin_properties() -> None:
-    class FooPlugin(CLIPlugin):
-        def on_cli_init(self, cli: Group) -> None:
-            return
-
-    app = Litestar(plugins=[FooPlugin(), SQLAlchemySerializationPlugin()])
-
-    assert app.openapi_schema_plugins == list(app.plugins.openapi)
-    assert app.cli_plugins == list(app.plugins.cli)
-    assert app.serialization_plugins == list(app.plugins.serialization)
 
 
 def test_plugin_registry() -> None:


### PR DESCRIPTION
Remove deprecated ``<plugin_type>_plugins`` properties from :class:`~litestar.Litestar`.

| Removed                           | Use instead                        |
|-----------------------------------|-------------------------------------|
| `Litestar.openapi_schema_plugins` | `Litestar.plugins.openapi_schema`   |
| `Litestar.cli_plugins`            | `Litestar.plugins.cli`              |
| `Litestar.serialization_plugins`  | `Litestar.serialization.cli`        |



