### PR TITLE
feat(middleware): Add `should_bypass_for_scope` to `ASGIMiddleware` to allow excluding middlewares dynamically

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -277,3 +277,12 @@
               id: ReadOnly[int]
 
         ``typing_extensions.ReadOnly`` should be used for python versions <3.13.
+
+
+    .. change:: Add ``should_bypass_for_scope`` to ``ASGIMiddleware`` to allow excluding middlewares dynamically
+        :type: feature
+        :pr: 4441
+
+        Add a new attribute :attr:`~litestar.middleware.ASGIMiddleware.should_bypass_for_scope`;
+        A callable which takes in a :class:`~litestar.types.Scope` and returns a boolean
+        to indicate whether to bypass the middleware for the current request.

--- a/tests/unit/test_middleware/test_base_middleware.py
+++ b/tests/unit/test_middleware/test_base_middleware.py
@@ -345,6 +345,29 @@ def test_asgi_middleware_exclude_dynamic_handler_by_pattern() -> None:
         mock.assert_not_called()
 
 
+def test_asgi_middleware_should_exclude_scope() -> None:
+    mock = MagicMock()
+
+    class SubclassMiddleware(ASGIMiddleware):
+        @staticmethod
+        def should_bypass_for_scope(scope: "Scope") -> bool:
+            return scope["path"].endswith(".jpg")
+
+        async def handle(self, scope: "Scope", receive: "Receive", send: "Send", next_app: "ASGIApp") -> None:
+            mock(scope["path"])
+            await next_app(scope, receive, send)
+
+    @get("/{file_name:str}")
+    def handler(file_name: str) -> str:
+        return file_name
+
+    with create_test_client([handler], middleware=[SubclassMiddleware()]) as client:
+        assert client.get("/test.txt").status_code == 200
+        assert client.get("/test.jpg").status_code == 200
+
+        mock.assert_called_once_with("/test.txt")
+
+
 @pytest.mark.parametrize("excludes", ["/", ("/", "/foo"), "/*", "/.*"])
 def test_asgi_middleware_exclude_by_pattern_warns_if_exclude_all(excludes: Union[str, tuple[str, ...]]) -> None:
     class SubclassMiddleware(ASGIMiddleware):


### PR DESCRIPTION
Add a new attribute `should_bypass_for_scope` to `ASGIMiddleware`; A callable which takes in a `Scope` and returns a boolean to indicate whether to bypass the middleware for the current request.