### PR TITLE
fix(openapi): fix specifications for responses without content

### DIFF
--- a/litestar/_openapi/responses.py
+++ b/litestar/_openapi/responses.py
@@ -27,7 +27,6 @@ from litestar.response import (
     Response as LitestarResponse,
 )
 from litestar.response.base import ASGIResponse
-from litestar.types.builtin_types import NoneType
 from litestar.typing import FieldDefinition
 from litestar.utils import get_enum_string_value, get_name
 
@@ -120,12 +119,12 @@ class ResponseFactory:
 
     def create_success_response(self) -> OpenAPIResponse:
         """Create the schema for a success response."""
-        if self.field_definition.is_subclass_of((NoneType, ASGIResponse)):
-            response = OpenAPIResponse(content=None, description=self.create_description())
-        elif self.field_definition.is_subclass_of(Redirect):
+        if self.field_definition.is_subclass_of(Redirect):
             response = self.create_redirect_response()
         elif self.field_definition.is_subclass_of(File):
             response = self.create_file_response()
+        elif self.field_definition.is_subclass_of(ASGIResponse) or not self.route_handler.returns_content:
+            response = self.create_empty_response()
         else:
             media_type = self.route_handler.media_type
 
@@ -162,6 +161,13 @@ class ResponseFactory:
             )
         self.set_success_response_headers(response)
         return response
+
+    def create_empty_response(self) -> OpenAPIResponse:
+        """Create the schema for a response with no content."""
+        return OpenAPIResponse(
+            content=None,
+            description=self.create_description(),
+        )
 
     def create_redirect_response(self) -> OpenAPIResponse:
         """Create the schema for a redirect response."""

--- a/tests/unit/test_openapi/test_config.py
+++ b/tests/unit/test_openapi/test_config.py
@@ -55,24 +55,15 @@ def test_allows_customization_of_operation_id_creator() -> None:
         openapi_config=OpenAPIConfig(title="my title", version="1.0.0", operation_id_creator=operation_id_creator),
     )
 
-    assert app.openapi_schema.to_schema()["paths"] == {
-        "/1": {
-            "get": {
-                "deprecated": False,
-                "operationId": "id_x",
-                "responses": {"200": {"description": "Request fulfilled, document follows", "headers": {}}},
-                "summary": "Handler1",
-            }
-        },
-        "/2": {
-            "get": {
-                "deprecated": False,
-                "operationId": "id_y",
-                "responses": {"200": {"description": "Request fulfilled, document follows", "headers": {}}},
-                "summary": "Handler2",
-            }
-        },
-    }
+    assert app.openapi_schema.paths is not None
+
+    assert "/1" in app.openapi_schema.paths
+    assert app.openapi_schema.paths["/1"].get is not None
+    assert app.openapi_schema.paths["/1"].get.operation_id == "id_x"
+
+    assert "/2" in app.openapi_schema.paths
+    assert app.openapi_schema.paths["/2"].get is not None
+    assert app.openapi_schema.paths["/2"].get.operation_id == "id_y"
 
 
 def test_raises_exception_when_no_config_in_place() -> None:


### PR DESCRIPTION
## Description

OpenAPI response specifications for responses without content were different from the actual behaviour in some cases.

This change aligns OpenAPI response specifications with the actual behaviour to not include any content when:
- status code is below `200`
- status code is `204`
- status code is `304`
- method is `HEAD`

## Closes

Closes #4598