### PR TITLE
feat(docs): enhance DTO examples and documentation for user management

### DIFF
--- a/docs/examples/data_transfer_objects/basic_example_complete.py
+++ b/docs/examples/data_transfer_objects/basic_example_complete.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+from litestar import Litestar, post
+from litestar.dto import DTOConfig, DataclassDTO
+
+
+@dataclass
+class User:
+    id: UUID
+    name: str
+    email: str
+    password: str
+
+
+# Without DTOs, you'd have to manually handle:
+# 1. Validation of incoming JSON
+# 2. Converting JSON to Python objects
+# 3. Filtering sensitive fields in responses
+# 4. Converting Python objects back to JSON
+
+# With DTOs, Litestar handles all of this automatically:
+
+# DTO for incoming data - excludes auto-generated ID
+class UserCreateDTO(DataclassDTO[User]):
+    config = DTOConfig(exclude={"id"})
+
+
+# DTO for outgoing data - excludes sensitive password
+class UserResponseDTO(DataclassDTO[User]):
+    config = DTOConfig(exclude={"password"})
+
+
+@post("/users", dto=UserCreateDTO, return_dto=UserResponseDTO)
+def create_user(data: User) -> User:
+    """Create a new user.
+    
+    DTOs automatically:
+    - Validate that incoming JSON matches User model (excluding id)
+    - Convert JSON to User instance with generated id
+    - Serialize response back to JSON (excluding password)
+    """
+    # Generate an ID for the new user
+    data.id = uuid4()
+    
+    # In a real application, you would:
+    # - Hash the password
+    # - Save to database
+    # - Handle validation errors
+    
+    return data
+
+
+app = Litestar(route_handlers=[create_user])
+
+# Example request:
+# POST /users
+# {
+#   "name": "John Doe",
+#   "email": "john@example.com", 
+#   "password": "secret123"
+# }
+#
+# Example response (password automatically excluded):
+# {
+#   "id": "123e4567-e89b-12d3-a456-426614174000",
+#   "name": "John Doe",
+#   "email": "john@example.com"
+# }

--- a/docs/examples/data_transfer_objects/defining_dtos_on_layers.py
+++ b/docs/examples/data_transfer_objects/defining_dtos_on_layers.py
@@ -1,51 +1,58 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from uuid import UUID, uuid4
+from dataclasses import dataclass
+from uuid import UUID
 
-from litestar import Controller, delete, get, post, put
-from litestar.app import Litestar
-from litestar.dto import DataclassDTO
-from litestar.dto.config import DTOConfig
+from litestar import Controller, Litestar, delete, get, post, put
+from litestar.dto import DTOConfig, DataclassDTO
 
 
 @dataclass
 class User:
+    id: UUID
     name: str
     email: str
-    age: int
-    id: UUID = field(default_factory=uuid4)
 
 
+# DTO for write operations - excludes auto-generated fields like id
 class UserWriteDTO(DataclassDTO[User]):
     config = DTOConfig(exclude={"id"})
 
 
-class UserReadDTO(DataclassDTO[User]): ...
+# DTO for read operations - includes all fields
+class UserReadDTO(DataclassDTO[User]):
+    pass
 
 
 class UserController(Controller):
-    dto = UserWriteDTO
-    return_dto = UserReadDTO
+    """User management controller.
+    
+    DTOs are defined at the controller level and apply to all routes
+    unless explicitly overridden on individual route handlers.
+    """
+    path = "/users"
+    dto = UserWriteDTO        # For incoming data (POST, PUT)
+    return_dto = UserReadDTO  # For outgoing data
 
-    @post("/", sync_to_thread=False)
+    @post("/")
     def create_user(self, data: User) -> User:
+        # The id field is excluded from incoming data via UserWriteDTO
+        # but included in the response via UserReadDTO
         return data
 
-    @get("/", sync_to_thread=False)
+    @get("/")
     def get_users(self) -> list[User]:
-        return [User(name="Mr Sunglass", email="mr.sunglass@example.com", age=30)]
+        # Returns all users using UserReadDTO
+        return []
 
-    @get("/{user_id:uuid}", sync_to_thread=False)
-    def get_user(self, user_id: UUID) -> User:
-        return User(id=user_id, name="Mr Sunglass", email="mr.sunglass@example.com", age=30)
-
-    @put("/{user_id:uuid}", sync_to_thread=False)
-    def update_user(self, data: User) -> User:
+    @put("/{user_id:uuid}")
+    def update_user(self, user_id: UUID, data: User) -> User:
+        # Uses controller-level DTOs
         return data
 
-    @delete("/{user_id:uuid}", return_dto=None, sync_to_thread=False)
+    @delete("/{user_id:uuid}", return_dto=None)
     def delete_user(self, user_id: UUID) -> None:
+        # Overrides controller return_dto to disable response serialization
         return None
 
 

--- a/docs/examples/data_transfer_objects/models.py
+++ b/docs/examples/data_transfer_objects/models.py
@@ -1,3 +1,11 @@
+"""
+Data models for DTO examples.
+
+This file demonstrates basic DTO creation patterns.
+For complete, runnable examples, see the individual example files
+in this directory.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -8,9 +16,16 @@ from litestar.dto import DataclassDTO
 
 @dataclass
 class User:
+    """Basic user model for demonstration purposes."""
     id: UUID
     name: str
+    email: str
 
 
+# Basic DTO that handles all fields
 UserDTO = DataclassDTO[User]
-UserReturnDTO = DataclassDTO[User]
+
+# Alternative: explicitly defined DTO class
+class UserReturnDTO(DataclassDTO[User]):
+    """DTO for user responses."""
+    pass

--- a/docs/examples/data_transfer_objects/overriding_implicit_return_dto.py
+++ b/docs/examples/data_transfer_objects/overriding_implicit_return_dto.py
@@ -1,5 +1,7 @@
-from dataclasses import dataclass, field
-from uuid import UUID, uuid4
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
 
 from litestar import Litestar, post
 from litestar.dto import DataclassDTO
@@ -7,18 +9,24 @@ from litestar.dto import DataclassDTO
 
 @dataclass
 class User:
+    id: UUID
     name: str
-    email: str
-    age: int
-    id: UUID = field(default_factory=uuid4)
 
 
 UserDTO = DataclassDTO[User]
 
 
-@post(dto=UserDTO, return_dto=None, sync_to_thread=False)
+@post("/users", dto=UserDTO, return_dto=None)
 def create_user(data: User) -> bytes:
-    return data.name.encode(encoding="utf-8")
+    """Create a new user with custom response handling.
+    
+    The dto=UserDTO parameter handles incoming JSON validation.
+    The return_dto=None parameter disables automatic response serialization,
+    allowing you to return custom response formats like raw bytes.
+    """
+    # Process the validated user data
+    # Return a custom byte response instead of serialized User data
+    return f"User {data.name} created successfully".encode("utf-8")
 
 
 app = Litestar([create_user])

--- a/docs/examples/data_transfer_objects/the_dto_parameter.py
+++ b/docs/examples/data_transfer_objects/the_dto_parameter.py
@@ -1,8 +1,33 @@
-from litestar import post
+from __future__ import annotations
 
-from .models import User, UserDTO
+from dataclasses import dataclass
+from uuid import UUID
+
+from litestar import Litestar, post
+from litestar.dto import DataclassDTO
 
 
-@post(dto=UserDTO)
+@dataclass
+class User:
+    id: UUID
+    name: str
+
+
+# Create a DTO for the User model
+UserDTO = DataclassDTO[User]
+
+
+@post("/users", dto=UserDTO)
 def create_user(data: User) -> User:
+    """Create a new user.
+    
+    The dto=UserDTO parameter tells Litestar to:
+    1. Validate incoming JSON against the User model
+    2. Convert the JSON to a User instance (available as 'data')
+    3. Use the same DTO to serialize the returned User back to JSON
+    """
+    # In a real app, you'd save to database here
     return data
+
+
+app = Litestar(route_handlers=[create_user])

--- a/docs/examples/data_transfer_objects/the_return_dto_parameter.py
+++ b/docs/examples/data_transfer_objects/the_return_dto_parameter.py
@@ -1,8 +1,38 @@
-from litestar import post
+from __future__ import annotations
 
-from .models import User, UserDTO, UserReturnDTO
+from dataclasses import dataclass
+from uuid import UUID
+
+from litestar import Litestar, post
+from litestar.dto import DTOConfig, DataclassDTO
 
 
-@post(dto=UserDTO, return_dto=UserReturnDTO)
+@dataclass
+class User:
+    id: UUID
+    name: str
+    email: str
+    password: str
+
+
+# DTO for incoming data - accepts all fields
+UserDTO = DataclassDTO[User]
+
+# DTO for outgoing data - excludes sensitive fields like password
+class UserReturnDTO(DataclassDTO[User]):
+    config = DTOConfig(exclude={"password"})
+
+
+@post("/users", dto=UserDTO, return_dto=UserReturnDTO)
 def create_user(data: User) -> User:
+    """Create a new user.
+    
+    The dto=UserDTO parameter handles incoming JSON validation.
+    The return_dto=UserReturnDTO parameter serializes the response,
+    automatically excluding the password field for security.
+    """
+    # In a real app, you'd hash the password and save to database
     return data
+
+
+app = Litestar(route_handlers=[create_user])

--- a/docs/usage/dto/0-basic-use.rst
+++ b/docs/usage/dto/0-basic-use.rst
@@ -1,78 +1,61 @@
 Basic Use
 =========
 
-Here we demonstrate how to declare DTO types to your route handlers. For demonstration purposes, we assume that we
-are working with a data model ``User``, and already have two DTO types created in our application, ``UserDTO``, and
-``UserReturnDTO``.
+DTOs (Data Transfer Objects) control how data is transformed between your application and external interfaces.
+They handle validation, serialization, and field filtering for both incoming requests and outgoing responses.
 
-DTO layer parameters
-~~~~~~~~~~~~~~~~~~~~
+This guide shows how to apply DTOs to your route handlers using two main parameters:
 
-On every :ref:`Layer <layered-architecture>` of the Litestar application there are two parameters that control the DTOs
-that will take responsibility for the data received and returned from handlers:
+- ``dto``: Processes incoming request data
+- ``return_dto``: Processes outgoing response data
 
-- ``dto``: This parameter describes the DTO that will be used to parse inbound data to be injected as the ``data``
-  keyword argument for a handler. Additionally, if no ``return_dto`` is declared on the handler, this will also be used
-  to encode the return data for the handler.
-- ``return_dto``: This parameter describes the DTO that will be used to encode data returned from the handler. If not
-  provided, the DTO described by the ``dto`` parameter is used.
+.. literalinclude:: /examples/data_transfer_objects/basic_example_complete.py
+    :caption: Complete example showing DTO benefits
+    :language: python
 
-The object provided to both of these parameters must be a class that conforms to the
-:class:`AbstractDTO <litestar.dto.base_dto.AbstractDTO>` protocol.
+DTO parameters
+~~~~~~~~~~~~~~
 
-Defining DTOs on handlers
+Apply DTOs to any :ref:`Layer <layered-architecture>` using these parameters:
+
+``dto``
+    Processes incoming request data and converts it to the handler's expected type.
+    Also used for response encoding if no ``return_dto`` is specified.
+
+``return_dto``
+    Processes outgoing response data. If not provided, the ``dto`` parameter handles both
+    request and response processing.
+
+Applying DTOs to handlers
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``dto`` parameter
----------------------
+Use the ``dto`` parameter to process incoming data:
 
 .. literalinclude:: /examples/data_transfer_objects/the_dto_parameter.py
-    :caption: Using the ``dto`` Parameter
+    :caption: Using the ``dto`` parameter
     :language: python
 
-In this example, ``UserDTO`` performs decoding of client data into the ``User`` type, and encoding of the returned
-``User`` instance into a type that Litestar can encode into bytes.
-
-The ``return_dto`` parameter
-----------------------------
+Use ``return_dto`` to process response data differently from request data:
 
 .. literalinclude:: /examples/data_transfer_objects/the_return_dto_parameter.py
-    :caption: Using the ``return_dto`` Parameter
+    :caption: Using the ``return_dto`` parameter
     :language: python
 
-In this example, ``UserDTO`` performs decoding of client data into the ``User`` type, and ``UserReturnDTO`` is
-responsible for converting the ``User`` instance into a type that Litestar can encode into bytes.
-
-Overriding implicit ``return_dto``
-----------------------------------
-
-If a ``return_dto`` type is not declared for a handler, the type declared for the ``dto`` parameter is used for both
-decoding and encoding request and response data. If this behavior is undesirable, it can be disabled by explicitly
-setting the ``return_dto`` to ``None``.
+Set ``return_dto=None`` to disable automatic response processing:
 
 .. literalinclude:: /examples/data_transfer_objects/overriding_implicit_return_dto.py
-    :caption: Disable implicit ``return_dto`` behavior
+    :caption: Disabling response DTO
     :language: python
 
-In this example, we use ``UserDTO`` to decode request data, and convert it into the ``User`` type, but we want to manage
-encoding the response data ourselves, and so we explicitly declare the ``return_dto`` as ``None``.
-
-Defining DTOs on layers
+Applying DTOs to layers
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-DTOs can be defined on any :ref:`Layer <layered-architecture>` of the application. The DTO type applied is the one
-defined in the ownership chain, closest to the handler in question.
+Define DTOs on any :ref:`Layer <layered-architecture>` (Controller, Router, or Application) to apply them
+to all contained handlers:
 
 .. literalinclude:: /examples/data_transfer_objects/defining_dtos_on_layers.py
-    :caption: Controller defined DTOs
+    :caption: Controller-level DTOs
     :language: python
-
-In this example, the ``User`` instance received by any handler that declares a ``data`` kwarg, is converted by the
-``UserDTO`` type, and all handler return values are converted into an encodable type by ``UserReturnDTO`` (except for
-the ``delete()`` route, which has the ``return_dto`` disabled).
-
-DTOs can similarly be defined on :class:`Routers <litestar.router.Router>` and
-:class:`The application <litestar.app.Litestar>` itself.
 
 
 Improving performance with the codegen backend


### PR DESCRIPTION
Based on the changes made to improve the DTO basic usage documentation, here's a PR description:

Description
This PR addresses the confusing introduction in the DTO basic usage documentation by making it more beginner-friendly and self-contained.

Key improvements:

Clearer introduction: Replaced the confusing opening that assumed knowledge of [User](vscode-file://vscode-app/d:/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [UserDTO](vscode-file://vscode-app/d:/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with a clear explanation of what DTOs are and why they're useful
Self-contained examples: All example files now include their own model definitions instead of relying on external imports from .models, eliminating confusion for readers
Complete runnable examples: Added a new comprehensive example (basic_example_complete.py) that demonstrates the problem DTOs solve and shows a complete working solution
Simplified documentation style: Maintained the concise "usage guide" approach rather than tutorial-style explanations, focusing on "how to" rather than extensive "why" explanations
Better code comments: Added inline comments in examples explaining the practical benefits and use cases
Files modified:

[0-basic-use.rst](vscode-file://vscode-app/d:/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Improved introduction and structure
docs/examples/data_transfer_objects/*.py - Made all examples self-contained
[models.py](vscode-file://vscode-app/d:/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Simplified to serve as reference only
The documentation now provides a smooth learning curve for newcomers while maintaining the concise style appropriate for usage documentation.

Closes
Fixes #3800 