### PR TITLE
refactor: simplify `encode_json` function

### DIFF
--- a/litestar/serialization/msgspec_hooks.py
+++ b/litestar/serialization/msgspec_hooks.py
@@ -162,7 +162,7 @@ def encode_json(value: Any, serializer: Callable[[Any], Any] | None = None) -> b
         SerializationException: If error encoding ``obj``.
     """
     try:
-        return msgspec.json.encode(value, enc_hook=serializer) if serializer else _msgspec_json_encoder.encode(value)
+        return msgspec.json.encode(value, enc_hook=serializer)
     except (TypeError, msgspec.EncodeError) as msgspec_error:
         raise SerializationException(str(msgspec_error)) from msgspec_error
 


### PR DESCRIPTION
After double checking type info: https://github.com/jcrist/msgspec/blob/bc60e96772c5e8a3babff967d86a9e7dfcdbfb1b/msgspec/json.pyi#L107

And implementation: https://github.com/jcrist/msgspec/blob/bc60e96772c5e8a3babff967d86a9e7dfcdbfb1b/msgspec/_core.c#L14223-L14224

And doing testing:

```python
>>> import msgspec
>>> msgspec.json.encode({}, enc_hook=None)
b'{}'
>>> msgspec.json.encode({})
b'{}'
```

I can be certain to say that this `if` is not required. It is better to remove it from the hot path.