### PR TITLE
docs: join clean args with `shlex`

### DIFF
--- a/tools/sphinx_ext/run_examples.py
+++ b/tools/sphinx_ext/run_examples.py
@@ -143,7 +143,7 @@ def exec_examples(app_file: Path, run_configs: list[list[str]]) -> str:
                     logger.error(f"Example: {app_file}:{args} yielded no results")
                 continue
 
-            result = "\n".join(("> " + (" ".join(clean_args)), *stdout))
+            result = "\n".join(("> " + (shlex.join(clean_args)), *stdout))
             results.append(result)
 
     return "\n".join(results)


### PR DESCRIPTION
Before:

```
curl http://127.0.0.1:8000/api/ -H Content-Type: application/json
```

After:

```
curl http://127.0.0.1:8000/api/ -H 'Content-Type: application/json'
```

Refs https://github.com/wemake-services/django-modern-rest/pull/668


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: https://litestar-org.github.io/litestar-docs-preview/4631
