### PR TITLE
fix(typing): allow ImmutableState instance to be passed to Litestar/AppConfig

### DIFF
--- a/litestar/app.py
+++ b/litestar/app.py
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
     from litestar.config.cors import CORSConfig
     from litestar.config.csrf import CSRFConfig
     from litestar.contrib.opentelemetry import OpenTelemetryPlugin
-    from litestar.datastructures import CacheControlHeader, ETag
+    from litestar.datastructures import CacheControlHeader, ETag, ImmutableState
     from litestar.dto import AbstractDTO
     from litestar.events.listener import EventListener
     from litestar.openapi.spec import SecurityRequirement
@@ -209,7 +209,7 @@ class Litestar(Router):
         security: Sequence[SecurityRequirement] | None = None,
         signature_namespace: Mapping[str, Any] | None = None,
         signature_types: Sequence[Any] | None = None,
-        state: State | None = None,
+        state: State | ImmutableState | None = None,
         stores: StoreRegistry | dict[str, Store] | None = None,
         tags: Sequence[str] | None = None,
         template_config: TemplateConfigType | None = None,
@@ -304,7 +304,7 @@ class Litestar(Router):
             signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
             signature_types: A sequence of types for use in forward reference resolution during signature modelling.
                 These types will be added to the signature namespace using their ``__name__`` attribute.
-            state: An optional :class:`State <.datastructures.State>` for application state.
+            state: An optional :class:`State <.datastructures.State>` or :class:`ImmutableState <.datastructures.ImmutableState>` for application state.
             stores: Central registry of :class:`Store <.stores.base.Store>` that will be available throughout the
                 application. If this is a dictionary to it will be passed to a
                 :class:`StoreRegistry <.stores.registry.StoreRegistry>`. If it is a

--- a/litestar/config/app.py
+++ b/litestar/config/app.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from litestar.config.allowed_hosts import AllowedHostsConfig
 from litestar.config.response_cache import ResponseCacheConfig
-from litestar.datastructures import State
+from litestar.datastructures import ImmutableState, State
 from litestar.events.emitter import SimpleEventEmitter
 from litestar.types.empty import Empty
 
@@ -196,8 +196,8 @@ class AppConfig:
 
     These types will be added to the signature namespace using their ``__name__`` attribute.
     """
-    state: State = field(default_factory=State)
-    """A :class:`State` <.datastructures.State>` instance holding application state."""
+    state: State | ImmutableState = field(default_factory=State)
+    """A :class:`State <.datastructures.State>` or :class:`ImmutableState <.datastructures.ImmutableState>` instance holding application state."""
     stores: StoreRegistry | dict[str, Store] | None = None
     """Central registry of :class:`Store <.stores.base.Store>` to be made available and be used throughout the
     application. Can be either a dictionary mapping strings to :class:`Store <.stores.base.Store>` instances, or an

--- a/litestar/testing/helpers.py
+++ b/litestar/testing/helpers.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from litestar.config.cors import CORSConfig
     from litestar.config.csrf import CSRFConfig
     from litestar.config.response_cache import ResponseCacheConfig
-    from litestar.datastructures import CacheControlHeader, ETag, State
+    from litestar.datastructures import CacheControlHeader, ETag, ImmutableState, State
     from litestar.dto import AbstractDTO
     from litestar.events import BaseEventEmitterBackend, EventListener
     from litestar.middleware.session.base import BaseBackendConfig
@@ -100,7 +100,7 @@ def create_test_client(
     session_config: BaseBackendConfig | None = None,
     signature_namespace: Mapping[str, Any] | None = None,
     signature_types: Sequence[Any] | None = None,
-    state: State | None = None,
+    state: State | ImmutableState | None = None,
     stores: StoreRegistry | dict[str, Store] | None = None,
     tags: Sequence[str] | None = None,
     template_config: TemplateConfig | None = None,
@@ -221,7 +221,7 @@ def create_test_client(
         signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
         signature_types: A sequence of types for use in forward reference resolution during signature modelling.
             These types will be added to the signature namespace using their ``__name__`` attribute.
-        state: An optional :class:`State <.datastructures.State>` for application state.
+        state: An optional :class:`State <.datastructures.State>` or :class:`ImmutableState <.datastructures.ImmutableState>` for application state.
         stores: Central registry of :class:`Store <.stores.base.Store>` that will be available throughout the
             application. If this is a dictionary to it will be passed to a
             :class:`StoreRegistry <.stores.registry.StoreRegistry>`. If it is a
@@ -353,7 +353,7 @@ def create_async_test_client(
     session_config: BaseBackendConfig | None = None,
     signature_namespace: Mapping[str, Any] | None = None,
     signature_types: Sequence[Any] | None = None,
-    state: State | None = None,
+    state: State | ImmutableState | None = None,
     stores: StoreRegistry | dict[str, Store] | None = None,
     tags: Sequence[str] | None = None,
     template_config: TemplateConfig | None = None,
@@ -472,7 +472,7 @@ def create_async_test_client(
         signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
         signature_types: A sequence of types for use in forward reference resolution during signature modelling.
             These types will be added to the signature namespace using their ``__name__`` attribute.
-        state: An optional :class:`State <.datastructures.State>` for application state.
+        state: An optional :class:`State <.datastructures.State>` or :class:`ImmutableState <.datastructures.ImmutableState>` for application state.
         stores: Central registry of :class:`Store <.stores.base.Store>` that will be available throughout the
             application. If this is a dictionary to it will be passed to a
             :class:`StoreRegistry <.stores.registry.StoreRegistry>`. If it is a

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -200,6 +200,7 @@ def test_before_send() -> None:
             headers.add("My-Header", Litestar.from_scope(scope).state.message)
 
     def on_startup(app: Litestar) -> None:
+        assert isinstance(app.state, State)
         app.state.message = "value injected during send"
 
     with create_test_client(handler, on_startup=[on_startup], before_send=[before_send_hook_handler]) as client:

--- a/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
+++ b/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
@@ -38,11 +38,10 @@ class CustomState(State):
 def test_application_immutable_state_injection() -> None:
     @get("/", media_type=MediaType.TEXT)
     def route_handler(state: ImmutableState) -> str:
-        assert state
+        assert isinstance(state, ImmutableState)
         return cast("str", state.msg)
 
-    with create_test_client(route_handler, state=State({"called": False})) as client:
-        client.app.state.msg = "hello"
+    with create_test_client(route_handler, state=ImmutableState({"called": False, "msg": "hello"})) as client:
         assert not client.app.state.called
         response = client.get("/")
         assert response.status_code == HTTP_200_OK
@@ -57,6 +56,7 @@ def test_application_state_injection(state_typing: type[State]) -> None:
         return cast("str", state.msg)  # type: ignore[attr-defined]
 
     with create_test_client(route_handler, state=State({"called": False})) as client:
+        assert isinstance(client.app.state, State)
         client.app.state.msg = "hello"
         assert not client.app.state.called
         response = client.get("/")

--- a/tests/unit/test_middleware/test_exception_handler_middleware.py
+++ b/tests/unit/test_middleware/test_exception_handler_middleware.py
@@ -9,6 +9,7 @@ from pytest_mock import MockerFixture
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from litestar import Litestar, MediaType, Request, Response, WebSocket, get, websocket
+from litestar.datastructures import State
 from litestar.exceptions import HTTPException, InternalServerException, LitestarException, ValidationException
 from litestar.exceptions.responses._debug_response import get_symbol_name
 from litestar.middleware._internal.exceptions.middleware import (
@@ -211,6 +212,7 @@ def test_exception_handler_middleware_calls_app_level_after_exception_hook() -> 
         app = scope.get("app")
         assert isinstance(exc, RuntimeError)
         assert app
+        assert isinstance(app.state, State)
         assert not app.state.called
         app.state.called = True
 

--- a/tests/unit/test_plugins/test_base.py
+++ b/tests/unit/test_plugins/test_base.py
@@ -8,6 +8,7 @@ from click import Group
 
 from litestar import Litestar, MediaType, get
 from litestar.constants import UNDEFINED_SENTINELS
+from litestar.datastructures import State
 from litestar.file_system import FileSystemRegistry
 from litestar.plugins import CLIPlugin, InitPlugin, OpenAPISchemaPlugin, PluginRegistry
 from litestar.plugins.attrs import AttrsSchemaPlugin
@@ -28,6 +29,7 @@ def test_plugin_on_app_init() -> None:
     tag = "on_app_init_called"
 
     def on_startup(app: Litestar) -> None:
+        assert isinstance(app.state, State)
         app.state.called = True
 
     class PluginWithInitOnly(InitPlugin):

--- a/tests/unit/test_testing/test_test_client.py
+++ b/tests/unit/test_testing/test_test_client.py
@@ -7,6 +7,7 @@ import anyio
 from _pytest.fixtures import FixtureRequest
 
 from litestar import Controller, Request, WebSocket, delete, head, patch, put, websocket
+from litestar.datastructures import State
 from litestar.middleware.session.base import BaseBackendConfig
 from litestar.status_codes import HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT
 from litestar.stores.base import Store
@@ -569,6 +570,7 @@ async def test_client_uses_native_loop() -> None:
 async def test_lifespan_uses_native_loop() -> None:
     @contextlib.asynccontextmanager
     async def lifespan(app: Litestar) -> AsyncGenerator[None, None]:
+        assert isinstance(app.state, State)
         app.state["loop"] = asyncio.get_running_loop()
         yield
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Hi. I wanted to use custom child of `ImmutableState` to be passed to `Litestar` instance, but mypy warned me I can't really do it, so instead of type-ignoring it, I created this PR.
- Maybe a bit cleaner solution (but not sure if it'll need more work) is to swap inheritance, so `ImmutableState` inherits from `State` instead, but I suppose it'll still require `isinstance` asserts I added in tests to satisfy type-checkers.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: https://litestar-org.github.io/litestar-docs-preview/4653
