### PR TITLE
ci: update workflow for doc preview

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,4 +1,4 @@
-name: Deploy documentation preview test
+name: Deploy documentation preview
 on:
   workflow_run:
     workflows: [Tests And Linting]


### PR DESCRIPTION
As recommended in the action when using a different repository and actions/checkout.
``
When using actions/checkout, you must also set persist-credentials: false in the checkout step to prevent authentication conflicts.
``