### PR TITLE
feat(template)!: Remove deprecated `TemplateContext`

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -89,5 +89,13 @@
         :pr: 4312
         :breaking:
 
-        Remove the deprecated ``litestar.types.internal_types.LitestarType`` type alias. Its usages can safely replaced
-        by using ``type[Litestar]`` directly.
+        Remove the deprecated ``litestar.types.internal_types.LitestarType`` type alias. In its stead,
+        ``type[Litestar]`` can be used.
+
+    .. change:: Remove deprecated ``TemplateContext``
+        :type: feature
+        :pr: 4313
+        :breaking:
+
+        Remove the deprecated ``litestar.template.base.TemplateContext`` type. Its usages should be replaced with
+        :class:`collections.abc.Mapping`.

--- a/litestar/template/base.py
+++ b/litestar/template/base.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Protocol, TypedDict, TypeVar, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, Callable, Protocol, TypeVar, cast, runtime_checkable
 
 from typing_extensions import Concatenate, ParamSpec, TypeAlias
 
-from litestar.utils.deprecation import warn_deprecation
 from litestar.utils.empty import value_or_default
 from litestar.utils.scope.state import ScopeState
 
@@ -148,23 +147,3 @@ class TemplateEngineProtocol(Protocol[TemplateType_co, ContextType_co]):
         Returns:
             None
         """
-
-
-class _TemplateContext(TypedDict):
-    """Dictionary representing a template context."""
-
-    request: Request[Any, Any, Any]
-    csrf_input: str
-
-
-def __getattr__(name: str) -> Any:
-    if name == "TemplateContext":
-        warn_deprecation(
-            "2.3.0",
-            "TemplateContext",
-            "import",
-            removal_in="3.0.0",
-            alternative="Mapping",
-        )
-        return _TemplateContext
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -102,11 +102,6 @@ def test_contrib_minijnja_deprecation() -> None:
         from litestar.contrib.minijnja import MiniJinjaTemplateEngine  # noqa: F401
 
 
-def test_litestar_templates_template_context_deprecation() -> None:
-    with pytest.warns(DeprecationWarning):
-        from litestar.template.base import TemplateContext  # noqa: F401
-
-
 def test_minijinja_from_state_deprecation() -> None:
     with pytest.warns(DeprecationWarning):
         from litestar.contrib.minijinja import minijinja_from_state  # noqa: F401


### PR DESCRIPTION
Remove the deprecated ``litestar.template.base.TemplateContext`` type. Its usages should be replaced with `collections.abc.Mapping`