### PR TITLE
fix(pydantic): add support for 'AwareDatetime' serialization

### DIFF
--- a/litestar/plugins/pydantic/dto.py
+++ b/litestar/plugins/pydantic/dto.py
@@ -68,6 +68,7 @@ if pydantic_v2 is not Empty:  # type: ignore[comparison-overlap]  # pragma: no c
             pydantic_v2.IPvAnyAddress: str,
             pydantic_v2.IPvAnyInterface: str,
             pydantic_v2.IPvAnyNetwork: str,
+            pydantic_v2.AwareDatetime: str,
         }
     )
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This PR fixes a bug where `pydantic.AwareDatetime` was not being correctly mapped in `PydanticDTO`.

As `AwareDatetime` is a distinct type in Pydantic v2, it needs to be explicitly mapped to `str` in the `_down_types` dictionary so that the DTO backend handles serialization correctly.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
Fixes #4502 