### PR TITLE
ci: Fix docs preview link

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -63,7 +63,7 @@ jobs:
             const issue_number = parseInt(process.env.PR_NUMBER, 10)
             const previewUrl = "https://litestar-org.github.io/litestar-docs-preview/" + issue_number
             const marker = "<!-- docs-preview -->"
-            const section = marker + "\n\n<hr>\n📚 Documentation preview 📚: " + previewUrl + "\n"
+            const section = marker + `\n\n<hr>\n📚 Documentation preview 📚: <a href="${previewUrl}">${previewUrl}</a> \n`
 
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,


### PR DESCRIPTION
Should be linked now

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4705">https://litestar-org.github.io/litestar-docs-preview/4705</a> 
