### PR TITLE
chore(piccolo): remove stale piccolo intersphinx mapping

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,6 @@ intersphinx_mapping = {
     "redis": ("https://redis.readthedocs.io/en/stable/", None),
     "structlog": ("https://www.structlog.org/en/stable/", None),
     "tortoise": ("https://tortoise.github.io/", None),
-    "piccolo": ("https://piccolo-orm.readthedocs.io/en/latest/", None),
     "opentelemetry": ("https://opentelemetry-python.readthedocs.io/en/latest/", None),
     "advanced-alchemy": ("https://advanced-alchemy.litestar.dev/latest/", None),
     "jinja2": ("https://jinja.palletsprojects.com/en/latest/", None),


### PR DESCRIPTION
The Piccolo ORM integration was deprecated in 2.x via #2704 and the bundled `litestar.contrib.piccolo` module has been gone for some time — Piccolo support now lives in the external `litestar-piccolo` library. The deprecation cleaned up the source but left one piece of residue in `docs/conf.py`: an intersphinx mapping pointing at piccolo-orm.readthedocs.io that nothing in the repo still uses.

This PR drops that mapping. The only references to `piccolo` left in `docs/` are plain-text mentions in the user-facing `databases/piccolo.rst` page (which links to the external library's GitHub) and historical entries in `whats-new-2.rst` / `2.x-changelog.rst` that already use the `:class:!...` form to suppress link resolution. None of them depend on intersphinx.

No production code, tests, or user-facing docs change. The `databases/piccolo.rst` page that points users at `litestar-piccolo` continues to work exactly as before.

Verification: `git grep "litestar\.contrib\.piccolo"` returns nothing outside historical release notes, `make lint` is clean, the full unit suite (5392 tests) passes, the docs examples pass, and `make docs` builds without warnings.

Closes #4729
Finishes #2692

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4732">https://litestar-org.github.io/litestar-docs-preview/4732</a> 
