### PR TITLE
docs(security): use PermissionDeniedException (403) in guards examples

### DIFF
--- a/docs/examples/security/guards.py
+++ b/docs/examples/security/guards.py
@@ -5,7 +5,7 @@ from pydantic import UUID4, BaseModel
 
 from litestar import Controller, Litestar, Router, get, post
 from litestar.connection import ASGIConnection
-from litestar.exceptions import NotAuthorizedException
+from litestar.exceptions import PermissionDeniedException
 from litestar.handlers.base import BaseRouteHandler
 
 
@@ -26,7 +26,7 @@ class User(BaseModel):
 
 def admin_user_guard(connection: ASGIConnection, _: BaseRouteHandler) -> None:
     if not connection.user.is_admin:
-        raise NotAuthorizedException()
+        raise PermissionDeniedException()
 
 
 @post(path="/user", guards=[admin_user_guard])
@@ -54,7 +54,7 @@ def secret_token_guard(connection: ASGIConnection, route_handler: BaseRouteHandl
         route_handler.opt.get("secret")
         and not connection.headers.get("Secret-Header", "") == route_handler.opt["secret"]
     ):
-        raise NotAuthorizedException()
+        raise PermissionDeniedException()
 
 
 @get(path="/secret", guards=[secret_token_guard], opt={"secret": environ.get("SECRET")})

--- a/docs/usage/security/guards.rst
+++ b/docs/usage/security/guards.rst
@@ -4,8 +4,8 @@ Guards
 Guards are :term:`callables <python:callable>` that receive two arguments - ``connection``, which is the :class:`Request <.connection.Request>` or :class:`WebSocket <.connection.WebSocket>` instance (both sub-classes of :class:`~.connection.ASGIConnection`), and ``route_handler``, which is a copy of the
 :class:`~.handlers.BaseRouteHandler`. Their role is to *authorize* the request by verifying that
 the connection is allowed to reach the endpoint handler in question. If verification fails, the guard should raise an
-:exc:`HTTPException`, usually a :class:`~.exceptions.NotAuthorizedException` with a
-``status_code`` of ``401``.
+:exc:`HTTPException`, usually a :class:`~.exceptions.PermissionDeniedException` with a
+``status_code`` of ``403``.
 
 To illustrate this we will implement a rudimentary role based authorization system in our Litestar app. As we have done
 for ``authentication``, we will assume that we added some sort of persistence layer without actually specifying it in


### PR DESCRIPTION
## Summary

- Guards perform **authorization** (is the user allowed?), not **authentication** (who is the user?), so the recommended exception should be `PermissionDeniedException` (403 Forbidden) rather than `NotAuthorizedException` (401 Unauthorized)
- Updates the guards example code and RST prose to use the correct exception and status code
- Aligns with the exceptions reference at `docs/usage/exceptions.rst` which already documents `PermissionDeniedException` at 403

Closes #4231

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: https://litestar-org.github.io/litestar-docs-preview/4692
