### PR TITLE
docs: add section on accessing OpenAPI schema files

### DIFF
--- a/docs/usage/openapi/index.rst
+++ b/docs/usage/openapi/index.rst
@@ -20,6 +20,41 @@ configuration globally to setting
 :ref:`specific kwargs on route <usage/openapi/schema_generation:Configuring schema generation on a route handler>`
 handler decorators.
 
+
+Accessing OpenAPI Schema Files
+------------------------------
+
+By default, the OpenAPI schema is available as a JSON file at ``{openapi_path}/openapi.json``. The default
+``openapi_path`` is ``/schema``, so the JSON schema is served at ``/schema/openapi.json``.
+
+This endpoint is useful when you need to import your API schema into external tools, such as
+`Scalar <https://scalar.com/>`_ API client's collection import feature, `Postman <https://www.postman.com/>`_,
+or other OpenAPI-compatible tools.
+
+To also serve the schema as YAML, add the :class:`YamlRenderPlugin <litestar.openapi.plugins.YamlRenderPlugin>` to
+your configuration:
+
+.. code-block:: python
+
+   from litestar import Litestar
+   from litestar.openapi.config import OpenAPIConfig
+   from litestar.openapi.plugins import ScalarRenderPlugin, YamlRenderPlugin
+
+   app = Litestar(
+       route_handlers=[...],
+       openapi_config=OpenAPIConfig(
+           title="My API",
+           version="1.0.0",
+           render_plugins=[ScalarRenderPlugin(), YamlRenderPlugin()],
+       ),
+   )
+
+This makes the schema available at both ``/schema/openapi.yaml`` and ``/schema/openapi.yml``.
+
+You can customize the root path by setting the :attr:`OpenAPIConfig.path <litestar.openapi.OpenAPIConfig.path>` attribute.
+See :doc:`ui_plugins` for more details on configuring the OpenAPI root path.
+
+
 .. toctree::
 
     schema_generation


### PR DESCRIPTION
## Summary
- Add a new section "Accessing OpenAPI Schema Files" to the OpenAPI documentation
- Document that JSON schema is available at `{openapi_path}/openapi.json` by default
- Show how to enable YAML endpoints by adding `YamlRenderPlugin`
- Mention use cases like importing into Scalar API client, Postman, etc.

Closes #3941

## Test plan
- [ ] Documentation builds without errors
- [ ] Links to other docs sections work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: https://litestar-org.github.io/litestar-docs-preview/4634
