### PR TITLE
fix(docs): code block in `usage/testing.rst`

### DIFF
--- a/docs/usage/testing.rst
+++ b/docs/usage/testing.rst
@@ -333,6 +333,7 @@ with the regular test client setup:
 By default, the subprocess client will capture all output from the litestar instance. To discard output in the main (testing) process, set the ``capture_output`` argument to ``False`` when creating the client:
 
 .. code-block:: python
+
     @pytest.fixture(name="async_client")
     async def fx_async_client() -> AsyncIterator[httpx.AsyncClient]:
         async with subprocess_async_client(workdir=ROOT, app="subprocess_sse_app:app", capture_output=False) as client:


### PR DESCRIPTION
https://github.com/litestar-org/litestar/pull/4579 is also needed to fix the docs completely.
cc @Kumzy :)