### PR TITLE
fix(docs): proper delete methods in repository tutorial

### DIFF
--- a/docs/tutorials/repository-tutorial/02-repository-introduction.rst
+++ b/docs/tutorials/repository-tutorial/02-repository-introduction.rst
@@ -38,9 +38,9 @@ the the synchronous and asynchronous repositories.
     +---------------------+----------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
     | ``upsert_many``     | Updating Data  | Updates or inserts multiple records based whether or not the primary key value on the model object is populated.                                                                                                                            |
     +---------------------+----------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | ``remove``          | Removing Data  | Remove a single record from the database.                                                                                                                                                                                                   |
+    | ``delete``          | Removing Data  | Remove a single record from the database.                                                                                                                                                                                                   |
     +---------------------+----------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | ``remove_many``     | Removing Data  | Remove one or more records from the database.                                                                                                                                                                                               |
+    | ``delete_many``     | Removing Data  | Remove one or more records from the database.                                                                                                                                                                                               |
     +---------------------+----------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 .. note::
@@ -115,7 +115,7 @@ Updating Data: The ``update`` method will ensure any updates made to the model o
         :lines: 64-68
         :linenos:
 
-Removing Data: The ``remove`` method accepts the primary key of the row you want to delete:
+Removing Data: The ``delete`` method accepts the primary key of the row you want to delete:
 
     .. literalinclude:: /examples/sqla/sqlalchemy_repository_crud.py
         :language: python


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
- In the repository tutorial, incorrect deletion methods are specified in the text – `remove` instead of `delete`.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
