### PR TITLE
fix: `KeyError` swallowing in `default_serializer`

### DIFF
--- a/litestar/serialization/msgspec_hooks.py
+++ b/litestar/serialization/msgspec_hooks.py
@@ -85,10 +85,12 @@ def default_serializer(value: Any, type_encoders: Mapping[Any, Callable[[Any], A
     type_encoders = {**DEFAULT_TYPE_ENCODERS, **(type_encoders or {})}
 
     for base in value.__class__.__mro__[:-1]:
-        encoder = type_encoders.get(base)
-        if encoder is None:
+        try:
+            encoder = type_encoders[base]
+        except KeyError:
             continue
-        return encoder(value)
+        else:
+            return encoder(value)
 
     raise TypeError(f"Unsupported type: {type(value)!r}")
 


### PR DESCRIPTION
It used to do several things that are not quite right:
1. `KeyError` raised in `encoder(value)` call was swallowed, it could potentially lead to a very hard to debug problems, when a `KeyError` bug in encoder would just select another one
2. `.get` + `if is None` is a bit tiny faster than `[]` with `except KeyError` in some cases
