### PR TITLE
fix: fix gettext builder failure in pydata sphinx theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -357,8 +357,12 @@ def delayed_setup(app: Sphinx) -> None:
     When running linkcheck pydata_sphinx_theme causes a build failure, and checking
     the builder in the initial `setup` function call is not possible, so the check
     and extension setup has to be delayed until the builder is initialized.
+
+    When running gettext pydata_sphinx_theme causes a build failure by attempting to
+    write to the _static directory, resulting in a FileNotFoundError for missing files
+    like pygments.css. See: https://github.com/pydata/pydata-sphinx-theme/issues/1840
     """
-    if app.builder.name == "linkcheck":
+    if app.builder.name == "linkcheck" or app.builder.name == "gettext":
         return
 
     app.setup_extension("pydata_sphinx_theme")


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

The pydata_sphinx_theme causes build failures when running gettext by attempting to write to the _static directory before initialization, resulting in FileNotFoundError for missing files like pygments.css.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Closes: #4546