### PR TITLE
fix: duplicate query parameters fail validation if one of the paramaters is a list

### DIFF
--- a/litestar/_kwargs/extractors.py
+++ b/litestar/_kwargs/extractors.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections import defaultdict
-from functools import lru_cache, partial
+from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, NamedTuple, cast
 
 from multidict import MultiDict, MultiDictProxy
@@ -39,7 +38,6 @@ __all__ = (
     "create_connection_value_extractor",
     "create_data_extractor",
     "create_multipart_extractor",
-    "create_query_default_dict",
     "create_url_encoded_data_extractor",
     "headers_extractor",
     "json_extractor",
@@ -172,26 +170,6 @@ def create_connection_value_extractor(
             ) from e
 
     return extractor
-
-
-@lru_cache(1024)
-def create_query_default_dict(
-    parsed_query: tuple[tuple[str, str], ...],
-) -> defaultdict[str, list[str]]:
-    """Transform a list of tuples into a default dict.
-
-    Args:
-        parsed_query: The parsed query list of tuples.
-
-    Returns:
-        A default dict
-    """
-    output: defaultdict[str, list[str]] = defaultdict(list)
-
-    for k, v in parsed_query:
-        output[k].append(v)
-
-    return output
 
 
 def parse_connection_query_params(connection: ASGIConnection, kwargs_model: KwargsModel) -> MultiDict[str]:

--- a/litestar/_kwargs/extractors.py
+++ b/litestar/_kwargs/extractors.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from functools import lru_cache, partial
 from typing import TYPE_CHECKING, Any, Callable, NamedTuple, cast
 
-from multidict import MultiDict
+from multidict import MultiDict, MultiDictProxy
 
 from litestar._multipart import parse_multipart_form
 from litestar._parsers import (
@@ -87,9 +87,9 @@ def create_connection_value_extractor_mv_safe(
     kwargs_model: KwargsModel,
     connection_key: str,
     expected_params: set[ParameterDefinition],
-    parser: Callable[[ASGIConnection, KwargsModel], MultiDict[str]] | None = None,
+    parser: (Callable[[ASGIConnection, KwargsModel], MultiDict[str] | MultiDictProxy[str]] | None) = None,
 ) -> Extractor:
-    """Create a kwargs extractor function which requires values to be a list, but is safe to use with aliases and sequences
+    """Create a kwargs extractor function which requires values to be a MultiDict, but is safe to use with aliases and sequences
 
     Args:
         kwargs_model: The KwargsModel instance.
@@ -106,7 +106,7 @@ def create_connection_value_extractor_mv_safe(
     key_is_sequence = {p.field_name: p.is_sequence for p in expected_params}
 
     async def extractor(values: dict[str, Any], connection: ASGIConnection) -> None:
-        data: MultiDict[str] = (
+        data: MultiDict[str] | MultiDictProxy[str] = (
             parser(connection, kwargs_model) if parser else MultiDict(getattr(connection, connection_key, {}))
         )
 

--- a/litestar/_kwargs/extractors.py
+++ b/litestar/_kwargs/extractors.py
@@ -85,7 +85,7 @@ def create_connection_value_extractor_mv_safe(
     kwargs_model: KwargsModel,
     connection_key: str,
     expected_params: set[ParameterDefinition],
-    parser: Callable[[ASGIConnection, KwargsModel], dict[str, list[str]]],
+    parser: Callable[[ASGIConnection, KwargsModel], dict[str, list[str]]] | None = None,
 ) -> Extractor:
     """Create a kwargs extractor function which requires values to be a list, but is safe to use with aliases and sequences
 
@@ -185,7 +185,7 @@ def create_query_default_dict(
     output: defaultdict[str, list[str]] = defaultdict(list)
 
     for k, v in parsed_query:
-        output[k].append(v)  # type: ignore[union-attr]
+        output[k].append(v)
 
     return output
 

--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -14,6 +14,7 @@ from litestar._kwargs.extractors import (
     body_extractor,
     cookies_extractor,
     create_connection_value_extractor,
+    create_connection_value_extractor_mv_safe,
     create_data_extractor,
     headers_extractor,
     parse_connection_headers,
@@ -175,7 +176,7 @@ class KwargsModel:
 
         if self.expected_query_params:
             extractors.append(
-                create_connection_value_extractor(
+                create_connection_value_extractor_mv_safe(
                     connection_key="query_params",
                     expected_params=self.expected_query_params,
                     kwargs_model=self,

--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -209,7 +209,10 @@ class KwargsModel:
             for key in dependencies
             if key in field_definitions
         }
-        ignored_keys = {*RESERVED_KWARGS, *(dependency.key for dependency in expected_dependencies)}
+        ignored_keys = {
+            *RESERVED_KWARGS,
+            *(dependency.key for dependency in expected_dependencies),
+        }
 
         param_definitions = {
             *(
@@ -312,8 +315,14 @@ class KwargsModel:
             if isinstance(data_field_definition.kwarg_definition, BodyKwarg):
                 media_type = data_field_definition.kwarg_definition.media_type
 
-            if media_type in (RequestEncodingType.MULTI_PART, RequestEncodingType.URL_ENCODED):
-                expected_form_data = (media_type, data_field_definition)  # pyright: ignore
+            if media_type in (
+                RequestEncodingType.MULTI_PART,
+                RequestEncodingType.URL_ENCODED,
+            ):
+                expected_form_data = (
+                    media_type,
+                    data_field_definition,
+                )  # pyright: ignore
                 expected_data_dto = signature_model._data_dto
             elif signature_model._data_dto:
                 expected_data_dto = signature_model._data_dto
@@ -335,10 +344,12 @@ class KwargsModel:
                 expected_query_parameters, dependency_kwargs_model.expected_query_params
             )
             expected_cookie_parameters = merge_parameter_sets(
-                expected_cookie_parameters, dependency_kwargs_model.expected_cookie_params
+                expected_cookie_parameters,
+                dependency_kwargs_model.expected_cookie_params,
             )
             expected_header_parameters = merge_parameter_sets(
-                expected_header_parameters, dependency_kwargs_model.expected_header_params
+                expected_header_parameters,
+                dependency_kwargs_model.expected_header_params,
             )
 
             if "data" in expected_reserved_kwargs and "data" in dependency_kwargs_model.expected_reserved_kwargs:
@@ -404,7 +415,13 @@ class KwargsModel:
                 try:
                     async with create_task_group() as task_group:
                         for dependency in batch:
-                            task_group.start_soon(resolve_dependency, dependency, connection, kwargs, cleanup_group)
+                            task_group.start_soon(
+                                resolve_dependency,
+                                dependency,
+                                connection,
+                                kwargs,
+                                cleanup_group,
+                            )
                 except _ExceptionGroup as excgroup:
                     raise excgroup.exceptions[0] from excgroup  # type: ignore[attr-defined]
 

--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -148,7 +148,7 @@ class KwargsModel:
 
         if self.expected_header_params:
             extractors.append(
-                create_connection_value_extractor(
+                create_connection_value_extractor_mv_safe(
                     connection_key="headers",
                     expected_params=self.expected_header_params,
                     kwargs_model=self,

--- a/tests/unit/test_kwargs/test_header_params.py
+++ b/tests/unit/test_kwargs/test_header_params.py
@@ -11,23 +11,57 @@ from litestar.testing import create_test_client
 @pytest.mark.parametrize(
     "t_type,param_dict, param, should_raise",
     [
-        (str, {"special-header": "123"}, Parameter(header="special-header", min_length=1, max_length=3), False),
-        (str, {"special-header": "123"}, Parameter(header="special-header", min_length=1, max_length=2), True),
+        (
+            str,
+            {"special-header": "123"},
+            Parameter(header="special-header", min_length=1, max_length=3),
+            False,
+        ),
+        (
+            str,
+            {"special-header": "123"},
+            Parameter(header="special-header", min_length=1, max_length=2),
+            True,
+        ),
         (str, {}, Parameter(header="special-header", min_length=1, max_length=2), True),
         (
             Optional[str],
             {},
-            Parameter(header="special-header", min_length=1, max_length=2, required=False, default=None),
+            Parameter(
+                header="special-header",
+                min_length=1,
+                max_length=2,
+                required=False,
+                default=None,
+            ),
             False,
         ),
-        (int, {"special-header": "123"}, Parameter(header="special-header", ge=100, le=201), False),
-        (int, {"special-header": "123"}, Parameter(header="special-header", ge=100, le=120), True),
+        (
+            int,
+            {"special-header": "123"},
+            Parameter(header="special-header", ge=100, le=201),
+            False,
+        ),
+        (
+            int,
+            {"special-header": "123"},
+            Parameter(header="special-header", ge=100, le=120),
+            True,
+        ),
         (int, {}, Parameter(header="special-header", ge=100, le=120), True),
-        (Optional[int], {}, Parameter(header="special-header", ge=100, le=120, required=False, default=None), False),
+        (
+            Optional[int],
+            {},
+            Parameter(header="special-header", ge=100, le=120, required=False, default=None),
+            False,
+        ),
     ],
 )
 def test_header_params(
-    t_type: Optional[Union[str, int]], param_dict: dict[str, str], param: ParameterKwarg, should_raise: bool
+    t_type: Optional[Union[str, int]],
+    param_dict: dict[str, str],
+    param: ParameterKwarg,
+    should_raise: bool,
 ) -> None:
     test_path = "/test"
 
@@ -42,6 +76,22 @@ def test_header_params(
             assert response.status_code == HTTP_400_BAD_REQUEST, response.json()
         else:
             assert response.status_code == HTTP_200_OK, response.json()
+
+
+def test_header_param_duplicate() -> None:
+    test_path = "/test"
+    param_dict: dict[str, str] = {"special_header": "123"}
+
+    @get(path=test_path)
+    def test_method(
+        special_header_str: Annotated[str, Parameter(header="special_header")],
+        special_header_int: Annotated[int, Parameter(header="special_header")],
+    ) -> None:
+        pass
+
+    with create_test_client(test_method) as client:
+        response = client.get(test_path, headers=param_dict)
+        assert response.status_code == HTTP_200_OK, response.json()
 
 
 def test_header_param_with_post() -> None:

--- a/tests/unit/test_kwargs/test_query_params.py
+++ b/tests/unit/test_kwargs/test_query_params.py
@@ -151,6 +151,42 @@ def test_query_param_arrays(expected_type: Any, provided_value: Any, default: An
         assert response.status_code == expected_response_code
 
 
+def test_query_param_duplicate_with_some_lists() -> None:
+    test_path = "/test"
+
+    @get(test_path)
+    def test_method(
+        some_string: Annotated[str, Parameter(query="a", required=True)],
+        list_str: Annotated[list[str], Parameter(query="a", required=True)],
+    ) -> None:
+        assert some_string == "bar" or some_string == "foo"
+        assert list_str == ["foo", "bar"]
+        return
+
+    with create_test_client(test_method) as client:
+        params = "a=foo&a=bar"
+        response = client.get(f"{test_path}?{params}")
+        assert response.status_code == 200
+
+
+def test_query_param_duplicate_with_some_lists_defaults() -> None:
+    test_path = "/test"
+
+    @get(test_path)
+    def test_method(
+        some_string: Annotated[str, Parameter(query="a", required=False, default="bar")],
+        list_str: Annotated[Optional[list[str]], Parameter(query="a", required=False, default=None)],
+    ) -> None:
+        assert some_string == "bar" or some_string == "foo"
+        assert list_str == ["foo", "bar"]
+        return
+
+    with create_test_client(test_method) as client:
+        params = "a=foo&a=bar"
+        response = client.get(f"{test_path}?{params}")
+        assert response.status_code == 200
+
+
 def test_query_kwarg() -> None:
     test_path = "/test"
 


### PR DESCRIPTION
## Description

Allow a single query parameter to be aliased to multiple Python parameters, even when one of the Python parameters is a list.

Previously, if a query paramater was remapped to multiple different Python paramenters by using `Parameter(query="alias")` and one of the Python parameters was a list, a validation error was raised.  This was inconsisent with how non-list query parameters worked.

Fixes #4242 
