### PR TITLE
feat: deprecate litestar.plugins.sqlalchemy module for v3 removal

### DIFF
--- a/litestar/plugins/sqlalchemy.py
+++ b/litestar/plugins/sqlalchemy.py
@@ -6,6 +6,16 @@ from typing import TYPE_CHECKING
 
 from litestar.utils import warn_deprecation
 
+# Module-level deprecation warning
+warn_deprecation(
+    deprecated_name="litestar.plugins.sqlalchemy",
+    version="2.18.0",
+    kind="import",
+    removal_in="3.0.0",
+    info="The 'litestar.plugins.sqlalchemy' module is deprecated. "
+         "Please import directly from 'advanced_alchemy.extensions.litestar' instead.",
+)
+
 __all__ = (
     "AlembicAsyncConfig",
     "AlembicCommands",

--- a/litestar/plugins/sqlalchemy.py
+++ b/litestar/plugins/sqlalchemy.py
@@ -1,4 +1,4 @@
-# ruff: noqa: F401, PLC0415
+# ruff: noqa: F401, PLC0415, TC004, RUF100
 # pyright: reportUnusedImport=false
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ warn_deprecation(
     kind="import",
     removal_in="3.0.0",
     info="The 'litestar.plugins.sqlalchemy' module is deprecated. "
-         "Please import directly from 'advanced_alchemy.extensions.litestar' instead.",
+    "Please import directly from 'advanced_alchemy.extensions.litestar' instead.",
 )
 
 __all__ = (

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -234,11 +234,9 @@ def test_deprecate_exception_response_content() -> None:
 
 def test_plugins_sqlalchemy_deprecation() -> None:
     """Test that importing from litestar.plugins.sqlalchemy raises deprecation warning."""
+    from litestar.plugins import sqlalchemy  # noqa: F401
 
-    # Remove the module from sys.modules if it's already been imported
-    if "litestar.plugins.sqlalchemy" in sys.modules:
-        del sys.modules["litestar.plugins.sqlalchemy"]
-
-    # Now import it fresh and catch the warning
     with pytest.warns(DeprecationWarning, match="litestar.plugins.sqlalchemy.*3.0.0"):
-        from litestar.plugins import sqlalchemy  # noqa: F401
+        importlib.reload(sqlalchemy)
+
+

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -229,3 +229,9 @@ def test_deprecate_exception_response_content() -> None:
 
     with pytest.raises(ImportError):
         from litestar.middleware.exceptions.middleware import OtherName  # noqa: F401
+
+
+def test_plugins_sqlalchemy_deprecation() -> None:
+    """Test that importing from litestar.plugins.sqlalchemy raises deprecation warning."""
+    with pytest.warns(DeprecationWarning, match="litestar.plugins.sqlalchemy.*3.0.0"):
+        from litestar.plugins import sqlalchemy  # noqa: F401

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -1,5 +1,4 @@
 import importlib
-import sys
 
 import pytest
 
@@ -234,9 +233,7 @@ def test_deprecate_exception_response_content() -> None:
 
 def test_plugins_sqlalchemy_deprecation() -> None:
     """Test that importing from litestar.plugins.sqlalchemy raises deprecation warning."""
-    from litestar.plugins import sqlalchemy  # noqa: F401
+    from litestar.plugins import sqlalchemy
 
     with pytest.warns(DeprecationWarning, match="litestar.plugins.sqlalchemy.*3.0.0"):
         importlib.reload(sqlalchemy)
-
-

--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -516,7 +516,7 @@ def test_multipart_handling_of_optional_values() -> None:
     @post("/", signature_types=[ProductForm])
     def handler(
         data: Annotated[ProductForm, Body(media_type=RequestEncodingType.MULTI_PART)],
-    ) -> dict[str, Any]:
+    ) -> Dict[str, Any]:
         return {
             "name": data.name,
             "int_field": data.int_field,

--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -1,4 +1,4 @@
-# ruff: noqa: UP006, UP007
+# ruff: noqa: UP006, UP007, UP045
 from __future__ import annotations
 
 from collections import defaultdict
@@ -406,7 +406,7 @@ def test_upload_multiple_files(file_count: int, optional: bool) -> None:
         annotation = Optional[annotation]  # type: ignore[misc, assignment]
 
     @post("/", signature_namespace={"annotation": annotation})
-    async def handler(data: annotation = Body(media_type=RequestEncodingType.MULTI_PART)) -> None:  # pyright: ignore[reportGeneralTypeIssues]
+    async def handler(data: annotation = Body(media_type=RequestEncodingType.MULTI_PART)) -> None:  # pyright: ignore
         assert len(data) == file_count
 
         for file in data:

--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -6,7 +6,7 @@ from dataclasses import asdict, dataclass
 from os import path
 from os.path import dirname, join, realpath
 from pathlib import Path
-from typing import Any, DefaultDict, Dict, List, Optional
+from typing import Any, DefaultDict, Dict, List, Optional, Type, Union
 
 import msgspec
 import pytest
@@ -432,7 +432,7 @@ class OptionalFiles:
 
 @pytest.mark.parametrize("file_model", (Files, OptionalFiles))
 @pytest.mark.parametrize("file_count", (1, 2))
-def test_upload_multiple_files_in_model(file_count: int, file_model: type[Files | OptionalFiles]) -> None:
+def test_upload_multiple_files_in_model(file_count: int, file_model: Type[Union[Files, OptionalFiles]]) -> None:
     @post("/", signature_namespace={"file_model": file_model})
     async def handler(data: file_model = Body(media_type=RequestEncodingType.MULTI_PART)) -> None:  # type: ignore[valid-type]
         assert len(data.file_list) == file_count  # type: ignore[attr-defined]

--- a/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
+++ b/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
@@ -1,7 +1,8 @@
-from typing import Annotated, Any, List, Optional, Type, cast
+from typing import Any, List, Optional, Type, cast
 
-import msgspec.json
+import msgspec
 import pytest
+from typing_extensions import Annotated
 
 from litestar import (
     Controller,


### PR DESCRIPTION
## Summary
Adds deprecation warning for the \`litestar.plugins.sqlalchemy\` module which will be removed in v3.0.

## Context
- Related to #4340 which removes this module in v3
- Follows deprecation policy to warn users before removal
- Part of the ongoing migration to advanced-alchemy

## Changes
- Add module-level deprecation warning to \`litestar.plugins.sqlalchemy\`
- Add test for deprecation warning

## Migration Path
Users should update their imports:
```python
# Old (deprecated)
from litestar.plugins.sqlalchemy import SQLAlchemyPlugin

# New
from advanced_alchemy.extensions.litestar import SQLAlchemyPlugin
```