### PR TITLE
docs: fix typo in htmx docs

### DIFF
--- a/docs/usage/htmx.rst
+++ b/docs/usage/htmx.rst
@@ -115,7 +115,7 @@ an :class:`~litestar.plugins.htmx.HTMXTemplate` response:
 
 .. note::
     - Return type is litestar's ``Template`` and not ``HTMXTemplate``.
-    - ``trigger_event``, ``params``, and ``after parameters`` are linked to one another.
+    - ``trigger_event``, ``params``, and ``after`` parameters are linked to one another.
     - If you are triggering an event then ``after`` is required and it must be one of ``receive``, ``settle``, or ``swap``.
 
 HTMX provides two types of responses - one that doesn't allow changes to the DOM and one that does.


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
