### PR TITLE
fix(jwt): `_normalize_datetime` was not fixing timezone

### DIFF
--- a/litestar/security/jwt/token.py
+++ b/litestar/security/jwt/token.py
@@ -30,7 +30,7 @@ def _normalize_datetime(value: datetime) -> datetime:
         A datetime instance
     """
     if value.tzinfo is not None:
-        value.astimezone(timezone.utc)
+        value = value.astimezone(timezone.utc)
 
     return value.replace(microsecond=0)
 


### PR DESCRIPTION
Example from repl:

```python
>>> import datetime as dt
>>> x = dt.datetime(2026, 2, 5, 12, 8, tzinfo=dt.timezone.min)
>>> x.astimezone(dt.timezone.utc)
datetime.datetime(2026, 2, 6, 12, 7, tzinfo=datetime.timezone.utc)
>>> x
datetime.datetime(2026, 2, 5, 12, 8, tzinfo=datetime.timezone(datetime.timedelta(days=-1, seconds=60)))
```

Notice that `astimezone` returns new value, not mutates the original one.

I've noticed that while porting some litestar goodies to my own project https://github.com/wemake-services/django-modern-rest
