### PR TITLE
refactor(typing): remove unused `tuple_types_regex` from typing utils

### DIFF
--- a/litestar/utils/typing.py
+++ b/litestar/utils/typing.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from collections import abc, defaultdict, deque
 from typing import (
     AbstractSet,


### PR DESCRIPTION
It is unused. Techincally it is not a protected name, but I think that it is safe to be removed, since it is not in `__all__`. 

The chances that someone is using it are low.