### PR TITLE
chore(docs): add blacken-docs with 80 char line length for code blocks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,12 @@ repos:
     rev: "v1.0.0"
     hooks:
       - id: sphinx-lint
+  - repo: https://github.com/adamchainz/blacken-docs
+    rev: "1.19.1"
+    hooks:
+      - id: blacken-docs
+        args: ["--line-length=80"]
+        types_or: [rst, markdown]
   - repo: local
     hooks:
       - id: pypi-readme

--- a/README.md
+++ b/README.md
@@ -71,10 +71,12 @@ pip install 'litestar[standard]'
 ```python title="app.py"
 from litestar import Litestar, get
 
+
 @get("/")
 async def hello_world() -> dict[str, str]:
     """Keeping the tradition alive with hello world."""
     return {"hello": "world"}
+
 
 app = Litestar(route_handlers=[hello_world])
 ```
@@ -285,7 +287,9 @@ from litestar.handlers.base import BaseRouteHandler
 from litestar.exceptions import NotAuthorizedException
 
 
-async def is_authorized(connection: ASGIConnection, handler: BaseRouteHandler) -> None:
+async def is_authorized(
+    connection: ASGIConnection, handler: BaseRouteHandler
+) -> None:
     # validate authorization
     # if not authorized, raise NotAuthorizedException
     raise NotAuthorizedException()

--- a/docs/PYPI_README.md
+++ b/docs/PYPI_README.md
@@ -68,10 +68,12 @@ pip install 'litestar[standard]'
 ```python title="app.py"
 from litestar import Litestar, get
 
+
 @get("/")
 async def hello_world() -> dict[str, str]:
     """Keeping the tradition alive with hello world."""
     return {"hello": "world"}
+
 
 app = Litestar(route_handlers=[hello_world])
 ```
@@ -282,7 +284,9 @@ from litestar.handlers.base import BaseRouteHandler
 from litestar.exceptions import NotAuthorizedException
 
 
-async def is_authorized(connection: ASGIConnection, handler: BaseRouteHandler) -> None:
+async def is_authorized(
+    connection: ASGIConnection, handler: BaseRouteHandler
+) -> None:
     # validate authorization
     # if not authorized, raise NotAuthorizedException
     raise NotAuthorizedException()

--- a/docs/migration/fastapi.rst
+++ b/docs/migration/fastapi.rst
@@ -17,7 +17,6 @@ controller methods. The handler can then be registered on an application or rout
 
             from fastapi import FastAPI
 
-
             app = FastAPI()
 
 
@@ -188,9 +187,7 @@ Litestar uses the same async context manager style as FastAPI, so the code does 
         .. code-block:: python
 
             @asynccontextmanager
-            async def lifespan(
-                app: FastAPI
-            ):
+            async def lifespan(app: FastAPI):
                 # Setup code here
                 yield
                 # Teardown code here
@@ -201,9 +198,7 @@ Litestar uses the same async context manager style as FastAPI, so the code does 
         .. code-block:: python
 
             @asynccontextmanager
-            async def lifespan(
-                app: Litestar
-            ):
+            async def lifespan(app: Litestar):
                 # Setup code here
                 yield
                 # Teardown code here
@@ -232,8 +227,7 @@ While with FastAPI you usually set cookies on the response ``Response`` object, 
         .. code-block:: python
 
             @get(response_cookies={"my-cookie": "cookie-value"})
-            async def handler() -> str:
-                ...
+            async def handler() -> str: ...
 
 
 Dependencies parameters
@@ -250,6 +244,7 @@ You can get the state either with the state kwarg in the handler or ``request.st
 
             from fastapi import Request
 
+
             async def get_arqredis(request: Request) -> ArqRedis:
                 return request.state.arqredis
 
@@ -259,6 +254,7 @@ You can get the state either with the state kwarg in the handler or ``request.st
         .. code-block:: python
 
             from litestar import State
+
 
             async def get_arqredis(state: State) -> ArqRedis:
                 return state.arqredis
@@ -279,6 +275,7 @@ In FastAPI, you pass the JSON object directly as a parameter to the endpoint, wh
             class ObjectType(BaseModel):
                 name: str
 
+
             @app.post("/items/")
             async def create_item(object_name: ObjectType) -> dict[str, str]:
                 return {"name": object_name.name}
@@ -291,8 +288,10 @@ In FastAPI, you pass the JSON object directly as a parameter to the endpoint, wh
             from litestar import Litestar, post
             from pydantic import BaseModel
 
+
             class ObjectType(BaseModel):
                 name: str
+
 
             @post("/items/")
             async def create_item(data: ObjectType) -> dict[str, str]:
@@ -330,9 +329,7 @@ Also FastAPI let you pass a dictionary while in Litestar you need to explicitly 
 
             @get("/uploads")
             async def get_uploads(app_settings) -> Template:
-                return Template(
-                    name="uploads.html", context={"debug": app_settings.debug}
-                )
+                return Template(name="uploads.html", context={"debug": app_settings.debug})
 
 Uploads
 ~~~~~~~
@@ -357,8 +354,13 @@ While this is more verbose, it's also more explicit and communicates the intent 
         .. code-block:: python
 
             @post("/upload/")
-            async def upload_file(data: Annotated[list[UploadFile], Body(media_type=RequestEncodingType.MULTI_PART)]) -> dict[str, str]:
+            async def upload_file(
+                data: Annotated[
+                    list[UploadFile], Body(media_type=RequestEncodingType.MULTI_PART)
+                ],
+            ) -> dict[str, str]:
                 return {"file_names": [file.filename for file in data]}
+
 
             app = Litestar([upload_file])
 
@@ -380,6 +382,7 @@ If migrating you just change your HTTPException import this will break.
 
             app = FastAPI()
 
+
             @app.get("/")
             async def index() -> None:
                 response_fields = {"array": "value"}
@@ -395,12 +398,15 @@ If migrating you just change your HTTPException import this will break.
             from litestar import Litestar, get
             from litestar.exceptions import HTTPException
 
+
             @get("/")
             async def index() -> None:
                 response_fields = {"array": "value"}
                 raise HTTPException(
-                    status_code=400, detail=f"can't get that field: {response_fields.get('array')}"
+                    status_code=400,
+                    detail=f"can't get that field: {response_fields.get('array')}",
                 )
+
 
             app = Litestar([index])
 

--- a/docs/migration/flask.rst
+++ b/docs/migration/flask.rst
@@ -32,7 +32,6 @@ Routing
 
             from flask import Flask
 
-
             app = Flask(__name__)
 
 
@@ -77,7 +76,6 @@ Path parameters
         .. code-block:: python
 
             from flask import Flask
-
 
             app = Flask(__name__)
 
@@ -146,7 +144,6 @@ the request can be accessed through an optional parameter in the handler functio
         .. code-block:: python
 
             from flask import Flask, request
-
 
             app = Flask(__name__)
 
@@ -275,12 +272,14 @@ in Litestar.
 
 .. code-block:: python
 
-   from litestar import Litestar
-   from litestar.static_files import create_static_files_router
+    from litestar import Litestar
+    from litestar.static_files import create_static_files_router
 
-    app = Litestar(route_handlers=[
-        create_static_files_router(path="/static", directories=["assets"]),
-    ])
+    app = Litestar(
+        route_handlers=[
+            create_static_files_router(path="/static", directories=["assets"]),
+        ]
+    )
 
 ..  seealso::
 
@@ -303,7 +302,6 @@ In addition to Jinja, Litestar supports `Mako <https://www.makotemplates.org/>`_
         .. code-block:: python
 
             from flask import Flask, render_template
-
 
             app = Flask(__name__)
 
@@ -332,7 +330,9 @@ In addition to Jinja, Litestar supports `Mako <https://www.makotemplates.org/>`_
 
             app = Litestar(
                 [hello],
-                template_config=TemplateConfig(directory="templates", engine=JinjaTemplateEngine),
+                template_config=TemplateConfig(
+                    directory="templates", engine=JinjaTemplateEngine
+                ),
             )
 
 
@@ -352,7 +352,6 @@ Setting cookies and headers
         .. code-block:: python
 
             from flask import Flask, make_response
-
 
             app = Flask(__name__)
 
@@ -416,7 +415,6 @@ For redirects, instead of ``redirect`` use ``Redirect``:
 
             from flask import Flask, redirect, url_for
 
-
             app = Flask(__name__)
 
 
@@ -467,7 +465,6 @@ Instead of using the ``abort`` function, raise an ``HTTPException``:
 
             from flask import Flask, abort
 
-
             app = Flask(__name__)
 
 
@@ -510,7 +507,6 @@ Setting status codes
         .. code-block:: python
 
             from flask import Flask
-
 
             app = Flask(__name__)
 
@@ -557,7 +553,6 @@ the data returned is intended to be serialized into JSON and will do so unless t
         .. code-block:: python
 
             from flask import Flask, Response
-
 
             app = Flask(__name__)
 
@@ -616,7 +611,6 @@ Error handling
 
             from flask import Flask
             from werkzeug.exceptions import HTTPException
-
 
             app = Flask(__name__)
 

--- a/docs/release-notes/2.x-changelog.rst
+++ b/docs/release-notes/2.x-changelog.rst
@@ -276,8 +276,10 @@
             from litestar import post, Litestar
             from litestar.dto import MsgspecDTO
 
+
             class Request(msgspec.Struct):
                 foo: Annotated[str, msgspec.Meta(min_length=3)]
+
 
             @post("/example/", dto=MsgspecDTO[Request])
             async def example(data: Request) -> Request:
@@ -449,7 +451,9 @@
         .. code-block:: python
 
             app = Litestar(
-                static_files_config=[StaticFilesConfig(path="/static", directories=["some_dir"])]
+                static_files_config=[
+                    StaticFilesConfig(path="/static", directories=["some_dir"])
+                ]
             )
 
 
@@ -724,7 +728,9 @@
 
             @post(path="/")
             async def upload_files_object(
-                data: Annotated[FileUpload, Body(media_type=RequestEncodingType.MULTI_PART)]
+                data: Annotated[
+                    FileUpload, Body(media_type=RequestEncodingType.MULTI_PART)
+                ],
             ) -> list[str]:
                 pass
 
@@ -1190,7 +1196,9 @@
                 bars: list[Bar]
 
 
-            FooDTO = DataclassDTO[Annotated[Foo, DTOConfig(rename_fields={"bars.0.id": "bar_id"})]]
+            FooDTO = DataclassDTO[
+                Annotated[Foo, DTOConfig(rename_fields={"bars.0.id": "bar_id"})]
+            ]
 
 
 .. changelog:: 2.3.2
@@ -1777,7 +1785,9 @@
         .. code-block:: python
 
             locations, total_count = await model_service.list_and_count(
-                statement=select(Model).where(ST_DWithin(UniqueLocation.location, geog, 1000)),
+                statement=select(Model).where(
+                    ST_DWithin(UniqueLocation.location, geog, 1000)
+                ),
                 account_id=str(account_id),
             )
 

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -339,6 +339,7 @@
 
           from typing import ReadOnly, TypedDict
 
+
           class User(TypedDict):
               id: ReadOnly[int]
 

--- a/docs/release-notes/whats-new-3.rst
+++ b/docs/release-notes/whats-new-3.rst
@@ -49,8 +49,7 @@ handler for the ``param`` parameter:
 .. code-block:: python
 
     @get("/")
-    def my_handler(param: int | None) -> ...:
-        ...
+    def my_handler(param: int | None) -> ...: ...
 
 This legacy behavior originates from our history of using Pydantic v1 models to represent handler signatures. In v3, we
 no longer make this implicit conversion. If you want to have a default value of ``None`` for an optional parameter, you
@@ -59,8 +58,7 @@ must explicitly set it:
 .. code-block:: python
 
     @get("/")
-    def my_handler(param: int | None = None) -> ...:
-        ...
+    def my_handler(param: int | None = None) -> ...: ...
 
 
 OpenAPI Controller Replaced by Plugins
@@ -140,6 +138,7 @@ If you were relying on this utility, you can define it yourself as follows:
 
     from inspect import isasyncgenfunction, isgeneratorfunction
 
+
     def is_sync_or_async_generator(obj: Any) -> bool:
         return isgeneratorfunction(obj) or isasyncgenfunction(obj)
 
@@ -160,24 +159,21 @@ Before:
 
 .. code-block:: python
 
-    class my_get_handler(get):
-        ... # custom handler
+    class my_get_handler(get): ...  # custom handler
+
 
     @my_get_handler()
-    async def handler() -> Any:
-        ...
+    async def handler() -> Any: ...
 
 After:
 
 .. code-block:: python
 
-    class MyHTTPRouteHandler(HTTPRouteHandler):
-        ... # custom handler
+    class MyHTTPRouteHandler(HTTPRouteHandler): ...  # custom handler
 
 
     @get(handler_class=MyHTTPRouteHandler)
-    async def handler() -> Any:
-        ...
+    async def handler() -> Any: ...
 
 
 Deprecated ``app`` parameter for ``Response.to_asgi_response`` has been removed
@@ -256,8 +252,7 @@ callable as its only argument and returns another ASGI callable:
 
 .. code-block:: python
 
-    def middleware(app: ASGIApp) -> ASGIApp:
-        ...
+    def middleware(app: ASGIApp) -> ASGIApp: ...
 
 
 .. seealso::

--- a/docs/usage/cli.rst
+++ b/docs/usage/cli.rst
@@ -96,11 +96,11 @@ entries should point to a :class:`click.Command` or :class:`click.Group`:
             from setuptools import setup
 
             setup(
-               name="my-litestar-plugin",
-               ...,
-               entry_points={
-                   "litestar.commands": ["my_command=my_litestar_plugin.cli:main"],
-               },
+                name="my-litestar-plugin",
+                ...,
+                entry_points={
+                    "litestar.commands": ["my_command=my_litestar_plugin.cli:main"],
+                },
             )
 
     .. tab-item:: pdm
@@ -200,6 +200,7 @@ This makes them suitable for tasks that should happen exactly once, like initial
                 yield
             finally:
                 print("i_run_after_shutdown_plugin")  # noqa: T201
+
 
     def create_app() -> Litestar:
         return Litestar(route_handlers=[], plugins=[StartupPrintPlugin()])

--- a/docs/usage/debugging.rst
+++ b/docs/usage/debugging.rst
@@ -139,5 +139,4 @@ The default value is `pdb <https://docs.python.org/3/library/pdb.html>`_.
 
         import ipdb
 
-
         app = Litestar(pdb_on_exception=True, debugger_module=ipdb)

--- a/docs/usage/dependency-injection.rst
+++ b/docs/usage/dependency-injection.rst
@@ -47,7 +47,8 @@ the application:
 
    # on the app
    app = Litestar(
-       route_handlers=[my_router], dependencies={"app_dependency": Provide(bool_fn)}
+       route_handlers=[my_router],
+       dependencies={"app_dependency": Provide(bool_fn)},
    )
 
 The above example illustrates how dependencies are declared on the different layers of the application.

--- a/docs/usage/htmx.rst
+++ b/docs/usage/htmx.rst
@@ -62,7 +62,9 @@ HTMX client.  You can configure this globally by using the ``HTMXPlugin`` or by 
         if request.htmx:  # if request has "HX-Request" header, then
             print(request.htmx)  # HTMXDetails instance
             print(request.htmx.current_url)
-        return HTMXTemplate(template_name="partial.html", context=context, push_url="/form")
+        return HTMXTemplate(
+            template_name="partial.html", context=context, push_url="/form"
+        )
 
 
     app = Litestar(
@@ -108,7 +110,9 @@ an :class:`~litestar.plugins.htmx.HTMXTemplate` response:
             re_swap="outerHTML",  # change swapping method
             re_target="#new-target",  # change target element
             trigger_event="showMessage",  # trigger event name
-            params={"alert": "Confirm your Choice."},  # parameter to pass to the event
+            params={
+                "alert": "Confirm your Choice."
+            },  # parameter to pass to the event
             after="receive",  #  when to trigger event,
             # possible values 'receive', 'settle', and 'swap'
         )

--- a/docs/usage/metrics/open-telemetry.rst
+++ b/docs/usage/metrics/open-telemetry.rst
@@ -22,7 +22,10 @@ the Litestar constructor:
 .. code-block:: python
 
    from litestar import Litestar
-   from litestar.contrib.opentelemetry import OpenTelemetryConfig, OpenTelemetryPlugin
+   from litestar.contrib.opentelemetry import (
+       OpenTelemetryConfig,
+       OpenTelemetryPlugin,
+   )
 
    open_telemetry_config = OpenTelemetryConfig()
 

--- a/docs/usage/middleware/builtin-middleware.rst
+++ b/docs/usage/middleware/builtin-middleware.rst
@@ -58,10 +58,12 @@ To enable CSRF protection in a Litestar application simply pass an instance of
         # GET is one of the safe methods
         return "some_resource"
 
+
     @post("{id:int}")
     async def create_resource(id: int) -> bool:
         # POST is one of the unsafe methods
         return True
+
 
     csrf_config = CSRFConfig(secret="my-secret")
 
@@ -72,7 +74,11 @@ The following snippet demonstrates how to change the cookie name to ``"some-cook
 
 .. code-block:: python
 
-    csrf_config = CSRFConfig(secret="my-secret", cookie_name='some-cookie-name', header_name='some-header-name')
+    csrf_config = CSRFConfig(
+        secret="my-secret",
+        cookie_name="some-cookie-name",
+        header_name="some-header-name",
+    )
 
 
 A CSRF protected route can be accessed by any client that can make a request with either the header or form-data key.
@@ -90,7 +96,6 @@ The following is an example using `httpx.Client <https://www.python-httpx.org/ap
 
     import httpx
 
-
     with httpx.Client() as client:
         get_response = client.get("http://localhost:8000/")
 
@@ -98,18 +103,27 @@ The following is an example using `httpx.Client <https://www.python-httpx.org/ap
         csrf = get_response.cookies["csrftoken"]
 
         # "x-csrftoken" is the default header name
-        post_response_using_header = client.post("http://localhost:8000/1", headers={"x-csrftoken": csrf})
+        post_response_using_header = client.post(
+            "http://localhost:8000/1", headers={"x-csrftoken": csrf}
+        )
         assert post_response_using_header.status_code == 201
 
         # "_csrf_token" is the default *non* configurable form-data key
-        post_response_using_form_data = client.post("http://localhost:8000/1", data={"_csrf_token": csrf})
+        post_response_using_form_data = client.post(
+            "http://localhost:8000/1", data={"_csrf_token": csrf}
+        )
         assert post_response_using_form_data.status_code == 201
 
         # despite the header being passed, this request will fail as it does not have a cookie in its session
         # note the usage of ``httpx.post`` instead of ``client.post``
-        post_response_with_no_persisted_cookie = httpx.post("http://localhost:8000/1", headers={"x-csrftoken": csrf})
+        post_response_with_no_persisted_cookie = httpx.post(
+            "http://localhost:8000/1", headers={"x-csrftoken": csrf}
+        )
         assert post_response_with_no_persisted_cookie.status_code == 403
-        assert "CSRF token verification failed" in post_response_with_no_persisted_cookie.text
+        assert (
+            "CSRF token verification failed"
+            in post_response_with_no_persisted_cookie.text
+        )
 
 Routes can be marked as being exempt from the protection offered by this middleware via
 :ref:`handler opts <handler_opts>`
@@ -226,7 +240,9 @@ You can configure the following additional brotli-specific values:
 
    app = Litestar(
        route_handlers=[...],
-       compression_config=CompressionConfig(backend="brotli", brotli_gzip_fallback=True),
+       compression_config=CompressionConfig(
+           backend="brotli", brotli_gzip_fallback=True
+       ),
    )
 
 Zstd
@@ -250,7 +266,9 @@ You can configure the following additional zstd-specific values:
 
    app = Litestar(
        route_handlers=[...],
-       compression_config=CompressionConfig(backend="zstd", zstd_gzip_fallback=True),
+       compression_config=CompressionConfig(
+           backend="zstd", zstd_gzip_fallback=True
+       ),
    )
 
 Rate-Limit Middleware

--- a/docs/usage/middleware/creating-middleware.rst
+++ b/docs/usage/middleware/creating-middleware.rst
@@ -114,21 +114,12 @@ be the *last* middleware on the *last* layer (i.e. the route handler).
     async def handler() -> None:
         pass
 
+
     router = Router(
-        "/",
-        [handler],
-        middleware=[
-            ThirdMiddleware(),
-            FourthMiddleware()
-        ]
+        "/", [handler], middleware=[ThirdMiddleware(), FourthMiddleware()]
     )
 
-    app = Litestar(
-        middleware=[
-            FirstMiddleware(),
-            SecondMiddleware()
-        ]
-    )
+    app = Litestar(middleware=[FirstMiddleware(), SecondMiddleware()])
 
 Constraints and plugins
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -204,7 +195,9 @@ follows:
    class MiddlewareProtocol(Protocol):
        def __init__(self, app: ASGIApp, **kwargs: Any) -> None: ...
 
-       async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None: ...
+       async def __call__(
+           self, scope: Scope, receive: Receive, send: Send
+       ) -> None: ...
 
 The ``__init__`` method receives and sets "app". *It's important to understand* that app is not an instance of Litestar in
 this case, but rather the next middleware in the stack, which is also an ASGI app.
@@ -229,10 +222,14 @@ specifies:
 
 
    class MyRequestLoggingMiddleware(MiddlewareProtocol):
-       def __init__(self, app: ASGIApp) -> None:  # can have other parameters as well
+       def __init__(
+           self, app: ASGIApp
+       ) -> None:  # can have other parameters as well
            self.app = app
 
-       async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+       async def __call__(
+           self, scope: Scope, receive: Receive, send: Send
+       ) -> None:
            if scope["type"] == "http":
                request = Request(scope)
                logger.info("Got request: %s - %s", request.method, request.url)
@@ -266,7 +263,9 @@ explore another example - redirecting the request to a different url from a midd
        def __init__(self, app: ASGIApp) -> None:
            self.app = app
 
-       async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+       async def __call__(
+           self, scope: Scope, receive: Receive, send: Send
+       ) -> None:
            if Request(scope).session is None:
                response = ASGIRedirectResponse(path="/login")
                await response(scope, receive, send)
@@ -308,7 +307,9 @@ this by doing the following:
            super().__init__(app)
            self.app = app
 
-       async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+       async def __call__(
+           self, scope: Scope, receive: Receive, send: Send
+       ) -> None:
            if scope["type"] == "http":
                start_time = time.monotonic()
 
@@ -344,7 +345,9 @@ create middleware:
        exclude = ["first_path", "second_path"]
        exclude_opt_key = "exclude_from_middleware"
 
-       async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+       async def __call__(
+           self, scope: Scope, receive: Receive, send: Send
+       ) -> None:
            start_time = time.monotonic()
 
            async def send_wrapper(message: "Message") -> None:

--- a/docs/usage/openapi/schema_generation.rst
+++ b/docs/usage/openapi/schema_generation.rst
@@ -11,7 +11,8 @@ OpenAPI schema generation is enabled by default. To configure it you can pass an
    from litestar.openapi import OpenAPIConfig
 
    app = Litestar(
-       route_handlers=[...], openapi_config=OpenAPIConfig(title="My API", version="1.0.0")
+       route_handlers=[...],
+       openapi_config=OpenAPIConfig(title="My API", version="1.0.0"),
    )
 
 
@@ -117,7 +118,8 @@ You can also modify the generated schema for the route handler using the followi
        path="/items/{pk:int}",
        responses={
            404: ResponseSpec(
-               data_container=ItemNotFound, description="Item was removed or not found"
+               data_container=ItemNotFound,
+               description="Item was removed or not found",
            )
        },
    )
@@ -152,8 +154,13 @@ app instance itself. For example:
            title="my api",
            version="1.0.0",
            tags=[
-               Tag(name="public", description="This endpoint is for external users"),
-               Tag(name="internal", description="This endpoint is for internal users"),
+               Tag(
+                   name="public", description="This endpoint is for external users"
+               ),
+               Tag(
+                   name="internal",
+                   description="This endpoint is for internal users",
+               ),
            ],
            security=[{"BearerToken": []}],
            components=Components(

--- a/docs/usage/plugins/index.rst
+++ b/docs/usage/plugins/index.rst
@@ -141,6 +141,7 @@ The following example shows a simple plugin that logs information about each rou
     from litestar.plugins import ReceiveRoutePlugin
     from litestar.routes import BaseRoute
 
+
     class RouteLoggerPlugin(ReceiveRoutePlugin):
         def receive_route(self, route: BaseRoute) -> None:
             print(f"Route registered: {route.path} [{', '.join(route.methods)}]")

--- a/docs/usage/responses.rst
+++ b/docs/usage/responses.rst
@@ -259,7 +259,9 @@ Litestar also supports returning ASGI applications directly, as you would respon
 
    @get("/")
    def handler() -> ASGIApp:
-       async def my_asgi_app(scope: Scope, receive: Receive, send: Send) -> None: ...
+       async def my_asgi_app(
+           scope: Scope, receive: Receive, send: Send
+       ) -> None: ...
 
        return my_asgi_app
 
@@ -280,7 +282,9 @@ Function ASGI Application
    from litestar.types import Receive, Scope, Send
 
 
-   async def my_asgi_app_function(scope: Scope, receive: Receive, send: Send) -> None:
+   async def my_asgi_app_function(
+       scope: Scope, receive: Receive, send: Send
+   ) -> None:
        # do something here
        ...
 
@@ -308,7 +312,9 @@ Class ASGI Application
 
 
    class ASGIApp:
-       async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+       async def __call__(
+           self, scope: Scope, receive: Receive, send: Send
+       ) -> None:
            # do something here
            ...
 
@@ -616,7 +622,9 @@ File responses send a file:
    @get(path="/file-download")
    def handle_file_download() -> File:
        return File(
-           path=Path(Path(__file__).resolve().parent, "report").with_suffix(".pdf"),
+           path=Path(Path(__file__).resolve().parent, "report").with_suffix(
+               ".pdf"
+           ),
            filename="report.pdf",
        )
 
@@ -644,7 +652,9 @@ For example:
    @get(path="/file-download", media_type="application/pdf")
    def handle_file_download() -> File:
        return File(
-           path=Path(Path(__file__).resolve().parent, "report").with_suffix(".pdf"),
+           path=Path(Path(__file__).resolve().parent, "report").with_suffix(
+               ".pdf"
+           ),
            filename="report.pdf",
        )
 

--- a/docs/usage/routing/handlers.rst
+++ b/docs/usage/routing/handlers.rst
@@ -14,7 +14,7 @@ For example:
 
     @get("/")
     def greet() -> str:
-       return "hello world"
+        return "hello world"
 
 In the above example, the :term:`decorator` includes all the information required to define the endpoint operation for
 the combination of the path ``"/"`` and the HTTP verb ``GET``. In this case it will be a HTTP response with a
@@ -71,7 +71,7 @@ This is particularly useful when you want to have optional
 
 
     @get(
-       ["/some-path", "/some-path/{some_id:int}"],
+        ["/some-path", "/some-path/{some_id:int}"],
     )
     async def my_route_handler(some_id: int = 1) -> None: ...
 
@@ -117,11 +117,11 @@ For example:
 
     @get(path="/")
     async def my_request_handler(
-       state: State,
-       request: Request,
-       headers: Dict[str, str],
-       query: Dict[str, Any],
-       cookies: Dict[str, Any],
+        state: State,
+        request: Request,
+        headers: Dict[str, str],
+        query: Dict[str, Any],
+        cookies: Dict[str, Any],
     ) -> None: ...
 
 .. tip:: You can define a custom typing for your application state and then use it as a type instead of just using the
@@ -171,10 +171,11 @@ The same can be achieved without a decorator, by using ``HTTPRouteHandler`` dire
 
     async def my_endpoint() -> None: ...
 
+
     handler = HTTPRouteHandler(
         path="/some-path",
         http_method=[HttpMethod.GET, HttpMethod.POST],
-        fn=my_endpoint
+        fn=my_endpoint,
     )
 
 
@@ -211,7 +212,7 @@ the :paramref:`~.handlers.HTTPRouteHandler.http_method` :term:`kwarg <argument>`
 
 
         class PartialResourceDTO(PydanticDTO[Resource]):
-           config = DTOConfig(partial=True)
+            config = DTOConfig(partial=True)
 
 
         @get(path="/resources")
@@ -236,7 +237,7 @@ the :paramref:`~.handlers.HTTPRouteHandler.http_method` :term:`kwarg <argument>`
 
         @patch(path="/resources/{pk:int}", dto=PartialResourceDTO)
         async def partially_update_resource(
-           data: DTOData[PartialResourceDTO], pk: int
+            data: DTOData[PartialResourceDTO], pk: int
         ) -> Resource: ...
 
 
@@ -271,9 +272,9 @@ A WebSocket connection can be handled with a :func:`@websocket() <.handlers.Webs
 
     @websocket(path="/socket")
     async def my_websocket_handler(socket: WebSocket) -> None:
-       await socket.accept()
-       await socket.send_json({...})
-       await socket.close()
+        await socket.accept()
+        await socket.send_json({...})
+        await socket.close()
 
 The :func:`@websocket() <.handlers.WebsocketRouteHandler>` :term:`decorator` can be used to create an instance of
 :class:`~.handlers.WebsocketRouteHandler`. Therefore, the below code is equivalent to the one above:
@@ -284,10 +285,12 @@ The :func:`@websocket() <.handlers.WebsocketRouteHandler>` :term:`decorator` can
     from litestar import WebSocket
     from litestar.handlers.websocket_handlers import WebsocketRouteHandler
 
+
     async def my_websocket_handler(socket: WebSocket) -> None:
-       await socket.accept()
-       await socket.send_json({...})
-       await socket.close()
+        await socket.accept()
+        await socket.send_json({...})
+        await socket.close()
+
 
     my_websocket_handler = WebsocketRouteHandler(
         path="/socket",
@@ -323,15 +326,15 @@ If you need to write your own ASGI application, you can do so using the :func:`@
 
     @asgi(path="/my-asgi-app")
     async def my_asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
-       if scope["type"] == "http":
-           if scope["method"] == "GET":
-               response = Response({"hello": "world"})
-               await response(scope=scope, receive=receive, send=send)
-           return
-       response = Response(
-           {"detail": "unsupported request"}, status_code=HTTP_400_BAD_REQUEST
-       )
-       await response(scope=scope, receive=receive, send=send)
+        if scope["type"] == "http":
+            if scope["method"] == "GET":
+                response = Response({"hello": "world"})
+                await response(scope=scope, receive=receive, send=send)
+            return
+        response = Response(
+            {"detail": "unsupported request"}, status_code=HTTP_400_BAD_REQUEST
+        )
+        await response(scope=scope, receive=receive, send=send)
 
 :func:`@asgi() <.handlers.asgi>` :term:`decorator` can be used to create an instance of
 :class:`~.handlers.ASGIRouteHandler`. Therefore, the code below is equivalent to the one above:
@@ -344,16 +347,18 @@ If you need to write your own ASGI application, you can do so using the :func:`@
     from litestar.status_codes import HTTP_400_BAD_REQUEST
     from litestar.types import Scope, Receive, Send
 
+
     async def my_asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
-       if scope["type"] == "http":
-           if scope["method"] == "GET":
-               response = Response({"hello": "world"})
-               await response(scope=scope, receive=receive, send=send)
-           return
-       response = Response(
-           {"detail": "unsupported request"}, status_code=HTTP_400_BAD_REQUEST
-       )
-       await response(scope=scope, receive=receive, send=send)
+        if scope["type"] == "http":
+            if scope["method"] == "GET":
+                response = Response({"hello": "world"})
+                await response(scope=scope, receive=receive, send=send)
+            return
+        response = Response(
+            {"detail": "unsupported request"}, status_code=HTTP_400_BAD_REQUEST
+        )
+        await response(scope=scope, receive=receive, send=send)
+
 
     my_asgi_app = ASGIRouteHandler(path="/my-asgi-app", fn=my_asgi_app)
 
@@ -393,8 +398,7 @@ The default value for :paramref:`~.handlers.base.BaseRouteHandler.name` is the v
 containing the route handler instance and paths. It can also be used to build a URL path for that handler:
 
 .. code-block:: python
-    :caption: Using the :paramref:`~.handlers.base.BaseRouteHandler.name` :term:`kwarg <argument>` to retrieve a route
-      handler instance and paths
+    :caption: Using the :paramref:`~.handlers.base.BaseRouteHandler.name` :term:`kwarg <argument>` to retrieve a route handler instance and paths
 
     from litestar import Litestar, Request, get
     from litestar.exceptions import NotFoundException
@@ -420,7 +424,9 @@ containing the route handler instance and paths. It can also be used to build a 
     def handler_four(request: Request, name: str) -> Redirect:
         handler_index = request.app.get_handler_index_by_name(name)
         if not handler_index:
-            raise NotFoundException(f"no handler matching the name {name} was found")
+            raise NotFoundException(
+                f"no handler matching the name {name} was found"
+            )
 
         # handler_index == { "paths": ["/"], "handler": ..., "qualname": ... }
         # do something with the handler index below, e.g. send a redirect response to the handler, or access
@@ -449,6 +455,7 @@ As a convenience, you can also pass the route handler directly to :meth:`~.app.L
     def handler_one() -> None:
         pass
 
+
     app = Litestar(route_handlers=[handler])
 
     app.route_reverse(handler_one)  # Returns "/abc"
@@ -471,24 +478,24 @@ the highest number of the :term:`keyword arguments <argument>` passed to the fun
 
 
     @get(
-       ["/some-path", "/some-path/{id:int}", "/some-path/{id:int}/{val:str}"],
-       name="handler_name",
+        ["/some-path", "/some-path/{id:int}", "/some-path/{id:int}/{val:str}"],
+        name="handler_name",
     )
     def handler(id: int = 1, val: str = "default") -> None: ...
 
 
     @get("/path-info")
     def path_info(request: Request) -> str:
-       path_optional = request.app.route_reverse("handler_name")
-       # /some-path`
+        path_optional = request.app.route_reverse("handler_name")
+        # /some-path`
 
-       path_partial = request.app.route_reverse("handler_name", id=100)
-       # /some-path/100
+        path_partial = request.app.route_reverse("handler_name", id=100)
+        # /some-path/100
 
-       path_full = request.app.route_reverse("handler_name", id=100, val="value")
-       # /some-path/100/value`
+        path_full = request.app.route_reverse("handler_name", id=100, val="value")
+        # /some-path/100/value`
 
-       return f"{path_optional} {path_partial} {path_full}"
+        return f"{path_optional} {path_partial} {path_full}"
 
 When a handler is associated with multiple routes having identical path :term:`parameters <parameter>`
 (e.g., an indexed handler registered across multiple routers), the output of :meth:`~.app.Litestar.route_reverse` is

--- a/docs/usage/routing/overview.rst
+++ b/docs/usage/routing/overview.rst
@@ -85,10 +85,10 @@ injected dependencies. For example:
 
     @get("/some-path")
     def route_handler(request: Request[Any, Any]) -> None:
-       @get("/sub-path")
-       def sub_path_handler() -> None: ...
+        @get("/sub-path")
+        def sub_path_handler() -> None: ...
 
-       request.app.register(sub_path_handler)
+        request.app.register(sub_path_handler)
 
 
     app = Litestar(route_handlers=[route_handler])
@@ -145,30 +145,30 @@ Their purpose is to allow users to utilize Python OOP for better code organizati
 
 
         class UserOrder(BaseModel):
-           user_id: int
-           order: str
+            user_id: int
+            order: str
 
 
         class PartialUserOrderDTO(PydanticDTO[UserOrder]):
-           config = DTOConfig(partial=True)
+            config = DTOConfig(partial=True)
 
 
         class UserOrderController(Controller):
-           path = "/user-order"
+            path = "/user-order"
 
-           @post()
-           async def create_user_order(self, data: UserOrder) -> UserOrder: ...
+            @post()
+            async def create_user_order(self, data: UserOrder) -> UserOrder: ...
 
-           @get(path="/{order_id:uuid}")
-           async def retrieve_user_order(self, order_id: UUID4) -> UserOrder: ...
+            @get(path="/{order_id:uuid}")
+            async def retrieve_user_order(self, order_id: UUID4) -> UserOrder: ...
 
-           @patch(path="/{order_id:uuid}", dto=PartialUserOrderDTO)
-           async def update_user_order(
-               self, order_id: UUID4, data: DTOData[PartialUserOrderDTO]
-           ) -> UserOrder: ...
+            @patch(path="/{order_id:uuid}", dto=PartialUserOrderDTO)
+            async def update_user_order(
+                self, order_id: UUID4, data: DTOData[PartialUserOrderDTO]
+            ) -> UserOrder: ...
 
-           @delete(path="/{order_id:uuid}")
-           async def delete_user_order(self, order_id: UUID4) -> None: ...
+            @delete(path="/{order_id:uuid}")
+            async def delete_user_order(self, order_id: UUID4) -> None: ...
 
 The above is a simple example of a "CRUD" controller for a model called ``UserOrder``. You can place as
 many :doc:`route handler methods </usage/routing/handlers>` on a controller,
@@ -196,10 +196,10 @@ Controllers
 
 
     class MyController(Controller):
-       path = "/controller"
+        path = "/controller"
 
-       @get()
-       def handler(self) -> None: ...
+        @get()
+        def handler(self) -> None: ...
 
 
     internal_router = Router(path="/internal", route_handlers=[MyController])

--- a/docs/usage/security/abstract-authentication-middleware.rst
+++ b/docs/usage/security/abstract-authentication-middleware.rst
@@ -12,18 +12,18 @@ To add authentication to your app using this class as a basis, subclass it and i
       :class:`~.middleware.authentication.AbstractAuthenticationMiddleware`
 
     from litestar.middleware import (
-       AbstractAuthenticationMiddleware,
-       AuthenticationResult,
+        AbstractAuthenticationMiddleware,
+        AuthenticationResult,
     )
     from litestar.connection import ASGIConnection
 
 
     class MyAuthenticationMiddleware(AbstractAuthenticationMiddleware):
-       async def authenticate_request(
-           self, connection: ASGIConnection
-       ) -> AuthenticationResult:
-           # do something here.
-           ...
+        async def authenticate_request(
+            self, connection: ASGIConnection
+        ) -> AuthenticationResult:
+            # do something here.
+            ...
 
 As you can see, ``authenticate_request`` is an async function that receives a connection instance and is supposed to return
 an :class:`~.middleware.authentication.AuthenticationResult` instance, which is a

--- a/docs/usage/security/excluding-and-including-endpoints.rst
+++ b/docs/usage/security/excluding-and-including-endpoints.rst
@@ -25,13 +25,13 @@ as well - it is included in the ``/schema`` pattern.
 .. code-block:: python
 
     session_auth = SessionAuth[User, ServerSideSessionBackend](
-    retrieve_user_handler=retrieve_user_handler,
-    # we must pass a config for a session backend.
-    # all session backends are supported
-    session_backend_config=ServerSideSessionConfig(),
-    # exclude any URLs that should not have authentication.
-    # We exclude the documentation URLs, signup and login.
-    exclude=["/login", "/signup", "/schema"],
+        retrieve_user_handler=retrieve_user_handler,
+        # we must pass a config for a session backend.
+        # all session backends are supported
+        session_backend_config=ServerSideSessionConfig(),
+        # exclude any URLs that should not have authentication.
+        # We exclude the documentation URLs, signup and login.
+        exclude=["/login", "/signup", "/schema"],
     )
     ...
 
@@ -46,13 +46,13 @@ under the ``/secured`` route will require authentication - all other routes do n
 
     ...
     session_auth = SessionAuth[User, ServerSideSessionBackend](
-    retrieve_user_handler=retrieve_user_handler,
-    # we must pass a config for a session backend.
-    # all session backends are supported
-    session_backend_config=ServerSideSessionConfig(),
-    # exclude any URLs that should not have authentication.
-    # We exclude the documentation URLs, signup and login.
-    exclude=[r"^(?!.*\/secured$).*$"],
+        retrieve_user_handler=retrieve_user_handler,
+        # we must pass a config for a session backend.
+        # all session backends are supported
+        session_backend_config=ServerSideSessionConfig(),
+        # exclude any URLs that should not have authentication.
+        # We exclude the documentation URLs, signup and login.
+        exclude=[r"^(?!.*\/secured$).*$"],
     )
     ...
 
@@ -64,13 +64,16 @@ can pass ``exclude_from_auth=True`` to the route handler as shown below.
 .. code-block:: python
 
     ...
+
+
     @get("/secured")
-    def secured_route() -> Any:
-        ...
+    def secured_route() -> Any: ...
+
 
     @get("/unsecured", exclude_from_auth=True)
-    def unsecured_route() -> Any:
-        ...
+    def unsecured_route() -> Any: ...
+
+
     ...
 
 You can set an alternative option key in the security configuration, e.g., you can use ``no_auth`` instead of
@@ -79,22 +82,24 @@ You can set an alternative option key in the security configuration, e.g., you c
 .. code-block:: python
 
     ...
+
+
     @get("/secured")
-    def secured_route() -> Any:
-        ...
+    def secured_route() -> Any: ...
+
 
     @get("/unsecured", no_auth=True)
-    def unsecured_route() -> Any:
-        ...
+    def unsecured_route() -> Any: ...
+
 
     session_auth = SessionAuth[User, ServerSideSessionBackend](
-    retrieve_user_handler=retrieve_user_handler,
-    # we must pass a config for a session backend.
-    # all session backends are supported
-    session_backend_config=ServerSideSessionConfig(),
-    # exclude any URLs that should not have authentication.
-    # We exclude the documentation URLs, signup and login.
-    exclude=["/login", "/signup", "/schema"],
-    exclude_opt_key="no_auth"  # default value is `exclude_from_auth`
+        retrieve_user_handler=retrieve_user_handler,
+        # we must pass a config for a session backend.
+        # all session backends are supported
+        session_backend_config=ServerSideSessionConfig(),
+        # exclude any URLs that should not have authentication.
+        # We exclude the documentation URLs, signup and login.
+        exclude=["/login", "/signup", "/schema"],
+        exclude_opt_key="no_auth",  # default value is `exclude_from_auth`
     )
     ...

--- a/docs/usage/templating.rst
+++ b/docs/usage/templating.rst
@@ -84,7 +84,9 @@ The above example will create a jinja Environment instance, but you can also pas
     from litestar.template import TemplateConfig
     from jinja2 import Environment, DictLoader
 
-    my_custom_env = Environment(loader=DictLoader({"index.html": "Hello {{name}}!"}))
+    my_custom_env = Environment(
+        loader=DictLoader({"index.html": "Hello {{name}}!"})
+    )
     app = Litestar(
         template_config=TemplateConfig(
             instance=JinjaTemplateEngine.from_environment(my_custom_env)
@@ -113,7 +115,9 @@ argument which should be the template class, and it specifies two methods:
 
 
    class TemplateEngineProtocol(Protocol[SomeTemplate]):
-       def __init__(self, directory: Union[DirectoryPath, List[DirectoryPath]]) -> None:
+       def __init__(
+           self, directory: Union[DirectoryPath, List[DirectoryPath]]
+       ) -> None:
            """Builds a template engine."""
            ...
 
@@ -358,7 +362,9 @@ container, so simply pass a string keyed dictionary of values:
 
    @get(path="/info")
    def info() -> Template:
-       return Template(template_name="info.html", context={"numbers": "1234567890"})
+       return Template(
+           template_name="info.html", context={"numbers": "1234567890"}
+       )
 
 
 Template callables

--- a/docs/usage/testing.rst
+++ b/docs/usage/testing.rst
@@ -298,6 +298,7 @@ in isolation.
 
     from my_app.main import health_check
 
+
     def test_health_check():
         with create_test_client([health_check]) as client:
             response = client.get("/health-check")
@@ -336,7 +337,9 @@ By default, the subprocess client will capture all output from the litestar inst
 
     @pytest.fixture(name="async_client")
     async def fx_async_client() -> AsyncIterator[httpx.AsyncClient]:
-        async with subprocess_async_client(workdir=ROOT, app="subprocess_sse_app:app", capture_output=False) as client:
+        async with subprocess_async_client(
+            workdir=ROOT, app="subprocess_sse_app:app", capture_output=False
+        ) as client:
             yield client
 
 
@@ -359,10 +362,13 @@ from the :doc:`route guards </usage/security/guards>` documentation:
     from litestar.handlers.base import BaseRouteHandler
 
 
-    def secret_token_guard(request: Request, route_handler: BaseRouteHandler) -> None:
+    def secret_token_guard(
+        request: Request, route_handler: BaseRouteHandler
+    ) -> None:
         if (
             route_handler.opt.get("secret")
-            and not request.headers.get("Secret-Header", "") == route_handler.opt["secret"]
+            and not request.headers.get("Secret-Header", "")
+            == route_handler.opt["secret"]
         ):
             raise NotAuthorizedException()
 
@@ -378,7 +384,11 @@ We already have our route handler in place:
     from my_app.guards import secret_token_guard
 
 
-    @get(path="/secret", guards=[secret_token_guard], opt={"secret": environ.get("SECRET")})
+    @get(
+        path="/secret",
+        guards=[secret_token_guard],
+        opt={"secret": environ.get("SECRET")},
+    )
     def secret_endpoint() -> None: ...
 
 We could thus test the guard function like so:
@@ -401,7 +411,9 @@ We could thus test the guard function like so:
         copied_endpoint_handler = secret_endpoint.copy()
         copied_endpoint_handler.opt["secret"] = None
         with pytest.raises(NotAuthorizedException):
-            secret_token_guard(request=request, route_handler=copied_endpoint_handler)
+            secret_token_guard(
+                request=request, route_handler=copied_endpoint_handler
+            )
 
 
     def test_secret_token_guard_success_scenario():


### PR DESCRIPTION
Fixes #3211

## Description

Add `blacken-docs` to the pre-commit configuration with a line length of 80 characters to prevent documentation code blocks from becoming too wide and requiring horizontal scrolling.

This change adds the `adamchainz/blacken-docs` pre-commit hook configured with `--line-length=80` to format Python code blocks in RST and Markdown documentation files.

## Closes

Fixes #3211

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: https://litestar-org.github.io/litestar-docs-preview/4622
