### PR TITLE
docs: update test line references in MessagePack section

### DIFF
--- a/docs/usage/requests.rst
+++ b/docs/usage/requests.rst
@@ -227,7 +227,7 @@ for ``Body``\ , by using :class:`RequestEncodingType.MESSAGEPACK <.enums.Request
 
         .. literalinclude:: ../../tests/examples/test_request_data.py
             :language: python
-            :lines: 136-141
+            :lines: 140-145
 
 Custom Request
 --------------


### PR DESCRIPTION
## Description

Fixed a typo has been corrected in the strings pertaining to request testing with MessagePack.

## Closes
