### PR TITLE
feat!: remove deprecated header properties

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -27,6 +27,7 @@
 
     .. change:: Remove deprecated plugin properties from ``Litestar``
         :type: feature
+        :pr: 4297
         :breaking:
 
         Remove deprecated ``<plugin_type>_plugins`` properties from :class:`Litestar`.
@@ -38,3 +39,11 @@
         ``Litestar.cli_plugins``             ``Litestar.plugins.cli``
         ``Litestar.serialization_plugins``   ``Litestar.serialization.cli``
         ===================================  ===================================
+
+    .. change:: Remove deprecated ``allow_reserved`` and ``allow_empty_value`` property from ``ResponseHeader`` and ``OpenAPIHeader``
+        :type: feature
+        :pr: 4299
+        :breaking:
+
+        Remove the deprecated properties ``allow_reserved`` and ``allow_empty_value`` from
+        :class:`~litestar.datastructures.ResponseHeader` and :class:`~litestar.openapi.spec.OpenAPIHeader`.

--- a/litestar/datastructures/response_header.py
+++ b/litestar/datastructures/response_header.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from litestar.exceptions import ImproperlyConfiguredException
-from litestar.utils import warn_deprecation
 
 if TYPE_CHECKING:
     from litestar.openapi.spec import Example
@@ -47,20 +46,6 @@ class ResponseHeader:
     Default value is `false`.
     """
 
-    allow_empty_value: bool = None  # type: ignore[assignment]
-    """Sets the ability to pass empty-valued parameters. This is valid only for
-    `query` parameters and allows sending a parameter with an empty value.
-    Default value is `false`. If.
-
-    [style](https://spec.openapis.org/oas/v3.1.0#parameterStyle) is used, and if behavior is `n/a` (cannot be
-    serialized), the value of `allowEmptyValue` SHALL be ignored. Use of this property is NOT RECOMMENDED, as it is
-    likely to be removed in a later revision.
-
-    The rules for serialization of the parameter are specified in one of two ways.
-    For simpler scenarios, a [schema](https://spec.openapis.org/oas/v3.1.0#parameterSchema) and [style](https://spec.openapis.org/oas/v3.1.0#parameterStyle)
-    can describe the structure and syntax of the parameter.
-    """
-
     style: str | None = None
     """Describes how the parameter value will be serialized depending on the
     type of the parameter value. Default values (based on value of `in`):
@@ -79,16 +64,6 @@ class ResponseHeader:
     For other types of parameters this property has no effect.
     When [style](https://spec.openapis.org/oas/v3.1.0#parameterStyle) is `form`, the default value is `true`.
     For all other styles, the default value is `false`.
-    """
-
-    allow_reserved: bool = None  # type: ignore[assignment]
-    """Determines whether the parameter value SHOULD allow reserved characters,
-    as defined by.
-
-    [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent-
-    encoding.
-
-    This property only applies to parameters with an `in` value of `query`. The default value is `false`.
     """
 
     example: Any | None = None
@@ -121,28 +96,6 @@ class ResponseHeader:
         """Ensure that either value is set or the instance is for documentation_only."""
         if not self.documentation_only and self.value is None:
             raise ImproperlyConfiguredException("value must be set if documentation_only is false")
-
-        if self.allow_reserved is None:
-            self.allow_reserved = False  # type: ignore[unreachable]
-        else:
-            warn_deprecation(
-                "2.13.1",
-                "allow_reserved",
-                kind="parameter",
-                removal_in="4",
-                info="This property is invalid for headers and will be ignored",
-            )
-
-        if self.allow_empty_value is None:
-            self.allow_empty_value = False  # type: ignore[unreachable]
-        else:
-            warn_deprecation(
-                "2.13.1",
-                "allow_empty_value",
-                kind="parameter",
-                removal_in="4",
-                info="This property is invalid for headers and will be ignored",
-            )
 
     def __hash__(self) -> int:
         return hash(self.name)

--- a/litestar/openapi/spec/header.py
+++ b/litestar/openapi/spec/header.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 from litestar.openapi.spec.base import BaseSchemaObject
-from litestar.utils import warn_deprecation
 
 if TYPE_CHECKING:
     from litestar.openapi.spec.example import Example
@@ -54,19 +53,6 @@ class OpenAPIHeader(BaseSchemaObject):
     deprecated: bool = False
     """Specifies that a parameter is deprecated and SHOULD be transitioned out of usage. Default value is ``False``."""
 
-    allow_empty_value: bool = None  # type: ignore[assignment]
-    """Sets the ability to pass empty-valued parameters. This is valid only for ``query`` parameters and allows sending
-    a parameter with an empty value. Default value is ``False``. If
-    `style <https://spec.openapis.org/oas/v3.1.0#parameterStyle>`__ is used, and if behavior is ``n/a`` (cannot be
-    serialized), the value of ``allowEmptyValue`` SHALL be ignored. Use of this property is NOT RECOMMENDED, as it is
-    likely to be removed in a later revision.
-
-    The rules for serialization of the parameter are specified in one of two ways.For simpler scenarios, a
-    `schema <https://spec.openapis.org/oas/v3.1.0#parameterSchema>`_ and
-    `style <https://spec.openapis.org/oas/v3.1.0#parameterStyle>`__ can describe the structure and syntax of the
-    parameter.
-    """
-
     style: str | None = None
     """Describes how the parameter value will be serialized depending on the
     type of the parameter value. Default values (based on value of ``in``):
@@ -84,13 +70,6 @@ class OpenAPIHeader(BaseSchemaObject):
     For other types of parameters this property has no effect.When
     `style <https://spec.openapis.org/oas/v3.1.0#parameterStyle>`__ is ``form``, the default value is ``True``. For all
     other styles, the default value is ``False``.
-    """
-
-    allow_reserved: bool = None  # type: ignore[assignment]
-    """Determines whether the parameter value SHOULD allow reserved characters, as defined by. :rfc:`3986`
-    (``:/?#[]@!$&'()*+,;=``) to be included without percent-encoding.
-
-    This property only applies to parameters with an ``in`` value of ``query``. The default value is ``False``.
     """
 
     example: Any | None = None
@@ -123,27 +102,4 @@ class OpenAPIHeader(BaseSchemaObject):
 
     @property
     def _exclude_fields(self) -> set[str]:
-        return {"name", "param_in", "allow_reserved", "allow_empty_value"}
-
-    def __post_init__(self) -> None:
-        if self.allow_reserved is None:
-            self.allow_reserved = False  # type: ignore[unreachable]
-        else:
-            warn_deprecation(
-                "2.13.1",
-                "allow_reserved",
-                kind="parameter",
-                removal_in="4",
-                info="This property is invalid for headers and will be ignored",
-            )
-
-        if self.allow_empty_value is None:
-            self.allow_empty_value = False  # type: ignore[unreachable]
-        else:
-            warn_deprecation(
-                "2.13.1",
-                "allow_empty_value",
-                kind="parameter",
-                removal_in="4",
-                info="This property is invalid for headers and will be ignored",
-            )
+        return {"name", "param_in"}

--- a/tests/unit/test_openapi/test_responses.py
+++ b/tests/unit/test_openapi/test_responses.py
@@ -574,25 +574,3 @@ def test_file_response_media_type(content_media_type: Any, expected: Any, create
 
     response = create_factory(handler).create_success_response()
     assert next(iter(response.content.values())).schema.content_media_type == expected  # type: ignore[union-attr]
-
-
-def test_response_header_deprecated_properties() -> None:
-    assert ResponseHeader(name="foo", value="bar").allow_empty_value is False
-    assert ResponseHeader(name="foo", value="bar").allow_reserved is False
-
-    with pytest.warns(DeprecationWarning, match="property is invalid for headers"):
-        ResponseHeader(name="foo", value="bar", allow_empty_value=True)
-
-    with pytest.warns(DeprecationWarning, match="property is invalid for headers"):
-        ResponseHeader(name="foo", value="bar", allow_reserved=True)
-
-
-def test_header_deprecated_properties() -> None:
-    assert OpenAPIHeader().allow_empty_value is False
-    assert OpenAPIHeader().allow_reserved is False
-
-    with pytest.warns(DeprecationWarning, match="property is invalid for headers"):
-        OpenAPIHeader(allow_empty_value=True)
-
-    with pytest.warns(DeprecationWarning, match="property is invalid for headers"):
-        OpenAPIHeader(allow_reserved=True)


### PR DESCRIPTION
Remove deprecated `allow_reserved` and `allow_empty_value` property from `ResponseHeader` and `OpenAPIHeader`