### PR TITLE
chore(deps): upgrade Swagger default version

### DIFF
--- a/litestar/openapi/plugins.py
+++ b/litestar/openapi/plugins.py
@@ -518,7 +518,7 @@ class SwaggerRenderPlugin(OpenAPIRenderPlugin):
 
     def __init__(
         self,
-        version: str = "5.18.2",
+        version: str = "5.31.0",
         js_url: str | None = None,
         css_url: str | None = None,
         standalone_preset_js_url: str | None = None,


### PR DESCRIPTION
Upgrade Default Swagger JS Bundle to `5.31.0` from `5.18.2` for better compatibility with OAS 3.1

It will as a result load faster, and fewer issues generating the Swagger

