### PR TITLE
docs: add FAQ/recipes section

### DIFF
--- a/docs/topics/faq.rst
+++ b/docs/topics/faq.rst
@@ -1,0 +1,42 @@
+FAQ & Common Recipes
+====================
+
+This section contains answers to frequently asked questions and common recipes
+for solving typical problems.
+
+.. contents:: Table of Contents
+    :local:
+    :depth: 2
+
+How do I see stack traces in error responses?
+---------------------------------------------
+
+By default, Litestar returns minimal error information in production for security
+reasons. To see full stack traces during development:
+
+**Option 1: Enable debug mode**
+
+.. code-block:: python
+
+    from litestar import Litestar
+
+    app = Litestar(
+        route_handlers=[...],
+        debug=True,  # Enables detailed error responses
+    )
+
+When ``debug=True``, exceptions will include full stack traces in the response.
+
+.. warning::
+    Never enable debug mode in production as it can expose sensitive information.
+
+**Option 2: Use the CLI debug flag**
+
+When running your application with the Litestar CLI:
+
+.. code-block:: bash
+
+    litestar run --debug
+
+.. note::
+    This FAQ section is a work in progress. Contributions are welcome!

--- a/docs/topics/index.rst
+++ b/docs/topics/index.rst
@@ -11,5 +11,6 @@ deployment strategies, ASGI and WSGI, and so on.
     :titlesonly:
     :caption: Articles
 
+    faq
     sync-vs-async
     deployment/index


### PR DESCRIPTION
## Summary

Adds a new FAQ & Common Recipes section to the documentation to address common questions from users.

- Creates `docs/topics/faq.rst` with initial FAQ content
- Adds the FAQ to the topics toctree in `docs/topics/index.rst`

## Initial Content

The first FAQ entry addresses a common question: **"How do I see stack traces in error responses?"**

This covers:
- Using `debug=True` in the Litestar app constructor
- Using the `--debug` CLI flag

## Future Expansion

The FAQ section is designed to be expanded over time with additional common questions and recipes. The structure is in place for contributors to easily add more entries.

Fixes #3450