### PR TITLE
fix: Optional[UploadFile] should be None when no file submitted in multipart form

### DIFF
--- a/litestar/_kwargs/extractors.py
+++ b/litestar/_kwargs/extractors.py
@@ -371,6 +371,14 @@ async def _extract_multipart(
 
     for name, tp in field_definition.get_type_hints().items():
         value = form_values.get(name)
+        if value == "" and is_optional_union(tp):
+            inner = make_non_optional_union(tp)
+            try:
+                if issubclass(inner, UploadFile):
+                    form_values[name] = None  # pyright: ignore
+                    continue
+            except TypeError:
+                pass
         if (
             value is not None
             and not isinstance(value, list)

--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -652,3 +652,39 @@ def test_empty_strings_consistency_between_encodings() -> None:
 
         # Results should be identical
         assert response_url.text == response_multipart.text
+
+
+# https://github.com/litestar-org/litestar/issues/4647
+def test_optional_upload_file_without_file_submitted() -> None:
+    """Optional[UploadFile] in a dataclass should be None when no file is submitted via multipart."""
+
+    @dataclass
+    class UploadForm:
+        file: Optional[UploadFile] = None
+
+    @post("/", signature_namespace={"UploadForm": UploadForm, "UploadFile": UploadFile})
+    async def handler(
+        data: Annotated[UploadForm, Body(media_type=RequestEncodingType.MULTI_PART)],
+    ) -> str:
+        return "none" if data.file is None else "file"
+
+    with create_test_client([handler]) as client:
+        # Simulate browser submitting form without selecting a file (sends filename="" with empty body)
+        response = client.post(
+            "/",
+            content=(
+                b"--testboundary\r\n"
+                b'Content-Disposition: form-data; name="file"; filename=""\r\n'
+                b"Content-Type: application/octet-stream\r\n\r\n"
+                b"\r\n"
+                b"--testboundary--\r\n"
+            ),
+            headers={"Content-Type": "multipart/form-data; boundary=testboundary"},
+        )
+        assert response.status_code == HTTP_201_CREATED
+        assert response.text == "none"
+
+        # Submitting with an actual file should still work
+        response = client.post("/", files={"file": ("test.txt", b"hello", "text/plain")})
+        assert response.status_code == HTTP_201_CREATED
+        assert response.text == "file"


### PR DESCRIPTION
Fixes #4647

When a browser submits a multipart form without selecting a file, the file field arrives as an empty string. Since 2.18.0 (PR #4271), this empty string is preserved instead of being converted to None, causing a 400 validation error for Optional[UploadFile] fields.

Fix: in `_extract_multipart`, when iterating type hints, if a field value is an empty string and the expected type is `Optional[UploadFile]` (or subclass), replace it with None before it reaches the conversion layer.

Changes:
- `litestar/_kwargs/extractors.py`
- regression test in `tests/unit/test_kwargs/test_multipart_data.py`