### PR TITLE
feat: generate OpenAPI params from typed reserved kwargs

### DIFF
--- a/litestar/_openapi/parameters.py
+++ b/litestar/_openapi/parameters.py
@@ -214,9 +214,7 @@ class ParameterFactory:
         for field_name, field_definition in intersection_fields:
             self.parameters.add(self.get_layered_parameter(field_name=field_name, field_definition=field_definition))
 
-    def _create_parameters_from_reserved_kwargs(
-        self, fields: dict[str, FieldDefinition]
-    ) -> None:
+    def _create_parameters_from_reserved_kwargs(self, fields: dict[str, FieldDefinition]) -> None:
         """Generate OpenAPI parameters from typed reserved kwargs (``query``, ``headers``, ``cookies``).
 
         When a handler annotates a reserved kwarg with a ``TypedDict``, each field of the
@@ -241,7 +239,7 @@ class ParameterFactory:
             if field_def.is_typeddict_type:
                 annotation = field_def.annotation
                 hints = get_type_hints(annotation, include_extras=True)
-                required_keys = getattr(annotation, "__required_keys__", set())
+                required_keys: frozenset[str] = getattr(annotation, "__required_keys__", frozenset())
                 for key, type_ in hints.items():
                     sub_field = FieldDefinition.from_kwarg(name=key, annotation=type_)
                     schema = self.schema_creator.for_field_definition(sub_field)

--- a/litestar/_openapi/parameters.py
+++ b/litestar/_openapi/parameters.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, get_type_hints
 
 from litestar._openapi.schema_generation import SchemaCreator
 from litestar._openapi.schema_generation.utils import get_formatted_examples
-from litestar.constants import RESERVED_KWARGS
+from litestar.constants import DOCUMENTABLE_RESERVED_KWARGS, RESERVED_KWARGS
 from litestar.enums import ParamType
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.openapi.spec.parameter import Parameter
@@ -214,6 +214,45 @@ class ParameterFactory:
         for field_name, field_definition in intersection_fields:
             self.parameters.add(self.get_layered_parameter(field_name=field_name, field_definition=field_definition))
 
+    def _create_parameters_from_reserved_kwargs(
+        self, fields: dict[str, FieldDefinition]
+    ) -> None:
+        """Generate OpenAPI parameters from typed reserved kwargs (``query``, ``headers``, ``cookies``).
+
+        When a handler annotates a reserved kwarg with a ``TypedDict``, each field of the
+        ``TypedDict`` is added as an individual OpenAPI parameter of the corresponding type
+        (query, header, or cookie).
+
+        Args:
+            fields: The handler's field definitions.
+        """
+        param_type_map: dict[str, ParamType] = {
+            "query": ParamType.QUERY,
+            "headers": ParamType.HEADER,
+            "cookies": ParamType.COOKIE,
+        }
+        for kwarg_name in DOCUMENTABLE_RESERVED_KWARGS:
+            field_def = fields.get(kwarg_name)
+            if field_def is None:
+                continue
+
+            param_type = param_type_map[kwarg_name]
+
+            if field_def.is_typeddict_type:
+                annotation = field_def.annotation
+                hints = get_type_hints(annotation, include_extras=True)
+                required_keys = getattr(annotation, "__required_keys__", set())
+                for key, type_ in hints.items():
+                    sub_field = FieldDefinition.from_kwarg(name=key, annotation=type_)
+                    schema = self.schema_creator.for_field_definition(sub_field)
+                    param = Parameter(
+                        name=key,
+                        param_in=param_type,
+                        required=key in required_keys,
+                        schema=schema,
+                    )
+                    self.parameters.add(param)
+
     def create_parameters_for_handler(self) -> list[Parameter]:
         """Create a list of path/query/header Parameter models for the given PathHandler."""
         handler_fields = self.route_handler.parsed_fn_signature.parameters
@@ -233,6 +272,7 @@ class ParameterFactory:
         )
 
         self.create_parameters_for_field_definitions(handler_fields)
+        self._create_parameters_from_reserved_kwargs(handler_fields)
         return self.parameters.list()
 
 

--- a/litestar/constants.py
+++ b/litestar/constants.py
@@ -21,6 +21,7 @@ OPENAPI_NOT_INITIALIZED: Final = "Litestar has not been instantiated with OpenAP
 REDIRECT_STATUS_CODES: Final = {301, 302, 303, 307, 308}
 REDIRECT_ALLOWED_MEDIA_TYPES: Final = {MediaType.TEXT, MediaType.HTML, MediaType.JSON}
 RESERVED_KWARGS: Final = {"state", "headers", "cookies", "request", "socket", "data", "query", "scope", "body"}
+DOCUMENTABLE_RESERVED_KWARGS: Final = {"query", "headers", "cookies"}
 SKIP_VALIDATION_NAMES: Final = {"request", "socket", "scope", "receive", "send"}
 UNDEFINED_SENTINELS: Final = {Signature.empty, Empty, Ellipsis, MISSING, UnsetType}
 WEBSOCKET_CLOSE: Final = "websocket.close"

--- a/tests/unit/test_openapi/test_reserved_kwargs_openapi.py
+++ b/tests/unit/test_openapi/test_reserved_kwargs_openapi.py
@@ -5,15 +5,13 @@ See: https://github.com/litestar-org/litestar/issues/2015
 
 from __future__ import annotations
 
-from typing import Optional, TypedDict, cast
-
-import pytest
+from typing import TypedDict
 
 from litestar import Litestar, get
 from litestar.enums import ParamType
 from litestar.openapi import OpenAPIConfig
-from litestar.openapi.spec import OpenAPI
 from litestar.openapi.spec.enums import OpenAPIType
+from litestar.openapi.spec.parameter import Parameter
 from litestar.testing import create_test_client
 
 
@@ -47,10 +45,10 @@ class TestTypedDictQueryParameters:
             return {}
 
         app = Litestar(route_handlers=[handler])
-        schema = cast("OpenAPI", app.openapi_schema)
-        params = schema.paths["/items"].get.parameters  # type: ignore[union-attr, index]
-        assert params is not None
+        parameters = app.openapi_schema.paths["/items"].get.parameters  # type: ignore[index, union-attr]
+        assert parameters is not None
 
+        params = [p for p in parameters if isinstance(p, Parameter)]
         param_names = {p.name for p in params}
         assert "page" in param_names
         assert "search" in param_names
@@ -61,13 +59,15 @@ class TestTypedDictQueryParameters:
             return {}
 
         app = Litestar(route_handlers=[handler])
-        schema = cast("OpenAPI", app.openapi_schema)
-        params = {p.name: p for p in schema.paths["/items"].get.parameters}  # type: ignore[union-attr, index]
+        parameters = app.openapi_schema.paths["/items"].get.parameters  # type: ignore[index, union-attr]
+        assert parameters is not None
+
+        params = {p.name: p for p in parameters if isinstance(p, Parameter)}
 
         assert params["page"].param_in == ParamType.QUERY
-        assert params["page"].schema.type == OpenAPIType.INTEGER  # type: ignore[union-attr]
+        assert params["page"].schema and params["page"].schema.type == OpenAPIType.INTEGER  # type: ignore[union-attr]
         assert params["search"].param_in == ParamType.QUERY
-        assert params["search"].schema.type == OpenAPIType.STRING  # type: ignore[union-attr]
+        assert params["search"].schema and params["search"].schema.type == OpenAPIType.STRING  # type: ignore[union-attr]
 
     def test_typeddict_query_required_keys(self) -> None:
         @get("/items")
@@ -75,8 +75,10 @@ class TestTypedDictQueryParameters:
             return {}
 
         app = Litestar(route_handlers=[handler])
-        schema = cast("OpenAPI", app.openapi_schema)
-        params = {p.name: p for p in schema.paths["/items"].get.parameters}  # type: ignore[union-attr, index]
+        parameters = app.openapi_schema.paths["/items"].get.parameters  # type: ignore[index, union-attr]
+        assert parameters is not None
+
+        params = {p.name: p for p in parameters if isinstance(p, Parameter)}
 
         assert params["page"].required is True
         assert params["search"].required is True
@@ -87,8 +89,10 @@ class TestTypedDictQueryParameters:
             return {}
 
         app = Litestar(route_handlers=[handler])
-        schema = cast("OpenAPI", app.openapi_schema)
-        params = {p.name: p for p in schema.paths["/items"].get.parameters}  # type: ignore[union-attr, index]
+        parameters = app.openapi_schema.paths["/items"].get.parameters  # type: ignore[index, union-attr]
+        assert parameters is not None
+
+        params = {p.name: p for p in parameters if isinstance(p, Parameter)}
 
         # QueryParams uses total=False, so all keys are optional
         assert params["page"].required is False
@@ -105,10 +109,10 @@ class TestTypedDictHeaderParameters:
             return {}
 
         app = Litestar(route_handlers=[handler])
-        schema = cast("OpenAPI", app.openapi_schema)
-        params = schema.paths["/items"].get.parameters  # type: ignore[union-attr, index]
-        assert params is not None
+        parameters = app.openapi_schema.paths["/items"].get.parameters  # type: ignore[index, union-attr]
+        assert parameters is not None
 
+        params = [p for p in parameters if isinstance(p, Parameter)]
         param_names = {p.name for p in params}
         assert "x_api_key" in param_names
         assert "x_request_id" in param_names
@@ -119,8 +123,10 @@ class TestTypedDictHeaderParameters:
             return {}
 
         app = Litestar(route_handlers=[handler])
-        schema = cast("OpenAPI", app.openapi_schema)
-        params = {p.name: p for p in schema.paths["/items"].get.parameters}  # type: ignore[union-attr, index]
+        parameters = app.openapi_schema.paths["/items"].get.parameters  # type: ignore[index, union-attr]
+        assert parameters is not None
+
+        params = {p.name: p for p in parameters if isinstance(p, Parameter)}
 
         assert params["x_api_key"].param_in == ParamType.HEADER
         assert params["x_request_id"].param_in == ParamType.HEADER
@@ -136,10 +142,10 @@ class TestTypedDictCookieParameters:
             return {}
 
         app = Litestar(route_handlers=[handler])
-        schema = cast("OpenAPI", app.openapi_schema)
-        params = schema.paths["/items"].get.parameters  # type: ignore[union-attr, index]
-        assert params is not None
+        parameters = app.openapi_schema.paths["/items"].get.parameters  # type: ignore[index, union-attr]
+        assert parameters is not None
 
+        params = [p for p in parameters if isinstance(p, Parameter)]
         param_names = {p.name for p in params}
         assert "session_id" in param_names
         assert "tracking_id" in param_names
@@ -150,8 +156,10 @@ class TestTypedDictCookieParameters:
             return {}
 
         app = Litestar(route_handlers=[handler])
-        schema = cast("OpenAPI", app.openapi_schema)
-        params = {p.name: p for p in schema.paths["/items"].get.parameters}  # type: ignore[union-attr, index]
+        parameters = app.openapi_schema.paths["/items"].get.parameters  # type: ignore[index, union-attr]
+        assert parameters is not None
+
+        params = {p.name: p for p in parameters if isinstance(p, Parameter)}
 
         assert params["session_id"].param_in == ParamType.COOKIE
         assert params["tracking_id"].param_in == ParamType.COOKIE
@@ -163,12 +171,11 @@ class TestUntypedReservedKwargsUnchanged:
 
     def test_dict_query_no_parameters(self) -> None:
         @get("/items")
-        async def handler(query: dict) -> dict:  # type: ignore[type-arg]
+        async def handler(query: dict) -> dict:
             return {}
 
         app = Litestar(route_handlers=[handler])
-        schema = cast("OpenAPI", app.openapi_schema)
-        params = schema.paths["/items"].get.parameters  # type: ignore[union-attr, index]
+        params = app.openapi_schema.paths["/items"].get.parameters  # type: ignore[index, union-attr]
         assert params is None
 
     def test_plain_dict_str_str_no_parameters(self) -> None:
@@ -177,8 +184,7 @@ class TestUntypedReservedKwargsUnchanged:
             return {}
 
         app = Litestar(route_handlers=[handler])
-        schema = cast("OpenAPI", app.openapi_schema)
-        params = schema.paths["/items"].get.parameters  # type: ignore[union-attr, index]
+        params = app.openapi_schema.paths["/items"].get.parameters  # type: ignore[index, union-attr]
         assert params is None
 
 
@@ -199,11 +205,11 @@ class TestOpenAPIJSONOutput:
             assert response.status_code == 200
             data = response.json()
 
-            params = data["paths"]["/items"]["get"]["parameters"]
-            param_names = {p["name"] for p in params}
+            parameters = data["paths"]["/items"]["get"]["parameters"]
+            param_names = {p["name"] for p in parameters}
             assert "page" in param_names
             assert "search" in param_names
 
-            page_param = next(p for p in params if p["name"] == "page")
+            page_param = next(p for p in parameters if p["name"] == "page")
             assert page_param["in"] == "query"
             assert page_param["schema"]["type"] == "integer"

--- a/tests/unit/test_openapi/test_reserved_kwargs_openapi.py
+++ b/tests/unit/test_openapi/test_reserved_kwargs_openapi.py
@@ -1,0 +1,209 @@
+"""Tests for OpenAPI schema generation from typed reserved kwargs (query, headers, cookies).
+
+See: https://github.com/litestar-org/litestar/issues/2015
+"""
+
+from __future__ import annotations
+
+from typing import Optional, TypedDict, cast
+
+import pytest
+
+from litestar import Litestar, get
+from litestar.enums import ParamType
+from litestar.openapi import OpenAPIConfig
+from litestar.openapi.spec import OpenAPI
+from litestar.openapi.spec.enums import OpenAPIType
+from litestar.testing import create_test_client
+
+
+class QueryParams(TypedDict, total=False):
+    page: int
+    search: str
+
+
+class RequiredQueryParams(TypedDict):
+    page: int
+    search: str
+
+
+class HeaderParams(TypedDict, total=False):
+    x_api_key: str
+    x_request_id: str
+
+
+class CookieParams(TypedDict, total=False):
+    session_id: str
+    tracking_id: str
+
+
+class TestTypedDictQueryParameters:
+    """Test that a TypedDict annotation on the ``query`` reserved kwarg
+    generates individual query parameters in the OpenAPI schema."""
+
+    def test_typeddict_query_generates_parameters(self) -> None:
+        @get("/items")
+        async def handler(query: QueryParams) -> dict:
+            return {}
+
+        app = Litestar(route_handlers=[handler])
+        schema = cast("OpenAPI", app.openapi_schema)
+        params = schema.paths["/items"].get.parameters  # type: ignore[union-attr, index]
+        assert params is not None
+
+        param_names = {p.name for p in params}
+        assert "page" in param_names
+        assert "search" in param_names
+
+    def test_typeddict_query_param_types_are_correct(self) -> None:
+        @get("/items")
+        async def handler(query: QueryParams) -> dict:
+            return {}
+
+        app = Litestar(route_handlers=[handler])
+        schema = cast("OpenAPI", app.openapi_schema)
+        params = {p.name: p for p in schema.paths["/items"].get.parameters}  # type: ignore[union-attr, index]
+
+        assert params["page"].param_in == ParamType.QUERY
+        assert params["page"].schema.type == OpenAPIType.INTEGER  # type: ignore[union-attr]
+        assert params["search"].param_in == ParamType.QUERY
+        assert params["search"].schema.type == OpenAPIType.STRING  # type: ignore[union-attr]
+
+    def test_typeddict_query_required_keys(self) -> None:
+        @get("/items")
+        async def handler(query: RequiredQueryParams) -> dict:
+            return {}
+
+        app = Litestar(route_handlers=[handler])
+        schema = cast("OpenAPI", app.openapi_schema)
+        params = {p.name: p for p in schema.paths["/items"].get.parameters}  # type: ignore[union-attr, index]
+
+        assert params["page"].required is True
+        assert params["search"].required is True
+
+    def test_typeddict_query_optional_keys(self) -> None:
+        @get("/items")
+        async def handler(query: QueryParams) -> dict:
+            return {}
+
+        app = Litestar(route_handlers=[handler])
+        schema = cast("OpenAPI", app.openapi_schema)
+        params = {p.name: p for p in schema.paths["/items"].get.parameters}  # type: ignore[union-attr, index]
+
+        # QueryParams uses total=False, so all keys are optional
+        assert params["page"].required is False
+        assert params["search"].required is False
+
+
+class TestTypedDictHeaderParameters:
+    """Test that a TypedDict annotation on the ``headers`` reserved kwarg
+    generates individual header parameters in the OpenAPI schema."""
+
+    def test_typeddict_headers_generates_parameters(self) -> None:
+        @get("/items")
+        async def handler(headers: HeaderParams) -> dict:
+            return {}
+
+        app = Litestar(route_handlers=[handler])
+        schema = cast("OpenAPI", app.openapi_schema)
+        params = schema.paths["/items"].get.parameters  # type: ignore[union-attr, index]
+        assert params is not None
+
+        param_names = {p.name for p in params}
+        assert "x_api_key" in param_names
+        assert "x_request_id" in param_names
+
+    def test_typeddict_headers_param_type_is_header(self) -> None:
+        @get("/items")
+        async def handler(headers: HeaderParams) -> dict:
+            return {}
+
+        app = Litestar(route_handlers=[handler])
+        schema = cast("OpenAPI", app.openapi_schema)
+        params = {p.name: p for p in schema.paths["/items"].get.parameters}  # type: ignore[union-attr, index]
+
+        assert params["x_api_key"].param_in == ParamType.HEADER
+        assert params["x_request_id"].param_in == ParamType.HEADER
+
+
+class TestTypedDictCookieParameters:
+    """Test that a TypedDict annotation on the ``cookies`` reserved kwarg
+    generates individual cookie parameters in the OpenAPI schema."""
+
+    def test_typeddict_cookies_generates_parameters(self) -> None:
+        @get("/items")
+        async def handler(cookies: CookieParams) -> dict:
+            return {}
+
+        app = Litestar(route_handlers=[handler])
+        schema = cast("OpenAPI", app.openapi_schema)
+        params = schema.paths["/items"].get.parameters  # type: ignore[union-attr, index]
+        assert params is not None
+
+        param_names = {p.name for p in params}
+        assert "session_id" in param_names
+        assert "tracking_id" in param_names
+
+    def test_typeddict_cookies_param_type_is_cookie(self) -> None:
+        @get("/items")
+        async def handler(cookies: CookieParams) -> dict:
+            return {}
+
+        app = Litestar(route_handlers=[handler])
+        schema = cast("OpenAPI", app.openapi_schema)
+        params = {p.name: p for p in schema.paths["/items"].get.parameters}  # type: ignore[union-attr, index]
+
+        assert params["session_id"].param_in == ParamType.COOKIE
+        assert params["tracking_id"].param_in == ParamType.COOKIE
+
+
+class TestUntypedReservedKwargsUnchanged:
+    """Verify that untyped/dict-typed reserved kwargs don't produce OpenAPI
+    parameters — preserving backward compatibility."""
+
+    def test_dict_query_no_parameters(self) -> None:
+        @get("/items")
+        async def handler(query: dict) -> dict:  # type: ignore[type-arg]
+            return {}
+
+        app = Litestar(route_handlers=[handler])
+        schema = cast("OpenAPI", app.openapi_schema)
+        params = schema.paths["/items"].get.parameters  # type: ignore[union-attr, index]
+        assert params is None
+
+    def test_plain_dict_str_str_no_parameters(self) -> None:
+        @get("/items")
+        async def handler(query: dict[str, str]) -> dict:
+            return {}
+
+        app = Litestar(route_handlers=[handler])
+        schema = cast("OpenAPI", app.openapi_schema)
+        params = schema.paths["/items"].get.parameters  # type: ignore[union-attr, index]
+        assert params is None
+
+
+class TestOpenAPIJSONOutput:
+    """Integration test that verifies the generated OpenAPI JSON output
+    via the test client, matching real-world usage."""
+
+    def test_typeddict_query_in_openapi_json(self) -> None:
+        @get("/items")
+        async def handler(query: QueryParams) -> dict:
+            return {}
+
+        with create_test_client(
+            route_handlers=[handler],
+            openapi_config=OpenAPIConfig(title="Test API", version="1.0.0"),
+        ) as client:
+            response = client.get("/schema/openapi.json")
+            assert response.status_code == 200
+            data = response.json()
+
+            params = data["paths"]["/items"]["get"]["parameters"]
+            param_names = {p["name"] for p in params}
+            assert "page" in param_names
+            assert "search" in param_names
+
+            page_param = next(p for p in params if p["name"] == "page")
+            assert page_param["in"] == "query"
+            assert page_param["schema"]["type"] == "integer"


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This PR implements core framework support for generating OpenAPI parameter schemas directly from strongly-typed reserved kwargs like `query`, `headers`, and `cookies`, significantly improving the developer experience (DX) and OpenAPI introspectability. 
Previously, when a developer annotated a reserved kwarg such as `query` with a `TypedDict`, the framework's OpenAPI generator skipped it entirely due to a blanket exclusion of `RESERVED_KWARGS` during schema parameter resolution in `parameters.py`.

### Key Technical Enhancements
**1. Semantic Parameter Parsing & Introspection**
Refactored the `litestar._openapi.parameters.ParameterFactory` to support introspection of `TypedDict` definitions applied to `DOCUMENTABLE_RESERVED_KWARGS` (`query`, `headers`, `cookies`). 
By deeply inspecting `__required_keys__` and utilizing Litestar's robust `SchemaCreator`, the OpenAPI spec now automatically generates exhaustive, type-safe schema attributes for each item present in the specified type dictionary.
*Before this PR (OpenAPI Schema omitted completely):*
```python
class SearchQuery(TypedDict, total=False):
    page: int
    search: str
@get("/items")
async def get_items(query: SearchQuery) -> None:
    ...
```
*After this PR (Schema effectively renders distinct parameters):*
```json
"parameters": [
  {
    "name": "page",
    "in": "query",
    "required": false,
    "schema": {"type": "integer"}
  },
  {
    "name": "search",
    "in": "query",
    "required": false,
    "schema": {"type": "string"}
  }
]
```
**2. Constant Refactoring Architecture (`litestar/constants.py`)**
Introduced an isolated `DOCUMENTABLE_RESERVED_KWARGS` constant namespace. This preserves backwards compatibility with `RESERVED_KWARGS` exclusions — effectively preventing internal kwargs (`state`, `request`, `scope`, etc) from incorrectly exposing into public OpenAPI outputs, whilst explicitly authorizing `query`, `headers`, and `cookies` to map their documentation properties.
**3. Extensive Validation & Unit Testing**
Includes a comprehensive test suite (`test_reserved_kwargs_openapi.py`) of 11 new granular unit tests covering:
* Positive assertion checks over `headers`, `query`, and `cookies` generation.
* Extractive verification mapping properties precisely to `ParamType.QUERY`, `ParamType.HEADER`, and `ParamType.COOKIE`.
* Required/Optional key property parsing validation utilizing typed variations.
* Negative code-path coverage ensuring generic dictionary definitions (e.g. `query: dict[str, str]`) safely bypass parameter injection without regression side-effects.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes #2015

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: https://litestar-org.github.io/litestar-docs-preview/4702
