### PR TITLE
fix(typing): `DataContainerType` should contain types, not instances

### DIFF
--- a/litestar/types/serialization.py
+++ b/litestar/types/serialization.py
@@ -61,6 +61,8 @@ EncodableStdLibIPType: TypeAlias = (
 )
 EncodableMsgSpecType: TypeAlias = "Ext | Raw | Struct"
 LitestarEncodableType: TypeAlias = "EncodableBuiltinType | EncodableBuiltinCollectionType | EncodableStdLibType | EncodableStdLibIPType | EncodableMsgSpecType | BaseModel | AttrsInstance"  # pyright: ignore
-DataContainerType: TypeAlias = "Struct | BaseModel | AttrsInstance | TypedDictClass | DataclassProtocol"  # pyright: ignore
+DataContainerType: TypeAlias = (  # pyright: ignore
+    "type[Struct] | type[BaseModel] | type[AttrsInstance] | TypedDictClass | DataclassProtocol"
+)
 PydanticV2FieldsListType: TypeAlias = "set[int] | set[str] | dict[int, Any] | dict[str, Any]"
 PydanticV1FieldsListType: TypeAlias = "IncEx | AbstractSetIntStr | MappingIntStrAny"  # pyright: ignore

--- a/tests/unit/test_testing/test_request_factory.py
+++ b/tests/unit/test_testing/test_request_factory.py
@@ -69,7 +69,7 @@ async def test_request_factory_create_with_data(data_cls: DataContainerType) -> 
     request = RequestFactory()._create_request_with_data(
         HttpMethod.POST,
         "/",
-        data=data_cls(**person_data),  # type: ignore[operator]
+        data=data_cls(**person_data),  # type: ignore[operator, arg-type]
     )
     body = await request.body()
     assert json.loads(body) == person_data


### PR DESCRIPTION
Since `mypy` and `pyright` both see a lot of `except ImportError:` above, they use `Any` and `Any` disables the type checking :(