### PR TITLE
fix(OpenAPI): Fix `Stream` response being treated as `File` response in OpenAPI schema

### DIFF
--- a/litestar/_openapi/responses.py
+++ b/litestar/_openapi/responses.py
@@ -124,7 +124,7 @@ class ResponseFactory:
             response = OpenAPIResponse(content=None, description=self.create_description())
         elif self.field_definition.is_subclass_of(Redirect):
             response = self.create_redirect_response()
-        elif self.field_definition.is_subclass_of((File, Stream)):
+        elif self.field_definition.is_subclass_of(File):
             response = self.create_file_response()
         else:
             media_type = self.route_handler.media_type

--- a/tests/unit/test_openapi/test_responses.py
+++ b/tests/unit/test_openapi/test_responses.py
@@ -27,7 +27,7 @@ from litestar.exceptions import (
 from litestar.handlers import HTTPRouteHandler
 from litestar.openapi.config import OpenAPIConfig
 from litestar.openapi.datastructures import ResponseSpec
-from litestar.openapi.spec import Example, OpenAPIHeader, OpenAPIMediaType, Reference, Schema
+from litestar.openapi.spec import Example, OpenAPIHeader, OpenAPIMediaType, OpenAPIResponse, Reference, Schema
 from litestar.openapi.spec.enums import OpenAPIType
 from litestar.response import File, Redirect, Stream, Template
 from litestar.routes import HTTPRoute
@@ -250,8 +250,12 @@ def test_create_success_response_with_stream(create_factory: CreateFactoryFixtur
         return Stream(iter([]))
 
     handler = get_registered_route_handler(handler, "test")
-    response = create_factory(handler, True).create_success_response()
-    assert response.description == "Stream Response"
+    response = create_factory(handler, False).create_success_response()
+    assert response == OpenAPIResponse(
+        description="Stream Response",
+        headers={},
+        content={"application/json": OpenAPIMediaType(schema=Schema())},
+    )
 
 
 def test_create_success_response_redirect(create_factory: CreateFactoryFixture) -> None:


### PR DESCRIPTION
Fix handler returning a `Stream` falsely indicating a file response in the OpenAPI schema:

```json
{
"description": "Stream Response",
"headers": {
  "content-length": {
    "schema": {
      "type": "string"
    },
    "description": "File size in bytes",
    "required": false,
    "deprecated": false
  },
  "last-modified": {
    "schema": {
      "type": "string",
      "format": "date-time"
    },
    "description": "Last modified data-time in RFC 2822 format",
    "required": false,
    "deprecated": false
  },
  "etag": {
    "schema": {
      "type": "string"
    },
    "description": "Entity tag",
    "required": false,
    "deprecated": false
  }
}
```

