### PR TITLE
chore: fix pyright type-ignore comments to use specific error codes

### DIFF
--- a/litestar/_asgi/asgi_router.py
+++ b/litestar/_asgi/asgi_router.py
@@ -170,7 +170,7 @@ class ASGIRouter:
 
         validate_node(node=self.root_route_map_node)
         if self._mount_routes:
-            self._mount_paths_regex = re.compile("|".join(sorted(set(self._mount_routes))))  # pyright: ignore
+            self._mount_paths_regex = re.compile("|".join(sorted(set(self._mount_routes))))
 
     async def lifespan(self, receive: LifeSpanReceive, send: LifeSpanSend) -> None:
         """Handle the ASGI "lifespan" event on application startup and shutdown.

--- a/litestar/_kwargs/extractors.py
+++ b/litestar/_kwargs/extractors.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -374,7 +376,7 @@ async def _extract_multipart(
         if value == "" and is_optional_union(tp):
             inner: Any = make_non_optional_union(tp)
             if isinstance(inner, type) and issubclass(inner, UploadFile):
-                form_values[name] = None  # pyright: ignore
+                form_values[name] = None  # pyright: ignore[reportArgumentType]
                 continue
         if (
             value is not None
@@ -384,8 +386,7 @@ async def _extract_multipart(
                 or (is_optional_union(tp) and is_non_string_sequence(make_non_optional_union(tp)))
             )
         ):
-            form_values[name] = [value]  # pyright: ignore
-
+            form_values[name] = [value]  # pyright: ignore[reportArgumentType]
     return form_values
 
 

--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -312,7 +312,7 @@ class KwargsModel:
                 media_type = data_field_definition.kwarg_definition.media_type
 
             if media_type in (RequestEncodingType.MULTI_PART, RequestEncodingType.URL_ENCODED):
-                expected_form_data = (media_type, data_field_definition)  # pyright: ignore
+                expected_form_data = (media_type, data_field_definition)  # pyright: ignore[reportAssignmentType]
                 expected_data_dto = signature_model._data_dto
             elif signature_model._data_dto:
                 expected_data_dto = signature_model._data_dto

--- a/litestar/_multipart.py
+++ b/litestar/_multipart.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import re

--- a/litestar/_openapi/schema_generation/constrained_fields.py
+++ b/litestar/_openapi/schema_generation/constrained_fields.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from datetime import UTC, date, datetime

--- a/litestar/_openapi/schema_generation/examples.py
+++ b/litestar/_openapi/schema_generation/examples.py
@@ -36,7 +36,7 @@ def _normalize_example_value(value: Any) -> Any:
         args = list(get_args(value))
         try:
             args.remove(msgspec.UnsetType)
-            value = typing.Union[tuple(args)]  # pyright: ignore
+            value = typing.Union[tuple(args)]
         except ValueError:
             # UnsetType not part of the Union
             pass

--- a/litestar/_openapi/schema_generation/plugins/struct.py
+++ b/litestar/_openapi/schema_generation/plugins/struct.py
@@ -55,7 +55,7 @@ class StructSchemaPlugin(OpenAPISchemaPlugin):
         # manually
         if struct_info.tag_field:
             # using a Literal here will set these as a const in the schema
-            property_fields[struct_info.tag_field] = FieldDefinition.from_annotation(Literal[struct_info.tag])  # pyright: ignore
+            property_fields[struct_info.tag_field] = FieldDefinition.from_annotation(Literal[struct_info.tag])
             required.append(struct_info.tag_field)
 
         return schema_creator.create_component_schema(

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from collections import OrderedDict, defaultdict, deque

--- a/litestar/_openapi/typescript_converter/converter.py
+++ b/litestar/_openapi/typescript_converter/converter.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from copy import copy

--- a/litestar/_signature/model.py
+++ b/litestar/_signature/model.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import re
@@ -116,7 +118,7 @@ class SignatureModel(Struct):
         Returns:
             An Exception
         """
-        method = connection.method if hasattr(connection, "method") else ScopeType.WEBSOCKET  # pyright: ignore
+        method = connection.method if hasattr(connection, "method") else ScopeType.WEBSOCKET  # pyright: ignore[reportAttributeAccessIssue]
         if client_errors := [
             err_message
             for err_message in messages
@@ -317,6 +319,5 @@ class SignatureModel(Struct):
             setattr(annotation, "_decoder", decoder)
 
         if meta_data:
-            annotation = Annotated[annotation, meta_data]  # pyright: ignore
-
+            annotation = Annotated[annotation, meta_data]
         return annotation

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -180,7 +180,7 @@ class Litestar(Router):
         compression_config: CompressionConfig | None = None,
         cors_config: CORSConfig | None = None,
         csrf_config: CSRFConfig | None = None,
-        dto: type[AbstractDTO] | None | EmptyType = Empty,
+        dto: type[AbstractDTO] | EmptyType | None = Empty,
         debug: bool | None = None,
         dependencies: Dependencies | None = None,
         etag: ETag | None = None,
@@ -205,7 +205,7 @@ class Litestar(Router):
         response_class: type[Response] | None = None,
         response_cookies: ResponseCookies | None = None,
         response_headers: ResponseHeaders | None = None,
-        return_dto: type[AbstractDTO] | None | EmptyType = Empty,
+        return_dto: type[AbstractDTO] | EmptyType | None = Empty,
         security: Sequence[SecurityRequirement] | None = None,
         signature_namespace: Mapping[str, Any] | None = None,
         signature_types: Sequence[Any] | None = None,
@@ -386,7 +386,7 @@ class Litestar(Router):
             (p.on_app_init for p in config.plugins if isinstance(p, InitPluginProtocol)),
             [self._patch_opentelemetry_middleware],
         ):
-            config = handler(config)  # pyright: ignore
+            config = handler(config)
 
         self.plugins = PluginRegistry(config.plugins)
 
@@ -583,7 +583,7 @@ class Litestar(Router):
     async def _call_lifespan_hook(self, hook: LifespanHook) -> None:
         ret = hook(self) if inspect.signature(hook).parameters else hook()  # type: ignore[call-arg]
 
-        if is_async_callable(hook):  # pyright: ignore
+        if is_async_callable(hook):  # pyright: ignore[reportArgumentType]
             await ret
 
     @asynccontextmanager
@@ -778,8 +778,7 @@ class Litestar(Router):
 
         # this narrows down to an ABC, but we assume a non-abstract subclass of the ABC superclass
         if is_class_and_subclass(value, WebsocketListener):
-            return value().to_handler()  # pyright: ignore
-
+            return value().to_handler()  # pyright: ignore[reportAbstractUsage]
         if isinstance(value, Router):
             if value is self:
                 raise ImproperlyConfiguredException("Cannot register a router on itself")
@@ -997,7 +996,7 @@ def _maybe_add_options_handler(
 ) -> list[HTTPRouteHandler]:
     handler_methods = {method for handler in http_handlers for method in handler.http_methods}
     if "OPTIONS" not in handler_methods:
-        options_handler = create_options_handler(path=path, allow_methods={*handler_methods, "OPTIONS"})  # pyright: ignore
+        options_handler = create_options_handler(path=path, allow_methods={*handler_methods, "OPTIONS"})  # pyright: ignore[reportArgumentType]
         options_handler = options_handler.merge(root)
         return [*http_handlers, options_handler]
     return http_handlers

--- a/litestar/channels/plugin.py
+++ b/litestar/channels/plugin.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import asyncio

--- a/litestar/cli/__init__.py
+++ b/litestar/cli/__init__.py
@@ -7,7 +7,7 @@ from importlib.util import find_spec
 if find_spec("rich_click") is not None:  # pragma: no cover
     import rich_click
 
-    rich_click.rich_click.THEME = "star-box"  # pyright: ignore
+    rich_click.rich_click.THEME = "star-box"  # pyright: ignore[reportAttributeAccessIssue]
     rich_click.rich_click.USE_RICH_MARKUP = True
     rich_click.rich_click.USE_MARKDOWN = False
     rich_click.rich_click.SHOW_ARGUMENTS = True

--- a/litestar/cli/_suggestions.py
+++ b/litestar/cli/_suggestions.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from typing import Final, NoReturn
 
 try:

--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import contextlib
@@ -142,7 +144,7 @@ class LoadedApp:
     is_factory: bool
 
 
-class LitestarGroup(Group):  # pyright: ignore
+class LitestarGroup(Group):  # pyright: ignore[reportGeneralTypeIssues]
     """:class:`click.Group` subclass that automatically injects ``app`` and ``env` kwargs into commands that request it.
 
     Use this as the ``cls`` for :class:`click.Group` if you're extending the internal CLI with a group. For ``command``s
@@ -281,7 +283,7 @@ def _inject_args(func: Callable[P, T]) -> Callable[P, T]:
 def _wrap_commands(commands: Iterable[Command]) -> None:
     for command in commands:
         if hasattr(command, "commands"):
-            _wrap_commands(command.commands.values())  # pyright: ignore
+            _wrap_commands(command.commands.values())  # pyright: ignore[reportAttributeAccessIssue]
         elif command.callback:
             command.callback = _inject_args(command.callback)
 
@@ -319,7 +321,7 @@ def _load_app_from_path(app_path: str) -> LoadedApp:
     if not isinstance(app, Litestar) and callable(app):
         app = app()
         is_factory = True
-    return LoadedApp(app=app, app_path=app_path, is_factory=is_factory)  # pyright: ignore
+    return LoadedApp(app=app, app_path=app_path, is_factory=is_factory)  # pyright: ignore[reportArgumentType]
 
 
 def _path_to_dotted_path(path: Path) -> str:
@@ -385,8 +387,7 @@ def _autodiscover_app(cwd: Path) -> LoadedApp:
                 os.environ["LITESTAR_APP"] = app_string
                 if not quiet_console and sys.stdout.isatty():
                     console.print(f"Using {app_name} factory from [bright_blue]{app_string}")
-                return LoadedApp(app=value(), app_path=f"{app_string}", is_factory=True)  # pyright: ignore
-
+                return LoadedApp(app=value(), app_path=f"{app_string}", is_factory=True)  # pyright: ignore[reportArgumentType]
     raise LitestarCLIException(f"Could not find {app_name} instance or factory")
 
 

--- a/litestar/cli/commands/core.py
+++ b/litestar/cli/commands/core.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import inspect
@@ -315,7 +317,7 @@ def run_command(
             # A guard statement at the beginning of this function prevents uvicorn from being unbound
             # See "reportUnboundVariable in:
             # https://microsoft.github.io/pyright/#/configuration?id=type-check-diagnostics-settings
-            uvicorn.run(  # pyright: ignore
+            uvicorn.run(
                 app=env.app_path,
                 host=host,
                 port=port,

--- a/litestar/cli/commands/schema.py
+++ b/litestar/cli/commands/schema.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from pathlib import Path
 
 import msgspec
@@ -79,9 +81,7 @@ def generate_typescript_specs(app: Litestar, output: Path, namespace: str) -> No
     try:
         specs = convert_openapi_to_typescript(app.openapi_schema, namespace)
         # beautifier will be defined if JSBEAUTIFIER_INSTALLED is True
-        specs_output = (
-            beautifier.beautify(specs.write()) if JSBEAUTIFIER_INSTALLED and beautifier else specs.write()  # pyright: ignore
-        )
+        specs_output = beautifier.beautify(specs.write()) if JSBEAUTIFIER_INSTALLED and beautifier else specs.write()
         output.write_text(specs_output)
     except OSError as e:  # pragma: no cover
         raise LitestarCLIException(f"failed to write schema to path {output}") from e

--- a/litestar/cli/commands/sessions.py
+++ b/litestar/cli/commands/sessions.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 try:
     import rich_click as click
 except ImportError:
@@ -57,5 +59,5 @@ def clear_sessions_command(app: Litestar) -> None:
         raise LitestarCLIException(f"{type(store)} does not support clearing all sessions")
 
     if Confirm.ask("[red]Delete all sessions?"):
-        anyio.run(store.delete_all)  # pyright: ignore
+        anyio.run(store.delete_all)
         console.print("[green]All active sessions deleted")

--- a/litestar/cli/main.py
+++ b/litestar/cli/main.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -45,9 +47,9 @@ def litestar_group(ctx: click.Context, app_path: str | None, app_dir: Path | Non
 
 # add sub commands here
 
-litestar_group.add_command(core.info_command)  # pyright: ignore
-litestar_group.add_command(core.run_command)  # pyright: ignore
-litestar_group.add_command(core.routes_command)  # pyright: ignore
-litestar_group.add_command(core.version_command)  # pyright: ignore
-litestar_group.add_command(sessions.sessions_group)  # pyright: ignore
-litestar_group.add_command(schema.schema_group)  # pyright: ignore
+litestar_group.add_command(core.info_command)  # pyright: ignore[reportArgumentType]
+litestar_group.add_command(core.run_command)  # pyright: ignore[reportArgumentType]
+litestar_group.add_command(core.routes_command)  # pyright: ignore[reportArgumentType]
+litestar_group.add_command(core.version_command)  # pyright: ignore[reportArgumentType]
+litestar_group.add_command(sessions.sessions_group)
+litestar_group.add_command(schema.schema_group)

--- a/litestar/concurrency.py
+++ b/litestar/concurrency.py
@@ -36,7 +36,7 @@ class _State:
 async def _run_sync_asyncio(fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
     ctx = contextvars.copy_context()
     bound_fn = partial(ctx.run, fn, *args, **kwargs)
-    return await asyncio.get_running_loop().run_in_executor(get_asyncio_executor(), bound_fn)  # pyright: ignore
+    return await asyncio.get_running_loop().run_in_executor(get_asyncio_executor(), bound_fn)
 
 
 async def _run_sync_trio(fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:

--- a/litestar/config/cors.py
+++ b/litestar/config/cors.py
@@ -118,7 +118,7 @@ class CORSConfig:
             headers["Access-Control-Allow-Credentials"] = str(self.allow_credentials).lower()
         if not self.is_allow_all_headers:
             headers["Access-Control-Allow-Headers"] = ", ".join(
-                sorted(set(self.allow_headers) | DEFAULT_ALLOWED_CORS_HEADERS)  # pyright: ignore
+                sorted(set(self.allow_headers) | DEFAULT_ALLOWED_CORS_HEADERS)
             )
         if self.allow_methods:
             headers["Access-Control-Allow-Methods"] = ", ".join(

--- a/litestar/connection/request.py
+++ b/litestar/connection/request.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import math
@@ -62,7 +64,7 @@ class Request(Generic[UserT, AuthT, StateT], ASGIConnection["HTTPRouteHandler", 
         "supports_push_promise",
     )
 
-    scope: HTTPScope  # pyright: ignore
+    scope: HTTPScope  # pyright: ignore[reportIncompatibleVariableOverride]
     """The ASGI scope attached to the connection."""
     receive: Receive
     """The ASGI receive function."""
@@ -278,8 +280,7 @@ class Request(Generic[UserT, AuthT, StateT], ASGIConnection["HTTPRouteHandler", 
                 else:
                     form_data = {}
 
-                self._connection_state.form = form_data  # pyright: ignore
-
+                self._connection_state.form = form_data  # pyright: ignore[reportAttributeAccessIssue]
             self._form = FormMultiDict.from_form_data(cast("dict[str, Any]", form_data))
 
         return self._form

--- a/litestar/connection/websocket.py
+++ b/litestar/connection/websocket.py
@@ -44,7 +44,7 @@ class WebSocket(Generic[UserT, AuthT, StateT], ASGIConnection["WebsocketRouteHan
 
     __slots__ = ("connection_state",)
 
-    scope: WebSocketScope  # pyright: ignore
+    scope: WebSocketScope  # pyright: ignore[reportIncompatibleVariableOverride]
     """The ASGI scope attached to the connection."""
     receive: Receive
     """The ASGI receive function."""

--- a/litestar/contrib/mako.py
+++ b/litestar/contrib/mako.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from collections.abc import Mapping
@@ -118,7 +120,7 @@ class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate, Mapping[str, Any]]
         """
         self._template_callables.append((key, template_callable))
 
-    def render_string(self, template_string: str, context: Mapping[str, Any]) -> str:  # pyright: ignore
+    def render_string(self, template_string: str, context: Mapping[str, Any]) -> str:
         """Render a template from a string with the given context.
 
         Args:

--- a/litestar/contrib/minijinja.py
+++ b/litestar/contrib/minijinja.py
@@ -124,7 +124,7 @@ class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate", StateP
                 directories = directory if isinstance(directory, list) else [directory]
 
                 for d in directories:
-                    template_path = Path(d) / name  # pyright: ignore[reportGeneralTypeIssues]
+                    template_path = Path(d) / name
                     if template_path.exists():
                         return template_path.read_text()
                 raise TemplateNotFoundException(template_name=name)

--- a/litestar/contrib/opentelemetry/config.py
+++ b/litestar/contrib/opentelemetry/config.py
@@ -20,7 +20,7 @@ except ImportError as e:
     raise MissingDependencyException("opentelemetry") from e
 
 
-from opentelemetry.trace import Span, TracerProvider  # pyright: ignore
+from opentelemetry.trace import Span, TracerProvider
 
 if TYPE_CHECKING:
     from opentelemetry.metrics import Meter, MeterProvider

--- a/litestar/contrib/opentelemetry/middleware.py
+++ b/litestar/contrib/opentelemetry/middleware.py
@@ -56,4 +56,4 @@ class OpenTelemetryInstrumentationMiddleware(AbstractMiddleware):
         Returns:
             None
         """
-        await self.open_telemetry_middleware(scope, receive, send)  # type: ignore[arg-type] # pyright: ignore[reportGeneralTypeIssues]
+        await self.open_telemetry_middleware(scope, receive, send)  # type: ignore[arg-type]

--- a/litestar/data_extractors.py
+++ b/litestar/data_extractors.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import inspect

--- a/litestar/datastructures/headers.py
+++ b/litestar/datastructures/headers.py
@@ -44,10 +44,10 @@ def _encode_headers(headers: Iterable[tuple[str, str]]) -> "RawHeadersList":
     return [(key.lower().encode("latin-1"), value.encode("latin-1")) for key, value in headers]
 
 
-class Headers(CIMultiDictProxy[str], MultiMixin[str]):  # pyright: ignore
+class Headers(CIMultiDictProxy[str], MultiMixin[str]):  # pyright: ignore[reportIncompatibleMethodOverride]
     """An immutable, case-insensitive multi dict for HTTP headers."""
 
-    def __init__(self, headers: Union[Mapping[str, str], "RawHeaders", MultiDict[str]] | None = None) -> None:  # pyright: ignore
+    def __init__(self, headers: Union[Mapping[str, str], "RawHeaders", MultiDict[str]] | None = None) -> None:
         """Initialize ``Headers``.
 
         Args:
@@ -57,7 +57,7 @@ class Headers(CIMultiDictProxy[str], MultiMixin[str]):  # pyright: ignore
             headers_: Union[Mapping[str, str], list[tuple[str, str]]] = {}
             if headers:
                 if isinstance(headers, Mapping):
-                    headers_ = headers  # pyright: ignore
+                    headers_ = headers  # pyright: ignore[reportAssignmentType]
                 else:
                     headers_ = [(key.decode("latin-1"), value.decode("latin-1")) for key, value in headers]
 

--- a/litestar/datastructures/multi_dicts.py
+++ b/litestar/datastructures/multi_dicts.py
@@ -41,17 +41,17 @@ class MultiMixin(Generic[T], MultiMapping[T], ABC):
                 yield key, value
 
 
-class MultiDict(BaseMultiDict[T], MultiMixin[T], Generic[T]):  # pyright: ignore
+class MultiDict(BaseMultiDict[T], MultiMixin[T], Generic[T]):  # pyright: ignore[reportIncompatibleMethodOverride]
     """MultiDict, using :class:`MultiDict <multidict.MultiDictProxy>`."""
 
-    def __init__(self, args: MultiMapping | Mapping[str, T] | Iterable[tuple[str, T]] | None = None) -> None:  # pyright: ignore
+    def __init__(self, args: MultiMapping | Mapping[str, T] | Iterable[tuple[str, T]] | None = None) -> None:
         """Initialize ``MultiDict`` from a`MultiMapping``,
         :class:`Mapping <typing.Mapping>` or an iterable of tuples.
 
         Args:
             args: Mapping-like structure to create the ``MultiDict`` from
         """
-        super().__init__(args or {})  # pyright: ignore
+        super().__init__(args or {})
 
     def immutable(self) -> ImmutableMultiDict[T]:
         """Create an.
@@ -61,24 +61,24 @@ class MultiDict(BaseMultiDict[T], MultiMixin[T], Generic[T]):  # pyright: ignore
         Returns:
             An immutable multi dict
         """
-        return ImmutableMultiDict[T](self)  # pyright: ignore
+        return ImmutableMultiDict[T](self)
 
     def copy(self) -> Self:
         """Return a shallow copy"""
         return type(self)(list(self.multi_items()))
 
 
-class ImmutableMultiDict(MultiDictProxy[T], MultiMixin[T], Generic[T]):  # pyright: ignore
+class ImmutableMultiDict(MultiDictProxy[T], MultiMixin[T], Generic[T]):  # pyright: ignore[reportIncompatibleMethodOverride]
     """Immutable MultiDict, using class:`MultiDictProxy <multidict.MultiDictProxy>`."""
 
-    def __init__(self, args: MultiMapping | Mapping[str, Any] | Iterable[tuple[str, Any]] | None = None) -> None:  # pyright: ignore
+    def __init__(self, args: MultiMapping | Mapping[str, Any] | Iterable[tuple[str, Any]] | None = None) -> None:
         """Initialize ``ImmutableMultiDict`` from a `MultiMapping``,
         :class:`Mapping <typing.Mapping>` or an iterable of tuples.
 
         Args:
             args: Mapping-like structure to create the ``ImmutableMultiDict`` from
         """
-        super().__init__(BaseMultiDict(args or {}))  # pyright: ignore
+        super().__init__(BaseMultiDict(args or {}))
 
     def mutable_copy(self) -> MultiDict[T]:
         """Create a mutable copy as a :class:`MultiDict`
@@ -111,10 +111,10 @@ class FormMultiDict(ImmutableMultiDict[Any]):
         items = []
         for k, v in form_data.items():
             if not isinstance(v, list):
-                items.append((k, v))  # pyright: ignore
+                items.append((k, v))
             else:
                 for sv in v:
-                    items.append((k, sv))  # pyright: ignore
+                    items.append((k, sv))
         return cls(items)
 
     async def close(self) -> None:

--- a/litestar/datastructures/state.py
+++ b/litestar/datastructures/state.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from collections.abc import Callable, Generator, Iterable, Iterator, Mapping, MutableMapping
@@ -130,7 +132,7 @@ class ImmutableState(Mapping[str, Any]):
 
         Customizes how the builtin "copy" function will work.
         """
-        return self.__class__(self._state, deep_copy=self._deep_copy)  # pyright: ignore
+        return self.__class__(self._state, deep_copy=self._deep_copy)
 
     def mutable_copy(self) -> State:
         """Return a mutable copy of the state object.
@@ -305,7 +307,7 @@ class State(ImmutableState, MutableMapping[str, Any]):
         Returns:
             A ``State``
         """
-        return self.__class__(self.dict(), deep_copy=self._deep_copy)  # pyright: ignore
+        return self.__class__(self.dict(), deep_copy=self._deep_copy)
 
     def immutable_copy(self) -> ImmutableState:
         """Return a shallow copy of the state object, setting it to be frozen.

--- a/litestar/di.py
+++ b/litestar/di.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from inspect import isasyncgenfunction, isclass, isfunction, isgeneratorfunction, ismethod
@@ -75,21 +77,19 @@ class Provide:
                 "Cannot cache generator dependency, consider using Lifespan Context instead."
             )
 
-        has_sync_callable = is_class_dependency or not is_async_callable(dependency)  # pyright: ignore
-
+        has_sync_callable = is_class_dependency or not is_async_callable(dependency)
         if sync_to_thread is not None:
             if has_generator_dependency:
                 warn_sync_to_thread_with_generator(dependency, stacklevel=3)  # type: ignore[arg-type]
             elif not has_sync_callable:
-                warn_sync_to_thread_with_async_callable(dependency, stacklevel=3)  # pyright: ignore
+                warn_sync_to_thread_with_async_callable(dependency, stacklevel=3)
         elif has_sync_callable and not has_generator_dependency:
-            warn_implicit_sync_to_thread(dependency, stacklevel=3)  # pyright: ignore
-
+            warn_implicit_sync_to_thread(dependency, stacklevel=3)
         if sync_to_thread and has_sync_callable:
-            self.dependency = ensure_async_callable(dependency)  # pyright: ignore
+            self.dependency = ensure_async_callable(dependency)
             self.has_sync_callable = False
         else:
-            self.dependency = dependency  # pyright: ignore
+            self.dependency = dependency
             self.has_sync_callable = has_sync_callable
 
         self.sync_to_thread = bool(sync_to_thread)

--- a/litestar/dto/_backend.py
+++ b/litestar/dto/_backend.py
@@ -842,7 +842,7 @@ def _create_struct_for_field_definitions(
             field_type = Annotated[field_type, field_definition.kwarg_definition]
 
         struct_fields.append(
-            (  # pyright: ignore
+            (  # pyright: ignore[reportArgumentType]
                 field_definition.name,
                 field_type,
                 _create_msgspec_field(field_definition),

--- a/litestar/dto/_codegen_backend.py
+++ b/litestar/dto/_codegen_backend.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 """DTO backends do the heavy lifting of decoding and validating raw bytes into domain models, and
 back again, to bytes.
 """

--- a/litestar/dto/base_dto.py
+++ b/litestar/dto/base_dto.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import dataclasses
@@ -88,7 +90,7 @@ class AbstractDTO(Generic[T]):
         if not field_definition.is_type_var:
             cls_dict.update(model_type=field_definition.annotation)
 
-        return type(f"{cls.__name__}[{annotation}]", (cls,), cls_dict)  # pyright: ignore
+        return type(f"{cls.__name__}[{annotation}]", (cls,), cls_dict)  # pyright: ignore[reportReturnType]
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         if (config := getattr(cls, "config", None)) and (model_type := getattr(cls, "model_type", None)):
@@ -111,17 +113,17 @@ class AbstractDTO(Generic[T]):
     def decode_builtins(self, value: dict[str, Any]) -> Any:
         """Decode a dictionary of Python values into an the DTO's datatype."""
 
-        backend = self._dto_backends[self.asgi_connection.route_handler.handler_id]["data_backend"]  # pyright: ignore
+        backend = self._dto_backends[self.asgi_connection.route_handler.handler_id]["data_backend"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
         return backend.populate_data_from_builtins(value, self.asgi_connection)
 
     def decode_bytes(self, value: bytes) -> Any:
         """Decode a byte string into an the DTO's datatype."""
 
-        backend = self._dto_backends[self.asgi_connection.route_handler.handler_id]["data_backend"]  # pyright: ignore
+        backend = self._dto_backends[self.asgi_connection.route_handler.handler_id]["data_backend"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
         return backend.populate_data_from_raw(value, self.asgi_connection)
 
     def data_to_encodable_type(self, data: T | Collection[T]) -> LitestarEncodableType:
-        backend = self._dto_backends[self.asgi_connection.route_handler.handler_id]["return_backend"]  # pyright: ignore
+        backend = self._dto_backends[self.asgi_connection.route_handler.handler_id]["return_backend"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
         return backend.encode_data(data)
 
     @classmethod
@@ -328,7 +330,7 @@ class AbstractDTO(Generic[T]):
 
         return {
             k: FieldDefinition.from_kwarg(annotation=v, name=k)
-            for k, v in get_type_hints(model_type, localns=namespace, include_extras=True).items()  # pyright: ignore
+            for k, v in get_type_hints(model_type, localns=namespace, include_extras=True).items()
         }
 
     @staticmethod

--- a/litestar/dto/data_structures.py
+++ b/litestar/dto/data_structures.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/litestar/events/emitter.py
+++ b/litestar/events/emitter.py
@@ -83,7 +83,7 @@ class SimpleEventEmitter(BaseEventEmitterBackend):
                 fn, args, kwargs = item
                 if kwargs:
                     fn = partial(fn, **kwargs)
-                task_group.start_soon(fn, *args)  # pyright: ignore[reportGeneralTypeIssues]
+                task_group.start_soon(fn, *args)
 
     async def __aenter__(self) -> SimpleEventEmitter:
         self._exit_stack = AsyncExitStack()

--- a/litestar/file_system.py
+++ b/litestar/file_system.py
@@ -271,8 +271,8 @@ class FsspecSyncWrapper(BaseFileSystem):
             start: Offset to start reading from
             end: Offset to stop reading at (inclusive)
         """
-        return await sync_to_thread(
-            self.wrapped_fs.cat_file,  # pyright: ignore
+        return await sync_to_thread(  # pyright: ignore[reportReturnType]
+            self.wrapped_fs.cat_file,
             str(path),
             start=start or None,
             end=end if end != -1 else None,
@@ -385,7 +385,7 @@ class FsspecAsyncWrapper(BaseFileSystem):
         # if we want to stream the whole thing we can use '.open_async' if it's
         # implemented
         if start == 0 and end == -1 and self._supports_open_async:
-            async with await self.wrapped_fs.open_async(path, mode="rb") as fh:  # pyright: ignore
+            async with await self.wrapped_fs.open_async(path, mode="rb") as fh:  # pyright: ignore[reportGeneralTypeIssues]
                 while chunk := await fh.read(chunksize):
                     yield chunk
             return

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import functools
@@ -138,7 +140,7 @@ class BaseRouteHandler:
         self._dto = dto
         self._return_dto = return_dto
         self.exception_handlers = exception_handlers or {}
-        self.guards: tuple[AsyncGuard, ...] = tuple(ensure_async_callable(guard) for guard in guards) if guards else ()  # pyright: ignore
+        self.guards: tuple[AsyncGuard, ...] = tuple(ensure_async_callable(guard) for guard in guards) if guards else ()  # pyright: ignore[reportAttributeAccessIssue]
         self.middleware = tuple(middleware) if middleware else ()
         self.name = name
         self.opt = dict(opt or {})
@@ -527,7 +529,7 @@ class BaseRouteHandler:
         Returns:
             A string
         """
-        target: type[AsyncAnyCallable] | AsyncAnyCallable  # pyright: ignore
+        target: type[AsyncAnyCallable] | AsyncAnyCallable  # pyright: ignore[reportInvalidTypeForm]
         target = unwrap_partial(self.fn)
         if not hasattr(target, "__qualname__"):
             target = type(target)

--- a/litestar/handlers/http_handlers/_options.py
+++ b/litestar/handlers/http_handlers/_options.py
@@ -30,7 +30,7 @@ def create_options_handler(path: str, allow_methods: Iterable[Method]) -> HTTPRo
         return Response(
             content=None,
             status_code=HTTP_204_NO_CONTENT,
-            headers={"Allow": ", ".join(sorted(allow_methods))},  # pyright: ignore
+            headers={"Allow": ", ".join(sorted(allow_methods))},
             media_type=MediaType.TEXT,
         )
 

--- a/litestar/handlers/http_handlers/_utils.py
+++ b/litestar/handlers/http_handlers/_utils.py
@@ -78,7 +78,7 @@ def create_data_handler(
         if after_request:
             response = await after_request(response)  # type: ignore[arg-type,misc]
 
-        return response.to_asgi_response(request=request, headers=normalize_headers(headers), cookies=cookies)  # pyright: ignore
+        return response.to_asgi_response(request=request, headers=normalize_headers(headers), cookies=cookies)  # pyright: ignore[reportFunctionMemberAccess]
 
     return handler
 
@@ -175,8 +175,7 @@ def normalize_http_method(http_methods: Method | Sequence[Method]) -> set[HttpMe
     output: set[str] = set()
 
     if isinstance(http_methods, str):
-        http_methods = [http_methods]  # pyright: ignore
-
+        http_methods = [http_methods]
     for method in http_methods:
         method_name = method.value.upper() if isinstance(method, HttpMethod) else method.upper()
         if method_name not in HTTP_METHOD_NAMES:

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import contextlib
@@ -297,7 +299,7 @@ class HTTPRouteHandler(BaseRouteHandler):
         self.after_request: AsyncAfterRequestHookHandler | None = (
             ensure_async_callable(after_request) if after_request else None  # type: ignore[assignment]
         )
-        self.after_response: AsyncAfterResponseHookHandler | None = (  # pyright: ignore
+        self.after_response: AsyncAfterResponseHookHandler | None = (  # pyright: ignore[reportAttributeAccessIssue]
             ensure_async_callable(after_response) if after_response else None
         )
         self.background = background
@@ -529,7 +531,7 @@ class HTTPRouteHandler(BaseRouteHandler):
 
     @property
     def request_max_body_size(self) -> int | None:
-        return value_or_default(self._request_max_body_size, None)  # pyright: ignore
+        return value_or_default(self._request_max_body_size, None)  # pyright: ignore[reportReturnType]
 
     def on_registration(self, route: BaseRoute, app: Litestar) -> None:
         super().on_registration(route=route, app=app)
@@ -708,7 +710,7 @@ class HTTPRouteHandler(BaseRouteHandler):
     async def _call_handler_function(
         self,
         request: Request,
-    ) -> ASGIApp:  # pyright: ignore[reportGeneralTypeIssues]
+    ) -> ASGIApp:
         """Call the before request handlers, retrieve any data required for the route handler, and call the route
         handler's ``to_response`` method.
 

--- a/litestar/handlers/websocket_handlers/stream.py
+++ b/litestar/handlers/websocket_handlers/stream.py
@@ -259,7 +259,7 @@ class WebSocketStreamHandler(WebsocketRouteHandler):
         self._return_dto = return_dto = self._resolve_return_dto(app=app, data_dto=self._dto)
 
         # make sure the closure doesn't capture self._ws_stream / self
-        send_mode: WebSocketMode = self._ws_stream_options.send_mode  # pyright: ignore
+        send_mode: WebSocketMode = self._ws_stream_options.send_mode  # pyright: ignore[reportAssignmentType]
         listen_for_disconnect = self._ws_stream_options.listen_for_disconnect
         warn_on_data_discard = self._ws_stream_options.warn_on_data_discard
 
@@ -292,8 +292,7 @@ class WebSocketStreamHandler(WebsocketRouteHandler):
                 send_handler=send_handler,
             )
 
-        self.fn = handler_fn  # pyright: ignore
-
+        self.fn = handler_fn  # pyright: ignore[reportGeneralTypeIssues]
         super().on_registration(route, app)
 
 

--- a/litestar/middleware/_internal/cors.py
+++ b/litestar/middleware/_internal/cors.py
@@ -111,7 +111,7 @@ class CORSMiddleware(AbstractMiddleware):
         if pre_flight_requested_headers:
             if self.config.is_allow_all_headers:
                 response_headers["Access-Control-Allow-Headers"] = ", ".join(
-                    sorted(set(pre_flight_requested_headers) | DEFAULT_ALLOWED_CORS_HEADERS)  # pyright: ignore
+                    sorted(set(pre_flight_requested_headers) | DEFAULT_ALLOWED_CORS_HEADERS)
                 )
             else:
                 all_allowed_headers = set(self.config.allow_headers).union(

--- a/litestar/middleware/allowed_hosts.py
+++ b/litestar/middleware/allowed_hosts.py
@@ -42,12 +42,11 @@ class AllowedHostsMiddleware(AbstractMiddleware):
             for host in config.allowed_hosts
         }
 
-        self.allowed_hosts_regex = re.compile("|".join(sorted(allowed_hosts)))  # pyright: ignore
-
+        self.allowed_hosts_regex = re.compile("|".join(sorted(allowed_hosts)))
         if config.www_redirect and (
             redirect_domains := {host.replace("www.", "") for host in config.allowed_hosts if host.startswith("www.")}
         ):
-            self.redirect_domains = re.compile("|".join(sorted(redirect_domains)))  # pyright: ignore
+            self.redirect_domains = re.compile("|".join(sorted(redirect_domains)))
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI callable.

--- a/litestar/middleware/base.py
+++ b/litestar/middleware/base.py
@@ -146,7 +146,7 @@ class AbstractMiddleware:
             ):
                 await self.app(scope, receive, send)
             else:
-                await original__call__(self, scope, receive, send)  # pyright: ignore
+                await original__call__(self, scope, receive, send)  # pyright: ignore[reportArgumentType]
 
         # https://github.com/python/mypy/issues/2427#issuecomment-384229898
         setattr(cls, "__call__", wrapped_call)

--- a/litestar/middleware/compression/middleware.py
+++ b/litestar/middleware/compression/middleware.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from io import BytesIO

--- a/litestar/middleware/constraints.py
+++ b/litestar/middleware/constraints.py
@@ -348,7 +348,7 @@ def check_middleware_constraints(middlewares: tuple[Middleware, ...]) -> None:
         else:
             # 'middleware' might be a class or an instance of a class
             middleware_type = type(middleware) if not inspect.isclass(middleware) else middleware
-            for base in middleware_type.mro()[:-1]:  # pyright: ignore
+            for base in middleware_type.mro()[:-1]:  # pyright: ignore[reportFunctionMemberAccess]
                 positions[base].append(i)
 
         if not (isinstance(middleware, ASGIMiddleware) and middleware.constraints):

--- a/litestar/middleware/rate_limit.py
+++ b/litestar/middleware/rate_limit.py
@@ -110,7 +110,7 @@ class RateLimitMiddleware(AbstractMiddleware):
             if self.config.set_rate_limit_headers:
                 send = self.create_send_wrapper(send=send, cache_object=cache_object)
 
-        await self.app(scope, receive, send)  # pyright: ignore
+        await self.app(scope, receive, send)
 
     def create_send_wrapper(self, send: Send, cache_object: CacheObject) -> Send:
         """Create a ``send`` function that wraps the original send to inject response headers.

--- a/litestar/middleware/session/base.py
+++ b/litestar/middleware/session/base.py
@@ -30,11 +30,10 @@ ConfigT = TypeVar("ConfigT", bound="BaseBackendConfig")
 BaseSessionBackendT = TypeVar("BaseSessionBackendT", bound="BaseSessionBackend")
 
 
-class BaseBackendConfig(ABC, Generic[BaseSessionBackendT]):  # pyright: ignore
+class BaseBackendConfig(ABC, Generic[BaseSessionBackendT]):
     """Configuration for Session middleware backends."""
 
-    _backend_class: type[BaseSessionBackendT]  # pyright: ignore
-
+    _backend_class: type[BaseSessionBackendT]
     key: str
     """Key to use for the cookie inside the header, e.g. ``session=<data>`` where ``session`` is the cookie key and
     ``<data>`` is the session data.
@@ -251,6 +250,6 @@ class SessionMiddleware(AbstractMiddleware, Generic[BaseSessionBackendT]):
 
         connection = ASGIConnection[Any, Any, Any, Any](scope, receive=receive, send=send)
         scope["session"] = await self.backend.load_from_connection(connection)
-        connection._connection_state.session_id = self.backend.get_session_id(connection)  # pyright: ignore [reportGeneralTypeIssues]
+        connection._connection_state.session_id = self.backend.get_session_id(connection)
 
         await self.app(scope, receive, self.create_send_wrapper(connection))

--- a/litestar/middleware/session/client_side.py
+++ b/litestar/middleware/session/client_side.py
@@ -217,7 +217,7 @@ class ClientSideSessionBackend(BaseSessionBackend["CookieBackendConfig"]):
 
 
 @dataclass
-class CookieBackendConfig(BaseBackendConfig[ClientSideSessionBackend]):  # pyright: ignore
+class CookieBackendConfig(BaseBackendConfig[ClientSideSessionBackend]):
     """Configuration for [SessionMiddleware] middleware."""
 
     _backend_class = ClientSideSessionBackend

--- a/litestar/middleware/session/server_side.py
+++ b/litestar/middleware/session/server_side.py
@@ -166,7 +166,7 @@ class ServerSideSessionBackend(BaseSessionBackend["ServerSideSessionConfig"]):
 
 
 @dataclass
-class ServerSideSessionConfig(BaseBackendConfig[ServerSideSessionBackend]):  # pyright: ignore
+class ServerSideSessionConfig(BaseBackendConfig[ServerSideSessionBackend]):
     """Base configuration for server side backends."""
 
     _backend_class = ServerSideSessionBackend

--- a/litestar/openapi/spec/schema.py
+++ b/litestar/openapi/spec/schema.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from collections.abc import Hashable, Mapping, Sequence

--- a/litestar/pagination.py
+++ b/litestar/pagination.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -41,7 +43,7 @@ class ClassicPagination(Generic[T]):
 # AA requires it's own `OffsetPagination` class in versions greater that 0.9.0
 # If we find it, use it.
 try:
-    from advanced_alchemy.service import OffsetPagination  # pyright: ignore
+    from advanced_alchemy.service import OffsetPagination  # pyright: ignore[reportAssignmentType]
 except ImportError:
 
     @dataclass

--- a/litestar/plugins/attrs.py
+++ b/litestar/plugins/attrs.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, TypeGuard
@@ -52,7 +54,7 @@ class AttrsSchemaPlugin(OpenAPISchemaPlugin):
         )
 
 
-def is_attrs_class(annotation: Any) -> TypeGuard[type[attrs.AttrsInstance]]:  # pyright: ignore
+def is_attrs_class(annotation: Any) -> TypeGuard[type[attrs.AttrsInstance]]:
     """Given a type annotation determine if the annotation is a class that includes an attrs attribute.
 
     Args:

--- a/litestar/plugins/base.py
+++ b/litestar/plugins/base.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import abc

--- a/litestar/plugins/flash.py
+++ b/litestar/plugins/flash.py
@@ -64,7 +64,7 @@ class FlashPlugin(InitPlugin):
             if isinstance(self.config.template_config.engine_instance, MiniJinjaTemplateEngine):
                 template_callable = _transform_state(get_flashes)
 
-        self.config.template_config.engine_instance.register_template_callable("get_flashes", template_callable)  # pyright: ignore[reportGeneralTypeIssues]
+        self.config.template_config.engine_instance.register_template_callable("get_flashes", template_callable)
         return app_config
 
 

--- a/litestar/plugins/prometheus/controller.py
+++ b/litestar/plugins/prometheus/controller.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import os

--- a/litestar/plugins/pydantic/__init__.py
+++ b/litestar/plugins/pydantic/__init__.py
@@ -29,9 +29,7 @@ def _model_dump(
     by_alias: bool = False,
     round_trip: bool = False,
 ) -> dict[str, Any]:
-    return (
-        model.model_dump(mode="json", by_alias=by_alias, round_trip=round_trip)  # pyright: ignore
-    )
+    return model.model_dump(mode="json", by_alias=by_alias, round_trip=round_trip)
 
 
 def _model_dump_json(
@@ -39,9 +37,7 @@ def _model_dump_json(
     by_alias: bool = False,
     round_trip: bool = False,
 ) -> str:
-    return (
-        model.model_dump_json(by_alias=by_alias, round_trip=round_trip)  # pyright: ignore
-    )
+    return model.model_dump_json(by_alias=by_alias, round_trip=round_trip)
 
 
 class PydanticPlugin(InitPlugin):

--- a/litestar/plugins/pydantic/dto.py
+++ b/litestar/plugins/pydantic/dto.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import dataclasses
@@ -47,7 +49,7 @@ _down_types: dict[Any, Any] = {
 }
 
 
-def convert_validation_error(validation_error: ValidationError) -> list[dict[str, Any]]:  # pyright: ignore[reportInvalidTypeForm,reportGeneralTypeIssues]
+def convert_validation_error(validation_error: ValidationError) -> list[dict[str, Any]]:
     error_list = validation_error.errors()
     for error in error_list:
         if isinstance(exception := error.get("ctx", {}).get("error"), Exception):
@@ -83,7 +85,7 @@ class PydanticDTO(AbstractDTO[T], Generic[T]):
     @classmethod
     def generate_field_definitions(
         cls,
-        model_type: type[pydantic.BaseModel],  # pyright: ignore[reportInvalidTypeForm,reportGeneralTypeIssues]
+        model_type: type[pydantic.BaseModel],
     ) -> Generator[DTOFieldDefinition, None, None]:
         model_info = get_model_info(model_type)
         model_fields = model_info.model_fields
@@ -103,7 +105,7 @@ class PydanticDTO(AbstractDTO[T], Generic[T]):
                 except AttributeError:
                     extra = field_info.json_schema_extra  # type: ignore[union-attr]
 
-                if extra is not None and extra.pop(DTO_FIELD_META_KEY, None):  # pyright: ignore
+                if extra is not None and extra.pop(DTO_FIELD_META_KEY, None):  # pyright: ignore[reportFunctionMemberAccess]
                     warn(
                         message="Declaring 'DTOField' via Pydantic's 'Field.extra' is deprecated. "
                         "Use 'Annotated', e.g., 'Annotated[str, DTOField(mark='read-only')]' instead. "

--- a/litestar/plugins/pydantic/plugins/schema.py
+++ b/litestar/plugins/pydantic/plugins/schema.py
@@ -145,7 +145,7 @@ class PydanticSchemaPlugin(OpenAPISchemaPlugin):
         return PYDANTIC_TYPE_MAP[field_definition.annotation]  # pragma: no cover
 
     @classmethod
-    def for_pydantic_model(cls, field_definition: FieldDefinition, schema_creator: SchemaCreator) -> Schema | Reference:  # pyright: ignore
+    def for_pydantic_model(cls, field_definition: FieldDefinition, schema_creator: SchemaCreator) -> Schema | Reference:
         """Create a schema object for a given pydantic model class.
 
         Args:

--- a/litestar/plugins/pydantic/utils.py
+++ b/litestar/plugins/pydantic/utils.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 # mypy: strict-equality=False
 # pyright: reportGeneralTypeIssues=false
 from __future__ import annotations
@@ -25,7 +27,7 @@ if TYPE_CHECKING:
 
 def is_pydantic_model_class(
     annotation: Any,
-) -> TypeGuard[type[pydantic.BaseModel]]:  # pyright: ignore
+) -> TypeGuard[type[pydantic.BaseModel]]:
     """Given a type annotation determine if the annotation is a subclass of pydantic's BaseModel.
 
     Args:
@@ -39,7 +41,7 @@ def is_pydantic_model_class(
 
 def is_pydantic_model_instance(
     annotation: Any,
-) -> TypeGuard[pydantic.BaseModel]:  # pyright: ignore
+) -> TypeGuard[pydantic.BaseModel]:
     """Given a type annotation determine if the annotation is an instance of pydantic's BaseModel.
 
     Args:
@@ -83,8 +85,8 @@ def pydantic_get_type_hints_with_generics_resolved(
 
 
 def is_pydantic_2_model(
-    obj: type[pydantic.BaseModel],  # pyright: ignore
-) -> TypeGuard[pydantic.BaseModel]:  # pyright: ignore
+    obj: type[pydantic.BaseModel],
+) -> TypeGuard[pydantic.BaseModel]:
     return issubclass(obj, pydantic.BaseModel)
 
 
@@ -93,7 +95,7 @@ def is_pydantic_undefined(value: Any) -> bool:
 
 
 def create_field_definitions_for_computed_fields(
-    model: type[pydantic.BaseModel],  # pyright: ignore
+    model: type[pydantic.BaseModel],
     prefer_alias: bool,
 ) -> dict[str, FieldDefinition]:
     """Create field definitions for computed fields.
@@ -148,7 +150,7 @@ def is_pydantic_root_model(annotation: Any) -> bool:
 class PydanticModelInfo:
     pydantic_version: Literal["1", "2"]
     field_definitions: dict[str, FieldDefinition]
-    model_fields: dict[str, pydantic.fields.FieldInfo]  # pyright: ignore[reportInvalidTypeForm,reportGeneralTypeIssues]
+    model_fields: dict[str, pydantic.fields.FieldInfo]
     title: str | None = None
     example: Any | None = None
     is_generic: bool = False
@@ -160,7 +162,7 @@ _CreateFieldDefinition = Callable[..., FieldDefinition]
 def _create_field_definition_v2(  # noqa: C901
     field_annotation: Any,
     *,
-    field_info: pydantic.fields.FieldInfo,  # pyright: ignore[reportInvalidTypeForm,reportGeneralTypeIssues]
+    field_info: pydantic.fields.FieldInfo,
     **field_definition_kwargs: Any,
 ) -> FieldDefinition:
     kwargs: dict[str, Any] = {}
@@ -191,7 +193,7 @@ def _create_field_definition_v2(  # noqa: C901
         kwargs["title"] = title
 
     for meta in field_info.metadata:
-        if isinstance(meta, pydantic.types.StringConstraints):  # pyright: ignore[reportAttributeAccessIssue]
+        if isinstance(meta, pydantic.types.StringConstraints):
             kwargs["min_length"] = meta.min_length
             kwargs["max_length"] = meta.max_length
             kwargs["pattern"] = meta.pattern
@@ -225,7 +227,7 @@ def get_model_info(
     annotation: Any,
     prefer_alias: bool = False,
 ) -> PydanticModelInfo:
-    model: type[pydantic.BaseModel]  # pyright: ignore[reportInvalidTypeForm,reportGeneralTypeIssues]
+    model: type[pydantic.BaseModel]
 
     if is_generic(annotation):
         is_generic_model = True
@@ -239,7 +241,7 @@ def get_model_info(
     title = model_config.get("title")
     example = model_config.get("example")
 
-    model_fields: dict[str, pydantic.fields.FieldInfo] = {  # pyright: ignore[reportInvalidTypeForm,reportGeneralTypeIssues]
+    model_fields: dict[str, pydantic.fields.FieldInfo] = {
         k: getattr(f, "field_info", f) for k, f in model_field_info.items()
     }
 

--- a/litestar/repository/exceptions.py
+++ b/litestar/repository/exceptions.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 try:
     from advanced_alchemy.exceptions import IntegrityError as ConflictError
     from advanced_alchemy.exceptions import NotFoundError, RepositoryError

--- a/litestar/repository/filters.py
+++ b/litestar/repository/filters.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 try:
     from advanced_alchemy.filters import (
         BeforeAfter,

--- a/litestar/repository/testing/generic_mock_repository.py
+++ b/litestar/repository/testing/generic_mock_repository.py
@@ -56,7 +56,7 @@ class GenericAsyncMockRepository(AbstractAsyncRepository[ModelT], Generic[ModelT
         Args:
             item: The type that the class has been parametrized with.
         """
-        return type(  # pyright:ignore
+        return type(  # pyright: ignore[reportReturnType]
             f"{cls.__name__}[{item.__name__}]",
             (cls,),
             {
@@ -217,7 +217,7 @@ class GenericAsyncMockRepository(AbstractAsyncRepository[ModelT], Generic[ModelT
                     setattr(existing, field_name, new_field_value)
 
             return existing, False
-        return await self.add(self.model_type(**kwargs)), True  # pyright: ignore[reportGeneralTypeIssues]
+        return await self.add(self.model_type(**kwargs)), True
 
     async def get_one(self, **kwargs: Any) -> ModelT:
         """Get instance identified by query filters.
@@ -436,7 +436,7 @@ class GenericSyncMockRepository(AbstractSyncRepository[ModelT], Generic[ModelT])
         Args:
             item: The type that the class has been parametrized with.
         """
-        return type(  # pyright:ignore
+        return type(  # pyright: ignore[reportReturnType]
             f"{cls.__name__}[{item.__name__}]",
             (cls,),
             {
@@ -595,7 +595,7 @@ class GenericSyncMockRepository(AbstractSyncRepository[ModelT], Generic[ModelT])
                     setattr(existing, field_name, new_field_value)
 
             return existing, False
-        return self.add(self.model_type(**kwargs)), True  # pyright: ignore[reportGeneralTypeIssues]
+        return self.add(self.model_type(**kwargs)), True
 
     def get_one(self, **kwargs: Any) -> ModelT:
         """Get instance identified by query filters.

--- a/litestar/response/base.py
+++ b/litestar/response/base.py
@@ -87,8 +87,7 @@ class ASGIResponse:
 
         if headers is not None:
             for k, v in headers.items() if isinstance(headers, dict) else headers:
-                self.headers.add(k, v)  # pyright: ignore
-
+                self.headers.add(k, v)  # pyright: ignore[reportArgumentType]
         media_type = get_enum_string_value(media_type or MediaType.JSON)
 
         status_allows_body = (

--- a/litestar/response/file.py
+++ b/litestar/response/file.py
@@ -338,7 +338,7 @@ class File(Response):
             filename=self.filename,
             background=self.background or background,
             chunk_size=self.chunk_size,
-            content_disposition_type=self.content_disposition_type,  # pyright: ignore
+            content_disposition_type=self.content_disposition_type,  # pyright: ignore[reportArgumentType]
             content_length=0,
             cookies=cookies,
             encoding=self.encoding,

--- a/litestar/router.py
+++ b/litestar/router.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
@@ -166,7 +168,7 @@ class Router:
         self.after_request: AsyncAfterRequestHookHandler | None = (
             ensure_async_callable(after_request) if after_request else None  # type: ignore[assignment]
         )
-        self.after_response: AsyncAfterResponseHookHandler | None = (  # pyright: ignore
+        self.after_response: AsyncAfterResponseHookHandler | None = (  # pyright: ignore[reportAttributeAccessIssue]
             ensure_async_callable(after_response) if after_response else None
         )
         self.before_request = ensure_async_callable(before_request) if before_request else None

--- a/litestar/security/jwt/auth.py
+++ b/litestar/security/jwt/auth.py
@@ -66,7 +66,7 @@ class BaseJWTAuth(Generic[UserType, TokenT], AbstractSecurityConfig[UserType, To
     """The value to use for the OpenAPI security scheme and security requirements."""
     description: str
     """Description for the OpenAPI security scheme."""
-    authentication_middleware_class: type[JWTAuthenticationMiddleware]  # pyright: ignore
+    authentication_middleware_class: type[JWTAuthenticationMiddleware]  # pyright: ignore[reportIncompatibleVariableOverride]
     """The authentication middleware class to use.
 
     Must inherit from :class:`JWTAuthenticationMiddleware`
@@ -423,7 +423,7 @@ class JWTCookieAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, TokenT]):
     """Controls whether or not a cookie is sent with cross-site requests. Defaults to ``lax``. """
     description: str = field(default="JWT cookie-based authentication and authorization.")
     """Description for the OpenAPI security scheme."""
-    authentication_middleware_class: type[JWTCookieAuthenticationMiddleware] = field(  # pyright: ignore
+    authentication_middleware_class: type[JWTCookieAuthenticationMiddleware] = field(  # pyright: ignore[reportIncompatibleVariableOverride]
         default=JWTCookieAuthenticationMiddleware
     )
     """The authentication middleware class to use. Must inherit from :class:`JWTCookieAuthenticationMiddleware`
@@ -661,7 +661,7 @@ class OAuth2PasswordBearerAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, 
     """Controls whether or not a cookie is sent with cross-site requests. Defaults to ``lax``. """
     description: str = field(default="OAUTH2 password bearer authentication and authorization.")
     """Description for the OpenAPI security scheme."""
-    authentication_middleware_class: type[JWTCookieAuthenticationMiddleware] = field(  # pyright: ignore
+    authentication_middleware_class: type[JWTCookieAuthenticationMiddleware] = field(  # pyright: ignore[reportIncompatibleVariableOverride]
         default=JWTCookieAuthenticationMiddleware
     )
     """The authentication middleware class to use.
@@ -747,7 +747,7 @@ class OAuth2PasswordBearerAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, 
                     scheme="Bearer",
                     name=self.auth_header,
                     security_scheme_in="header",
-                    flows=OAuthFlows(password=self.oauth_flow),  # pyright: ignore[reportGeneralTypeIssues]
+                    flows=OAuthFlows(password=self.oauth_flow),
                     bearer_format="JWT",
                     description=self.description,
                 )

--- a/litestar/security/session_auth/auth.py
+++ b/litestar/security/session_auth/auth.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 class SessionAuth(Generic[UserType, BaseSessionBackendT], AbstractSecurityConfig[UserType, dict[str, Any]]):
     """Session Based Security Backend."""
 
-    session_backend_config: BaseBackendConfig[BaseSessionBackendT]  # pyright: ignore
+    session_backend_config: BaseBackendConfig[BaseSessionBackendT]
     """A session backend config."""
     retrieve_user_handler: Callable[[Any, ASGIConnection], SyncOrAsyncUnion[Any | None]]
     """Callable that receives the ``auth`` value from the authentication middleware and returns a ``user`` value.
@@ -36,7 +36,7 @@ class SessionAuth(Generic[UserType, BaseSessionBackendT], AbstractSecurityConfig
 
     """
 
-    authentication_middleware_class: type[SessionAuthMiddleware] = field(default=SessionAuthMiddleware)  # pyright: ignore
+    authentication_middleware_class: type[SessionAuthMiddleware] = field(default=SessionAuthMiddleware)  # pyright: ignore[reportIncompatibleVariableOverride]
     """The authentication middleware class to use.
 
     Must inherit from :class:`SessionAuthMiddleware <litestar.security.session_auth.middleware.SessionAuthMiddleware>`
@@ -106,7 +106,7 @@ class SessionAuth(Generic[UserType, BaseSessionBackendT], AbstractSecurityConfig
         Returns:
             A subclass of :class:`BaseSessionBackend <litestar.middleware.session.base.BaseSessionBackend>`
         """
-        return self.session_backend_config._backend_class(config=self.session_backend_config)  # pyright: ignore
+        return self.session_backend_config._backend_class(config=self.session_backend_config)
 
     @property
     def openapi_components(self) -> Components:
@@ -120,7 +120,7 @@ class SessionAuth(Generic[UserType, BaseSessionBackendT], AbstractSecurityConfig
                 "sessionCookie": SecurityScheme(
                     type="apiKey",
                     name=self.session_backend_config.key,
-                    security_scheme_in="cookie",  # pyright: ignore
+                    security_scheme_in="cookie",
                     description="Session cookie authentication.",
                 )
             }

--- a/litestar/serialization/msgspec_hooks.py
+++ b/litestar/serialization/msgspec_hooks.py
@@ -187,7 +187,7 @@ def decode_json(
 
 def decode_json(  # type: ignore[misc]
     value: str | bytes,
-    target_type: type[T] | EmptyType = Empty,  # pyright: ignore
+    target_type: type[T] | EmptyType = Empty,
     type_decoders: TypeDecodersSequence | None = None,
     strict: bool = True,
 ) -> Any:
@@ -263,7 +263,7 @@ def decode_msgpack(
 
 def decode_msgpack(  # type: ignore[misc]
     value: bytes,
-    target_type: type[T] | EmptyType = Empty,  # pyright: ignore[reportInvalidTypeVarUse]
+    target_type: type[T] | EmptyType = Empty,
     type_decoders: TypeDecodersSequence | None = None,
     strict: bool = True,
 ) -> Any:

--- a/litestar/stores/valkey.py
+++ b/litestar/stores/valkey.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/litestar/template/config.py
+++ b/litestar/template/config.py
@@ -47,7 +47,7 @@ class TemplateConfig(Generic[EngineType]):
         """Instantiate the template engine."""
         template_engine = cast(
             "EngineType",
-            self.engine(directory=self.directory, engine_instance=None) if isclass(self.engine) else self.engine,  # pyright: ignore
+            self.engine(directory=self.directory, engine_instance=None) if isclass(self.engine) else self.engine,  # pyright: ignore[reportArgumentType]
         )
         if callable(self.engine_callback):
             self.engine_callback(template_engine)

--- a/litestar/testing/client/_base.py
+++ b/litestar/testing/client/_base.py
@@ -98,7 +98,7 @@ async def _set_session_data(client: TestClient | AsyncTestClient, data: dict[str
     )
 
     session_id = client._session_backend.get_session_id(connection)
-    connection._connection_state.session_id = session_id  # pyright: ignore [reportGeneralTypeIssues]
+    connection._connection_state.session_id = session_id
     await client._session_backend.store_in_message(
         scope_session=data, message=fake_http_send_message(mutable_headers), connection=connection
     )

--- a/litestar/testing/life_span_handler.py
+++ b/litestar/testing/life_span_handler.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import contextlib

--- a/litestar/testing/request_factory.py
+++ b/litestar/testing/request_factory.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import json
@@ -240,7 +242,7 @@ class RequestFactory:
         user: Any = None,
         auth: Any = None,
         request_media_type: RequestEncodingType = RequestEncodingType.JSON,
-        data: dict[str, Any] | DataContainerType | None = None,  # pyright: ignore
+        data: dict[str, Any] | DataContainerType | None = None,
         files: dict[str, FileTypes] | list[tuple[str, FileTypes]] | None = None,
         query_params: dict[str, str | list[str]] | None = None,
         state: dict[str, Any] | None = None,
@@ -365,7 +367,7 @@ class RequestFactory:
         user: Any = None,
         auth: Any = None,
         request_media_type: RequestEncodingType = RequestEncodingType.JSON,
-        data: dict[str, Any] | DataContainerType | None = None,  # pyright: ignore
+        data: dict[str, Any] | DataContainerType | None = None,
         query_params: dict[str, str | list[str]] | None = None,
         state: dict[str, Any] | None = None,
         path_params: dict[str, str] | None = None,
@@ -419,7 +421,7 @@ class RequestFactory:
         user: Any = None,
         auth: Any = None,
         request_media_type: RequestEncodingType = RequestEncodingType.JSON,
-        data: dict[str, Any] | DataContainerType | None = None,  # pyright: ignore
+        data: dict[str, Any] | DataContainerType | None = None,
         query_params: dict[str, str | list[str]] | None = None,
         state: dict[str, Any] | None = None,
         path_params: dict[str, str] | None = None,
@@ -473,7 +475,7 @@ class RequestFactory:
         user: Any = None,
         auth: Any = None,
         request_media_type: RequestEncodingType = RequestEncodingType.JSON,
-        data: dict[str, Any] | DataContainerType | None = None,  # pyright: ignore
+        data: dict[str, Any] | DataContainerType | None = None,
         query_params: dict[str, str | list[str]] | None = None,
         state: dict[str, Any] | None = None,
         path_params: dict[str, str] | None = None,

--- a/litestar/testing/transport.py
+++ b/litestar/testing/transport.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from io import BytesIO

--- a/litestar/types/protocols.py
+++ b/litestar/types/protocols.py
@@ -108,7 +108,7 @@ T_co = TypeVar("T_co", covariant=True)
 
 
 @runtime_checkable
-class InstantiableCollection(Collection[T_co], Protocol[T_co]):  # pyright: ignore
+class InstantiableCollection(Collection[T_co], Protocol[T_co]):
     """A protocol for instantiable collection types."""
 
     def __init__(self, iterable: Iterable[T_co], /) -> None: ...

--- a/litestar/types/serialization.py
+++ b/litestar/types/serialization.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any

--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import dataclasses

--- a/litestar/utils/helpers.py
+++ b/litestar/utils/helpers.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import os
@@ -101,7 +103,7 @@ def get_exception_group() -> type[BaseException]:
     try:
         return cast("type[BaseException]", ExceptionGroup)  # type:ignore[name-defined]
     except NameError:
-        from exceptiongroup import ExceptionGroup as _ExceptionGroup  # pyright: ignore
+        from exceptiongroup import ExceptionGroup as _ExceptionGroup  # pyright: ignore[reportMissingImports]
 
         return cast("type[BaseException]", _ExceptionGroup)
 

--- a/litestar/utils/predicates.py
+++ b/litestar/utils/predicates.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from collections import defaultdict, deque
@@ -144,7 +146,7 @@ def is_generic(annotation: Any) -> bool:
     Returns:
         True if the annotation is a subclass of :data:`Generic <typing.Generic>` otherwise ``False``.
     """
-    return is_class_and_subclass(annotation, Generic)  # pyright: ignore
+    return is_class_and_subclass(annotation, Generic)  # pyright: ignore[reportArgumentType]
 
 
 def is_mapping(annotation: Any) -> TypeGuard[Mapping[Any, Any]]:

--- a/litestar/utils/scope/__init__.py
+++ b/litestar/utils/scope/__init__.py
@@ -25,7 +25,7 @@ def get_serializer_from_scope(scope: Scope) -> Serializer:
     type_encoders = route_handler.type_encoders if hasattr(route_handler, "type_encoders") else app.type_encoders or {}
 
     if response_class := (
-        route_handler.response_class  # pyright: ignore
+        route_handler.response_class  # pyright: ignore[reportAttributeAccessIssue]
         if hasattr(route_handler, "response_class")
         else app.response_class
     ):

--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -31,7 +31,7 @@ _GLOBAL_NAMES = {
     for namespace, export in chain(
         tuple(getmembers(types)), tuple(getmembers(connection)), tuple(getmembers(datastructures))
     )
-    if namespace[0].isupper() and namespace in chain(types.__all__, connection.__all__, datastructures.__all__)  # pyright: ignore
+    if namespace[0].isupper() and namespace in chain(types.__all__, connection.__all__, datastructures.__all__)
 }
 """A mapping of names used for handler signature forward-ref resolution.
 
@@ -146,8 +146,7 @@ def get_fn_type_hints(fn: Any, namespace: dict[str, Any] | None = None) -> dict[
 
     # inspect the underlying function for methods
     if hasattr(fn_to_inspect, "__func__"):
-        fn_to_inspect = fn_to_inspect.__func__  # pyright: ignore
-
+        fn_to_inspect = fn_to_inspect.__func__  # pyright: ignore[reportFunctionMemberAccess]
     # Order important. If a litestar name has been overridden in the function module, we want
     # to use that instead of the litestar one.
     namespace = {

--- a/litestar/utils/sync.py
+++ b/litestar/utils/sync.py
@@ -27,14 +27,14 @@ def ensure_async_callable(fn: Callable[P, Awaitable[T]]) -> Callable[P, Awaitabl
 def ensure_async_callable(fn: Callable[P, T]) -> Callable[P, Awaitable[T]]: ...
 
 
-def ensure_async_callable(fn: Callable[P, T]) -> Callable[P, Awaitable[T]]:  # pyright: ignore
+def ensure_async_callable(fn: Callable[P, T]) -> Callable[P, Awaitable[T]]:  # pyright: ignore[reportInconsistentOverload]
     """Ensure that ``fn`` is an asynchronous callable.
     If it is an asynchronous, return the original object, else wrap it in an
     ``AsyncCallable``
     """
     if is_async_callable(fn):
         return fn
-    return AsyncCallable(fn)  # pyright: ignore
+    return AsyncCallable(fn)  # pyright: ignore[reportReturnType]
 
 
 class AsyncCallable:
@@ -43,7 +43,7 @@ class AsyncCallable:
     :attr:`func`
     """
 
-    def __init__(self, fn: Callable[P, T]) -> None:  # pyright: ignore
+    def __init__(self, fn: Callable[P, T]) -> None:
         self.func = fn
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> Awaitable[T]:  # type: ignore[valid-type]

--- a/litestar/utils/typing.py
+++ b/litestar/utils/typing.py
@@ -61,8 +61,7 @@ __all__ = (
 
 
 T = TypeVar("T")
-UnionT = TypeVar("UnionT", bound="Union")  # pyright: ignore
-
+UnionT = TypeVar("UnionT", bound="Union")  # pyright: ignore[reportInvalidTypeForm]
 instantiable_type_mapping = {
     AbstractSet: set,
     DefaultDict: defaultdict,
@@ -150,7 +149,7 @@ def make_non_optional_union(annotation: UnionT | None) -> UnionT:
         The union with all original members, except ``NoneType``.
     """
     args = tuple(tp for tp in get_args(annotation) if tp is not NoneType)
-    return cast("UnionT", Union[args])  # pyright: ignore
+    return cast("UnionT", Union[args])
 
 
 def unwrap_annotation(annotation: Any) -> tuple[Any, tuple[Any, ...], set[Any]]:
@@ -307,6 +306,5 @@ def _substitute_typevars(obj: Any, typevar_map: Mapping[Any, Any]) -> Any:
             return obj.__bound__
 
         if obj.__constraints__:
-            return Union[obj.__constraints__]  # pyright: ignore
-
+            return Union[obj.__constraints__]
     return obj

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -337,10 +337,14 @@ exclude = [
   "tests/unit/test_contrib/test_sqlalchemy.py",
   "tests/unit/test_plugins/test_pydantic/test_openapi.py",
   "tests/unit/test_repository/test_generic_mock_repository.py",
+  "**/node_modules/**",
+  "**/__pycache__/**",
+  "**/.venv/**",
+  "**/.*"
 ]
 include = ["litestar", "tests"]
 pythonVersion = "3.11"
-reportUnnecessaryTypeIgnoreComments = true
+reportUnnecessaryTypeIgnoreComment = true
 
 [tool.slotscheck]
 exclude-classes = """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import importlib.util

--- a/tests/e2e/test_life_cycle_hooks/test_after_response.py
+++ b/tests/e2e/test_life_cycle_hooks/test_after_response.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from unittest.mock import MagicMock, call
 
 import pytest
@@ -14,7 +16,7 @@ def test_after_response_resolution(layer: str, sync: bool) -> None:
 
     if sync:
 
-        def handler(_: Request) -> None:  # pyright: ignore
+        def handler(_: Request) -> None:  # pyright: ignore[reportRedeclaration]
             mock(layer)
 
     else:

--- a/tests/e2e/test_life_cycle_hooks/test_before_request.py
+++ b/tests/e2e/test_life_cycle_hooks/test_before_request.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from typing import Any, Optional
 
 import pytest

--- a/tests/e2e/test_response_caching.py
+++ b/tests/e2e/test_response_caching.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 import gzip
 import random
 from datetime import timedelta
@@ -224,7 +226,7 @@ def test_middleware_not_applied_to_non_cached_routes(
     cur = client.app.asgi_router.root_route_map_node.children["/"].asgi_handlers["GET"][0]
     while hasattr(cur, "app"):
         unpacked_middleware.append(cur)
-        cur = cur.app  # pyright: ignore
+        cur = cur.app  # pyright: ignore[reportFunctionMemberAccess]
     unpacked_middleware.append(cur)
 
     assert len([m for m in unpacked_middleware if isinstance(m, ResponseCacheMiddleware)]) == int(expect_applied)

--- a/tests/e2e/test_router_registration.py
+++ b/tests/e2e/test_router_registration.py
@@ -48,10 +48,10 @@ def test_register_with_controller_class(controller: type[Controller]) -> None:
     for route in router.routes:
         if isinstance(route, HTTPRoute):
             if len(route.methods) == 2:
-                assert sorted(route.methods) == sorted(["GET", "OPTIONS"])  # pyright: ignore
+                assert sorted(route.methods) == sorted(["GET", "OPTIONS"])
                 assert route.path == "/base/test/{id:int}"
             elif len(route.methods) == 3:
-                assert sorted(route.methods) == sorted(["GET", "POST", "OPTIONS"])  # pyright: ignore
+                assert sorted(route.methods) == sorted(["GET", "POST", "OPTIONS"])
                 assert route.path == "/base/test"
 
 
@@ -63,10 +63,10 @@ def test_register_with_router_instance(controller: type[Controller]) -> None:
     for route in base_router.routes:
         if isinstance(route, HTTPRoute):
             if len(route.methods) == 2:
-                assert sorted(route.methods) == sorted(["GET", "OPTIONS"])  # pyright: ignore
+                assert sorted(route.methods) == sorted(["GET", "OPTIONS"])
                 assert route.path == "/base/top-level/test/{id:int}"
             elif len(route.methods) == 3:
-                assert sorted(route.methods) == sorted(["GET", "POST", "OPTIONS"])  # pyright: ignore
+                assert sorted(route.methods) == sorted(["GET", "POST", "OPTIONS"])
                 assert route.path == "/base/top-level/test"
 
 
@@ -92,10 +92,10 @@ def test_register_with_route_handler_functions() -> None:
     for route in router.routes:
         if isinstance(route, HTTPRoute):
             if len(route.methods) == 2:
-                assert sorted(route.methods) == sorted(["GET", "OPTIONS"])  # pyright: ignore
+                assert sorted(route.methods) == sorted(["GET", "OPTIONS"])
                 assert route.path == "/base/second"
             else:
-                assert sorted(route.methods) == sorted(["GET", "POST", "PATCH", "OPTIONS"])  # pyright: ignore
+                assert sorted(route.methods) == sorted(["GET", "POST", "PATCH", "OPTIONS"])
                 assert route.path == "/base/first"
                 assert route.path == "/base/first"
 

--- a/tests/e2e/test_routing/test_route_reverse.py
+++ b/tests/e2e/test_routing/test_route_reverse.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from datetime import date, datetime, time, timedelta
 from pathlib import Path
 from uuid import UUID

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -43,7 +43,7 @@ async def maybe_async(obj: T) -> T: ...
 
 
 async def maybe_async(obj: Awaitable[T] | T) -> T:
-    return await obj if inspect.isawaitable(obj) else obj  # pyright: ignore
+    return await obj if inspect.isawaitable(obj) else obj  # pyright: ignore[reportReturnType]
 
 
 class _AsyncContextManagerWrapper(AbstractAsyncContextManager):

--- a/tests/unit/test_channels/test_plugin.py
+++ b/tests/unit/test_channels/test_plugin.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import asyncio

--- a/tests/unit/test_channels/test_subscriber.py
+++ b/tests/unit/test_channels/test_subscriber.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import asyncio

--- a/tests/unit/test_cli/test_core_commands.py
+++ b/tests/unit/test_cli/test_core_commands.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 import io
 import os
 import re

--- a/tests/unit/test_cli/test_ssl.py
+++ b/tests/unit/test_cli/test_ssl.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 import sys
 from pathlib import Path
 from typing import Optional, Protocol, cast

--- a/tests/unit/test_connection/test_base.py
+++ b/tests/unit/test_connection/test_base.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from typing import Any
 
 from litestar import Litestar, get

--- a/tests/unit/test_contrib/test_opentelemetry.py
+++ b/tests/unit/test_contrib/test_opentelemetry.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from typing import cast
 
 import pytest

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -53,7 +53,7 @@ async def test_controller_http_method(
         path = test_path
 
         @decorator()
-        def test_method(self) -> return_annotation:  # pyright: ignore
+        def test_method(self) -> return_annotation:  # pyright: ignore[reportInvalidTypeForm]
             return return_value
 
     with create_test_client(MyController) as client:

--- a/tests/unit/test_datastructures/test_multi_dicts.py
+++ b/tests/unit/test_datastructures/test_multi_dicts.py
@@ -25,13 +25,13 @@ def test_multi_multi_items(multi_class: type[MultiDict | ImmutableMultiDict]) ->
 
 def test_multi_dict_as_immutable() -> None:
     data = [("key", "value"), ("key", "value2"), ("key2", "value3")]
-    multi = MultiDict[str](data)  # pyright: ignore
+    multi = MultiDict[str](data)
     assert multi.immutable().dict() == ImmutableMultiDict(data).dict()
 
 
 def test_immutable_multi_dict_as_mutable() -> None:
     data = [("key", "value"), ("key", "value2"), ("key2", "value3")]
-    multi = ImmutableMultiDict[str](data)  # pyright: ignore
+    multi = ImmutableMultiDict[str](data)
     assert multi.mutable_copy().dict() == MultiDict(data).dict()
 
 

--- a/tests/unit/test_datastructures/test_upload_file.py
+++ b/tests/unit/test_datastructures/test_upload_file.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from os import urandom
 from pathlib import Path
 from typing import Optional

--- a/tests/unit/test_dto/test_factory/test_backends/test_backends.py
+++ b/tests/unit/test_dto/test_factory/test_backends/test_backends.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import inspect

--- a/tests/unit/test_dto/test_factory/test_backends/test_base_dto.py
+++ b/tests/unit/test_dto/test_factory/test_backends/test_base_dto.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/unit/test_dto/test_factory/test_base_dto.py
+++ b/tests/unit/test_dto/test_factory/test_base_dto.py
@@ -23,7 +23,7 @@ T = TypeVar("T", bound=Model)
 
 def get_backend(dto_type: type[DataclassDTO[Any]]) -> DTOBackend:
     value = next(iter(dto_type._dto_backends.values()))
-    return value["data_backend"]  # pyright: ignore
+    return value["data_backend"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
 
 
 def test_forward_referenced_type_argument_raises_exception() -> None:
@@ -53,14 +53,14 @@ def test_type_narrowing_with_annotated_scalar_type_arg() -> None:
 
 def test_type_narrowing_with_only_type_var() -> None:
     t = TypeVar("t", bound=Model)
-    generic_dto = DataclassDTO[t]  # pyright: ignore
+    generic_dto = DataclassDTO[t]  # pyright: ignore[reportGeneralTypeIssues]
     assert generic_dto is DataclassDTO
 
 
 def test_type_narrowing_with_annotated_type_var() -> None:
     config = DTOConfig()
     t = TypeVar("t", bound=Model)
-    generic_dto = DataclassDTO[Annotated[t, config]]  # pyright: ignore
+    generic_dto = DataclassDTO[Annotated[t, config]]  # pyright: ignore[reportGeneralTypeIssues]
     assert generic_dto is not DataclassDTO
     assert issubclass(generic_dto, DataclassDTO)
     assert generic_dto.config is config
@@ -75,17 +75,17 @@ def test_extra_annotated_metadata_ignored() -> None:
 
 def test_overwrite_config() -> None:
     first = DTOConfig(exclude={"a"})
-    generic_dto = DataclassDTO[Annotated[T, first]]  # pyright: ignore
+    generic_dto = DataclassDTO[Annotated[T, first]]  # pyright: ignore[reportGeneralTypeIssues]
     second = DTOConfig(exclude={"b"})
-    dto = generic_dto[Annotated[Model, second]]  # pyright: ignore
+    dto = generic_dto[Annotated[Model, second]]  # pyright: ignore[reportInvalidTypeArguments]
     assert dto.config is second
 
 
 def test_existing_config_not_overwritten() -> None:
     assert getattr(DataclassDTO, "_config", None) is None
     first = DTOConfig(exclude={"a"})
-    generic_dto = DataclassDTO[Annotated[T, first]]  # pyright: ignore
-    dto = generic_dto[Model]  # pyright: ignore
+    generic_dto = DataclassDTO[Annotated[T, first]]  # pyright: ignore[reportGeneralTypeIssues]
+    dto = generic_dto[Model]  # pyright: ignore[reportInvalidTypeArguments]
     assert dto.config is first
 
 
@@ -111,7 +111,7 @@ def test_config_field_rename(asgi_connection: Request[Any, Any, Any]) -> None:
     DataclassDTO._dto_backends = {}
     dto_type = DataclassDTO[Annotated[Model, config]]
     dto_type.create_for_field_definition(FieldDefinition.from_kwarg(Model, name="data"), handler_id="handler_id")
-    field_definitions = dto_type._dto_backends["handler_id"]["data_backend"].parsed_field_definitions  # pyright: ignore
+    field_definitions = dto_type._dto_backends["handler_id"]["data_backend"].parsed_field_definitions  # pyright: ignore[reportTypedDictNotRequiredAccess]
     assert field_definitions[0].serialization_name == "z"
 
 
@@ -157,7 +157,7 @@ def test_sub_types_supported() -> None:
         handler_id="handler_id", field_definition=FieldDefinition.from_kwarg(SubType, name="data")
     )
     assert (
-        dto_type._dto_backends["handler_id"]["data_backend"].parsed_field_definitions[-1].name == "c"  # pyright: ignore
+        dto_type._dto_backends["handler_id"]["data_backend"].parsed_field_definitions[-1].name == "c"  # pyright: ignore[reportTypedDictNotRequiredAccess]
     )
 
 

--- a/tests/unit/test_dto/test_factory/test_integration.py
+++ b/tests/unit/test_dto/test_factory/test_integration.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence

--- a/tests/unit/test_dto/test_factory/test_utils.py
+++ b/tests/unit/test_dto/test_factory/test_utils.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from typing import Generic, Optional, TypeVar
 
 from litestar.dto import DataclassDTO

--- a/tests/unit/test_dto/test_integration.py
+++ b/tests/unit/test_dto/test_integration.py
@@ -71,7 +71,7 @@ def test_set_dto_none_disables_inherited_dto(ModelDataDTO: type[AbstractDTO]) ->
 
     mock_dto = MagicMock(spec=ModelDataDTO)
 
-    with create_test_client(route_handlers=handler, dto=mock_dto) as client:  # pyright:ignore
+    with create_test_client(route_handlers=handler, dto=mock_dto) as client:
         response = client.post("/", json={"hello": "world"})
         assert response.status_code == 201
         assert response.json() == {"hello": "world"}

--- a/tests/unit/test_file_system.py
+++ b/tests/unit/test_file_system.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 import pathlib
 from collections.abc import AsyncGenerator, Generator
 from typing import Any

--- a/tests/unit/test_handlers/test_http_handlers/test_media_type.py
+++ b/tests/unit/test_handlers/test_http_handlers/test_media_type.py
@@ -33,7 +33,7 @@ class CustomStrEnum(StrEnum):
 )
 def test_media_type_inference(annotation: Any, expected_media_type: MediaType) -> None:
     @get("/")
-    def handler() -> annotation:  # pyright: ignore
+    def handler() -> annotation:  # pyright: ignore[reportInvalidTypeForm]
         return None
 
     app = Litestar(route_handlers=[handler])

--- a/tests/unit/test_handlers/test_http_handlers/test_validations.py
+++ b/tests/unit/test_handlers/test_http_handlers/test_validations.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType

--- a/tests/unit/test_handlers/test_websocket_handlers/test_listeners.py
+++ b/tests/unit/test_handlers/test_websocket_handlers/test_listeners.py
@@ -24,7 +24,7 @@ from litestar.types.asgi_types import WebSocketMode
 @pytest.fixture
 def listener_class(mock: MagicMock) -> type[WebsocketListener]:
     class Listener(WebsocketListener):
-        def on_receive(self, data: str) -> str:  # pyright: ignore
+        def on_receive(self, data: str) -> str:
             mock(data)
             return data
 
@@ -401,13 +401,13 @@ def test_websocket_listener_class_hook_dependencies() -> None:
     class Listener(WebsocketListener):
         path = "/{name: str}"
 
-        def on_accept(self, name: str, state: State, query: dict, some: str) -> None:  # pyright: ignore
+        def on_accept(self, name: str, state: State, query: dict, some: str) -> None:
             on_accept_mock(name=name, state=state, query=query, some=some)
 
-        def on_disconnect(self, name: str, state: State, query: dict, some: str) -> None:  # pyright: ignore
+        def on_disconnect(self, name: str, state: State, query: dict, some: str) -> None:
             on_disconnect_mock(name=name, state=state, query=query, some=some)
 
-        def on_receive(self, data: bytes) -> None:  # pyright: ignore
+        def on_receive(self, data: bytes) -> None:
             pass
 
     with (
@@ -439,7 +439,7 @@ def test_listeners_lifespan_hooks_and_manager_raises(hook_name: str) -> None:
 
     with pytest.raises(ImproperlyConfiguredException):
 
-        @websocket_listener("/", **{hook_name: hook_callback}, connection_lifespan=lifespan)  # pyright: ignore
+        @websocket_listener("/", **{hook_name: hook_callback}, connection_lifespan=lifespan)  # pyright: ignore[reportArgumentType, reportCallIssue]
         def handler(data: bytes) -> None:
             pass
 

--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -405,7 +407,7 @@ def test_upload_multiple_files(file_count: int, optional: bool) -> None:
         annotation = Optional[annotation]  # type: ignore[misc, assignment]
 
     @post("/", signature_namespace={"annotation": annotation})
-    async def handler(data: annotation = Body(media_type=RequestEncodingType.MULTI_PART)) -> None:  # pyright: ignore
+    async def handler(data: annotation = Body(media_type=RequestEncodingType.MULTI_PART)) -> None:  # pyright: ignore[reportInvalidTypeForm]
         assert len(data) == file_count
 
         for file in data:

--- a/tests/unit/test_kwargs/test_path_params.py
+++ b/tests/unit/test_kwargs/test_path_params.py
@@ -157,7 +157,7 @@ def test_path_param_type_resolution(
     mock = MagicMock()
 
     @get("/some/test/path/{test:" + param_type_name + "}")
-    def handler(test: param_type_class) -> None:  # pyright: ignore
+    def handler(test: param_type_class) -> None:  # pyright: ignore[reportInvalidTypeForm]
         mock(test)
 
     with create_test_client(handler) as client:

--- a/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
+++ b/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from typing import Annotated, Any, Optional, cast
 
 import msgspec.json

--- a/tests/unit/test_middleware/test_allowed_hosts_middleware.py
+++ b/tests/unit/test_middleware/test_allowed_hosts_middleware.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from litestar.types import Receive, Scope, Send
 
 
-class DummyApp(MiddlewareProtocol):  # pyright: ignore
+class DummyApp(MiddlewareProtocol):
     async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
         return
 
@@ -28,7 +28,7 @@ def test_allowed_hosts_middleware() -> None:
     cur = client.app.asgi_router.root_route_map_node.children["/"].asgi_handlers["GET"][0]
     while hasattr(cur, "app"):
         unpacked_middleware.append(cur)
-        cur = cast("Any", cur.app)  # pyright: ignore
+        cur = cast("Any", cur.app)  # pyright: ignore[reportFunctionMemberAccess]
     unpacked_middleware.append(cur)
 
     allowed_hosts_middleware, *_ = unpacked_middleware

--- a/tests/unit/test_middleware/test_compression_middleware.py
+++ b/tests/unit/test_middleware/test_compression_middleware.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 import zlib
 from collections.abc import AsyncIterator, Callable
 from io import BytesIO

--- a/tests/unit/test_middleware/test_cors_middleware.py
+++ b/tests/unit/test_middleware/test_cors_middleware.py
@@ -12,7 +12,7 @@ from litestar.types.asgi_types import Method
 
 
 def test_setting_cors_middleware() -> None:
-    cors_config = CORSConfig()  # pyright: ignore
+    cors_config = CORSConfig()
     assert cors_config.allow_credentials is False
     assert cors_config.allow_headers == ["*"]
     assert cors_config.allow_methods == ["*"]
@@ -26,7 +26,7 @@ def test_setting_cors_middleware() -> None:
         cur = client.app.asgi_handler
         while hasattr(cur, "app"):
             unpacked_middleware.append(cur)
-            cur = cast("Any", cur.app)  # pyright: ignore
+            cur = cast("Any", cur.app)  # pyright: ignore[reportFunctionMemberAccess]
         unpacked_middleware.append(cur)
         assert len(unpacked_middleware) == 4
         cors_middleware = cast("Any", unpacked_middleware[0])

--- a/tests/unit/test_middleware/test_middleware_handling.py
+++ b/tests/unit/test_middleware/test_middleware_handling.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -53,7 +55,7 @@ class MiddlewareWithArgsAndKwargs(BaseHTTPMiddleware):
     [
         BaseMiddlewareRequestLoggingMiddleware,
         # Middleware(MiddlewareWithArgsAndKwargs, kwarg="123Jeronimo"),  # pyright: ignore[reportGeneralTypeIssues] # noqa: ERA001
-        # Middleware(MiddlewareProtocolRequestLoggingMiddleware, kwarg="123Jeronimo"),  # type: ignore[arg-type] # pyright: ignore[reportGeneralTypeIssues] # noqa: ERA001
+        # Middleware(MiddlewareProtocolRequestLoggingMiddleware, kwarg="123Jeronimo"),  # type: ignore[arg-type] # noqa: ERA001
         DefineMiddleware(MiddlewareWithArgsAndKwargs, 1, kwarg="123Jeronimo"),  # type: ignore[arg-type]
         DefineMiddleware(MiddlewareProtocolRequestLoggingMiddleware, kwarg="123Jeronimo"),
     ],
@@ -70,7 +72,7 @@ def test_custom_middleware_processing(middleware: Any) -> None:
         cur = client.app.asgi_router.root_route_map_node.children["/"].asgi_handlers["GET"][0]
         while hasattr(cur, "app"):
             unpacked_middleware.append(cur)
-            cur = cast("ASGIApp", cur.app)  # pyright: ignore
+            cur = cast("ASGIApp", cur.app)  # pyright: ignore[reportFunctionMemberAccess]
         unpacked_middleware.append(cur)
 
         middleware_instance, *_ = unpacked_middleware

--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import dataclasses

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -426,7 +426,7 @@ def test_unwrap_new_type() -> None:
 
 def test_unwrap_nested_new_type() -> None:
     FancyString = NewType("FancyString", str)
-    FancierString = NewType("FancierString", FancyString)  # pyright: ignore
+    FancierString = NewType("FancierString", FancyString)
 
     @get("/")
     async def handler(

--- a/tests/unit/test_openapi/test_path_item.py
+++ b/tests/unit/test_openapi/test_path_item.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import dataclasses

--- a/tests/unit/test_openapi/test_request_body.py
+++ b/tests/unit/test_openapi/test_request_body.py
@@ -172,7 +172,7 @@ def test_upload_file_model_schema_generation() -> None:
 def test_request_body_generation_with_dto(create_request: RequestBodyFactory) -> None:
     mock_dto = MagicMock(spec=AbstractDTO)
 
-    @post(path="/form-upload", dto=mock_dto)  # pyright: ignore
+    @post(path="/form-upload", dto=mock_dto)
     async def handler(data: dict[str, Any]) -> None:
         return None
 

--- a/tests/unit/test_openapi/test_responses.py
+++ b/tests/unit/test_openapi/test_responses.py
@@ -553,7 +553,7 @@ def test_response_generation_with_dto(create_factory: CreateFactoryFixture) -> N
     mock_dto = MagicMock(spec=AbstractDTO)
     mock_dto.create_openapi_schema.return_value = Schema()
 
-    @post(path="/form-upload", return_dto=mock_dto)  # pyright: ignore
+    @post(path="/form-upload", return_dto=mock_dto)
     async def handler(data: dict[str, Any]) -> dict[str, Any]:
         return data
 

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 import sys
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
@@ -595,6 +597,7 @@ def test_not_generating_examples_property() -> None:
 
 def test_process_schema_result_with_unregistered_object_schema() -> None:
     """This test ensures that if a schema is created for an object and not registered in the schema registry, the
+
     schema is returned as-is, and not referenced.
     """
     schema = Schema(title="has title", type=OpenAPIType.OBJECT)
@@ -607,11 +610,11 @@ def test_type_union(base_type: type) -> None:
     if base_type is dataclass:
 
         @dataclass
-        class ModelA:  # pyright: ignore
+        class ModelA:  # pyright: ignore[reportRedeclaration]
             pass
 
         @dataclass
-        class ModelB:  # pyright: ignore
+        class ModelB:  # pyright: ignore[reportRedeclaration]
             pass
 
     else:
@@ -637,11 +640,11 @@ def test_type_union_with_none(base_type: type) -> None:
     if base_type is dataclass:
 
         @dataclass
-        class ModelA:  # pyright: ignore
+        class ModelA:  # pyright: ignore[reportRedeclaration]
             pass
 
         @dataclass
-        class ModelB:  # pyright: ignore
+        class ModelB:  # pyright: ignore[reportRedeclaration]
             pass
 
     else:
@@ -712,7 +715,7 @@ def test_unconsumed_path_parameters_are_documented() -> None:
     params = app.openapi_schema.paths["/{param1}/{param2}/{param3}"].get.parameters  # type: ignore[index, union-attr]
     assert params
     assert len(params) == 3
-    for i, param in enumerate(sorted(params, key=lambda p: p.name), 1):  # pyright: ignore
+    for i, param in enumerate(sorted(params, key=lambda p: p.name), 1):  # pyright: ignore[reportAttributeAccessIssue]
         assert isinstance(param, OpenAPIParameter)
         assert param.name == f"param{i}"
         assert param.required is True

--- a/tests/unit/test_openapi/test_security_schemes.py
+++ b/tests/unit/test_openapi/test_security_schemes.py
@@ -97,7 +97,7 @@ def test_schema_with_route_security_overridden(protected_route: "HTTPRouteHandle
 def test_layered_security_declaration() -> None:
     class MyController(Controller):
         path = "/controller"
-        security = [{"controllerToken": []}]  # pyright: ignore
+        security = [{"controllerToken": []}]
 
         @get("", security=[{"handlerToken": []}])
         def my_handler(self) -> None: ...

--- a/tests/unit/test_openapi/test_spec_generation.py
+++ b/tests/unit/test_openapi/test_spec_generation.py
@@ -17,7 +17,7 @@ from tests.models import DataclassPerson, MsgSpecStructPerson, TypedDictPerson
 @pytest.mark.parametrize("cls", (DataclassPerson, TypedDictPerson, MsgSpecStructPerson))
 def test_spec_generation(cls: Any) -> None:
     @post("/")
-    def handler(data: cls) -> cls:  # pyright: ignore
+    def handler(data: cls) -> cls:  # pyright: ignore[reportInvalidTypeForm]
         return data
 
     with create_test_client(handler) as client:

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from itertools import islice
 from typing import Any, Optional
 

--- a/tests/unit/test_plugins/test_base.py
+++ b/tests/unit/test_plugins/test_base.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/unit/test_plugins/test_pydantic/conftest.py
+++ b/tests/unit/test_plugins/test_pydantic/conftest.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/tests/unit/test_plugins/test_pydantic/test_dto.py
+++ b/tests/unit/test_plugins/test_pydantic/test_dto.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from datetime import UTC, datetime

--- a/tests/unit/test_plugins/test_pydantic/test_inject_pydantic.py
+++ b/tests/unit/test_plugins/test_pydantic/test_inject_pydantic.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 import pydantic as pydantic_v2
 import pytest
 

--- a/tests/unit/test_plugins/test_pydantic/test_integration.py
+++ b/tests/unit/test_plugins/test_pydantic/test_integration.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from typing import Annotated, Any
 from unittest.mock import ANY
 
@@ -27,7 +29,7 @@ def test_pydantic_v2_validation_error_raises_400(meta: Any) -> None:
     annotation = Annotated[Model, meta] if meta is not None else Model
 
     @post(dto=ModelDTO, signature_namespace={"annotation": annotation})
-    def handler(data: annotation) -> Any:  # pyright: ignore
+    def handler(data: annotation) -> Any:  # pyright: ignore[reportInvalidTypeForm]
         return data
 
     model_json = {"foo": "too long"}
@@ -197,7 +199,7 @@ def test_private_fields(model_type: BaseModelType) -> None:
 )
 def test_dto_with_non_instantiable_types(base_model: BaseModelType, type_: Any, in_: Any) -> None:
     class Model(base_model):  # type: ignore[misc, valid-type]
-        foo: type_  # pyright: ignore
+        foo: type_  # pyright: ignore[reportInvalidTypeForm]
 
     @post("/", dto=PydanticDTO[Model])
     async def handler(data: Model) -> Model:
@@ -341,7 +343,7 @@ def test_pydantic_v2_round_trip() -> None:
 
     @get("/")
     async def handler() -> Model:
-        return Model(foo=resp)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType]
+        return Model(foo=resp)  # type: ignore[arg-type]
 
     with create_test_client([handler], plugins=[PydanticPlugin(round_trip=True)]) as client:
         assert client.get("/").json() == {"foo": resp}

--- a/tests/unit/test_plugins/test_pydantic/test_pydantic_dto_factory.py
+++ b/tests/unit/test_plugins/test_pydantic/test_pydantic_dto_factory.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/tests/unit/test_plugins/test_pydantic/test_schema_plugin.py
+++ b/tests/unit/test_plugins/test_pydantic/test_schema_plugin.py
@@ -122,7 +122,7 @@ def test_root_model_schema_generation() -> None:
         scales: bool
 
     class Pet(pydantic_v2.RootModel[BasePet]):
-        root: Annotated[  # pyright: ignore
+        root: Annotated[  # pyright: ignore[reportIncompatibleVariableOverride]
             Union[
                 Annotated[Cat, pydantic_v2.Tag("cat")],
                 Annotated[Dog, pydantic_v2.Tag("dog")],

--- a/tests/unit/test_repository/models_bigint.py
+++ b/tests/unit/test_repository/models_bigint.py
@@ -13,8 +13,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 class BigIntAuthor(BigIntAuditBase):
     """The Author domain object."""
 
-    name: Mapped[str] = mapped_column(String(length=100))  # pyright: ignore
-    dob: Mapped[date] = mapped_column(nullable=True)  # pyright: ignore
+    name: Mapped[str] = mapped_column(String(length=100))
+    dob: Mapped[date] = mapped_column(nullable=True)
     books: Mapped[list[BigIntBook]] = relationship(
         lazy="selectin",
         back_populates="author",
@@ -25,9 +25,9 @@ class BigIntAuthor(BigIntAuditBase):
 class BigIntBook(BigIntBase):
     """The Book domain object."""
 
-    title: Mapped[str] = mapped_column(String(length=250))  # pyright: ignore
-    author_id: Mapped[int] = mapped_column(ForeignKey("big_int_author.id"))  # pyright: ignore
-    author: Mapped[BigIntAuthor] = relationship(  # pyright: ignore
+    title: Mapped[str] = mapped_column(String(length=250))
+    author_id: Mapped[int] = mapped_column(ForeignKey("big_int_author.id"))
+    author: Mapped[BigIntAuthor] = relationship(
         lazy="joined",
         innerjoin=True,
         back_populates="books",
@@ -37,15 +37,15 @@ class BigIntBook(BigIntBase):
 class BigIntEventLog(BigIntAuditBase):
     """The event log domain object."""
 
-    logged_at: Mapped[datetime] = mapped_column(default=datetime.now())  # pyright: ignore
-    payload: Mapped[dict] = mapped_column(default=lambda: {})  # pyright: ignore
+    logged_at: Mapped[datetime] = mapped_column(default=datetime.now())
+    payload: Mapped[dict] = mapped_column(default=lambda: {})
 
 
 class BigIntModelWithFetchedValue(BigIntBase):
     """The ModelWithFetchedValue BigIntBase."""
 
-    val: Mapped[int]  # pyright: ignore
-    updated: Mapped[datetime] = mapped_column(  # pyright: ignore
+    val: Mapped[int]
+    updated: Mapped[datetime] = mapped_column(
         server_default=func.current_timestamp(),
         onupdate=func.current_timestamp(),
         server_onupdate=FetchedValue(),
@@ -61,23 +61,23 @@ bigint_item_tag = Table(
 
 
 class BigIntItem(BigIntBase):
-    name: Mapped[str] = mapped_column(String(length=50))  # pyright: ignore
-    description: Mapped[str] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
+    name: Mapped[str] = mapped_column(String(length=50))
+    description: Mapped[str] = mapped_column(String(length=100), nullable=True)
     tags: Mapped[list[BigIntTag]] = relationship(secondary=lambda: bigint_item_tag, back_populates="items")
 
 
 class BigIntTag(BigIntBase):
     """The event log domain object."""
 
-    name: Mapped[str] = mapped_column(String(length=50))  # pyright: ignore
+    name: Mapped[str] = mapped_column(String(length=50))
     items: Mapped[list[BigIntItem]] = relationship(secondary=lambda: bigint_item_tag, back_populates="tags")
 
 
 class BigIntRule(BigIntAuditBase):
     """The rule domain object."""
 
-    name: Mapped[str] = mapped_column(String(length=250))  # pyright: ignore
-    config: Mapped[dict] = mapped_column(default=lambda: {})  # pyright: ignore
+    name: Mapped[str] = mapped_column(String(length=250))
+    config: Mapped[dict] = mapped_column(default=lambda: {})
 
 
 class RuleAsyncRepository(SQLAlchemyAsyncRepository[BigIntRule]):

--- a/tests/unit/test_repository/models_uuid.py
+++ b/tests/unit/test_repository/models_uuid.py
@@ -14,8 +14,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 class UUIDAuthor(base.UUIDAuditBase):
     """The UUIDAuthor domain object."""
 
-    name: Mapped[str] = mapped_column(String(length=100))  # pyright: ignore
-    dob: Mapped[date] = mapped_column(nullable=True)  # pyright: ignore
+    name: Mapped[str] = mapped_column(String(length=100))
+    dob: Mapped[date] = mapped_column(nullable=True)
     books: Mapped[list[UUIDBook]] = relationship(
         lazy="selectin",
         back_populates="author",
@@ -26,23 +26,23 @@ class UUIDAuthor(base.UUIDAuditBase):
 class UUIDBook(base.UUIDBase):
     """The Book domain object."""
 
-    title: Mapped[str] = mapped_column(String(length=250))  # pyright: ignore
-    author_id: Mapped[UUID] = mapped_column(ForeignKey("uuid_author.id"))  # pyright: ignore
-    author: Mapped[UUIDAuthor] = relationship(lazy="joined", innerjoin=True, back_populates="books")  # pyright: ignore
+    title: Mapped[str] = mapped_column(String(length=250))
+    author_id: Mapped[UUID] = mapped_column(ForeignKey("uuid_author.id"))
+    author: Mapped[UUIDAuthor] = relationship(lazy="joined", innerjoin=True, back_populates="books")
 
 
 class UUIDEventLog(base.UUIDAuditBase):
     """The event log domain object."""
 
-    logged_at: Mapped[datetime] = mapped_column(default=datetime.now())  # pyright: ignore
-    payload: Mapped[dict] = mapped_column(default={})  # pyright: ignore
+    logged_at: Mapped[datetime] = mapped_column(default=datetime.now())
+    payload: Mapped[dict] = mapped_column(default={})
 
 
 class UUIDModelWithFetchedValue(base.UUIDBase):
     """The ModelWithFetchedValue UUIDBase."""
 
-    val: Mapped[int]  # pyright: ignore
-    updated: Mapped[datetime] = mapped_column(  # pyright: ignore
+    val: Mapped[int]
+    updated: Mapped[datetime] = mapped_column(
         server_default=func.current_timestamp(),
         onupdate=func.current_timestamp(),
         server_onupdate=FetchedValue(),
@@ -58,23 +58,23 @@ uuid_item_tag = Table(
 
 
 class UUIDItem(base.UUIDBase):
-    name: Mapped[str] = mapped_column(String(length=50))  # pyright: ignore
-    description: Mapped[str] = mapped_column(String(length=100), nullable=True)  # pyright: ignore
+    name: Mapped[str] = mapped_column(String(length=50))
+    description: Mapped[str] = mapped_column(String(length=100), nullable=True)
     tags: Mapped[list[UUIDTag]] = relationship(secondary=lambda: uuid_item_tag, back_populates="items")
 
 
 class UUIDTag(base.UUIDAuditBase):
     """The event log domain object."""
 
-    name: Mapped[str] = mapped_column(String(length=50))  # pyright: ignore
+    name: Mapped[str] = mapped_column(String(length=50))
     items: Mapped[list[UUIDItem]] = relationship(secondary=lambda: uuid_item_tag, back_populates="tags")
 
 
 class UUIDRule(base.UUIDAuditBase):
     """The rule domain object."""
 
-    name: Mapped[str] = mapped_column(String(length=250))  # pyright: ignore
-    config: Mapped[dict] = mapped_column(default=lambda: {})  # pyright: ignore
+    name: Mapped[str] = mapped_column(String(length=250))
+    config: Mapped[dict] = mapped_column(default=lambda: {})
 
 
 class RuleAsyncRepository(SQLAlchemyAsyncRepository[UUIDRule]):

--- a/tests/unit/test_response/test_file_response.py
+++ b/tests/unit/test_response/test_file_response.py
@@ -295,7 +295,7 @@ def test_file_with_passed_in_file_info(tmpdir: Path) -> None:
 
     @get("/", media_type="application/octet-stream")
     def handler() -> File:
-        return File(filename="text.txt", path=path, file_system=fs, file_info=fs_info)  # pyright: ignore
+        return File(filename="text.txt", path=path, file_system=fs, file_info=fs_info)  # pyright: ignore[reportArgumentType]
 
     with create_test_client(handler) as client:
         response = client.get("/")

--- a/tests/unit/test_response/test_streaming_response.py
+++ b/tests/unit/test_response/test_streaming_response.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 """A large part of the tests in this file were adapted from:
 
 https://github.com/encode/starlette/blob/master/tests/test_responses.py And are meant to ensure our compatibility with

--- a/tests/unit/test_response/test_type_decoders.py
+++ b/tests/unit/test_response/test_type_decoders.py
@@ -38,8 +38,7 @@ def websocket_listener_handler() -> type[WebsocketListener]:
         path = "/ws-listener"
         type_decoders = [handler_decoder]
 
-        def on_receive(self, data: str) -> None:  # pyright: ignore [reportIncompatibleMethodOverride]
-            ...
+        def on_receive(self, data: str) -> None: ...
 
     return WebSocketHandler
 

--- a/tests/unit/test_security/test_jwt/test_auth.py
+++ b/tests/unit/test_security/test_jwt/test_auth.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 import dataclasses
 import secrets
 import string
@@ -769,7 +771,7 @@ def create_jwt_app(auth_cls: Any, request: pytest.FixtureRequest) -> CreateJWTAp
         client = create_test_client(route_handlers=[handler]).__enter__()
         request.addfinalizer(client.__exit__)
 
-        return jwt_auth, client  # pyright: ignore
+        return jwt_auth, client  # pyright: ignore[reportReturnType]
 
     return create
 

--- a/tests/unit/test_security/test_security.py
+++ b/tests/unit/test_security/test_security.py
@@ -97,7 +97,7 @@ def test_abstract_security_config_registers_route_handlers(
                             "app": SecurityScheme(
                                 type="http",
                                 name="test",
-                                security_scheme_in="cookie",  # pyright: ignore
+                                security_scheme_in="cookie",
                                 description="test.",
                             )
                         }

--- a/tests/unit/test_signature/test_parsing.py
+++ b/tests/unit/test_signature/test_parsing.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from types import ModuleType
@@ -177,7 +179,7 @@ def test_collection_union_struct_fields(with_optional: bool) -> None:
         annotation = Optional[annotation]  # type: ignore[misc]
 
     @get("/", signature_namespace={"annotation": annotation})
-    def handler(param: annotation) -> None:  # pyright: ignore
+    def handler(param: annotation) -> None:  # pyright: ignore[reportInvalidTypeForm]
         return None
 
     with create_test_client([handler], debug=True) as client:

--- a/tests/unit/test_signature/test_validation.py
+++ b/tests/unit/test_signature/test_validation.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from dataclasses import dataclass
 from typing import Annotated, Generic, Optional, TypeVar
 

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -576,7 +576,7 @@ async def test_valkey_store_with_client_shutdown(valkey_service: None) -> None:
     # the check on connection is a mimic of https://github.com/redis/redis-py/blob/d529c2ad8d2cf4dcfb41bfd93ea68cfefd81aa66/tests/test_asyncio/test_connection_pool.py#L35-L39
     await valkey_store._shutdown()
     assert not any(
-        x.is_connected  # pyright: ignore
+        x.is_connected  # pyright: ignore[reportAttributeAccessIssue]
         for x in valkey_store._valkey.connection_pool._available_connections
         + list(valkey_store._valkey.connection_pool._in_use_connections)
     )

--- a/tests/unit/test_template/test_built_in.py
+++ b/tests/unit/test_template/test_built_in.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union

--- a/tests/unit/test_template/test_template.py
+++ b/tests/unit/test_template/test_template.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import sys

--- a/tests/unit/test_testing/test_request_factory.py
+++ b/tests/unit/test_testing/test_request_factory.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 import json
 from collections.abc import Callable
 from dataclasses import dataclass

--- a/tests/unit/test_typing.py
+++ b/tests/unit/test_typing.py
@@ -212,7 +212,7 @@ def test_field_definition_is_type_var_predicate() -> None:
     """Test FieldDefinition.is_type_var."""
     assert FieldDefinition.from_annotation(int).is_type_var is False
     assert FieldDefinition.from_annotation(T).is_type_var is True
-    assert FieldDefinition.from_annotation(Union[int, T]).is_type_var is False  # pyright: ignore
+    assert FieldDefinition.from_annotation(Union[int, T]).is_type_var is False  # pyright: ignore[reportGeneralTypeIssues]
 
 
 def test_field_definition_is_union_predicate() -> None:
@@ -477,8 +477,8 @@ def test_warn_default_inside_kwarg_definition_and_default_empty() -> None:
 @pytest.mark.parametrize(
     "annotation",
     [
-        pytest.param(TypeAliasType("IntAlias", int), id="typing.TypeAliasType"),  # pyright: ignore
-        pytest.param(TeTypeAliasType("IntAlias", int), id="typing_extensions.TypeAliasType"),  # pyright: ignore
+        pytest.param(TypeAliasType("IntAlias", int), id="typing.TypeAliasType"),  # pyright: ignore[reportGeneralTypeIssues]
+        pytest.param(TeTypeAliasType("IntAlias", int), id="typing_extensions.TypeAliasType"),  # pyright: ignore[reportGeneralTypeIssues]
     ],
 )
 def test_is_type_alias_type(annotation: Any) -> None:

--- a/tests/unit/test_utils/test_scope.py
+++ b/tests/unit/test_utils/test_scope.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 from litestar.utils.scope.state import CONNECTION_STATE_KEY, ScopeState

--- a/tests/unit/test_utils/test_signature.py
+++ b/tests/unit/test_utils/test_signature.py
@@ -1,3 +1,5 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
+
 from __future__ import annotations
 
 import inspect

--- a/tests/unit/test_websocket_class_resolution.py
+++ b/tests/unit/test_websocket_class_resolution.py
@@ -85,7 +85,7 @@ def test_listener_websocket_class_resolution_of_layers(
         path = "/"
         websocket_class = handler_websocket_class
 
-        def on_receive(self, data: str) -> str:  # pyright: ignore
+        def on_receive(self, data: str) -> str:
             return data
 
     router = Router(path="/", route_handlers=[Handler], websocket_class=router_websocket_class)


### PR DESCRIPTION
Closes #4688

## Summary

The pyright config had a typo (`reportUnnecessaryTypeIgnoreComments` instead of `reportUnnecessaryTypeIgnoreComment`) so the unnecessary-type-ignore check was silently disabled. Fixing the setting name exposed ~300 errors.

All bare `# pyright: ignore` comments have been replaced with specific rules (e.g. `# pyright: ignore[reportReturnType]`). Stale references to renamed rules like `reportGeneralTypeIssues` have been removed.

For files where `# type: ignore` is required by mypy but not pyright, a per-file `# pyright: reportUnnecessaryTypeIgnoreComment=false` directive is added to suppress the false positive — pyright flags mypy's `# type: ignore` as unnecessary when it doesn't see an error on that line.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: https://litestar-org.github.io/litestar-docs-preview/4689
