### PR TITLE
docs: restore SerializationPlugin implementation example

### DIFF
--- a/docs/examples/plugins/serialization_plugin_protocol.py
+++ b/docs/examples/plugins/serialization_plugin_protocol.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import get_args, get_origin
+
+from litestar import Litestar, get
+from litestar.dto import AbstractDTO, DataclassDTO
+from litestar.plugins import SerializationPlugin
+from litestar.typing import FieldDefinition
+
+
+@dataclass
+class Company:
+    id: int
+    name: str
+
+
+class CompanySerializationPlugin(SerializationPlugin):
+    def __init__(self) -> None:
+        self._type_dto_map: dict[type, type[AbstractDTO]] = {}
+
+    @staticmethod
+    def _unwrap_collection(annotation: object) -> object:
+        if get_origin(annotation) in (list, tuple, set):
+            return next(iter(get_args(annotation)), annotation)
+        return annotation
+
+    def supports_type(self, field_definition: FieldDefinition) -> bool:
+        annotation = self._unwrap_collection(field_definition.annotation)
+        return isinstance(annotation, type) and issubclass(annotation, Company)
+
+    def create_dto_for_type(self, field_definition: FieldDefinition) -> type[AbstractDTO]:
+        annotation = self._unwrap_collection(field_definition.annotation)
+        assert isinstance(annotation, type)
+        if (cached := self._type_dto_map.get(annotation)) is not None:
+            return cached
+        dto_type: type[AbstractDTO] = DataclassDTO[annotation]
+        self._type_dto_map[annotation] = dto_type
+        return dto_type
+
+
+@get("/", sync_to_thread=False)
+def get_company() -> Company:
+    return Company(id=1, name="ACME")
+
+
+app = Litestar(route_handlers=[get_company], plugins=[CompanySerializationPlugin()])

--- a/docs/usage/plugins/index.rst
+++ b/docs/usage/plugins/index.rst
@@ -71,28 +71,25 @@ that annotation.
 Example
 +++++++
 
-The following example shows the implementation pattern of a ``SerializationPlugin`` for
-`SQLAlchemy <https://www.sqlalchemy.org/>`_ models. For the actual implementation, see the
-``advanced_alchemy`` library documentation.
+The following example shows a minimal ``SerializationPlugin`` implementation that mirrors the pattern used by
+``advanced-alchemy``'s :class:`~advanced_alchemy.extensions.litestar.SQLAlchemySerializationPlugin`:
 
-:meth:`supports_type(self, field_definition: FieldDefinition) -> bool: <advanced_alchemy.extensions.litestar.SQLAlchemySerializationPlugin.supports_type>`
-returns a :class:`bool` indicating whether the plugin supports serialization for the given type. Specifically, we return
-``True`` if the parsed type is either a collection of SQLAlchemy models or a single SQLAlchemy model.
+.. literalinclude:: /examples/plugins/serialization_plugin_protocol.py
+   :language: python
+   :caption: ``SerializationPlugin`` implementation example
 
-:meth:`create_dto_for_type(self, field_definition: FieldDefinition) -> type[AbstractDTO]: <advanced_alchemy.extensions.litestar.SQLAlchemySerializationPlugin.create_dto_for_type>`
-takes a :class:`FieldDefinition <litestar.typing.FieldDefinition>` instance as an argument and returns a
-:class:`SQLAlchemyDTO <advanced_alchemy.extensions.litestar.dto.SQLAlchemyDTO>` subclass and includes some logic that may be
-interesting to potential serialization plugin authors.
+``CompanySerializationPlugin.supports_type()`` returns a :class:`bool` indicating whether the plugin should be used for
+a given type. The example unwraps collection annotations (``list[Company]``, ``tuple[Company, ...]``, etc.) so that a
+handler returning either ``Company`` or a collection of ``Company`` instances is recognised as the same underlying model.
 
-The first thing the method does is check if the parsed type is a collection of SQLAlchemy models or a single SQLAlchemy
-model, retrieves the model type in either case and assigns it to the ``annotation`` variable.
+``CompanySerializationPlugin.create_dto_for_type()`` receives the same :class:`FieldDefinition <litestar.typing.FieldDefinition>`
+and must return an :class:`AbstractDTO <litestar.dto.base_dto.AbstractDTO>` subclass. It first unwraps any collection
+wrapper to recover the concrete model type, checks the ``_type_dto_map`` cache, and if no DTO has been built yet,
+parametrises :class:`~litestar.dto.DataclassDTO` with the annotation, caches it, and returns it. Caching keeps a single
+DTO class per model so handlers that reference the same model type reuse the same serializer.
 
-The method then checks if ``annotation`` is already in the ``_type_dto_map`` dictionary. If it is, it returns the
-corresponding DTO type. This is done to ensure that multiple :class:`SQLAlchemyDTO <advanced_alchemy.extensions.litestar.dto.SQLAlchemyDTO>`
-subtypes are not created for the same model.
-
-If the annotation is not in the ``_type_dto_map`` dictionary, the method creates a new DTO type for the annotation,
-adds it to the ``_type_dto_map`` dictionary, and returns it.
+For a production-grade implementation using SQLAlchemy models instead of dataclasses, refer to the
+``advanced-alchemy`` library documentation.
 
 
 DIPlugin

--- a/docs/usage/plugins/index.rst
+++ b/docs/usage/plugins/index.rst
@@ -85,7 +85,7 @@ handler returning either ``Company`` or a collection of ``Company`` instances is
 ``CompanySerializationPlugin.create_dto_for_type()`` receives the same :class:`FieldDefinition <litestar.typing.FieldDefinition>`
 and must return an :class:`AbstractDTO <litestar.dto.base_dto.AbstractDTO>` subclass. It first unwraps any collection
 wrapper to recover the concrete model type, checks the ``_type_dto_map`` cache, and if no DTO has been built yet,
-parametrises :class:`~litestar.dto.DataclassDTO` with the annotation, caches it, and returns it. Caching keeps a single
+parametrises :class:`DataclassDTO <litestar.dto.dataclass_dto.DataclassDTO>` with the annotation, caches it, and returns it. Caching keeps a single
 DTO class per model so handlers that reference the same model type reuse the same serializer.
 
 For a production-grade implementation using SQLAlchemy models instead of dataclasses, refer to the


### PR DESCRIPTION
## Summary

Fixes #3778.

The ``SerializationPlugin`` section of ``docs/usage/plugins/index.rst`` currently describes the caching pattern used by a serialization plugin (\"check the ``_type_dto_map`` dictionary, add it to the dictionary, return it\") but does not actually show any code. The original ``literalinclude`` directive pointed at ``litestar/contrib/sqlalchemy/plugins/serialization.py``, which was removed when the SQLAlchemy plugin moved to ``advanced-alchemy`` (08297fd), leaving the prose orphaned.

## Changes

- Add a new standalone example ``docs/examples/plugins/serialization_plugin_protocol.py`` that implements ``SerializationPlugin`` for a ``Company`` dataclass. It mirrors the exact caching pattern used by ``advanced-alchemy``'s ``SQLAlchemySerializationPlugin`` (unwrap collection annotations, check a ``_type_dto_map`` cache, parametrise ``DataclassDTO`` on first encounter).
- Update ``docs/usage/plugins/index.rst`` ``SerializationPlugin`` → ``Example`` to ``literalinclude`` the new example and describe its behaviour in terms of the concrete implementation shown. Keep a pointer to advanced-alchemy for production SQLAlchemy usage.

The example is standalone and doesn't require any external dependencies; ``ruff check`` / ``ruff format`` pass locally.

## Test plan

- [ ] Sphinx build renders the updated page
- [ ] ``literalinclude`` directive resolves (example path exists)
- [ ] ``python docs/examples/plugins/serialization_plugin_protocol.py`` imports cleanly

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4711">https://litestar-org.github.io/litestar-docs-preview/4711</a> 
