### PR TITLE
fix(pydantic-dto): handle Optional computed_field returning None (#4458)

### DIFF
--- a/litestar/plugins/pydantic/dto.py
+++ b/litestar/plugins/pydantic/dto.py
@@ -150,6 +150,13 @@ class PydanticDTO(AbstractDTO[T], Generic[T]):
                     if field_info.default_factory and not is_pydantic_undefined(field_info.default_factory)
                     else None
                 )
+            else:
+                # Computed fields don't expose FieldInfo; mark Optional[...] as default=None so
+                # the transfer struct treats them as optional when the computed value is None.
+                if field_definition.is_optional:
+                    default = None
+                else:
+                    default = Empty
 
             yield replace(
                 DTOFieldDefinition.from_field_definition(

--- a/tests/unit/test_plugins/test_pydantic/test_computed_optional_field.py
+++ b/tests/unit/test_plugins/test_pydantic/test_computed_optional_field.py
@@ -1,0 +1,50 @@
+from typing import Optional
+
+import pydantic as pydantic_v2
+
+from litestar import get
+from litestar.dto import DTOConfig
+from litestar.plugins.pydantic import PydanticDTO
+from litestar.testing import create_test_client
+
+
+class Status(pydantic_v2.BaseModel):
+    a: str
+    b: str
+
+
+class Result(pydantic_v2.BaseModel):
+    @pydantic_v2.computed_field
+    def status(self) -> Optional[Status]:
+        return None
+
+
+class ResultDTO(PydanticDTO[Result]):
+    # codegen enabled by default
+    config = DTOConfig(include={"status"})
+
+
+class ResultDTO_NoCodegen(PydanticDTO[Result]):
+    config = DTOConfig(include={"status"}, experimental_codegen_backend=False)
+
+
+def test_computed_optional_returns_none_with_codegen_fails() -> None:
+    @get("/", return_dto=ResultDTO)
+    async def handler() -> Result:
+        return Result()
+
+    with create_test_client([handler]) as client:
+        res = client.get("/")
+        assert res.status_code == 200
+        assert res.json() == {"status": None}
+
+
+def test_computed_optional_returns_none_without_codegen_ok() -> None:
+    @get("/", return_dto=ResultDTO_NoCodegen)
+    async def handler() -> Result:
+        return Result()
+
+    with create_test_client([handler]) as client:
+        res = client.get("/")
+        assert res.status_code == 200
+        assert res.json() == {"status": None}


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Bug: codegen treated Optional computed_field as required because computed fields lack FieldInfo, so msgspec.Struct required the field and crashed when value was None.
- Fix: in PydanticDTO.generate_field_definitions, for computed fields without FieldInfo, set default=None if annotation is Optional[...].
- Impact: response encoding for Optional computed fields now returns null instead of raising.

## Closes

Closes #4458

- How to test: pytest -q tests/unit/test_plugins/test_pydantic/test_computed_optional_field.py
- No breaking changes; only affects Optional computed fields in Pydantic v2.