### PR TITLE
fix(serialization/msgspec_hooks): avoid dict allocation in default_serializer when no custom type_encoders

### DIFF
--- a/litestar/serialization/msgspec_hooks.py
+++ b/litestar/serialization/msgspec_hooks.py
@@ -82,16 +82,11 @@ def default_serializer(value: Any, type_encoders: Mapping[Any, Callable[[Any], A
     Raises:
         TypeError: if value is not supported
     """
-    type_encoders = {**DEFAULT_TYPE_ENCODERS, **(type_encoders or {})}
+    encoders = DEFAULT_TYPE_ENCODERS if not type_encoders else {**DEFAULT_TYPE_ENCODERS, **type_encoders}
 
     for base in value.__class__.__mro__[:-1]:
-        try:
-            encoder = type_encoders[base]
-        except KeyError:
-            continue
-        else:
+        if (encoder := encoders.get(base)) is not None:
             return encoder(value)
-
     raise TypeError(f"Unsupported type: {type(value)!r}")
 
 

--- a/tests/unit/test_response/test_serialization.py
+++ b/tests/unit/test_response/test_serialization.py
@@ -1,6 +1,11 @@
 import enum
+import re
+from collections import deque
 from collections.abc import Callable
-from pathlib import Path, PurePath, PureWindowsPath
+from datetime import date, datetime, time
+from decimal import Decimal
+from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
+from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
 from typing import Any, cast
 
 import msgspec
@@ -8,8 +13,10 @@ import pytest
 from pytest import FixtureRequest
 
 from litestar import MediaType, Response
+from litestar.datastructures.secret_values import SecretBytes, SecretString
 from litestar.exceptions import ImproperlyConfiguredException
-from litestar.serialization import get_serializer
+from litestar.serialization import default_serializer, get_serializer
+from litestar.serialization.msgspec_hooks import DEFAULT_TYPE_ENCODERS
 from tests.models import DataclassPersonFactory, MsgSpecStructPerson
 
 person = DataclassPersonFactory.build()
@@ -89,3 +96,104 @@ def test_response_validation_of_unknown_media_types(
     else:
         rendered = response.render(content, media_type=media_type)
         assert rendered == (content if isinstance(content, bytes) else content.encode("utf-8"))
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (Path("/tmp/file"), "/tmp/file"),
+        (PurePosixPath("/a/b"), "/a/b"),
+        (IPv4Address("1.2.3.4"), "1.2.3.4"),
+        (IPv4Network("192.0.2.0/24"), "192.0.2.0/24"),
+        (IPv6Address("::1"), "::1"),
+        (IPv6Network("::1/128"), "::1/128"),
+        (datetime(2024, 1, 15, 12, 0, 0), "2024-01-15T12:00:00"),
+        (date(2024, 1, 15), "2024-01-15"),
+        (time(12, 30, 0), "12:30:00"),
+        (deque([1, 2, 3]), [1, 2, 3]),
+        (Decimal("3.14"), 3.14),
+        (Decimal("42"), 42),
+        (re.compile(r"\d+"), r"\d+"),
+        (SecretString("s3cr3t"), "******"),
+        (SecretBytes(b"s3cr3t"), "******"),
+    ],
+)
+def test_default_serializer_builtin_types(value: Any, expected: Any) -> None:
+    assert default_serializer(value) == expected
+
+
+def test_default_serializer_unsupported_type_raises() -> None:
+    class Unregistered:
+        pass
+
+    with pytest.raises(TypeError, match="Unsupported type"):
+        default_serializer(Unregistered())
+
+
+def test_default_serializer_empty_type_encoders_preserves_defaults() -> None:
+    """Falsy type_encoders={} must not suppress DEFAULT_TYPE_ENCODERS."""
+    assert default_serializer(Path("/tmp"), type_encoders={}) == default_serializer(Path("/tmp"), type_encoders=None)
+
+
+def test_default_serializer_custom_encoder_overrides_default() -> None:
+    assert default_serializer(Path("/x"), type_encoders={Path: lambda v: "overridden"}) == "overridden"
+
+
+def test_default_serializer_custom_encoder_extends_defaults() -> None:
+    class Custom:
+        pass
+
+    result_custom = default_serializer(Custom(), type_encoders={Custom: lambda v: "custom"})
+    result_default = default_serializer(Path("/x"), type_encoders={Custom: lambda v: "custom"})
+    assert result_custom == "custom"
+    assert result_default == "/x"
+
+
+def test_default_serializer_mro_subclass_uses_base_encoder() -> None:
+    class Base:
+        pass
+
+    class Child(Base):
+        pass
+
+    assert default_serializer(Child(), type_encoders={Base: lambda v: "base"}) == "base"
+
+
+def test_default_serializer_mro_subclass_encoder_takes_priority() -> None:
+    class Base:
+        pass
+
+    class Child(Base):
+        pass
+
+    result = default_serializer(Child(), type_encoders={Base: lambda v: "base", Child: lambda v: "child"})
+    assert result == "child"
+
+
+def test_default_serializer_repeated_calls_consistent() -> None:
+    """Same type serialized multiple times must always return the same result."""
+    values = [Decimal("1.5"), Decimal("2.5"), Decimal("3.0")]
+    assert [default_serializer(v) for v in values] == [1.5, 2.5, 3.0]
+
+
+def test_default_serializer_does_not_mutate_default_type_encoders() -> None:
+    snapshot = dict(DEFAULT_TYPE_ENCODERS)
+
+    class Extra:
+        pass
+
+    default_serializer(Path("/x"), type_encoders={Extra: lambda v: "extra"})
+    assert dict(DEFAULT_TYPE_ENCODERS) == snapshot
+
+
+def test_get_serializer_custom_encoders_independent() -> None:
+    """Two serializers from get_serializer must not share per-type state."""
+
+    class Foo:
+        pass
+
+    s1 = get_serializer({Foo: lambda v: "s1"})
+    s2 = get_serializer({Foo: lambda v: "s2"})
+    assert s1(Foo()) == "s1"
+    assert s2(Foo()) == "s2"
+    assert s1(Foo()) == "s1"


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
- follow [Litestar's AI Policy](https://github.com/litestar-org/.github/blob/main/AI_POLICY.md)

If the pull request is not yet ready for review (e.g. tests or other checks are still failing),
please submit it as a draft PR, to avoid noise for reviewers.
-->

## Description

Avoid dict allocation in default_serializer when no custom type_encoders

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #4701


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4710">https://litestar-org.github.io/litestar-docs-preview/4710</a> 
