### PR TITLE
fix(docs): make layered param cookie optional in example

### DIFF
--- a/docs/examples/parameters/layered_parameters.py
+++ b/docs/examples/parameters/layered_parameters.py
@@ -37,6 +37,6 @@ router = Router(
 app = Litestar(
     route_handlers=[router],
     parameters={
-        "app_param": Parameter(str, cookie="special-cookie"),
+        "app_param": Parameter(str, cookie="special-cookie", required=False),
     },
 )


### PR DESCRIPTION
## Description

Modified the [docs/examples/parameters/layered_parameters.py](https://github.com/litestar-org/litestar/blob/main/docs/examples/parameters/layered_parameters.py) example to make the `app_param` cookie parameter optional (`required=False`).
Previously, running this example would result in `400 Bad Request` errors when accessing endpoints (such as the OpenAPI schema) if the `special-cookie` was not present. This change ensures the example is runnable and the documentation remains accurate.

## Closes
Closes #4499