### PR TITLE
chore(pydantic): finalize contrib.pydantic namespace removal

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -190,8 +190,6 @@ nitpick_ignore = [
     (PY_CLASS, "litestar.contrib.mako.P"),
     (PY_CLASS, "JWTDecodeOptions"),
     (PY_CLASS, "litestar.template.base.P"),
-    (PY_CLASS, "litestar.contrib.pydantic.PydanticDTO"),
-    (PY_CLASS, "litestar.contrib.pydantic.PydanticPlugin"),
     (PY_CLASS, "typing.Self"),
     (PY_CLASS, "attr.AttrsInstance"),
     (PY_CLASS, "typing_extensions.TypeGuard"),

--- a/docs/release-notes/2.x-changelog.rst
+++ b/docs/release-notes/2.x-changelog.rst
@@ -1600,7 +1600,7 @@
         :pr: 2404
         :issue: 2373
 
-        A new :class:`~litestar.contrib.pydantic.PydanticPlugin` has been added, which
+        A new ``PydanticPlugin`` has been added, which
         can be used to configure Pydantic behaviour. Currently it supports setting a
         ``prefer_alias`` option, which will pass the ``by_alias=True`` flag to Pydantic
         when exporting models, as well as generate schemas accordingly.
@@ -2704,7 +2704,7 @@
         `Pydantic <https://docs.pydantic.dev/latest/>`_ have been added:
 
         - :class:`~litestar.contrib.msgspec.MsgspecDTO`
-        - :class:`~litestar.contrib.pydantic.PydanticDTO`
+        - ``PydanticDTO``
 
     .. change:: DTOs: Arbitrary generic wrappers
         :pr: 1801

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -289,7 +289,7 @@
         :issue: 4349
 
         New ``round_trip: bool`` parameter
-        to :class:`~litestar.contrib.pydantic.PydanticPlugin` allows
+        to ``PydanticPlugin`` allows
         serializing types like ``pydanctic.Json`` correctly.
 
     .. change:: Remove deprecated ``litestar.contrib.minijinja.minijinja_from_state`` function

--- a/docs/release-notes/whats-new-2.rst
+++ b/docs/release-notes/whats-new-2.rst
@@ -439,7 +439,7 @@ and can be used to define DTOs:
 - :class:`litestar.dto.dataclass_dto.DataclassDTO`
 - :class:`litestar.dto.msgspec_dto.MsgspecDTO`
 - :class:`advanced_alchemy.extensions.litestar.dto.SQLAlchemyDTO`
-- :class:`litestar.contrib.pydantic.PydanticDTO`
+- ``litestar.contrib.pydantic.PydanticDTO``
 - :class:`!litestar.contrib.piccolo.PiccoloDTO`
 
 For example, to define a DTO from a dataclass:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,7 +302,6 @@ module = [
   "litestar.contrib.sqlalchemy.*",
   "litestar.plugins.pydantic.*",
   "tests.unit.test_contrib.test_sqlalchemy",
-  "tests.unit.test_contrib.test_pydantic.*",
   "tests.unit.test_logging.test_logging_config",
   "litestar.openapi.spec.base",
   "litestar.utils.helpers",


### PR DESCRIPTION
The `litestar.contrib.pydantic` namespace was removed from disk in PR #4339, but a few residual references survived: two Sphinx nitpick suppressions in `docs/conf.py` pointing at the deleted `PydanticDTO` and `PydanticPlugin`, four `:class:` cross-references to those same symbols in the historical 2.x release notes, and a dead `[tool.mypy.overrides]` `module` entry in `pyproject.toml` targeting `tests.unit.test_contrib.test_pydantic.*` — a path that no longer exists (pydantic tests live at `tests/unit/test_plugins/test_pydantic/`).

This PR cleans them up. The Sphinx suppressions are dropped because the symbols they suppress no longer exist. The four historical cross-references are demoted to plain literal backticks so Sphinx no longer attempts to resolve dead targets. The mypy override is removed; `make lint` clean confirms the pattern was unreachable.

No production code is touched and no test behavior changes — the existing pydantic test suite at `tests/unit/test_plugins/test_pydantic/` runs unchanged. Mirrors the `contrib.msgspec` precedent in PR #4730.

Verification: `git grep \"litestar\\.contrib\\.pydantic\"` returns nothing outside the historical release notes, `make lint` is clean, the full unit suite (5392 tests) passes, the docs examples pass, and `make docs` builds without warnings.

Closes #4722

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4733">https://litestar-org.github.io/litestar-docs-preview/4733</a> 
