### PR TITLE
docs(usage/excluding-and-including-endpoints): fix misleading regex examples in exclude docs, use anchored patterns for prefix matching

### DIFF
--- a/docs/usage/security/excluding-and-including-endpoints.rst
+++ b/docs/usage/security/excluding-and-including-endpoints.rst
@@ -13,9 +13,11 @@ Excluding routes
 --------------------
 
 The ``exclude`` argument takes a :class:`string <str>` or :class:`list` of :class:`strings <str>` that are interpreted
-as regex patterns. For example, the configuration below would apply authentication to all endpoints except those where
-the route starts with ``/login``, ``/signup``, or ``/schema``. Thus, one does not have to exclude ``/schema/swagger``
-as well - it is included in the ``/schema`` pattern.
+as regex patterns matched against the full path. Because the patterns are not implicitly anchored, a pattern like
+``/schema`` would match *any* path containing ``/schema``, not just paths that start with it. To match only paths that
+start with a given prefix, anchor the pattern with ``^``. For example, the configuration below would apply
+authentication to all endpoints except those where the route starts with ``/login``, ``/signup``, or ``/schema``.
+Thus, one does not have to exclude ``/schema/swagger`` as well — it is covered by the ``^/schema`` pattern.
 
 .. danger::
 
@@ -31,7 +33,7 @@ as well - it is included in the ``/schema`` pattern.
     session_backend_config=ServerSideSessionConfig(),
     # exclude any URLs that should not have authentication.
     # We exclude the documentation URLs, signup and login.
-    exclude=["/login", "/signup", "/schema"],
+    exclude=[r"^/login", r"^/signup", r"^/schema"],
     )
     ...
 
@@ -94,7 +96,7 @@ You can set an alternative option key in the security configuration, e.g., you c
     session_backend_config=ServerSideSessionConfig(),
     # exclude any URLs that should not have authentication.
     # We exclude the documentation URLs, signup and login.
-    exclude=["/login", "/signup", "/schema"],
+    exclude=[r"^/login", r"^/signup", r"^/schema"],
     exclude_opt_key="no_auth"  # default value is `exclude_from_auth`
     )
     ...

--- a/docs/usage/security/excluding-and-including-endpoints.rst
+++ b/docs/usage/security/excluding-and-including-endpoints.rst
@@ -27,13 +27,13 @@ Thus, one does not have to exclude ``/schema/swagger`` as well — it is covered
 .. code-block:: python
 
     session_auth = SessionAuth[User, ServerSideSessionBackend](
-    retrieve_user_handler=retrieve_user_handler,
-    # we must pass a config for a session backend.
-    # all session backends are supported
-    session_backend_config=ServerSideSessionConfig(),
-    # exclude any URLs that should not have authentication.
-    # We exclude the documentation URLs, signup and login.
-    exclude=[r"^/login", r"^/signup", r"^/schema"],
+        retrieve_user_handler=retrieve_user_handler,
+        # we must pass a config for a session backend.
+        # all session backends are supported
+        session_backend_config=ServerSideSessionConfig(),
+        # exclude any URLs that should not have authentication.
+        # We exclude the documentation URLs, signup and login.
+        exclude=[r"^/login", r"^/signup", r"^/schema"],
     )
     ...
 
@@ -48,13 +48,13 @@ under the ``/secured`` route will require authentication - all other routes do n
 
     ...
     session_auth = SessionAuth[User, ServerSideSessionBackend](
-    retrieve_user_handler=retrieve_user_handler,
-    # we must pass a config for a session backend.
-    # all session backends are supported
-    session_backend_config=ServerSideSessionConfig(),
-    # exclude any URLs that should not have authentication.
-    # We exclude the documentation URLs, signup and login.
-    exclude=[r"^(?!.*\/secured$).*$"],
+        retrieve_user_handler=retrieve_user_handler,
+        # we must pass a config for a session backend.
+        # all session backends are supported
+        session_backend_config=ServerSideSessionConfig(),
+        # exclude any URLs that should not have authentication.
+        # We exclude the documentation URLs, signup and login.
+        exclude=[r"^(?!.*\/secured$).*$"],
     )
     ...
 
@@ -90,13 +90,13 @@ You can set an alternative option key in the security configuration, e.g., you c
         ...
 
     session_auth = SessionAuth[User, ServerSideSessionBackend](
-    retrieve_user_handler=retrieve_user_handler,
-    # we must pass a config for a session backend.
-    # all session backends are supported
-    session_backend_config=ServerSideSessionConfig(),
-    # exclude any URLs that should not have authentication.
-    # We exclude the documentation URLs, signup and login.
-    exclude=[r"^/login", r"^/signup", r"^/schema"],
-    exclude_opt_key="no_auth"  # default value is `exclude_from_auth`
+        retrieve_user_handler=retrieve_user_handler,
+        # we must pass a config for a session backend.
+        # all session backends are supported
+        session_backend_config=ServerSideSessionConfig(),
+        # exclude any URLs that should not have authentication.
+        # We exclude the documentation URLs, signup and login.
+        exclude=[r"^/login", r"^/signup", r"^/schema"],
+        exclude_opt_key="no_auth"  # default value is `exclude_from_auth`
     )
     ...


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Fix misleading regex examples in exclude docs, use anchored patterns for prefix matching

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Closes #4695 


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: https://litestar-org.github.io/litestar-docs-preview/4696
