### PR TITLE
fix(sse): remove redundant cast of  `ServerSentEventMessage.comment` to string

### DIFF
--- a/litestar/response/sse.py
+++ b/litestar/response/sse.py
@@ -103,7 +103,7 @@ class ServerSentEventMessage:
     def encode(self) -> bytes:
         buffer = StringIO()
         if self.comment is not None:
-            for chunk in _LINE_BREAK_RE.split(str(self.comment)):
+            for chunk in _LINE_BREAK_RE.split(self.comment):
                 buffer.write(f": {chunk}")
                 buffer.write(self.sep)
 


### PR DESCRIPTION
It is already `str` or `None`, we check for `None` just above.