### PR TITLE
fix(tools): Incorrect index check in changelog insertion

### DIFF
--- a/tools/prepare_release.py
+++ b/tools/prepare_release.py
@@ -373,7 +373,7 @@ def _write_changelog_entry(changelog_entry: str) -> None:
         (i for i, line in enumerate(changelog_lines) if line.startswith(".. changelog::")),
         None,
     )
-    if not line_no:
+    if line_no is None:
         raise ValueError("Changelog start not found")
 
     changelog_lines[line_no:line_no] = changelog_entry.splitlines()


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

**Summary:**
Fixes a bug in `_write_changelog_entry` where the changelog insertion would fail if the `.. changelog::` marker was on the first line of the file.

**Result:**
Changelog entries are now inserted correctly, even when the marker is at the top of the file.
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
* gh-4400