### PR TITLE
fix: bound methods incorrectly handled in DI leading to spurious warn…

### DIFF
--- a/litestar/di.py
+++ b/litestar/di.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from inspect import isasyncgenfunction, isclass, isfunction, isgeneratorfunction
+from inspect import isasyncgenfunction, isclass, isfunction, isgeneratorfunction, ismethod
 from typing import TYPE_CHECKING, Any
 
 from litestar._signature import SignatureModel
@@ -59,7 +59,8 @@ class Provide:
 
         is_class_dependency = isclass(dependency)
         is_function = isfunction(dependency)
-        is_callable_instance = not is_class_dependency and not is_function
+        is_method = ismethod(dependency)
+        is_callable_instance = not is_class_dependency and not is_function and not is_method
         if is_class_dependency or is_callable_instance:
             check_target = dependency.__call__  # type: ignore[operator]
         else:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- #4459 introduced a regression causing spurious warnings when providing bound methods to di
- This PR has a separate check for methods so we can correctly identify bound asyncgens

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

closes #4596 
