### PR TITLE
feat(typing)!: Remove deprecated `LitestarType` type alias

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -83,3 +83,11 @@
         - :meth:`~litestar.response.Template.to_asgi_response`
 
         Existing code still using ``encoded_headers`` should be migrated to using the ``headers`` parameter instead.
+
+    .. change:: Remove deprecated ``LitestarType``
+        :type: feature
+        :pr: 4312
+        :breaking:
+
+        Remove the deprecated ``litestar.types.internal_types.LitestarType`` type alias. Its usages can safely replaced
+        by using ``type[Litestar]`` directly.

--- a/litestar/types/internal_types.py
+++ b/litestar/types/internal_types.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable, Literal, NamedTuple
 
-from litestar.utils.deprecation import warn_deprecation
-
 __all__ = (
     "ControllerRouterHandler",
     "PathParameterDefinition",
@@ -16,7 +14,6 @@ __all__ = (
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
-    from litestar.app import Litestar
     from litestar.controller import Controller
     from litestar.handlers import BaseRouteHandler
     from litestar.handlers.asgi_handlers import ASGIRouteHandler
@@ -34,9 +31,6 @@ ControllerRouterHandler: TypeAlias = "type[Controller] | RouteHandlerType | Rout
 RouteHandlerMapItem: TypeAlias = 'dict[Method | Literal["websocket", "asgi"], BaseRouteHandler]'
 TemplateConfigType: TypeAlias = "TemplateConfig[EngineType]"
 
-# deprecated
-_LitestarType: TypeAlias = "Litestar"
-
 
 class PathParameterDefinition(NamedTuple):
     """Path parameter tuple."""
@@ -45,16 +39,3 @@ class PathParameterDefinition(NamedTuple):
     full: str
     type: type
     parser: Callable[[str], Any] | None
-
-
-def __getattr__(name: str) -> Any:
-    if name == "LitestarType":
-        warn_deprecation(
-            "2.2.1",
-            "LitestarType",
-            "import",
-            removal_in="3.0.0",
-            alternative="Litestar",
-        )
-        return _LitestarType
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -97,11 +97,6 @@ def test_repository_deprecations(import_path: str, import_name: str) -> None:
     assert getattr(module, import_name)
 
 
-def test_litestar_type_deprecation() -> None:
-    with pytest.warns(DeprecationWarning):
-        from litestar.types.internal_types import LitestarType  # noqa: F401
-
-
 def test_contrib_minijnja_deprecation() -> None:
     with pytest.warns(DeprecationWarning):
         from litestar.contrib.minijnja import MiniJinjaTemplateEngine  # noqa: F401


### PR DESCRIPTION
Remove the deprecated `litestar.types.internal_types.LitestarType` type alias. Its usages can safely replaced by using `type[Litestar]` directly
