### PR TITLE
refactor: keep iterator on the main thread

### DIFF
--- a/litestar/response/streaming.py
+++ b/litestar/response/streaming.py
@@ -73,7 +73,7 @@ class ASGIStreamingResponse(ASGIResponse):
 
         self.disconnect_event = Event()
         self.iterator: AsyncIterable[str | bytes] | AsyncGenerator[str | bytes, None] = (
-            iterator if isinstance(iterator, (AsyncIterable, AsyncIterator)) else AsyncIteratorWrapper(iterator)
+            iterator if isinstance(iterator, AsyncIterable) else AsyncIteratorWrapper(iterator)
         )
 
     async def _listen_for_disconnect(self, receive: Receive) -> None:
@@ -207,7 +207,8 @@ class Stream(Response[StreamType[Union[str, bytes]]]):
         media_type = get_enum_string_value(media_type or self.media_type or MediaType.JSON)
 
         iterator = self.iterator
-        if not isinstance(iterator, (Iterable, Iterator, AsyncIterable, AsyncIterator)) and callable(iterator):
+
+        if not isinstance(iterator, (Iterable, AsyncIterable)) and callable(iterator):
             iterator = iterator()
 
         return ASGIStreamingResponse(


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

## Description

To prevent cross-thread reference errors with `Stream` iterators, we keep iterators on the main context and listen for a disconnect asynchronously instead of vice versa.

I have properly split the changes into 3 separate commits for better diffs.

## Other changes

- Reuse `stream_event` dictionary to avoid recreating the dictionary on every iteration.
- Remove redundant type checks, e.g. `AsyncIterable` covers `AsyncIterator` too.
- Some miscellaneous inlining and using terse expressions like `chain(self.cookies, cookies or ())`

