### PR TITLE
feat(v2/middleware): Backport `should_bypass_for_scope` to enable upgrade path to static middleware excludes in v3

### DIFF
--- a/litestar/middleware/_utils.py
+++ b/litestar/middleware/_utils.py
@@ -44,6 +44,15 @@ def build_exclude_path_pattern(
         ) from e
 
 
+def should_bypass_for_path_pattern(scope: Scope, pattern: Pattern | None = None) -> bool:
+    return bool(
+        pattern
+        and pattern.findall(
+            scope["raw_path"].decode() if getattr(scope.get("route_handler", {}), "is_mount", False) else scope["path"]
+        )
+    )
+
+
 def should_bypass_middleware(
     *,
     exclude_http_methods: Sequence[Method] | None = None,
@@ -73,9 +82,4 @@ def should_bypass_middleware(
     if exclude_http_methods and scope.get("method") in exclude_http_methods:
         return True
 
-    return bool(
-        exclude_path_pattern
-        and exclude_path_pattern.findall(
-            scope["raw_path"].decode() if getattr(scope.get("route_handler", {}), "is_mount", False) else scope["path"]
-        )
-    )
+    return should_bypass_for_path_pattern(scope, exclude_path_pattern)


### PR DESCRIPTION
Backport #4441, and include a deprecation warning that will be raised when the usage of `exclude_path_pattern` would break with an upgrade to v3. In that case, users are advised to migrate to `should_bypass_for_scope` instead.