### PR TITLE
ci: add manual docs things with selective input (#4258)

### DIFF
--- a/docs/_static/versioning.js
+++ b/docs/_static/versioning.js
@@ -1,7 +1,7 @@
+const urlRoot = DOCUMENTATION_OPTIONS.URL_ROOT ?? "";
+
 const loadVersions = async () => {
-  const res = await fetch(
-    DOCUMENTATION_OPTIONS.URL_ROOT + "_static/versions.json",
-  );
+  const res = await fetch(urlRoot + "_static/versions.json");
   if (res.status !== 200) {
     return null;
   }
@@ -32,7 +32,7 @@ const addVersionWarning = (currentVersion, latestVersion) => {
 
   const latestLink = document.createElement("a");
   latestLink.textContent = "Click here to go to the latest version";
-  latestLink.href = DOCUMENTATION_OPTIONS.URL_ROOT + "../latest";
+  latestLink.href = urlRoot + "../latest";
   container.appendChild(latestLink);
 
   header.before(container);
@@ -75,7 +75,7 @@ const addVersionSelect = (currentVersion, versionSpec) => {
 
     const navLink = document.createElement("a");
     navLink.classList.add("nav-link", "nav-internal");
-    navLink.href = DOCUMENTATION_OPTIONS.URL_ROOT + `../${version}`;
+    navLink.href = urlRoot + `../${version}`;
     navLink.textContent = formatVersionName(
       version,
       version === versionSpec.latest,


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- tries to fix no version swpper in prod docs

Open https://docs.litestar.dev/latest/index.html and in console:
```
// current
console.log(DOCUMENTATION_OPTIONS.URL_ROOT);  // undefined
console.log(DOCUMENTATION_OPTIONS.URL_ROOT + "_static/versions.json");  // "undefined_static/versions.json"

// w/ fix
const urlRoot = DOCUMENTATION_OPTIONS.URL_ROOT ?? "";
fetch(urlRoot + "_static/versions.json").then(r => r.json()).then(console.log);
```
<img width="1478" height="112" alt="image" src="https://github.com/user-attachments/assets/6d748371-036f-43d4-8822-fc3ca10f8b08" />
