### PR TITLE
fix(dto): codegen backend crashes on optional nested fields

### DIFF
--- a/litestar/dto/_codegen_backend.py
+++ b/litestar/dto/_codegen_backend.py
@@ -563,8 +563,7 @@ class TransferFunctionFactory:
 
         self._add_stmt(f"{assignment_target} = {source_value_name}")
 
-    # complexity is 13 due to the nested union fallthrough fix (#4504)
-    def _create_transfer_nested_union_type_data(  # noqa: C901
+    def _create_transfer_nested_union_type_data(
         self,
         transfer_type: UnionType,
         source_value_name: str,
@@ -643,8 +642,6 @@ class TransferFunctionFactory:
         # For unions like Optional[NestedModel], generate isinstance checks for
         # nested types so their fields get transferred.
         # Everything else (e.g. None) falls through to the else branch unchanged.
-        # Note: this method is only called when transfer_type.has_nested is True,
-        # so at least one inner type will have nested_field_info.
         conditional = "if"
         for inner_type in simple_types:
             if inner_type.nested_field_info:

--- a/tests/unit/test_dto/test_factory/test_backends/test_backends.py
+++ b/tests/unit/test_dto/test_factory/test_backends/test_backends.py
@@ -49,7 +49,6 @@ class OptionalNestedOuter:
     inner: Optional[OptionalNestedInner] = None
 
 
-
 @dataclass
 class DC:
     a: int
@@ -353,7 +352,6 @@ def test_backend_encode_optional_nested_none(backend_cls: type[DTOBackend]) -> N
     result = to_builtins(data)
     assert result["name"] == "test"
     assert result["inner"] is None
-
 
 
 def test_transfer_only_touches_included_attributes(backend_cls: type[DTOBackend]) -> None:


### PR DESCRIPTION
## Description

The codegen backend was only handling the first nested type in a union and returning early. So for something like `Optional[NestedModel]`, the `None` case never got generated, which led to a `TypeError` at runtime.

Fixed this by generating `isinstance` checks for all nested types and adding a final `else` fallthrough for everything else (matching the behavior of the non-codegen backend).

## Closes

Fixes #4504 
Fixes #3785 

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: https://litestar-org.github.io/litestar-docs-preview/4616
