### PR TITLE
fix(cli): extract preparsed options from `ctx.params` instead of `opts`

### DIFF
--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -200,8 +200,8 @@ class LitestarExtensionGroup(LitestarGroup):
         super().__init__(name=name, commands=commands, **attrs)
 
         self._prepare_done = False
-        self._preparsed_app_dir: str | None = None
-        self._preparsed_app_path: Path | None = None
+        self._preparsed_app_dir: Path | None = None
+        self._preparsed_app_path: str | None = None
 
         for entry_point in entry_points(group="litestar.commands"):
             command = entry_point.load()
@@ -243,18 +243,10 @@ class LitestarExtensionGroup(LitestarGroup):
         """Preparse launch arguments and save app_path & app_dir to slots.
         This block is triggered in any case, but its results are only used if the --help command is invoked.
         """
-        parser = self.make_parser(ctx)
-
-        original_ignore_unknown_option = ctx.ignore_unknown_options
-        ctx.ignore_unknown_options = True
-
-        opts, remaining_args, order = parser.parse_args(list(args))
-        self._preparsed_app_path = opts.get("app_path", None)
-        self._preparsed_app_dir = opts.get("app_dir", None)
-
-        ctx.ignore_unknown_options = original_ignore_unknown_option
-
-        return super().parse_args(ctx, args)
+        args = super().parse_args(ctx, args)
+        self._preparsed_app_path = ctx.params.get("app_path", None)
+        self._preparsed_app_dir = ctx.params.get("app_dir", None)
+        return args
 
     def list_commands(self, ctx: Context) -> list[str]:
         self._prepare(ctx)

--- a/tests/unit/test_cli/test_cli.py
+++ b/tests/unit/test_cli/test_cli.py
@@ -91,3 +91,22 @@ def test_invalid_import_in_app_argument(
 
     result = runner.invoke(cli_command, ["--app", "main:create_app", "--app-dir", app_dir, "info"])
     assert isinstance(result.exception, ModuleNotFoundError)
+
+# https://github.com/litestar-org/litestar/issues/4331
+@pytest.mark.xdist_group("cli_autodiscovery")
+def test_help_option_with_app_dir(
+    runner: "CliRunner", create_app_file: CreateAppFileFixture
+) -> None:
+    app_file = "main.py"
+    app_file_without_extension = app_file.split(".")[0]
+    create_app_file(
+        file=app_file,
+        directory="src",
+        content=CREATE_APP_FILE_CONTENT,
+        subdir="help_with_app_dir",
+        init_content=f"from .{app_file_without_extension} import create_app",
+    )
+    app_dir = "docker/neurogate"
+    result = runner.invoke(cli_command, ["--app-dir", app_dir, "--help"])
+
+    assert result.output.strip().startswith("Usage: litestar [OPTIONS] COMMAND [ARGS]...")


### PR DESCRIPTION
# Description
## Closes
Fixes #4331
## Summary
- Fixed annotation of `_preparsed_app_dir` and `_preparsed_app_path` according to types of options https://github.com/litestar-org/litestar/blob/78ae4c1/litestar/cli/main.py#L19-L26
- Modified `app_path` and `app_dir` value extraction approach. `parser.parse_args(list(args))` doesn't involve options machinery processing (e.g., type validation and casting), so it returns raw options (strings).

## Test plan
- Added `test_help_option_with_app_dir` test to verify correct CLI behavior when using --app-dir and --help options together
