### PR TITLE
docs: add section on default OpenAPI schema file endpoints

### DIFF
--- a/docs/usage/openapi/ui_plugins.rst
+++ b/docs/usage/openapi/ui_plugins.rst
@@ -137,6 +137,34 @@ Here's some example plugin configurations:
         .. literalinclude:: /examples/openapi/plugins/swagger_ui_config.py
             :language: python
 
+Default OpenAPI Schema Files
+----------------------------
+
+By default, Litestar always serves the OpenAPI schema as a JSON file, even if you don't explicitly configure it. The
+following endpoints are available under the OpenAPI root path (``/schema`` by default):
+
+- ``/schema/openapi.json`` — The OpenAPI schema as JSON. This is always available, as it is required by the UI plugins.
+- ``/schema/openapi.yaml`` and ``/schema/openapi.yml`` — The OpenAPI schema as YAML. Available when
+  :class:`YamlRenderPlugin <litestar.openapi.plugins.YamlRenderPlugin>` is included in ``render_plugins``.
+
+.. note::
+
+    The YAML endpoints require the `PyYAML <https://pyyaml.org/wiki/PyYAMLDocumentation>`_ library, which can be
+    installed via the ``litestar[yaml]`` package extra.
+
+These files can be used to import your API schema into external tools such as `Scalar API Client
+<https://docs.scalar.com/api-client/rest-api-client>`_, `Postman <https://www.postman.com/>`_, or any other tool that
+supports OpenAPI specifications.
+
+For example, if your app is running at ``http://localhost:8000``, you can access:
+
+- ``http://localhost:8000/schema/openapi.json``
+- ``http://localhost:8000/schema/openapi.yaml``
+
+If you change the root path (see below), the schema files will be served under the new root path instead, e.g.,
+``/docs/openapi.json``.
+
+
 Configuring the OpenAPI Root Path
 ---------------------------------
 


### PR DESCRIPTION
## Problem

The documentation for OpenAPI didn't explicitly document the availability of the default schema file endpoints (`openapi.json`, `openapi.yaml`, `openapi.yml`). Users had to discover these paths by reading the source code or stumbling upon brief mentions in other sections.

## Solution

Added a new "Default OpenAPI Schema Files" section to the OpenAPI UI Plugins documentation that clearly documents:

- `/schema/openapi.json` — always available (auto-registered even without explicit config)
- `/schema/openapi.yaml` and `/schema/openapi.yml` — available with `YamlRenderPlugin`
- Note about PyYAML dependency requirement
- Example URLs for common use
- How these paths change when the root path is customized
- Mention of external tools (Scalar API Client, Postman) that can consume these endpoints

## Files Changed

- `docs/usage/openapi/ui_plugins.rst`: Added new documentation section before the "Configuring the OpenAPI Root Path" section

Closes #3941

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4641">https://litestar-org.github.io/litestar-docs-preview/4641</a> 
