### PR TITLE
fix(openapi): generate requestBody for body parameter

### DIFF
--- a/litestar/_openapi/path_item.py
+++ b/litestar/_openapi/path_item.py
@@ -62,12 +62,17 @@ class PathItemFactory:
         signature_fields = route_handler.parsed_fn_signature.parameters
 
         request_body = None
+        request_body_field = None
         if data_field := signature_fields.get("data"):
             request_body = create_request_body(
                 self.context, route_handler.handler_id, route_handler.data_dto, data_field
             )
+            request_body_field = data_field
+        elif body_field := signature_fields.get("body"):
+            request_body = create_request_body(self.context, route_handler.handler_id, None, body_field)
+            request_body_field = body_field
 
-        raises_validation_error = bool(data_field or self._path_item.parameters or parameters)
+        raises_validation_error = bool(request_body_field or self._path_item.parameters or parameters)
         responses = create_responses_for_handler(
             self.context, route_handler, raises_validation_error=raises_validation_error
         )

--- a/litestar/_openapi/request_body.py
+++ b/litestar/_openapi/request_body.py
@@ -34,7 +34,9 @@ def create_request_body(
     Returns:
         A RequestBody instance.
     """
-    media_type: RequestEncodingType | str = RequestEncodingType.JSON
+    media_type: RequestEncodingType | str = (
+        "application/octet-stream" if data_field.is_subclass_of(bytes) else RequestEncodingType.JSON
+    )
     schema_creator = SchemaCreator.from_openapi_context(context, prefer_alias=True)
     if isinstance(data_field.kwarg_definition, BodyKwarg) and data_field.kwarg_definition.media_type:
         media_type = data_field.kwarg_definition.media_type


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

OpenAPI generation now correctly creates requestBody when using the `body: bytes` parameter. Previously only `data` parameter was checked.

- Check both `data` and `body` fields in `path_item.py`
- Default to `application/octet-stream` for `bytes` type
- Add tests for all body parameter syntaxes

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Fixes #4482
