### PR TITLE
fix: logic in `rate_limit` middleware

### DIFF
--- a/litestar/middleware/rate_limit.py
+++ b/litestar/middleware/rate_limit.py
@@ -158,9 +158,6 @@ class RateLimitMiddleware(AbstractMiddleware):
             cache_object = CacheObject(**decode_json(value=cached_string))
             if cache_object.reset <= now:
                 return CacheObject(history=[], reset=now + duration)
-
-            while cache_object.history and cache_object.history[-1] <= now - duration:
-                cache_object.history.pop()
             return cache_object
 
         return CacheObject(history=[], reset=now + duration)


### PR DESCRIPTION
The part that I delete can never realistically happen. Why? Because `reset` is set to `now + duration`, on the line which was above the `while` loop `reset` is checked to be `<= now`. `now` never changes.

All items are removed there.

These lines were also not covered.

I can't think of a case, when this can actually happen.


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: https://litestar-org.github.io/litestar-docs-preview/4683
