### PR TITLE
docs: updating docs to reflect correct vscode debugging type

### DIFF
--- a/docs/usage/debugging.rst
+++ b/docs/usage/debugging.rst
@@ -116,7 +116,7 @@ Using uvicorn
 
         {
             "name": "Python: Litestar app",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "uvicorn",
             "justMyCode": true,


### PR DESCRIPTION
## Description

- Fixing the VSCode debug type in the documentation

## Closes
Closes: #4462 