### PR TITLE
fix: do not check for `Path` in `default_deserializer`

### DIFF
--- a/litestar/serialization/msgspec_hooks.py
+++ b/litestar/serialization/msgspec_hooks.py
@@ -12,7 +12,7 @@ from ipaddress import (
     IPv6Interface,
     IPv6Network,
 )
-from pathlib import PurePath
+from pathlib import Path, PurePath
 from re import Pattern
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, overload
 from uuid import UUID


### PR DESCRIPTION
Because all `Path` instances are instances of `PurePath` as well. https://github.com/python/cpython/blob/d4e5802588db3459f04d4b8013cc571a8988e203/Lib/pathlib/__init__.py#L855

It is true for all python versions.
