### PR TITLE
fix(routing): Fix header name when raising `MethodNotAllowedException`

### DIFF
--- a/litestar/_asgi/routing_trie/traversal.py
+++ b/litestar/_asgi/routing_trie/traversal.py
@@ -84,7 +84,7 @@ def parse_node_handlers(
         try:
             return node.asgi_handlers[method]
         except KeyError as e:
-            raise MethodNotAllowedException(headers={"allowed": ", ".join(node.asgi_handlers.keys())}) from e
+            raise MethodNotAllowedException(headers={"allow": ", ".join(node.asgi_handlers.keys())}) from e
     return node.asgi_handlers["websocket"]
 
 

--- a/tests/e2e/test_routing/test_path_resolution.py
+++ b/tests/e2e/test_routing/test_path_resolution.py
@@ -161,7 +161,7 @@ async def test_http_route_raises_for_unsupported_method(anyio_backend: str) -> N
     with create_test_client(route_handlers=[my_get_handler, my_post_handler]) as client:
         response = client.delete("/")
         assert response.status_code == HTTP_405_METHOD_NOT_ALLOWED
-        assert response.headers.get("allowed", "") == "GET, POST, OPTIONS"
+        assert response.headers.get("allow", "") == "GET, POST, OPTIONS"
 
 
 def test_path_order() -> None:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

https://github.com/litestar-org/litestar/pull/4289 used the wrong header name.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Closes https://github.com/litestar-org/litestar/issues/4277 (for good).
