### PR TITLE
perf(docs): set a timeout on async resource test issue HTTP calls

### DIFF
--- a/docs/examples/testing/async_resource_test_issue.py
+++ b/docs/examples/testing/async_resource_test_issue.py
@@ -35,5 +35,5 @@ def app(http_test_client: httpx.AsyncClient) -> Litestar:
 
 def test_handler(app: Litestar) -> None:
     with TestClient(app) as client:
-        response = client.get("/")
+        response = client.get("/", timeout=10.0)
         assert response.json() == {"status": 200}


### PR DESCRIPTION
Add a timeout to the HTTP call in docs/examples/testing/async_resource_test_issue.py to avoid indefinite hangs.

Reason: Network calls without a timeout can hang a worker indefinitely.

Validation: `/Users/tejasattarde/Desktop/gh-patchbot/.venv/bin/python -m py_compile docs/examples/testing/async_resource_test_issue.py`.

Context: py-http-timeout at docs/examples/testing/async_resource_test_issue.py:38.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: https://litestar-org.github.io/litestar-docs-preview/4630
