### PR TITLE
fix: Use `inspect.iscoroutinefunction` instead of `asyncio.iscoroutinefunction` to address deprecation warning in Python 3.14+

### DIFF
--- a/litestar/utils/predicates.py
+++ b/litestar/utils/predicates.py
@@ -41,7 +41,7 @@ from litestar.utils.typing import get_origin_or_inner_type
 
 if sys.version_info >= (3, 10):
     from inspect import iscoroutinefunction
-else:
+else:  # pragma: no cover
     from asyncio import iscoroutinefunction
 
 if TYPE_CHECKING:

--- a/litestar/utils/predicates.py
+++ b/litestar/utils/predicates.py
@@ -42,6 +42,8 @@ from litestar.utils.typing import get_origin_or_inner_type
 if sys.version_info >= (3, 10):
     from inspect import iscoroutinefunction
 else:  # pragma: no cover
+    # In Python 3.9, AsyncMock is not detected
+    # as a coroutine function, so one test was failing.
     from asyncio import iscoroutinefunction
 
 if TYPE_CHECKING:

--- a/litestar/utils/predicates.py
+++ b/litestar/utils/predicates.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from asyncio import iscoroutinefunction
+import sys
 from collections import defaultdict, deque
 from collections.abc import Iterable as CollectionsIterable
 from dataclasses import is_dataclass
@@ -39,6 +39,11 @@ from litestar.types.builtin_types import NoneType, UnionTypes
 from litestar.utils.helpers import unwrap_partial
 from litestar.utils.typing import get_origin_or_inner_type
 
+if sys.version_info >= (3, 10):
+    from inspect import iscoroutinefunction
+else:
+    from asyncio import iscoroutinefunction
+
 if TYPE_CHECKING:
     from litestar.types.protocols import DataclassProtocol
 
@@ -65,7 +70,7 @@ T = TypeVar("T")
 
 
 def is_async_callable(value: Callable[P, T]) -> TypeGuard[Callable[P, Awaitable[T]]]:
-    """Extend :func:`asyncio.iscoroutinefunction` to additionally detect async :func:`functools.partial` objects and
+    """Extend :func:`inspect.iscoroutinefunction` to additionally detect async :func:`functools.partial` objects and
     class instances with ``async def __call__()`` defined.
 
     Args:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Fixes a deprecation warning [introduced in Python 3.14][gh-122875].

I've tested this change with

```console
$ uv run pytest -q tests/unit/test_utils/test_predicates.py::test_is_async_callable
..........                                                                   [100%]
10 passed in 0.10s
```

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

NA.

[gh-122875]: https://github.com/python/cpython/pull/122875
