### PR TITLE
fix(ci): update docs preview to edit PR description instead of comment

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -63,7 +63,7 @@ jobs:
             const issue_number = parseInt(process.env.PR_NUMBER, 10)
             const previewUrl = "https://litestar-org.github.io/litestar-docs-preview/" + issue_number
             const marker = "<!-- docs-preview -->"
-            const section = marker + "\n\n----\n📚 Documentation preview 📚: " + previewUrl + "\n"
+            const section = marker + "\n\n<hr>\n📚 Documentation preview 📚: " + previewUrl + "\n"
 
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,


### PR DESCRIPTION
## Description

Update the docs preview workflow to append the preview link directly into the PR description (first message) instead of posting a separate comment. This makes the preview link easier to find, as requested in #3304.

The implementation:
- Uses an HTML marker comment (`<!-- docs-preview -->`) for idempotent updates
- On first run, appends a `📚 Documentation preview 📚` section to the PR body
- On subsequent runs, updates the existing section in place
- Follows the same pattern used by `readthedocs/actions/preview`

## Closes

Closes #3304