### PR TITLE
chore(htmx): finalize contrib.htmx removal residue

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,7 +168,6 @@ nitpick_ignore = [
     (PY_CLASS, "litestar.response.RedirectResponse"),
     (PY_CLASS, "litestar.response_containers.Redirect"),
     (PY_CLASS, "litestar.response_containers.Template"),
-    (PY_CLASS, "litestar.contrib.htmx.request.HTMXRequest"),
     (PY_CLASS, "litestar.typing.ParsedType"),
     (PY_METH, "litestar.dto.factory.DTOData.create_instance"),
     (PY_METH, "litestar.dto.interface.DTOInterface.data_to_encodable_type"),


### PR DESCRIPTION
The `litestar.contrib.htmx` package was split out into the standalone `litestar-htmx` library back in #3837, with a thin re-export shim left at `litestar.plugins.htmx`. PR #4226 set out to clean up the leftovers but was closed unmerged.  This cleans up the docs references that are no longer used.


Closes #4725
Finishes #4226

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4731">https://litestar-org.github.io/litestar-docs-preview/4731</a> 
