### PR TITLE
fix(cli): pass the `--app-dir` option to the uvicorn subprocess when the reload option is enabled.

### DIFF
--- a/litestar/cli/commands/core.py
+++ b/litestar/cli/commands/core.py
@@ -87,6 +87,7 @@ def _run_uvicorn_in_subprocess(
         "port": port,
         "workers": workers,
         "factory": env.is_app_factory,
+        "app-dir": env.cwd,
     }
     if fd is not None:
         process_args["fd"] = fd

--- a/tests/unit/test_cli/test_core_commands.py
+++ b/tests/unit/test_cli/test_core_commands.py
@@ -176,6 +176,7 @@ def test_run_command(
             f"{path.stem}:app",
             f"--host={host}",
             f"--port={port}",
+            f"--app-dir={path.parent}",
         ]
         if fd is not None:
             expected_args.append(f"--fd={fd}")

--- a/tests/unit/test_cli/test_ssl.py
+++ b/tests/unit/test_cli/test_ssl.py
@@ -320,6 +320,7 @@ def test_arguments_passed(
             "--host=127.0.0.1",
             "--port=8000",
             "--workers=2",
+            f"--app-dir={path.parent}",
         ]
         if ssl_certfile is not None:
             expected_args.append(f"--ssl-certfile={project_path / ssl_certfile}")


### PR DESCRIPTION
# Description

## Closes
Closes #4329

## Summary
When `--reload` is enabled, spawns uvicorn subprocess with a fresh `sys.path`, which loses the `--app-dir` value. To preserve this value in `sys.path`, `--app-dir` must be explicitly passed to the uvicorn subprocess.

## Test plan
- `test_run_command` and `test_arguments_passed` might cover uvicorn parameter passing