### PR TITLE
fix(middleware): handle missing route_handler in scope for exclude_opt_key check

### DIFF
--- a/litestar/middleware/_utils.py
+++ b/litestar/middleware/_utils.py
@@ -81,8 +81,10 @@ def should_bypass_middleware(
     if scope["type"] not in scopes:
         return True
 
-    if exclude_opt_key and scope["route_handler"].opt.get(exclude_opt_key):
-        return True
+    if exclude_opt_key:
+        route_handler = scope.get("route_handler")
+        if route_handler is not None and route_handler.opt.get(exclude_opt_key):
+            return True
 
     if exclude_http_methods and scope.get("method") in exclude_http_methods:
         return True

--- a/tests/unit/test_middleware/test_base_middleware.py
+++ b/tests/unit/test_middleware/test_base_middleware.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union, cast
 from unittest.mock import MagicMock, call
 from warnings import catch_warnings
 
@@ -9,6 +9,7 @@ from litestar.datastructures.headers import MutableScopeHeaders
 from litestar.enums import ScopeType
 from litestar.exceptions import LitestarWarning, ValidationException
 from litestar.middleware import AbstractMiddleware, ASGIMiddleware, DefineMiddleware
+from litestar.middleware._utils import should_bypass_middleware
 from litestar.response.base import ASGIResponse
 from litestar.status_codes import HTTP_400_BAD_REQUEST
 from litestar.testing import create_test_client
@@ -409,3 +410,54 @@ def test_asgi_middleware_exclude_by_opt_key() -> None:
     with create_test_client(handler, middleware=[SubclassMiddleware()]) as client:
         assert client.get("/").status_code == 200
         mock.assert_not_called()
+
+
+def test_should_bypass_middleware_exclude_opt_key_without_route_handler_in_scope() -> None:
+    """Test that should_bypass_middleware does not raise KeyError when
+    'route_handler' is not yet set in the ASGI scope.
+
+    This can happen when a middleware wraps the entire ASGI application
+    (including the router), such as OpenTelemetry, and runs before the
+    route has been resolved.
+
+    Regression test for https://github.com/litestar-org/litestar/issues/4468
+    """
+    scope = cast("Scope", {"type": "http", "path": "/test", "method": "GET"})
+    result = should_bypass_middleware(
+        exclude_opt_key="skip_middleware",
+        scope=scope,
+        scopes={ScopeType.HTTP},
+    )
+    # Without route_handler in scope, the middleware should NOT be bypassed
+    # (it cannot determine if the handler opts out, so it should run)
+    assert result is False
+
+
+def test_should_bypass_middleware_exclude_opt_key_with_route_handler_in_scope() -> None:
+    """Test that should_bypass_middleware correctly checks exclude_opt_key
+    when route_handler IS present in scope."""
+    handler_mock = MagicMock()
+    handler_mock.opt = {"skip_middleware": True}
+
+    scope = cast("Scope", {"type": "http", "path": "/test", "method": "GET", "route_handler": handler_mock})
+    result = should_bypass_middleware(
+        exclude_opt_key="skip_middleware",
+        scope=scope,
+        scopes={ScopeType.HTTP},
+    )
+    assert result is True
+
+
+def test_should_bypass_middleware_exclude_opt_key_handler_without_opt() -> None:
+    """Test that should_bypass_middleware does not bypass when the route_handler
+    exists but does not have the opt key set."""
+    handler_mock = MagicMock()
+    handler_mock.opt = {}
+
+    scope = cast("Scope", {"type": "http", "path": "/test", "method": "GET", "route_handler": handler_mock})
+    result = should_bypass_middleware(
+        exclude_opt_key="skip_middleware",
+        scope=scope,
+        scopes={ScopeType.HTTP},
+    )
+    assert result is False


### PR DESCRIPTION
## Summary

Fixes #4468

- Fixed `KeyError: 'route_handler'` in `should_bypass_middleware` when `exclude_opt_key` is set on a middleware that wraps the entire ASGI application (e.g., OpenTelemetry)
- Changed `scope["route_handler"]` to `scope.get("route_handler")` with a proper None check
- Added regression tests for the three relevant cases

## Root Cause

In `litestar/middleware/_utils.py`, the `should_bypass_middleware` function directly accesses `scope["route_handler"]` on line 84 when checking `exclude_opt_key`. However, middlewares like OpenTelemetry are added as the outermost ASGI wrapper in `_create_asgi_handler()`, meaning they execute **before** the ASGI router resolves the route handler and populates `scope["route_handler"]`.

This causes every request to crash with `KeyError: 'route_handler'` when any middleware using `exclude_opt_key` runs before route resolution.

## Before

```python
if exclude_opt_key and scope["route_handler"].opt.get(exclude_opt_key):
    return True
```
This raises `KeyError` when `route_handler` is not in the scope.

## After

```python
if exclude_opt_key:
    route_handler = scope.get("route_handler")
    if route_handler is not None and route_handler.opt.get(exclude_opt_key):
        return True
```
Gracefully handles the missing key. When `route_handler` is not yet available, the middleware is not bypassed (it cannot determine opt-out, so it runs as expected).

Note: `match_exclude_path` (line 55) already uses the safe pattern `scope.get("route_handler", None)`, so this fix brings consistency to the module.

## Test plan

- [x] Added `test_should_bypass_middleware_exclude_opt_key_without_route_handler_in_scope` - verifies no KeyError when route_handler is missing from scope
- [x] Added `test_should_bypass_middleware_exclude_opt_key_with_route_handler_in_scope` - verifies bypass works correctly when handler opts out
- [x] Added `test_should_bypass_middleware_exclude_opt_key_handler_without_opt` - verifies no bypass when handler doesn't have the opt key
- [x] All 97 existing middleware tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)