### PR TITLE
fix(openapi): generate parameters for model-typed query/headers/cookies kwargs 

### DIFF
--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -573,7 +573,7 @@ def test_query_model_generates_parameters(query_model: type) -> None:
     params = app.openapi_schema.paths["/"].get.parameters  # type: ignore[index, union-attr]
     assert params is not None
 
-    param_map = {p.name: p for p in params}
+    param_map: dict[str, OpenAPIParameter] = {p.name: p for p in params}  # type: ignore[misc, union-attr]
     assert "name" in param_map
     assert "age" in param_map
     assert "nickname" in param_map
@@ -588,7 +588,7 @@ def test_query_model_generates_parameters(query_model: type) -> None:
 
 def test_query_dict_does_not_generate_parameters() -> None:
     @get("/")
-    async def handler(query: dict) -> None:  # type: ignore[type-arg]
+    async def handler(query: dict) -> None:
         pass
 
     app = Litestar([handler])
@@ -610,7 +610,7 @@ def test_query_model_with_all_optional_fields() -> None:
     params = app.openapi_schema.paths["/"].get.parameters  # type: ignore[index, union-attr]
     assert params is not None
 
-    param_map = {p.name: p for p in params}
+    param_map: dict[str, OpenAPIParameter] = {p.name: p for p in params}  # type: ignore[misc, union-attr]
     assert param_map["name"].required is False
     assert param_map["page"].required is False
 
@@ -629,7 +629,7 @@ def test_query_model_with_all_required_fields() -> None:
     params = app.openapi_schema.paths["/"].get.parameters  # type: ignore[index, union-attr]
     assert params is not None
 
-    param_map = {p.name: p for p in params}
+    param_map: dict[str, OpenAPIParameter] = {p.name: p for p in params}  # type: ignore[misc, union-attr]
     assert param_map["name"].required is True
     assert param_map["age"].required is True
 
@@ -647,7 +647,7 @@ def test_query_model_alongside_regular_params() -> None:
     params = app.openapi_schema.paths["/"].get.parameters  # type: ignore[index, union-attr]
     assert params is not None
 
-    param_map = {p.name: p for p in params}
+    param_map: dict[str, OpenAPIParameter] = {p.name: p for p in params}  # type: ignore[misc, union-attr]
     assert "name" in param_map
     assert param_map["name"].param_in == ParamType.QUERY
     assert "extra_param" in param_map
@@ -668,7 +668,7 @@ def test_headers_model_generates_header_parameters() -> None:
     params = app.openapi_schema.paths["/"].get.parameters  # type: ignore[index, union-attr]
     assert params is not None
 
-    param_map = {p.name: p for p in params}
+    param_map: dict[str, OpenAPIParameter] = {p.name: p for p in params}  # type: ignore[misc, union-attr]
     assert "x_custom" in param_map
     assert param_map["x_custom"].param_in == ParamType.HEADER
     assert param_map["x_custom"].required is True
@@ -691,7 +691,7 @@ def test_cookies_model_generates_cookie_parameters() -> None:
     params = app.openapi_schema.paths["/"].get.parameters  # type: ignore[index, union-attr]
     assert params is not None
 
-    param_map = {p.name: p for p in params}
+    param_map: dict[str, OpenAPIParameter] = {p.name: p for p in params}  # type: ignore[misc, union-attr]
     assert "session_id" in param_map
     assert param_map["session_id"].param_in == ParamType.COOKIE
     assert param_map["session_id"].required is True
@@ -742,7 +742,7 @@ def test_issue_2015_pydantic_model_query_openapi() -> None:
 
     params = schema.paths["/"].get.parameters  # type: ignore[index, union-attr]
     assert params is not None, "Expected query parameters in OpenAPI schema, got None"
-    param_map = {p.name: p for p in params}
+    param_map: dict[str, OpenAPIParameter] = {p.name: p for p in params}  # type: ignore[misc, union-attr]
 
     assert "even" in param_map
     assert "odd" in param_map


### PR DESCRIPTION

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
 
## Summary                                                                                                                             
                                                                                                                                      
- Decompose model-typed query, headers, and cookies reserved kwargs into individual OpenAPI parameters                              
- Supports dataclasses, Pydantic, msgspec Struct, TypedDict, and attrs                                                              
- Backward compatible — non-model types like dict are unaffected                                                                    
                                                                                                                                                                                                                                                                            
## Test plan                                                                                                                           
                                                                                                                                      
- Parametrized tests across all 5 model types                                                                                       
- Backward compat, optional/required fields, headers/cookies support                                                                
- E2E and issue #2015 regression tests  


<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes #2015        
