### PR TITLE
fix: fix(litestar/config/app): fix Litestar init() and AppConfig defaults inconsistency

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -261,3 +261,23 @@
             difference is expected. Some test cases may break though if they relied on
             the fact that the middleware wrapper created by ``ASGIMiddleware`` was
             always being called
+
+    .. change:: Fix Litestar init() and AppConfig defaults inconsistency
+        :type: bugfix
+        :pr: TBD
+        :issue: 4296
+
+        Fixed inconsistency between :class:`Litestar` direct initialization and
+        :class:`~litestar.config.app.AppConfig` defaults. Previously, certain
+        configuration parameters behaved differently when passed directly to
+        ``Litestar()`` versus when using ``AppConfig`` with ``Litestar.from_config()``.
+
+        Key changes:
+        - ``logging_config`` with ``Empty`` now properly defaults to ``LoggingConfig`` in both initialization methods
+        - ``response_cache_config`` with ``None`` now properly defaults to ``ResponseCacheConfig`` in both methods
+        - ``request_max_body_size`` type annotation corrected to remove ``EmptyType`` since ``Empty`` is not allowed for this parameter
+        - All default values are now consistent between ``Litestar()`` and ``AppConfig`` initialization
+
+        This ensures that applications using ``AppConfig`` behave identically to those
+        using direct ``Litestar`` initialization, maintaining backwards compatibility
+        and predictable behavior.

--- a/litestar/config/app.py
+++ b/litestar/config/app.py
@@ -6,9 +6,9 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable
 
 from litestar.config.allowed_hosts import AllowedHostsConfig
-from litestar.config.response_cache import ResponseCacheConfig
 from litestar.datastructures import State
 from litestar.events.emitter import SimpleEventEmitter
+from litestar.openapi.config import OpenAPIConfig
 from litestar.types.empty import Empty
 
 if TYPE_CHECKING:
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from litestar.config.compression import CompressionConfig
     from litestar.config.cors import CORSConfig
     from litestar.config.csrf import CSRFConfig
+    from litestar.config.response_cache import ResponseCacheConfig
     from litestar.connection import Request, WebSocket
     from litestar.datastructures import CacheControlHeader, ETag
     from litestar.di import Provide
@@ -25,7 +26,6 @@ if TYPE_CHECKING:
     from litestar.events.emitter import BaseEventEmitterBackend
     from litestar.events.listener import EventListener
     from litestar.logging.config import BaseLoggingConfig
-    from litestar.openapi.config import OpenAPIConfig
     from litestar.openapi.spec import SecurityRequirement
     from litestar.plugins import PluginProtocol
     from litestar.stores.base import Store
@@ -134,7 +134,7 @@ class AppConfig:
     """A list of callables returning async context managers, wrapping the lifespan of the ASGI application"""
     listeners: list[EventListener] = field(default_factory=list)
     """A list of :class:`EventListener <.events.listener.EventListener>`."""
-    logging_config: BaseLoggingConfig | None = field(default=None)
+    logging_config: BaseLoggingConfig | EmptyType | None = field(default=Empty)
     """An instance of :class:`BaseLoggingConfig <.logging.config.BaseLoggingConfig>` subclass."""
     middleware: list[Middleware] = field(default_factory=list)
     """A list of :class:`Middleware <.types.Middleware>`."""
@@ -142,7 +142,9 @@ class AppConfig:
     """A list of :class:`LifespanHook <.types.LifespanHook>` called during application shutdown."""
     on_startup: list[LifespanHook] = field(default_factory=list)
     """A list of :class:`LifespanHook <.types.LifespanHook>` called during application startup."""
-    openapi_config: OpenAPIConfig | None = field(default=None)
+    openapi_config: OpenAPIConfig | None = field(
+        default_factory=lambda: OpenAPIConfig(title="Litestar API", version="1.0.0")
+    )
     """Defaults to :data:`DEFAULT_OPENAPI_CONFIG <litestar.app.DEFAULT_OPENAPI_CONFIG>`"""
     opt: dict[str, Any] = field(default_factory=dict)
     """A string keyed dictionary of arbitrary values that can be accessed in :class:`Guards <.types.Guard>` or
@@ -167,7 +169,7 @@ class AppConfig:
     """List of plugins"""
     request_class: type[Request] | None = field(default=None)
     """An optional subclass of :class:`Request <.connection.Request>` to use for http connections."""
-    request_max_body_size: int | None | EmptyType = Empty
+    request_max_body_size: int | None = field(default=10_000_000)
     """Maximum allowed size of the request body in bytes. If this size is exceeded, a '413 - Request Entity Too Large'
     error response is returned."""
     response_class: type[Response] | None = field(default=None)
@@ -176,7 +178,7 @@ class AppConfig:
     """A list of :class:`Cookie <.datastructures.Cookie>`."""
     response_headers: ResponseHeaders = field(default_factory=list)
     """A string keyed dictionary mapping :class:`ResponseHeader <.datastructures.ResponseHeader>`."""
-    response_cache_config: ResponseCacheConfig = field(default_factory=ResponseCacheConfig)
+    response_cache_config: ResponseCacheConfig | None = field(default=None)
     """Configures caching behavior of the application."""
     return_dto: type[AbstractDTO] | None | EmptyType = field(default=Empty)
     """:class:`AbstractDTO <.dto.base_dto.AbstractDTO>` to use for serializing outbound response

--- a/tests/integration/test_appconfig_integration.py
+++ b/tests/integration/test_appconfig_integration.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import pytest
+
+from litestar import get, post
+from litestar.app import AppConfig, Litestar
+from litestar.config.response_cache import ResponseCacheConfig
+from litestar.openapi.config import OpenAPIConfig
+from litestar.testing import TestClient
+
+
+class TestAppConfigIntegration:
+    def test_basic_app_functionality(self):
+        @get("/")
+        async def handler() -> dict[str, str]:
+            return {"message": "Hello World"}
+
+        config = AppConfig(route_handlers=[handler])
+        app1 = Litestar.from_config(config)
+
+        app2 = Litestar(route_handlers=[handler])
+
+        with TestClient(app1) as client1, TestClient(app2) as client2:
+            response1 = client1.get("/")
+            response2 = client2.get("/")
+
+            assert response1.status_code == response2.status_code == 200
+            assert response1.json() == response2.json() == {"message": "Hello World"}
+
+    def test_logging_functionality(self):
+        @get("/test")
+        async def handler() -> dict[str, str]:
+            return {"test": "logging"}
+
+        config = AppConfig(route_handlers=[handler])
+        app1 = Litestar.from_config(config)
+
+        app2 = Litestar(route_handlers=[handler])
+
+        logger1 = app1.get_logger("test")
+        logger2 = app2.get_logger("test")
+
+        assert logger1 is not None
+        assert logger2 is not None
+        assert type(logger1) == type(logger2)
+
+        # Just verify the loggers exist and are the same type
+        assert hasattr(logger1, "info")
+        assert hasattr(logger2, "info")
+
+    def test_openapi_functionality(self):
+        @get("/test", tags=["test"])
+        async def handler() -> dict[str, str]:
+            return {"test": "openapi"}
+
+        config = AppConfig(route_handlers=[handler])
+        app1 = Litestar.from_config(config)
+
+        app2 = Litestar(route_handlers=[handler])
+
+        with TestClient(app1) as client1, TestClient(app2) as client2:
+            response1 = client1.get("/schema/openapi.json")
+            response2 = client2.get("/schema/openapi.json")
+
+            assert response1.status_code == response2.status_code == 200
+
+            schema1 = response1.json()
+            schema2 = response2.json()
+
+            assert schema1["openapi"] == schema2["openapi"]
+            assert schema1["info"]["title"] == schema2["info"]["title"] == "Litestar API"
+            assert schema1["info"]["version"] == schema2["info"]["version"] == "1.0.0"
+            assert "/test" in schema1["paths"]
+            assert "/test" in schema2["paths"]
+
+    def test_request_body_size_limits(self):
+        @post("/upload")
+        async def upload_handler(data: dict) -> dict[str, str]:
+            return {"status": "success", "data": str(data)}
+
+        config = AppConfig(route_handlers=[upload_handler], request_max_body_size=100)
+        app1 = Litestar.from_config(config)
+
+        app2 = Litestar(route_handlers=[upload_handler], request_max_body_size=100)
+
+        assert app1.request_max_body_size == app2.request_max_body_size == 100
+
+        small_data = {"message": "test"}
+
+        with TestClient(app1) as client1:
+            response1 = client1.post("/upload", json=small_data)
+            assert response1.status_code == 201
+
+        with TestClient(app2) as client2:
+            response2 = client2.post("/upload", json=small_data)
+            assert response2.status_code == 201
+
+    def test_response_caching(self):
+        @get("/cached")
+        async def cached_handler() -> dict[str, str]:
+            return {"timestamp": "123456"}
+
+        config = AppConfig(
+            route_handlers=[cached_handler], response_cache_config=ResponseCacheConfig(default_expiration=60)
+        )
+        app1 = Litestar.from_config(config)
+
+        app2 = Litestar(
+            route_handlers=[cached_handler], response_cache_config=ResponseCacheConfig(default_expiration=60)
+        )
+
+        assert app1.response_cache_config is not None
+        assert app2.response_cache_config is not None
+        assert app1.response_cache_config.default_expiration == app2.response_cache_config.default_expiration == 60
+
+        with TestClient(app1) as client1, TestClient(app2) as client2:
+            response1 = client1.get("/cached")
+            response2 = client2.get("/cached")
+
+            assert response1.status_code == response2.status_code == 200
+            assert response1.json() == response2.json()
+
+    def test_middleware_compatibility(self):
+        from typing import Callable
+
+        from litestar.middleware import MiddlewareProtocol
+
+        class CustomMiddleware(MiddlewareProtocol):
+            def __init__(self, app: Callable) -> None:
+                self.app = app
+
+            async def __call__(self, scope: dict, receive: Callable, send: Callable) -> None:
+                if scope["type"] == "http":
+                    # Add custom header
+                    async def send_wrapper(message):
+                        if message["type"] == "http.response.start":
+                            headers = list(message.get("headers", []))
+                            headers.append([b"x-custom-header", b"test-value"])
+                            message["headers"] = headers
+                        await send(message)
+
+                    await self.app(scope, receive, send_wrapper)
+                else:
+                    await self.app(scope, receive, send)
+
+        @get("/test")
+        async def handler() -> dict[str, str]:
+            return {"test": "middleware"}
+
+        config = AppConfig(route_handlers=[handler], middleware=[CustomMiddleware])
+        app1 = Litestar.from_config(config)
+
+        app2 = Litestar(route_handlers=[handler], middleware=[CustomMiddleware])
+
+        with TestClient(app1) as client1, TestClient(app2) as client2:
+            response1 = client1.get("/test")
+            response2 = client2.get("/test")
+
+            assert response1.status_code == response2.status_code == 200
+            assert response1.headers["x-custom-header"] == response2.headers["x-custom-header"] == "test-value"
+
+    def test_exception_handlers_compatibility(self):
+        from litestar import Request
+        from litestar.exceptions import HTTPException
+        from litestar.response import Response
+
+        def custom_exception_handler(request: Request, exc: HTTPException) -> Response:
+            return Response(content={"custom_error": True, "detail": exc.detail}, status_code=exc.status_code)
+
+        @get("/error")
+        async def error_handler() -> dict[str, str]:
+            raise HTTPException(status_code=400, detail="Test error")
+
+        config = AppConfig(route_handlers=[error_handler], exception_handlers={HTTPException: custom_exception_handler})
+        app1 = Litestar.from_config(config)
+
+        app2 = Litestar(route_handlers=[error_handler], exception_handlers={HTTPException: custom_exception_handler})
+
+        with TestClient(app1) as client1, TestClient(app2) as client2:
+            response1 = client1.get("/error")
+            response2 = client2.get("/error")
+
+            assert response1.status_code == response2.status_code == 400
+            assert response1.json() == response2.json() == {"custom_error": True, "detail": "Test error"}
+
+    def test_lifecycle_hooks_compatibility(self):
+        startup_called = []
+        shutdown_called = []
+
+        async def startup_hook(app: Litestar) -> None:
+            startup_called.append(True)
+
+        async def shutdown_hook(app: Litestar) -> None:
+            shutdown_called.append(True)
+
+        config = AppConfig(on_startup=[startup_hook], on_shutdown=[shutdown_hook])
+        app1 = Litestar.from_config(config)
+
+        app2 = Litestar(on_startup=[startup_hook], on_shutdown=[shutdown_hook])
+
+        assert len(app1.on_startup) == len(app2.on_startup) == 1
+        assert len(app1.on_shutdown) == len(app2.on_shutdown) == 1
+
+        assert app1.on_startup == app2.on_startup
+        assert app1.on_shutdown == app2.on_shutdown
+
+
+class TestAppConfigRealWorldScenarios:
+    def test_api_with_auth_and_caching(self):
+        from litestar import Controller
+
+        class ApiController(Controller):
+            path = "/api"
+
+            @get("/users/{user_id:int}", cache=60)
+            async def get_user(self, user_id: int) -> dict[str, int]:
+                return {"id": user_id, "name": f"User {user_id}"}
+
+            @post("/users")
+            async def create_user(self, data: dict) -> dict[str, int]:
+                return {"id": 1, **data}
+
+        config = AppConfig(
+            route_handlers=[ApiController],
+            response_cache_config=ResponseCacheConfig(default_expiration=120),
+            openapi_config=OpenAPIConfig(title="User API", version="1.0.0", description="A simple user management API"),
+        )
+        app1 = Litestar.from_config(config)
+
+        app2 = Litestar(
+            route_handlers=[ApiController],
+            response_cache_config=ResponseCacheConfig(default_expiration=120),
+            openapi_config=OpenAPIConfig(title="User API", version="1.0.0", description="A simple user management API"),
+        )
+
+        with TestClient(app1) as client1, TestClient(app2) as client2:
+            response1 = client1.get("/api/users/1")
+            response2 = client2.get("/api/users/1")
+
+            assert response1.status_code == response2.status_code == 200
+            assert response1.json() == response2.json()
+
+            user_data = {"name": "John Doe"}
+            response1 = client1.post("/api/users", json=user_data)
+            response2 = client2.post("/api/users", json=user_data)
+
+            assert response1.status_code == response2.status_code == 201  # 201 for POST is correct
+            assert response1.json() == response2.json()
+
+            response1 = client1.get("/schema/openapi.json")
+            response2 = client2.get("/schema/openapi.json")
+
+            assert response1.status_code == response2.status_code == 200
+            schema1 = response1.json()
+            schema2 = response2.json()
+            assert schema1["info"]["title"] == schema2["info"]["title"] == "User API"
+
+    def test_debug_mode_consistency(self):
+        @get("/error")
+        async def error_handler() -> dict[str, str]:
+            raise ValueError("Test error")
+
+        config = AppConfig(route_handlers=[error_handler], debug=True)
+        app1 = Litestar.from_config(config)
+
+        app2 = Litestar(route_handlers=[error_handler], debug=True)
+
+        assert app1.debug is app2.debug is True
+
+        with TestClient(app1) as client1, TestClient(app2) as client2:
+            response1 = client1.get("/error")
+            response2 = client2.get("/error")
+
+            assert response1.status_code == response2.status_code == 500
+
+        config = AppConfig(route_handlers=[error_handler], debug=False)
+        app3 = Litestar.from_config(config)
+
+        app4 = Litestar(route_handlers=[error_handler], debug=False)
+
+        assert app3.debug is app4.debug is False
+
+        with TestClient(app3) as client3, TestClient(app4) as client4:
+            response3 = client3.get("/error")
+            response4 = client4.get("/error")
+
+            assert response3.status_code == response4.status_code == 500

--- a/tests/unit/test_appconfig_defaults.py
+++ b/tests/unit/test_appconfig_defaults.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import pytest
+
+from litestar.app import AppConfig, Litestar
+from litestar.config.response_cache import ResponseCacheConfig
+from litestar.logging.config import LoggingConfig
+from litestar.openapi.config import OpenAPIConfig
+from litestar.types import Empty
+
+
+class TestAppConfigDefaults:
+    def test_appconfig_defaults_match_litestar_init(self):
+        config = AppConfig()
+        app_from_config = Litestar.from_config(config)
+        app_direct = Litestar()
+
+        assert type(app_from_config.logging_config) == type(app_direct.logging_config)
+        assert isinstance(app_from_config.logging_config, LoggingConfig)
+        assert isinstance(app_direct.logging_config, LoggingConfig)
+
+        assert type(app_from_config.response_cache_config) == type(app_direct.response_cache_config)
+        assert isinstance(app_from_config.response_cache_config, ResponseCacheConfig)
+        assert isinstance(app_direct.response_cache_config, ResponseCacheConfig)
+
+        assert type(app_from_config.openapi_config) == type(app_direct.openapi_config)
+        assert isinstance(app_from_config.openapi_config, OpenAPIConfig)
+        assert isinstance(app_direct.openapi_config, OpenAPIConfig)
+        assert app_from_config.openapi_config.title == app_direct.openapi_config.title
+        assert app_from_config.openapi_config.version == app_direct.openapi_config.version
+
+        assert app_from_config.request_max_body_size == app_direct.request_max_body_size
+        assert app_from_config.request_max_body_size == 10_000_000
+
+    def test_appconfig_raw_defaults(self):
+        config = AppConfig()
+
+        assert config.logging_config is Empty
+        assert config.response_cache_config is None
+        assert config.openapi_config is not None
+        assert isinstance(config.openapi_config, OpenAPIConfig)
+        assert config.request_max_body_size == 10_000_000
+
+    def test_custom_values_preserved(self):
+        custom_logging = LoggingConfig(version=1)
+        custom_cache = ResponseCacheConfig(default_expiration=120)
+        custom_openapi = OpenAPIConfig(title="Custom API", version="2.0.0")
+        custom_body_size = 5_000_000
+
+        config = AppConfig(
+            logging_config=custom_logging,
+            response_cache_config=custom_cache,
+            openapi_config=custom_openapi,
+            request_max_body_size=custom_body_size,
+        )
+        app_from_config = Litestar.from_config(config)
+
+        app_direct = Litestar(
+            logging_config=custom_logging,
+            response_cache_config=custom_cache,
+            openapi_config=custom_openapi,
+            request_max_body_size=custom_body_size,
+        )
+
+        assert app_from_config.logging_config.version == app_direct.logging_config.version == 1
+        assert (
+            app_from_config.response_cache_config.default_expiration
+            == app_direct.response_cache_config.default_expiration
+            == 120
+        )
+        assert app_from_config.openapi_config.title == app_direct.openapi_config.title == "Custom API"
+        assert app_from_config.request_max_body_size == app_direct.request_max_body_size == 5_000_000
+
+    def test_none_values_handled_correctly(self):
+        config = AppConfig(logging_config=None, response_cache_config=None, openapi_config=None)
+        app_from_config = Litestar.from_config(config)
+
+        app_direct = Litestar(logging_config=None, response_cache_config=None, openapi_config=None)
+
+        assert app_from_config.logging_config == app_direct.logging_config
+        assert app_from_config.response_cache_config == app_direct.response_cache_config
+        assert app_from_config.openapi_config == app_direct.openapi_config
+
+    def test_functional_behavior_equality(self):
+        config = AppConfig()
+        app_from_config = Litestar.from_config(config)
+        app_direct = Litestar()
+
+        logger1 = app_from_config.get_logger("test")
+        logger2 = app_direct.get_logger("test")
+        assert logger1 is not None
+        assert logger2 is not None
+        assert type(logger1) == type(logger2)
+
+        assert app_from_config.openapi_config is not None
+        assert app_direct.openapi_config is not None
+        assert app_from_config.openapi_config.title == app_direct.openapi_config.title
+
+        assert app_from_config.request_max_body_size == app_direct.request_max_body_size
+
+    def test_backwards_compatibility(self):
+        configs = [
+            AppConfig(),
+            AppConfig(debug=True),
+            AppConfig(request_max_body_size=1_000_000),
+            AppConfig(openapi_config=OpenAPIConfig(title="Test", version="1.0.0")),
+        ]
+
+        for config in configs:
+            app = Litestar.from_config(config)
+            assert app is not None
+            assert hasattr(app, "logging_config")
+            assert hasattr(app, "openapi_config")
+            assert hasattr(app, "request_max_body_size")
+
+    def test_edge_cases(self):
+        config = AppConfig(
+            openapi_config=OpenAPIConfig(title="", version=""),
+        )
+        app = Litestar.from_config(config)
+        assert app.openapi_config.title == ""
+        assert app.openapi_config.version == ""
+
+        config = AppConfig(request_max_body_size=0)
+        app = Litestar.from_config(config)
+        assert app.request_max_body_size == 0
+
+        config = AppConfig(request_max_body_size=1_000_000_000)
+        app = Litestar.from_config(config)
+        assert app.request_max_body_size == 1_000_000_000
+
+
+class TestAppConfigMutationLogic:
+    def test_empty_logging_config_becomes_loggingconfig(self):
+        config = AppConfig()
+        app = Litestar.from_config(config)
+
+        assert isinstance(app.logging_config, LoggingConfig)
+        assert app.logging_config.version == 1
+
+    def test_none_response_cache_config_becomes_responsecacheconfig(self):
+        config = AppConfig()
+        app = Litestar.from_config(config)
+
+        assert isinstance(app.response_cache_config, ResponseCacheConfig)
+        assert app.response_cache_config.default_expiration == 60
+
+    def test_empty_values_in_direct_init(self):
+        app = Litestar(
+            logging_config=Empty,
+            response_cache_config=None,
+            request_max_body_size=None,
+        )
+
+        assert isinstance(app.logging_config, LoggingConfig)
+        assert isinstance(app.response_cache_config, ResponseCacheConfig)
+        assert app.request_max_body_size is None
+
+
+class TestAppConfigTypeAnnotations:
+    def test_logging_config_type_annotation(self):
+        import inspect
+
+        sig = inspect.signature(AppConfig.__init__)
+        param = sig.parameters["logging_config"]
+
+        assert "EmptyType" in str(param.annotation)
+
+    def test_request_max_body_size_type_annotation(self):
+        import inspect
+
+        sig = inspect.signature(AppConfig.__init__)
+        param = sig.parameters["request_max_body_size"]
+
+        assert "EmptyType" not in str(param.annotation)
+        assert "int" in str(param.annotation)


### PR DESCRIPTION
…ults inconsistency

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

    Fixed inconsistency between :class:`Litestar` direct initialization and
        :class:`~litestar.config.app.AppConfig` defaults. Previously, certain
        configuration parameters behaved differently when passed directly to
        ``Litestar()`` versus when using ``AppConfig`` with ``Litestar.from_config()``.

        Key changes:
        - ``logging_config`` with ``Empty`` now properly defaults to ``LoggingConfig`` in both initialization methods
        - ``response_cache_config`` with ``None`` now properly defaults to ``ResponseCacheConfig`` in both methods
        - ``request_max_body_size`` type annotation corrected to remove ``EmptyType`` since ``Empty`` is not allowed for this parameter
        - All default values are now consistent between ``Litestar()`` and ``AppConfig`` initialization

        This ensures that applications using ``AppConfig`` behave identically to those
        using direct ``Litestar`` initialization, maintaining backwards compatibility
        and predictable behavior.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Closes #4296
