### PR TITLE
feat(openapi): use root_path for default server URL

### DIFF
--- a/litestar/_openapi/plugin.py
+++ b/litestar/_openapi/plugin.py
@@ -158,7 +158,15 @@ class OpenAPIPlugin(InitPlugin, ReceiveRoutePlugin):
 
             @get(paths, media_type=plugin_.media_type, sync_to_thread=False, name=handler_name)
             def _handler(request: Request) -> bytes:
-                return plugin_.render(request, self.provide_openapi_schema())
+                schema = self.provide_openapi_schema()
+                # If servers haven't been explicitly set and root_path is present, use it
+                if (
+                    schema.get("servers") == [{"url": "/"}]
+                    and (root_path := request.scope.get("root_path"))
+                    and root_path
+                ):
+                    schema = {**schema, "servers": [{"url": root_path}]}
+                return plugin_.render(request, schema)
 
             return _handler
 


### PR DESCRIPTION
## Description

When no servers are explicitly configured in `OpenAPIConfig`, this change uses the ASGI `root_path` from the request scope as the default server URL. This makes the OpenAPI schema work correctly when the app is deployed behind a reverse proxy with a path prefix.

Previously, the default server URL was always `"/"` regardless of the `root_path` setting. Now, if `root_path` is present in the scope and no custom servers are configured, the schema endpoint dynamically sets the server URL to the `root_path` value.

This follows the approach suggested by @peterschutt in the issue discussion.

Closes #2077

## Changes

- Modified `litestar/_openapi/plugin.py` to check for `root_path` in the request scope when serving the OpenAPI schema
- If no explicit servers are configured and `root_path` is present, uses it as the default server URL

## AI Disclosure

This PR was created with AI assistance (Claude by Anthropic). The implementation follows the approach outlined by maintainers in the issue discussion.

Co-Authored-By: AI Assistant (Claude) <ai-assistant@contributor-bot.dev>