### PR TITLE
fix(ci): improve error message when `test_success` fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Report success or fail
-        run: exit ${{ needs.test.result == 'success' && '0' || '1' }}
+        run: |
+          echo "test workflow exited with ${{ needs.test.result }}"
+          exit ${{ needs.test.result == 'success' && '0' || '1' }}
 
   test_typing_extensions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Right now it just produces `exit 1` with no clear explanation why: https://github.com/litestar-org/litestar/actions/runs/17946021454/job/51033375959?pr=4318

Which causes questions like https://github.com/litestar-org/litestar/pull/4318#issuecomment-3324487641
