### PR TITLE
feat: Added exclude_spans option for otel config

### DIFF
--- a/litestar/contrib/opentelemetry/config.py
+++ b/litestar/contrib/opentelemetry/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 from litestar.contrib.opentelemetry._utils import get_route_details_from_scope
 from litestar.contrib.opentelemetry.middleware import (
@@ -77,6 +77,8 @@ class OpenTelemetryConfig:
     OpenTelemetry supports excluding urls by passing an env in the format '{exclude_urls_env_key}_EXCLUDED_URLS'. With
     the default being ``LITESTAR_EXCLUDED_URLS``.
     """
+    exclude_spans: list[Literal["receive", "send"]] | None = None
+    """Optionally exclude HTTP send and/or receive spans from the trace."""
     scopes: Scopes | None = field(default=None)
     """ASGI scopes processed by the middleware, if None both ``http`` and ``websocket`` will be processed."""
     middleware_class: type[OpenTelemetryInstrumentationMiddleware] = field(

--- a/litestar/contrib/opentelemetry/middleware.py
+++ b/litestar/contrib/opentelemetry/middleware.py
@@ -38,6 +38,7 @@ class OpenTelemetryInstrumentationMiddleware(AbstractMiddleware):
             client_response_hook=config.client_response_hook_handler,  # type: ignore[arg-type]
             default_span_details=config.scope_span_details_extractor,
             excluded_urls=get_excluded_urls(config.exclude_urls_env_key),
+            exclude_spans=config.exclude_spans,
             meter=config.meter,
             meter_provider=config.meter_provider,
             server_request_hook=config.server_request_hook_handler,


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Adds a config option to exclude_spans for the Otel middleware
- This allows excluding the send receive spans to improve performance and reduce noise for example in streaming endpoints where every stream event is logged as an ASGI event

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes #4533 
