### PR TITLE
fix(docs): ensure class member order follows source

### DIFF
--- a/docs/reference/middleware/index.rst
+++ b/docs/reference/middleware/index.rst
@@ -1,8 +1,8 @@
 middleware
 ==========
 
-.. automodule:: litestar.middleware
-
+.. automodule:: litestar.middleware.base
+    :members:
 
 .. toctree::
     :maxdepth: 1

--- a/docs/release-notes/whats-new-2.rst
+++ b/docs/release-notes/whats-new-2.rst
@@ -187,11 +187,11 @@ Imports
 +----------------------------------------------------+------------------------------------------------------------------------+
 | ``starlite.AuthenticationResult``                  | :class:`.middleware.authentication.AuthenticationResult`               |
 +----------------------------------------------------+------------------------------------------------------------------------+
-| ``starlite.AbstractMiddleware``                    | :class:`.middleware.AbstractMiddleware`                                |
+| ``starlite.AbstractMiddleware``                    | :class:`.middleware.base.AbstractMiddleware`                           |
 +----------------------------------------------------+------------------------------------------------------------------------+
-| ``starlite.DefineMiddleware``                      | :class:`.middleware.DefineMiddleware`                                  |
+| ``starlite.DefineMiddleware``                      | :class:`.middleware.base.DefineMiddleware`                             |
 +----------------------------------------------------+------------------------------------------------------------------------+
-| ``starlite.MiddlewareProtocol``                    | :class:`.middleware.MiddlewareProtocol`                                |
+| ``starlite.MiddlewareProtocol``                    | :class:`.middleware.base.MiddlewareProtocol`                           |
 +----------------------------------------------------+------------------------------------------------------------------------+
 | **Security**                                                                                                                |
 +----------------------------------------------------+------------------------------------------------------------------------+

--- a/docs/release-notes/whats-new-3.rst
+++ b/docs/release-notes/whats-new-3.rst
@@ -337,7 +337,7 @@ parameter.
 Middleware configuration constraints
 -------------------------------------
 
-:class:`~litestar.middleware.ASGIMiddleware`\ s can now express constraints for how
+:class:`~litestar.middleware.base.ASGIMiddleware`\ s can now express constraints for how
 they are applied in the middleware stack, which are then validated on application
 startup.
 

--- a/docs/usage/middleware/creating-middleware.rst
+++ b/docs/usage/middleware/creating-middleware.rst
@@ -25,7 +25,7 @@ Extending ``ASGIMiddleware``
 ----------------------------
 
 While using functions is a perfectly viable approach, the recommended way to handle this
-is by using the :class:`~litestar.middleware.ASGIMiddleware` abstract base class, which
+is by using the :class:`~litestar.middleware.base.ASGIMiddleware` abstract base class, which
 also includes functionality to dynamically skip the middleware based on ASGI
 ``scope["type"]``, handler ``opt`` keys or path patterns and a simple way to pass
 configuration to middlewares; It does not implement an ``__init__`` method, so
@@ -64,7 +64,7 @@ keep track of all these implicit couplings and dependencies, or downright imposs
 the middleware is implemented in a separate package and has no knowledge about how it is
 being applied.
 
-To help with this, :class:`~litestar.middleware.ASGIMiddleware` allows to specify a set
+To help with this, :class:`~litestar.middleware.base.ASGIMiddleware` allows to specify a set
 of :class:`~litestar.middleware.constraints.MiddlewareConstraints` - Once configured,
 these will be validated on application startup.
 
@@ -149,7 +149,7 @@ Now suppose that ``MyCustomMiddleware`` has the constraint ``first=True`` then t
 Migrating from ``MiddlewareProtocol`` / ``AbstractMiddleware``
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-:class:`~litestar.middleware.ASGIMiddleware` was introduced in Litestar 2.15. If you've
+:class:`~litestar.middleware.base.ASGIMiddleware` was introduced in Litestar 2.15. If you've
 been using ``MiddlewareProtocol`` / ``AbstractMiddleware`` to implement your middlewares
 before, there's a simple migration path to using ``ASGIMiddleware``.
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

At first glance, other modules works fine. e.g. https://docs.litestar.dev/main/reference/middleware/logging.html#litestar.middleware.logging.LoggingMiddlewareConfig

<img width="200" height="200" alt="Image" src="https://github.com/user-attachments/assets/d59c8cc3-a3f5-4a6b-a1a6-3b9d47968793" />

After digging in, i found that if a class is imported into `__init__.py` via `from ... import ...` and added to `__all__`, Sphinx may lose the original source order of its members so i changed to document classes directly from their original module, rather than through indirect imports in `__init__.py`.

| Before                                                                                                   | After                                                                                                    |
|----------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
| <img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/67035e4e-8f12-4e4d-8561-a29cf7ef0762" /> | <img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/66ca97b4-c7e6-4d83-a965-c81a8c6c511d" /> |

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
close #4393