### PR TITLE
feat: Allows Rate Limit Config to be passed in as a list of [DurationUnit, int]

### DIFF
--- a/litestar/middleware/rate_limit.py
+++ b/litestar/middleware/rate_limit.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from time import time
-from typing import TYPE_CHECKING, Any, Callable, Literal, cast, Union, get_args
+from typing import TYPE_CHECKING, Any, Callable, Literal, cast, get_args
 
 from litestar.datastructures import MutableScopeHeaders
 from litestar.enums import ScopeType
@@ -216,7 +216,7 @@ class RateLimitMiddleware(AbstractMiddleware):
 class RateLimitConfig:
     """Configuration for ``RateLimitMiddleware``"""
 
-    rate_limit: Union[tuple[DurationUnit, int], list]
+    rate_limit: tuple[DurationUnit, int] | list
     """A tuple or list containing a time unit (second, minute, hour, day) and quantity, e.g. ("day", 1) or ["minute", 5]."""
     exclude: str | list[str] | None = field(default=None)
     """A pattern or list of patterns to skip in the rate limiting middleware."""

--- a/tests/unit/test_middleware/test_rate_limit_middleware.py
+++ b/tests/unit/test_middleware/test_rate_limit_middleware.py
@@ -307,8 +307,8 @@ def test_custom_identity_function() -> None:
 
 @pytest.mark.parametrize("unit", ["minute", "second", "hour", "day"])
 async def test_bad_rate_limit_input(unit: DurationUnit) -> None:
-    with pytest.raises(TypeError) as exc:
-        config = RateLimitConfig(rate_limit=[2, unit])
+    with pytest.raises(TypeError):
+        RateLimitConfig(rate_limit=[2, unit])
 
 @travel(datetime.now(UTC), tick=False)
 def test_check_throttle_handler_with_list() -> None:


### PR DESCRIPTION
## Description

- Added the ability to pass the rate_limit in as a list.  Checks are performed to ensure that the types are correct, and then the list is cast into the tuple expected by the rest of the code.

Fixes #1262