### PR TITLE
fix(tests): temporarily explicitly skip failing logging tests

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -11,7 +11,6 @@ from contextlib import AbstractAsyncContextManager, AbstractContextManager, cont
 from pathlib import Path
 from typing import Any, TypeVar, cast, overload
 
-import pytest
 from _pytest.logging import LogCaptureHandler, _LiveLoggingNullHandler
 
 from litestar._openapi.schema_generation import SchemaCreator
@@ -83,11 +82,15 @@ def cleanup_logging_impl() -> Generator:
         # Don't interfere with PyTest handler config
         if not isinstance(std_handler, (_LiveLoggingNullHandler, LogCaptureHandler)):
             std_root_logger.removeHandler(std_handler)
-    picologging = pytest.importorskip("picologging")
-    # Reset root logger (`picologging` module)
-    pico_root_logger: picologging.Logger = picologging.getLogger()  # type: ignore[name-defined,unused-ignore] # pyright: ignore[reportPrivateUsage,reportGeneralTypeIssues,reportAssignmentType,reportInvalidTypeForm]
-    for pico_handler in pico_root_logger.handlers:
-        pico_root_logger.removeHandler(pico_handler)
+    try:
+        import picologging
+
+        # Reset root logger (`picologging` module)
+        pico_root_logger: picologging.Logger = picologging.getLogger()  # type: ignore[name-defined,unused-ignore] # pyright: ignore[reportPrivateUsage,reportGeneralTypeIssues,reportAssignmentType,reportInvalidTypeForm]
+        for pico_handler in pico_root_logger.handlers:
+            pico_root_logger.removeHandler(pico_handler)
+    except ImportError:
+        pass
 
     yield
 

--- a/tests/unit/test_middleware/test_exception_handler_middleware.py
+++ b/tests/unit/test_middleware/test_exception_handler_middleware.py
@@ -1,3 +1,4 @@
+import sys
 from collections.abc import Generator
 from inspect import getinnerframes
 from typing import TYPE_CHECKING, Any, Callable, Optional
@@ -221,6 +222,7 @@ def test_exception_handler_middleware_calls_app_level_after_exception_hook() -> 
         (False, None, False),
     ],
 )
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason="Broken. Skip because of pending removal in v3")
 def test_exception_handler_default_logging(
     get_logger: "GetLogger",
     caplog: "LogCaptureFixture",
@@ -342,6 +344,7 @@ def test_pdb_on_exception(mocker: MockerFixture) -> None:
     mock_post_mortem.assert_called_once()
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason="Broken. Skip because of pending removal in v3")
 def test_get_debug_from_scope(get_logger: "GetLogger", caplog: "LogCaptureFixture") -> None:
     @get("/test")
     def handler() -> None:

--- a/tests/unit/test_middleware/test_logging_middleware.py
+++ b/tests/unit/test_middleware/test_logging_middleware.py
@@ -1,3 +1,4 @@
+import sys
 from collections.abc import Generator
 from logging import INFO
 from typing import TYPE_CHECKING, Annotated, Any
@@ -58,6 +59,7 @@ def test_logging_middleware_config_validation() -> None:
         LoggingMiddlewareConfig(request_log_fields=None)  # type: ignore[arg-type]
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason="Broken. Skip because of pending removal in v3")
 def test_logging_middleware_regular_logger(
     get_logger: "GetLogger", caplog: "LogCaptureFixture", handler: HTTPRouteHandler
 ) -> None:
@@ -125,6 +127,7 @@ def test_logging_middleware_struct_logger(handler: HTTPRouteHandler) -> None:
         }
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason="Broken. Skip because of pending removal in v3")
 def test_logging_middleware_exclude_pattern(
     get_logger: "GetLogger", caplog: "LogCaptureFixture", handler: HTTPRouteHandler
 ) -> None:
@@ -150,6 +153,7 @@ def test_logging_middleware_exclude_pattern(
         assert len(caplog.messages) == 2
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason="Broken. Skip because of pending removal in v3")
 def test_logging_middleware_exclude_opt_key(
     get_logger: "GetLogger", caplog: "LogCaptureFixture", handler: HTTPRouteHandler
 ) -> None:
@@ -176,6 +180,7 @@ def test_logging_middleware_exclude_opt_key(
 
 
 @pytest.mark.parametrize("include", [True, False])
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason="Broken. Skip because of pending removal in v3")
 def test_logging_middleware_compressed_response_body(
     get_logger: "GetLogger", include: bool, caplog: "LogCaptureFixture", handler: HTTPRouteHandler
 ) -> None:
@@ -232,6 +237,7 @@ async def test_logging_middleware_post_binary_file_without_structlog(monkeypatch
 
 
 @pytest.mark.parametrize("logger_name", ("litestar", "other"))
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason="Broken. Skip because of pending removal in v3")
 def test_logging_messages_are_not_doubled(
     get_logger: "GetLogger", logger_name: str, caplog: "LogCaptureFixture"
 ) -> None:
@@ -257,6 +263,7 @@ def test_logging_messages_are_not_doubled(
         assert len(caplog.messages) == 2
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason="Broken. Skip because of pending removal in v3")
 def test_logging_middleware_log_fields(
     get_logger: "GetLogger", caplog: "LogCaptureFixture", handler: HTTPRouteHandler
 ) -> None:


### PR DESCRIPTION
I noticed that there are some logging tests which fail under Python >= 3.13, but were skipped implicitly through a misconfigured helper function. This PR makes those skips explicit.

The failing tests are due to the test setup, not a broken feature. I'm skipping them for now, as both tests and feature will be removed/majorly changed in #4610 and #4593.