### PR TITLE
fix(request): content-length check incompatible with decompression middleware

### DIFF
--- a/docs/usage/requests.rst
+++ b/docs/usage/requests.rst
@@ -304,7 +304,7 @@ To disable this limit for a specific handler / router / controller, it can be se
     For requests that define a ``Content-Length`` header, Litestar will not attempt to
     read the request body should the header value exceed the ``request_max_body_size``.
 
-    If the header value is within the allowed bounds, Litestar will verify during the
-    streaming of the request body that it does not exceed the size specified in the
-    header. Should the request exceed this size, it will abort the request with a
-    ``400 - Bad Request``.
+    Validation that the actual request body matches the ``Content-Length`` header is
+    delegated to the ASGI server (e.g. uvicorn). This ensures compatibility with
+    request decompression middleware, where the decompressed body may legitimately
+    exceed the wire-format ``Content-Length``.

--- a/litestar/connection/request.py
+++ b/litestar/connection/request.py
@@ -208,23 +208,12 @@ class Request(Generic[UserT, AuthT, StateT], ASGIConnection["HTTPRouteHandler", 
                     if body:
                         total_bytes_streamed += len(body)
 
-                        # if a 'content-length' header was set, check if we have
-                        # received more bytes than specified. in most cases this should
-                        # be caught before it hits the application layer and an ASGI
-                        # server (e.g. uvicorn) will not allow this, but since it's not
-                        # forbidden according to the HTTP or ASGI spec, we err on the
-                        # side of caution and still perform this check.
-                        #
-                        # uvicorn documented behaviour for this case:
-                        # https://github.com/encode/uvicorn/blob/fe3910083e3990695bc19c2ef671dd447262ae18/docs/server-behavior.md?plain=1#L11
-                        if announced_content_length:
-                            if total_bytes_streamed > announced_content_length:
-                                raise ClientException("Malformed request")
-
-                        # we don't have a 'content-length' header, likely a chunked
-                        # transfer. we don't really care and simply check if we have
-                        # received more bytes than allowed
-                        elif total_bytes_streamed > max_content_length:
+                        # enforce the request body size limit on actual bytes
+                        # received. content-length validation is intentionally left to
+                        # the ASGI server (e.g. uvicorn) since middleware such as
+                        # request decompression can legitimately cause the streamed
+                        # body to exceed the wire-format content-length.
+                        if total_bytes_streamed > max_content_length:
                             raise RequestEntityTooLarge
 
                         yield body

--- a/tests/unit/test_connection/test_request.py
+++ b/tests/unit/test_connection/test_request.py
@@ -538,15 +538,34 @@ def test_state() -> None:
         assert response.json() == {"state": 2}
 
 
-def test_request_body_exceeds_content_length() -> None:
-    @post("/")
-    def handler(body: bytes) -> None:
-        pass
+def test_request_body_exceeding_content_length_is_allowed() -> None:
+    """Body larger than Content-Length but within request_max_body_size succeeds.
+
+    Decompression middleware can legitimately produce a body larger than the
+    wire-format Content-Length. Content-length enforcement is delegated to the
+    ASGI server (e.g. uvicorn).
+    """
+
+    @post("/", request_max_body_size=10)
+    def handler(body: bytes) -> bytes:
+        return body
 
     with create_test_client([handler]) as client:
         response = client.post("/", headers={"content-length": "1"}, content=b"ab")
-        assert response.status_code == HTTP_400_BAD_REQUEST
-        assert response.json() == {"status_code": 400, "detail": "Malformed request"}
+        assert response.status_code == 201
+        assert response.content == b"ab"
+
+
+def test_request_body_exceeding_content_length_still_enforces_max_body_size() -> None:
+    """Content-length mismatch is allowed, but request_max_body_size is still enforced."""
+
+    @post("/", request_max_body_size=1)
+    def handler(body: bytes) -> bytes:
+        return body
+
+    with create_test_client([handler]) as client:
+        response = client.post("/", headers={"content-length": "1"}, content=b"ab")
+        assert response.status_code == HTTP_413_REQUEST_ENTITY_TOO_LARGE
 
 
 def test_request_body_exceeds_max_request_body_size() -> None:


### PR DESCRIPTION
## Summary

- Remove the content-length integrity check in `Request.stream()` that raised `ClientException("Malformed request")` when streamed bytes exceeded the `Content-Length` header
- Replace with unconditional `request_max_body_size` enforcement on all requests
- Update docs to reflect that content-length validation is delegated to the ASGI server

Closes #4125

## Detail

`Request.stream()` previously compared `total_bytes_streamed` against the `Content-Length` header and raised a 400 if the body exceeded it. This breaks when request decompression middleware wraps the ASGI `receive` function — the decompressed body is legitimately larger than the wire-format `Content-Length`.

The fix removes this check entirely. This is safe because:

1. **ASGI servers already enforce this** — uvicorn, granian, and hypercorn validate content-length at the transport layer ([uvicorn docs](https://github.com/encode/uvicorn/blob/fe3910083e3990695bc19c2ef671dd447262ae18/docs/server-behavior.md?plain=1#L11))
2. **`request_max_body_size` still enforces body limits** — the 413 response for oversized bodies is unchanged
3. **The old code had a subtle bug** — the `if/elif` structure meant that when `Content-Length` was present, `request_max_body_size` enforcement was unreachable (only the content-length check ran)

### Behavioral change

| Scenario | Before | After |
|----------|--------|-------|
| Body > Content-Length, within `request_max_body_size` | 400 Bad Request | **Request succeeds** |
| Body > `request_max_body_size` | 400 Bad Request (if Content-Length set) | **413 Request Entity Too Large** |
| Body > `request_max_body_size`, no Content-Length | 413 | 413 (unchanged) |

This is intentional — the previous behavior was incorrect when decompression middleware was in use, and the content-length check was redundant with ASGI server enforcement.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4690">https://litestar-org.github.io/litestar-docs-preview/4690</a> 
