### PR TITLE
fix: add an explicit test that `q` can be non-`float`

### DIFF
--- a/tests/unit/test_datastructures/test_headers.py
+++ b/tests/unit/test_datastructures/test_headers.py
@@ -358,7 +358,6 @@ def test_etag_to_header_weak() -> None:
     (
         ("text/plain", ["text/plain"], "text/plain"),
         ("text/plain", [MediaType.TEXT], MediaType.TEXT),
-        ("text/plain", ["text/plain"], "text/plain"),
         ("text/plain", ["text/html"], None),
         ("text/*", ["text/html"], "text/html"),
         ("*/*", ["text/html"], "text/html"),


### PR DESCRIPTION
This `suppress(ValueError)` was never tested: https://github.com/litestar-org/litestar/blob/55b69239fda945518f0dc69f7c511efb2d836c7f/litestar/datastructures/headers.py#L403-L404

I also removed a duplicate test case.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: https://litestar-org.github.io/litestar-docs-preview/4667
