### PR TITLE
feat!: Remove deprecated `traceback_line_limit` parameter from `LoggingConfig` 

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -47,3 +47,12 @@
 
         Remove the deprecated properties ``allow_reserved`` and ``allow_empty_value`` from
         :class:`~litestar.datastructures.ResponseHeader` and :class:`~litestar.openapi.spec.OpenAPIHeader`.
+
+    .. change:: Remove deprecated ``traceback_line_limit`` parameter of ``LoggingConfig``
+        :type: feature
+        :breaking:
+        :pr: 4300
+
+        The ``traceback_line_limit`` parameter of :class:`~litestar.logging.config.LoggingConfig` has been removed. This
+        parameter had no effect since version ``2.9.0``, so it can be removed safely from applications without any
+        change in behaviour.

--- a/tests/unit/test_logging/test_logging_config.py
+++ b/tests/unit/test_logging/test_logging_config.py
@@ -535,19 +535,6 @@ def test_excluded_fields(logging_module: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "traceback_line_limit, expected_warning_deprecation_called",
-    [
-        [-1, False],
-        [20, True],
-    ],
-)
-def test_traceback_line_limit_deprecation(traceback_line_limit: int, expected_warning_deprecation_called: bool) -> None:
-    with patch("litestar.logging.config.warn_deprecation") as mock_warning_deprecation:
-        LoggingConfig(traceback_line_limit=traceback_line_limit)
-        assert mock_warning_deprecation.called is expected_warning_deprecation_called
-
-
-@pytest.mark.parametrize(
     "disable_stack_trace, exception_to_raise, handler_called",
     [
         # will log the stack trace


### PR DESCRIPTION
Remove `traceback_line_limit` from `LoggingConfig` et al.
