### PR TITLE
fix: Improve `Accept.best_match` typing

### DIFF
--- a/litestar/datastructures/headers.py
+++ b/litestar/datastructures/headers.py
@@ -10,7 +10,6 @@ from typing import (
     Any,
     ClassVar,
     Optional,
-    TypeVar,
     Union,
     cast,
     overload,
@@ -424,9 +423,6 @@ class MediaTypeHeader:
         )
 
 
-_DefaultT = TypeVar("_DefaultT", bound=Optional[str])
-
-
 class Accept:
     """An ``Accept`` header."""
 
@@ -449,9 +445,9 @@ class Accept:
     def best_match(self, provided_types: list[str], default: None = None) -> Optional[str]: ...
 
     @overload
-    def best_match(self, provided_types: list[str], default: _DefaultT) -> Union[str, _DefaultT]: ...
+    def best_match(self, provided_types: list[str], default: str) -> str: ...
 
-    def best_match(self, provided_types: list[str], default: Optional[_DefaultT] = None) -> Union[str, _DefaultT]:
+    def best_match(self, provided_types: list[str], default: Optional[str] = None) -> Optional[str]:
         """Find the best matching media type for the request.
 
         Args:


### PR DESCRIPTION
It used to be this way: 

```python
.best_match(['application/json'], default='application/json')
# -> reveals `Optional[str]` as the return type
```

However, default is `str` and this is a typing error.
Example: https://mypy-play.net/?mypy=latest&python=3.12&flags=strict&gist=60f387573191d8b6357b6d1a6bf4383d

Now it works as expected when passing `best_match(['application/json'], default='application/json')` and reveals `str` as the return type. Full testing is here: https://mypy-play.net/?mypy=latest&python=3.12&flags=strict&gist=8ae293ccffaaa2649ee0dfd5d6ff9245
