### PR TITLE
fix(logging): emit log without stack trace when exception is in disable_stack_trace

### DIFF
--- a/litestar/logging/config.py
+++ b/litestar/logging/config.py
@@ -120,20 +120,34 @@ def _default_exception_logging_handler_factory(is_struct_logger: bool) -> Except
     if is_struct_logger:
 
         def _default_exception_logging_handler(logger: Logger, scope: Scope, tb: list[str]) -> None:
-            logger.exception(
-                "Uncaught exception",
-                connection_type=scope["type"],
-                path=scope["path"],
-            )
+            if tb:
+                logger.exception(
+                    "Uncaught exception",
+                    connection_type=scope["type"],
+                    path=scope["path"],
+                )
+            else:
+                logger.error(
+                    "Uncaught exception",
+                    connection_type=scope["type"],
+                    path=scope["path"],
+                )
 
     else:
 
         def _default_exception_logging_handler(logger: Logger, scope: Scope, tb: list[str]) -> None:
-            logger.exception(
-                "Uncaught exception (connection_type=%s, path=%r):",
-                scope["type"],
-                scope["path"],
-            )
+            if tb:
+                logger.exception(
+                    "Uncaught exception (connection_type=%s, path=%r):",
+                    scope["type"],
+                    scope["path"],
+                )
+            else:
+                logger.error(
+                    "Uncaught exception (connection_type=%s, path=%r):",
+                    scope["type"],
+                    scope["path"],
+                )
 
     return _default_exception_logging_handler
 

--- a/litestar/middleware/_internal/exceptions/middleware.py
+++ b/litestar/middleware/_internal/exceptions/middleware.py
@@ -222,12 +222,12 @@ class ExceptionHandlerMiddleware:
         exc = exc_info()
         exc_detail: set[Union[Exception, int]] = {exc[0], getattr(exc[0], "status_code", None)}  # type: ignore[arg-type]  # noqa: UP007
 
-        if (
-            (
-                logging_config.log_exceptions == "always"
-                or (logging_config.log_exceptions == "debug" and self._get_debug_scope(scope))
-            )
-            and logging_config.exception_logging_handler
-            and exc_detail.isdisjoint(logging_config.disable_stack_trace)
-        ):
-            logging_config.exception_logging_handler(logger, scope, format_exception(*exc))
+        should_log = (
+            logging_config.log_exceptions == "always"
+            or (logging_config.log_exceptions == "debug" and self._get_debug_scope(scope))
+        ) and logging_config.exception_logging_handler
+
+        if should_log:
+            include_stack_trace = exc_detail.isdisjoint(logging_config.disable_stack_trace)
+            tb = format_exception(*exc) if include_stack_trace else []
+            logging_config.exception_logging_handler(logger, scope, tb)

--- a/litestar/middleware/_internal/exceptions/middleware.py
+++ b/litestar/middleware/_internal/exceptions/middleware.py
@@ -223,12 +223,11 @@ class ExceptionHandlerMiddleware:
         exc_detail: set[Union[Exception, int]] = {exc[0], getattr(exc[0], "status_code", None)}  # type: ignore[arg-type]  # noqa: UP007
 
         handler = logging_config.exception_logging_handler
-        should_log = (
-            logging_config.log_exceptions == "always"
-            or (logging_config.log_exceptions == "debug" and self._get_debug_scope(scope))
-        ) and handler is not None
+        should_log = logging_config.log_exceptions == "always" or (
+            logging_config.log_exceptions == "debug" and self._get_debug_scope(scope)
+        )
 
-        if should_log:
+        if should_log and handler is not None:
             include_stack_trace = exc_detail.isdisjoint(logging_config.disable_stack_trace)
             tb = format_exception(*exc) if include_stack_trace else []
             handler(logger, scope, tb)

--- a/litestar/middleware/_internal/exceptions/middleware.py
+++ b/litestar/middleware/_internal/exceptions/middleware.py
@@ -222,12 +222,13 @@ class ExceptionHandlerMiddleware:
         exc = exc_info()
         exc_detail: set[Union[Exception, int]] = {exc[0], getattr(exc[0], "status_code", None)}  # type: ignore[arg-type]  # noqa: UP007
 
+        handler = logging_config.exception_logging_handler
         should_log = (
             logging_config.log_exceptions == "always"
             or (logging_config.log_exceptions == "debug" and self._get_debug_scope(scope))
-        ) and logging_config.exception_logging_handler
+        ) and handler is not None
 
         if should_log:
             include_stack_trace = exc_detail.isdisjoint(logging_config.disable_stack_trace)
             tb = format_exception(*exc) if include_stack_trace else []
-            logging_config.exception_logging_handler(logger, scope, tb)
+            handler(logger, scope, tb)

--- a/tests/unit/test_logging/test_logging_config.py
+++ b/tests/unit/test_logging/test_logging_config.py
@@ -587,7 +587,7 @@ def test_default_handler_uses_error_when_stack_trace_suppressed() -> None:
     """
     handler = _default_exception_logging_handler_factory(is_struct_logger=False)
     mock_logger = MagicMock()
-    scope: dict = {"type": "http", "path": "/error"}
+    scope: Any = {"type": "http", "path": "/error"}
 
     # With traceback present -> logger.exception
     handler(mock_logger, scope, ["Traceback ..."])

--- a/tests/unit/test_logging/test_logging_config.py
+++ b/tests/unit/test_logging/test_logging_config.py
@@ -576,3 +576,23 @@ def test_disable_stack_trace(
             assert len(tb) > 0, "Stack trace should be present"
         else:
             assert tb == [], "Stack trace should be suppressed but handler should still be called"
+
+
+def test_default_handler_uses_error_when_stack_trace_suppressed() -> None:
+    """The default exception logging handler should call ``logger.error``
+    (not ``logger.exception``) when the stack trace is suppressed via
+    ``disable_stack_trace``.  This exercises the ``else`` branch inside
+    ``_default_exception_logging_handler_factory(is_struct_logger=False)``.
+    """
+    logging_config = LoggingConfig(disable_stack_trace={ValueError})
+
+    @get("/error")
+    async def error_route() -> None:
+        raise ValueError("boom")
+
+    with create_test_client([error_route], logging_config=logging_config, debug=True) as client:
+        logger = client.app.logger
+        with patch.object(logger, "error") as mock_error, patch.object(logger, "exception") as mock_exception:
+            _ = client.get("/error")
+            mock_error.assert_called_once()
+            mock_exception.assert_not_called()

--- a/tests/unit/test_logging/test_logging_config.py
+++ b/tests/unit/test_logging/test_logging_config.py
@@ -535,15 +535,15 @@ def test_excluded_fields(logging_module: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "disable_stack_trace, exception_to_raise, handler_called",
+    "disable_stack_trace, exception_to_raise, expect_tb",
     [
-        # will log the stack trace
+        # will log WITH the stack trace (tb is non-empty)
         [set(), HTTPException, True],
         [set(), ValueError, True],
         [{400}, HTTPException, True],
         [{NameError}, ValueError, True],
         [{400, NameError}, ValueError, True],
-        # will not log the stack trace
+        # will log WITHOUT the stack trace (tb is empty)
         [{NotFoundException}, HTTPException, False],
         [{404}, HTTPException, False],
         [{ValueError}, ValueError, False],
@@ -554,7 +554,7 @@ def test_excluded_fields(logging_module: str) -> None:
 def test_disable_stack_trace(
     disable_stack_trace: set[Union[int, type[Exception]]],
     exception_to_raise: type[Exception],
-    handler_called: bool,
+    expect_tb: bool,
 ) -> None:
     mock_handler = MagicMock()
 
@@ -570,7 +570,9 @@ def test_disable_stack_trace(
         else:
             _ = client.get("/error")
 
-        if handler_called:
-            assert mock_handler.called, "Exception logging handler should have been called"
+        assert mock_handler.called, "Exception logging handler should always be called"
+        tb = mock_handler.call_args[0][2]
+        if expect_tb:
+            assert len(tb) > 0, "Stack trace should be present"
         else:
-            assert not mock_handler.called, "Exception logging handler should not have been called"
+            assert tb == [], "Stack trace should be suppressed but handler should still be called"

--- a/tests/unit/test_logging/test_structlog_config.py
+++ b/tests/unit/test_logging/test_structlog_config.py
@@ -2,7 +2,7 @@
 
 import datetime
 import sys
-from typing import Callable, Union
+from typing import Any, Callable, Union
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -239,7 +239,7 @@ def test_structlog_default_handler_uses_error_when_stack_trace_suppressed() -> N
     """
     handler = _default_exception_logging_handler_factory(is_struct_logger=True)
     mock_logger = MagicMock()
-    scope: dict = {"type": "http", "path": "/error"}
+    scope: Any = {"type": "http", "path": "/error"}
 
     # With traceback present -> logger.exception
     handler(mock_logger, scope, ["Traceback ..."])


### PR DESCRIPTION
## Summary

`disable_stack_trace` suppresses exception logging entirely instead of only suppressing the stack trace. When an exception's status code or class matches an entry in `disable_stack_trace`, the `handle_exception_logging` method short-circuits completely — no log line is emitted at all, not even a one-line error message.

The fix separates the "should we log?" decision from the "should we include the stack trace?" decision:

- The handler is now always invoked when logging is enabled, regardless of `disable_stack_trace`
- When the exception matches `disable_stack_trace`, the handler receives an empty traceback list (`[]`) instead of the formatted exception
- When it doesn't match, the handler receives the full traceback as before

## Changes

- `litestar/middleware/_internal/exceptions/middleware.py` — split the `handle_exception_logging` conditional into a "should log" check and a separate "include stack trace" check; pass `[]` when stack trace is suppressed
- `litestar/logging/config.py` — default exception logging handlers (both standard-lib and structlog) now check `tb`: use `logger.exception()` when traceback is present, `logger.error()` when it is empty
- `tests/unit/test_logging/test_logging_config.py` — updated `test_disable_stack_trace` to assert the handler IS always called, and that `tb` is empty when stack trace is suppressed
- `tests/unit/test_logging/test_structlog_config.py` — same update for `test_structlog_disable_stack_trace`

## Test plan

- All 10 parametrized cases in both test files updated to verify: handler is always called, `tb` is non-empty when stack trace is expected, `tb` is `[]` when stack trace is suppressed
- Custom handlers that inspect the `tb` argument will see `[]` for suppressed exceptions and can decide their own behavior
- Backward compatible: no change in behavior when `disable_stack_trace` is empty (the default)

Fixes #4510
