### PR TITLE
chore(sqlalchemy): finalize contrib.sqlalchemy namespace removal

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,8 +153,6 @@ nitpick_ignore = [
     (PY_ATTR, "litestar.dto.factory.DTOConfig.underscore_fields_private"),
     (PY_CLASS, "anyio.abc.BlockingPortal"),
     (PY_CLASS, "litestar.contrib.msgspec.MsgspecDTO"),
-    (PY_CLASS, "litestar.contrib.sqlalchemy.types.JsonB"),
-    (PY_CLASS, "litestar.contrib.sqlalchemy.plugins.SQLAlchemyInitPlugin"),
     (PY_CLASS, "litestar.contrib.repository.filters.NotInCollectionFilter"),
     (PY_CLASS, "litestar.contrib.repository.filters.NotInSearchFilter"),
     (PY_CLASS, "litestar.contrib.repository.filters.OnBeforeAfter"),

--- a/docs/examples/sqla/plugins/sqlalchemy_async_before_send_handler.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_async_before_send_handler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from litestar import Litestar
-from litestar.plugins.sqlalchemy import (
+from advanced_alchemy.extensions.litestar import (
     SQLAlchemyAsyncConfig,
     SQLAlchemyInitPlugin,
     async_autocommit_before_send_handler,

--- a/docs/examples/sqla/plugins/sqlalchemy_async_before_send_handler.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_async_before_send_handler.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from litestar import Litestar
 from advanced_alchemy.extensions.litestar import (
     SQLAlchemyAsyncConfig,
     SQLAlchemyInitPlugin,
     async_autocommit_before_send_handler,
 )
+
+from litestar import Litestar
 
 config = SQLAlchemyAsyncConfig(
     connection_string="sqlite+aiosqlite:///:memory:", before_send_handler=async_autocommit_before_send_handler

--- a/docs/examples/sqla/plugins/sqlalchemy_async_dependencies.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_async_dependencies.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import select
 
 from litestar import Litestar, post
-from litestar.plugins.sqlalchemy import SQLAlchemyAsyncConfig, SQLAlchemyInitPlugin
+from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyInitPlugin
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession

--- a/docs/examples/sqla/plugins/sqlalchemy_async_dependencies.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_async_dependencies.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyInitPlugin
 from sqlalchemy import select
 
 from litestar import Litestar, post
-from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyInitPlugin
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession

--- a/docs/examples/sqla/plugins/sqlalchemy_async_init_plugin_example.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_async_init_plugin_example.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyInitPlugin
 from sqlalchemy import select
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
-from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyInitPlugin
 
 if TYPE_CHECKING:
     from typing import Any

--- a/docs/examples/sqla/plugins/sqlalchemy_async_init_plugin_example.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_async_init_plugin_example.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
-from litestar.plugins.sqlalchemy import SQLAlchemyAsyncConfig, SQLAlchemyInitPlugin
+from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyInitPlugin
 
 if TYPE_CHECKING:
     from typing import Any

--- a/docs/examples/sqla/plugins/sqlalchemy_async_plugin_example.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_async_plugin_example.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
+from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
 from sqlalchemy import select
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
-from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession

--- a/docs/examples/sqla/plugins/sqlalchemy_async_plugin_example.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_async_plugin_example.py
@@ -7,7 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
-from litestar.plugins.sqlalchemy import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
+from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession

--- a/docs/examples/sqla/plugins/sqlalchemy_async_serialization_dto.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_async_serialization_dto.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from advanced_alchemy.extensions.litestar import SQLAlchemyDTO
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
-from advanced_alchemy.extensions.litestar import SQLAlchemyDTO
 
 
 class Base(DeclarativeBase): ...

--- a/docs/examples/sqla/plugins/sqlalchemy_async_serialization_dto.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_async_serialization_dto.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
-from litestar.plugins.sqlalchemy import SQLAlchemyDTO
+from advanced_alchemy.extensions.litestar import SQLAlchemyDTO
 
 
 class Base(DeclarativeBase): ...

--- a/docs/examples/sqla/plugins/sqlalchemy_async_serialization_plugin.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_async_serialization_plugin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
-from litestar.plugins.sqlalchemy import SQLAlchemySerializationPlugin
+from advanced_alchemy.extensions.litestar import SQLAlchemySerializationPlugin
 
 
 class Base(DeclarativeBase): ...

--- a/docs/examples/sqla/plugins/sqlalchemy_async_serialization_plugin.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_async_serialization_plugin.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from advanced_alchemy.extensions.litestar import SQLAlchemySerializationPlugin
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
-from advanced_alchemy.extensions.litestar import SQLAlchemySerializationPlugin
 
 
 class Base(DeclarativeBase): ...

--- a/docs/examples/sqla/plugins/sqlalchemy_async_serialization_plugin_marking_fields.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_async_serialization_plugin_marking_fields.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
 from litestar.dto import dto_field
-from litestar.plugins.sqlalchemy import SQLAlchemySerializationPlugin
+from advanced_alchemy.extensions.litestar import SQLAlchemySerializationPlugin
 
 
 class Base(DeclarativeBase): ...

--- a/docs/examples/sqla/plugins/sqlalchemy_async_serialization_plugin_marking_fields.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_async_serialization_plugin_marking_fields.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+from advanced_alchemy.extensions.litestar import SQLAlchemySerializationPlugin
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
 from litestar.dto import dto_field
-from advanced_alchemy.extensions.litestar import SQLAlchemySerializationPlugin
 
 
 class Base(DeclarativeBase): ...

--- a/docs/examples/sqla/plugins/sqlalchemy_sync_before_send_handler.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_sync_before_send_handler.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+from advanced_alchemy.extensions.litestar import (
+    SQLAlchemyInitPlugin,
+    SQLAlchemySyncConfig,
+    sync_autocommit_before_send_handler,
+)
+
 from litestar import Litestar
-from advanced_alchemy.extensions.litestar import SQLAlchemyInitPlugin, SQLAlchemySyncConfig, sync_autocommit_before_send_handler
 
 config = SQLAlchemySyncConfig(
     connection_string="sqlite:///:memory:",

--- a/docs/examples/sqla/plugins/sqlalchemy_sync_before_send_handler.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_sync_before_send_handler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from litestar import Litestar
-from litestar.plugins.sqlalchemy import SQLAlchemyInitPlugin, SQLAlchemySyncConfig, sync_autocommit_before_send_handler
+from advanced_alchemy.extensions.litestar import SQLAlchemyInitPlugin, SQLAlchemySyncConfig, sync_autocommit_before_send_handler
 
 config = SQLAlchemySyncConfig(
     connection_string="sqlite:///:memory:",

--- a/docs/examples/sqla/plugins/sqlalchemy_sync_dependencies.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_sync_dependencies.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import select
 
 from litestar import Litestar, post
-from litestar.plugins.sqlalchemy import SQLAlchemyInitPlugin, SQLAlchemySyncConfig
+from advanced_alchemy.extensions.litestar import SQLAlchemyInitPlugin, SQLAlchemySyncConfig
 
 if TYPE_CHECKING:
     from sqlalchemy import Engine

--- a/docs/examples/sqla/plugins/sqlalchemy_sync_dependencies.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_sync_dependencies.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from advanced_alchemy.extensions.litestar import SQLAlchemyInitPlugin, SQLAlchemySyncConfig
 from sqlalchemy import select
 
 from litestar import Litestar, post
-from advanced_alchemy.extensions.litestar import SQLAlchemyInitPlugin, SQLAlchemySyncConfig
 
 if TYPE_CHECKING:
     from sqlalchemy import Engine

--- a/docs/examples/sqla/plugins/sqlalchemy_sync_init_plugin_example.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_sync_init_plugin_example.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
-from litestar.plugins.sqlalchemy import SQLAlchemyInitPlugin, SQLAlchemySyncConfig
+from advanced_alchemy.extensions.litestar import SQLAlchemyInitPlugin, SQLAlchemySyncConfig
 
 if TYPE_CHECKING:
     from typing import Any

--- a/docs/examples/sqla/plugins/sqlalchemy_sync_init_plugin_example.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_sync_init_plugin_example.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from advanced_alchemy.extensions.litestar import SQLAlchemyInitPlugin, SQLAlchemySyncConfig
 from sqlalchemy import select
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
-from advanced_alchemy.extensions.litestar import SQLAlchemyInitPlugin, SQLAlchemySyncConfig
 
 if TYPE_CHECKING:
     from typing import Any

--- a/docs/examples/sqla/plugins/sqlalchemy_sync_plugin_example.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_sync_plugin_example.py
@@ -7,7 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
-from litestar.plugins.sqlalchemy import SQLAlchemyPlugin, SQLAlchemySyncConfig
+from advanced_alchemy.extensions.litestar import SQLAlchemyPlugin, SQLAlchemySyncConfig
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session

--- a/docs/examples/sqla/plugins/sqlalchemy_sync_plugin_example.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_sync_plugin_example.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
+from advanced_alchemy.extensions.litestar import SQLAlchemyPlugin, SQLAlchemySyncConfig
 from sqlalchemy import select
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
-from advanced_alchemy.extensions.litestar import SQLAlchemyPlugin, SQLAlchemySyncConfig
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session

--- a/docs/examples/sqla/plugins/sqlalchemy_sync_serialization_plugin.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_sync_serialization_plugin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
-from litestar.plugins.sqlalchemy import SQLAlchemySerializationPlugin
+from advanced_alchemy.extensions.litestar import SQLAlchemySerializationPlugin
 
 
 class Base(DeclarativeBase): ...

--- a/docs/examples/sqla/plugins/sqlalchemy_sync_serialization_plugin.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_sync_serialization_plugin.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from advanced_alchemy.extensions.litestar import SQLAlchemySerializationPlugin
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
-from advanced_alchemy.extensions.litestar import SQLAlchemySerializationPlugin
 
 
 class Base(DeclarativeBase): ...

--- a/docs/examples/sqla/plugins/sqlalchemy_sync_serialization_plugin_marking_fields.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_sync_serialization_plugin_marking_fields.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
 from litestar.dto import dto_field
-from litestar.plugins.sqlalchemy import SQLAlchemySerializationPlugin
+from advanced_alchemy.extensions.litestar import SQLAlchemySerializationPlugin
 
 
 class Base(DeclarativeBase): ...

--- a/docs/examples/sqla/plugins/sqlalchemy_sync_serialization_plugin_marking_fields.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_sync_serialization_plugin_marking_fields.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+from advanced_alchemy.extensions.litestar import SQLAlchemySerializationPlugin
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, post
 from litestar.dto import dto_field
-from advanced_alchemy.extensions.litestar import SQLAlchemySerializationPlugin
 
 
 class Base(DeclarativeBase): ...

--- a/docs/examples/sqla/plugins/tutorial/full_app_with_init_plugin.py
+++ b/docs/examples/sqla/plugins/tutorial/full_app_with_init_plugin.py
@@ -1,5 +1,10 @@
 from collections.abc import AsyncGenerator
 
+from advanced_alchemy.extensions.litestar import (
+    SQLAlchemyAsyncConfig,
+    SQLAlchemyInitPlugin,
+    SQLAlchemySerializationPlugin,
+)
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -7,11 +12,6 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, get, post, put
 from litestar.exceptions import ClientException, NotFoundException
-from advanced_alchemy.extensions.litestar import (
-    SQLAlchemyAsyncConfig,
-    SQLAlchemyInitPlugin,
-    SQLAlchemySerializationPlugin,
-)
 from litestar.status_codes import HTTP_409_CONFLICT
 
 

--- a/docs/examples/sqla/plugins/tutorial/full_app_with_init_plugin.py
+++ b/docs/examples/sqla/plugins/tutorial/full_app_with_init_plugin.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, get, post, put
 from litestar.exceptions import ClientException, NotFoundException
-from litestar.plugins.sqlalchemy import (
+from advanced_alchemy.extensions.litestar import (
     SQLAlchemyAsyncConfig,
     SQLAlchemyInitPlugin,
     SQLAlchemySerializationPlugin,

--- a/docs/examples/sqla/plugins/tutorial/full_app_with_plugin.py
+++ b/docs/examples/sqla/plugins/tutorial/full_app_with_plugin.py
@@ -1,5 +1,6 @@
 from collections.abc import AsyncGenerator
 
+from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -7,7 +8,6 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, get, post, put
 from litestar.exceptions import ClientException, NotFoundException
-from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
 from litestar.status_codes import HTTP_409_CONFLICT
 
 

--- a/docs/examples/sqla/plugins/tutorial/full_app_with_plugin.py
+++ b/docs/examples/sqla/plugins/tutorial/full_app_with_plugin.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from litestar import Litestar, get, post, put
 from litestar.exceptions import ClientException, NotFoundException
-from litestar.plugins.sqlalchemy import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
+from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
 from litestar.status_codes import HTTP_409_CONFLICT
 
 

--- a/docs/examples/sqla/plugins/tutorial/full_app_with_serialization_plugin.py
+++ b/docs/examples/sqla/plugins/tutorial/full_app_with_serialization_plugin.py
@@ -1,6 +1,7 @@
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
+from advanced_alchemy.extensions.litestar import SQLAlchemySerializationPlugin
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -9,7 +10,6 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from litestar import Litestar, get, post, put
 from litestar.datastructures import State
 from litestar.exceptions import ClientException, NotFoundException
-from advanced_alchemy.extensions.litestar import SQLAlchemySerializationPlugin
 from litestar.status_codes import HTTP_409_CONFLICT
 
 

--- a/docs/examples/sqla/plugins/tutorial/full_app_with_serialization_plugin.py
+++ b/docs/examples/sqla/plugins/tutorial/full_app_with_serialization_plugin.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from litestar import Litestar, get, post, put
 from litestar.datastructures import State
 from litestar.exceptions import ClientException, NotFoundException
-from litestar.plugins.sqlalchemy import SQLAlchemySerializationPlugin
+from advanced_alchemy.extensions.litestar import SQLAlchemySerializationPlugin
 from litestar.status_codes import HTTP_409_CONFLICT
 
 

--- a/docs/examples/sqla/sqlalchemy_async_repository.py
+++ b/docs/examples/sqla/sqlalchemy_async_repository.py
@@ -4,6 +4,14 @@ from datetime import date
 from typing import TYPE_CHECKING
 from uuid import UUID
 
+from advanced_alchemy.extensions.litestar import (
+    AsyncSessionConfig,
+    SQLAlchemyAsyncConfig,
+    SQLAlchemyInitPlugin,
+    base,
+    filters,
+    repository,
+)
 from pydantic import BaseModel as _BaseModel
 from pydantic import TypeAdapter
 from sqlalchemy import ForeignKey, select
@@ -15,14 +23,6 @@ from litestar.di import Provide
 from litestar.handlers.http_handlers.decorators import delete, patch, post
 from litestar.pagination import OffsetPagination
 from litestar.params import Parameter
-from advanced_alchemy.extensions.litestar import (
-    AsyncSessionConfig,
-    SQLAlchemyAsyncConfig,
-    SQLAlchemyInitPlugin,
-    base,
-    filters,
-    repository,
-)
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession

--- a/docs/examples/sqla/sqlalchemy_async_repository.py
+++ b/docs/examples/sqla/sqlalchemy_async_repository.py
@@ -15,7 +15,7 @@ from litestar.di import Provide
 from litestar.handlers.http_handlers.decorators import delete, patch, post
 from litestar.pagination import OffsetPagination
 from litestar.params import Parameter
-from litestar.plugins.sqlalchemy import (
+from advanced_alchemy.extensions.litestar import (
     AsyncSessionConfig,
     SQLAlchemyAsyncConfig,
     SQLAlchemyInitPlugin,

--- a/docs/examples/sqla/sqlalchemy_declarative_models.py
+++ b/docs/examples/sqla/sqlalchemy_declarative_models.py
@@ -4,12 +4,12 @@ import uuid
 from datetime import date
 from uuid import UUID
 
+from advanced_alchemy.extensions.litestar import AsyncSessionConfig, SQLAlchemyAsyncConfig, SQLAlchemyPlugin, base
 from sqlalchemy import ForeignKey, func, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from litestar import Litestar, get
-from advanced_alchemy.extensions.litestar import AsyncSessionConfig, SQLAlchemyAsyncConfig, SQLAlchemyPlugin, base
 
 
 # The SQLAlchemy base includes a declarative model for you to use in your models.

--- a/docs/examples/sqla/sqlalchemy_declarative_models.py
+++ b/docs/examples/sqla/sqlalchemy_declarative_models.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from litestar import Litestar, get
-from litestar.plugins.sqlalchemy import AsyncSessionConfig, SQLAlchemyAsyncConfig, SQLAlchemyPlugin, base
+from advanced_alchemy.extensions.litestar import AsyncSessionConfig, SQLAlchemyAsyncConfig, SQLAlchemyPlugin, base
 
 
 # The SQLAlchemy base includes a declarative model for you to use in your models.

--- a/docs/examples/sqla/sqlalchemy_repository_bulk_operations.py
+++ b/docs/examples/sqla/sqlalchemy_repository_bulk_operations.py
@@ -6,7 +6,7 @@ from rich import get_console
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Mapped, Session, sessionmaker
 
-from litestar.plugins.sqlalchemy import base, repository
+from advanced_alchemy.extensions.litestar import base, repository
 from litestar.repository.filters import LimitOffset
 
 here = Path(__file__).parent

--- a/docs/examples/sqla/sqlalchemy_repository_bulk_operations.py
+++ b/docs/examples/sqla/sqlalchemy_repository_bulk_operations.py
@@ -2,11 +2,11 @@ import json
 from pathlib import Path
 from typing import Any
 
+from advanced_alchemy.extensions.litestar import base, repository
 from rich import get_console
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Mapped, Session, sessionmaker
 
-from advanced_alchemy.extensions.litestar import base, repository
 from litestar.repository.filters import LimitOffset
 
 here = Path(__file__).parent

--- a/docs/examples/sqla/sqlalchemy_repository_crud.py
+++ b/docs/examples/sqla/sqlalchemy_repository_crud.py
@@ -6,11 +6,10 @@ from datetime import date, datetime
 from uuid import UUID
 
 import anyio
+from advanced_alchemy.extensions.litestar import base, repository
 from rich import get_console
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.orm import Mapped
-
-from advanced_alchemy.extensions.litestar import base, repository
 
 console = get_console()
 

--- a/docs/examples/sqla/sqlalchemy_repository_crud.py
+++ b/docs/examples/sqla/sqlalchemy_repository_crud.py
@@ -10,7 +10,7 @@ from rich import get_console
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.orm import Mapped
 
-from litestar.plugins.sqlalchemy import base, repository
+from advanced_alchemy.extensions.litestar import base, repository
 
 console = get_console()
 

--- a/docs/examples/sqla/sqlalchemy_repository_extension.py
+++ b/docs/examples/sqla/sqlalchemy_repository_extension.py
@@ -14,7 +14,7 @@ from sqlalchemy.types import String
 
 from litestar import Litestar, get, post
 from litestar.di import Provide
-from litestar.plugins.sqlalchemy import (
+from advanced_alchemy.extensions.litestar import (
     AsyncSessionConfig,
     SQLAlchemyAsyncConfig,
     SQLAlchemyInitPlugin,

--- a/docs/examples/sqla/sqlalchemy_repository_extension.py
+++ b/docs/examples/sqla/sqlalchemy_repository_extension.py
@@ -7,13 +7,6 @@ import unicodedata
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
-from pydantic import BaseModel as _BaseModel
-from pydantic import TypeAdapter
-from sqlalchemy.orm import Mapped, declarative_mixin, mapped_column
-from sqlalchemy.types import String
-
-from litestar import Litestar, get, post
-from litestar.di import Provide
 from advanced_alchemy.extensions.litestar import (
     AsyncSessionConfig,
     SQLAlchemyAsyncConfig,
@@ -21,6 +14,13 @@ from advanced_alchemy.extensions.litestar import (
     base,
     repository,
 )
+from pydantic import BaseModel as _BaseModel
+from pydantic import TypeAdapter
+from sqlalchemy.orm import Mapped, declarative_mixin, mapped_column
+from sqlalchemy.types import String
+
+from litestar import Litestar, get, post
+from litestar.di import Provide
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession

--- a/docs/examples/sqla/sqlalchemy_sync_repository.py
+++ b/docs/examples/sqla/sqlalchemy_sync_repository.py
@@ -15,7 +15,7 @@ from litestar.di import Provide
 from litestar.handlers.http_handlers.decorators import delete, patch, post
 from litestar.pagination import OffsetPagination
 from litestar.params import Parameter
-from litestar.plugins.sqlalchemy import (
+from advanced_alchemy.extensions.litestar import (
     SQLAlchemyInitPlugin,
     SQLAlchemySyncConfig,
     base,

--- a/docs/examples/sqla/sqlalchemy_sync_repository.py
+++ b/docs/examples/sqla/sqlalchemy_sync_repository.py
@@ -4,6 +4,12 @@ from datetime import date
 from typing import TYPE_CHECKING
 from uuid import UUID
 
+from advanced_alchemy.extensions.litestar import (
+    SQLAlchemyInitPlugin,
+    SQLAlchemySyncConfig,
+    base,
+    repository,
+)
 from pydantic import BaseModel as _BaseModel
 from pydantic import TypeAdapter
 from sqlalchemy import ForeignKey, select
@@ -15,12 +21,6 @@ from litestar.di import Provide
 from litestar.handlers.http_handlers.decorators import delete, patch, post
 from litestar.pagination import OffsetPagination
 from litestar.params import Parameter
-from advanced_alchemy.extensions.litestar import (
-    SQLAlchemyInitPlugin,
-    SQLAlchemySyncConfig,
-    base,
-    repository,
-)
 from litestar.repository.filters import LimitOffset
 
 if TYPE_CHECKING:

--- a/docs/release-notes/2.x-changelog.rst
+++ b/docs/release-notes/2.x-changelog.rst
@@ -2612,7 +2612,7 @@
         :type: feature
         :pr: 1780
 
-        When using the :class:`litestar.contrib.sqlalchemy.types.JsonB` type with an
+        When using the ``litestar.contrib.sqlalchemy.types.JsonB`` type with an
         Oracle Database engine, a JSON check constraint will be created for that
         column.
 
@@ -3610,7 +3610,7 @@
         :type: feature
         :pr: 1395
 
-        A :class:`SQLAlchemyInitPlugin <litestar.contrib.sqlalchemy.plugins.SQLAlchemyInitPlugin>` was added,
+        A ``SQLAlchemyInitPlugin`` was added,
         providing support for managed synchronous and asynchronous sessions.
 
         .. note::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ dev = [
   "starlette",
   "trio",
   "aiosqlite",
+  "duckdb-engine",
   "asyncpg>=0.29.0",
   "psycopg[pool,binary]>=3.1.10,<3.2; python_version < \"3.13\"",
   "psycopg[pool]<3.2.4; python_version >= \"3.13\"",  # Bug in 3.2.4: https://github.com/psycopg/psycopg/issues/1128

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,7 @@ requires = ["hatchling"]
 
 [tool.coverage.run]
 concurrency = ["multiprocessing", "thread"]
-omit = ["*/tests/*", "*/litestar/plugins/sqlalchemy.py", "*/litestar/_kwargs/types.py"]
+omit = ["*/tests/*", "*/litestar/_kwargs/types.py"]
 parallel = true
 plugins = ["covdefaults"]
 source = ["litestar"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -299,9 +299,7 @@ module = [
 
 [[tool.mypy.overrides]]
 module = [
-  "litestar.contrib.sqlalchemy.*",
   "litestar.plugins.pydantic.*",
-  "tests.unit.test_contrib.test_sqlalchemy",
   "tests.unit.test_contrib.test_pydantic.*",
   "tests.unit.test_logging.test_logging_config",
   "litestar.openapi.spec.base",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -333,7 +333,6 @@ exclude = [
   "litestar/plugins/pydantic/plugins/init.py",
   "litestar/plugins/pydantic/plugins/schema.py",
   "litestar/plugins/pydantic/dto_factory.py",
-  "tests/unit/test_contrib/test_sqlalchemy.py",
   "tests/unit/test_plugins/test_pydantic/test_openapi.py",
   "tests/unit/test_repository/test_generic_mock_repository.py",
   "**/node_modules/**",
@@ -497,7 +496,6 @@ known-first-party = ["litestar", "tests", "examples"]
   "UP045",
   "RUF043",
 ]
-"tests/unit/test_contrib/test_sqlalchemy/**/*.*" = ["UP006"]
 "tests/unit/test_openapi/test_typescript_converter/test_converter.py" = ["W293"]
 "tests/unit/test_typing.py" = ["UP006", "UP035"]
 "tools/**/*.*" = ["D", "ARG", "EM", "TRY", "G", "FBT"]

--- a/uv.lock
+++ b/uv.lock
@@ -1052,6 +1052,56 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/66/744b4931b799a42f8cb9bc7a6f169e7b8e51195b62b246db407fd90bf15f/duckdb-1.5.2.tar.gz", hash = "sha256:638da0d5102b6cb6f7d47f83d0600708ac1d3cb46c5e9aaabc845f9ba4d69246", size = 18017166, upload-time = "2026-04-13T11:30:09.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/b0/d13e7e396d86c245290b3e93f692a2d27c2fe99f857aaf9205003c00c978/duckdb-1.5.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7f69164b048e498b9e9140a24343108a5ae5f17bfb3485185f55fdf9b1aa924d", size = 30020978, upload-time = "2026-04-13T11:28:52.486Z" },
+    { url = "https://files.pythonhosted.org/packages/70/7b/ae1ec7f516394aa55501d1949af1f731be8d9d7433f0acc3f4632a0ba484/duckdb-1.5.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:81fc4fbf0b5e25840b39ba2a10b78c6953c0314d5d0434191e7898f34ab1bba3", size = 15947821, upload-time = "2026-04-13T11:28:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a5/cae0105e01a85f85ead61723bb42dab14c2f8ec49f91e67a2372c02574a4/duckdb-1.5.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:56d38b3c4e0ef2abb58898d0fd423933999ed535c45e75e9d9f72e1d5fed69b8", size = 14201656, upload-time = "2026-04-13T11:28:58.316Z" },
+    { url = "https://files.pythonhosted.org/packages/50/db/46c57e8813ac33762bddc9545610ed648751c5b6a379abf2dc6035505ce4/duckdb-1.5.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:376856066c65ccd55fcb3a380bbe33a71ce089fc4623d229ffc6e82251afdb6d", size = 19285181, upload-time = "2026-04-13T11:29:01.041Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/67694010693ec8c8c975e6991f48ef886d35ecbdaa2f287234882a403c21/duckdb-1.5.2-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c69907354ffee94ba8cf782daf0480dab7557f21ce27fffa6c0ea8f74ed4b8e2", size = 21394852, upload-time = "2026-04-13T11:29:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/52/9f/2b1618c5a93949a70dcf105293db7e27bb2b2cc4aeb1ff46b806f430ec81/duckdb-1.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:d9b4f5430bf4f05d4c0dc4c55c75def3a5af4be0343be20fa2bfc577343fbfc9", size = 13095526, upload-time = "2026-04-13T11:29:06.265Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e9/cb39e0d94a32f5333e819112fd01439a31f541f9c56a31b66f9bd209704b/duckdb-1.5.2-cp311-cp311-win_arm64.whl", hash = "sha256:2323c1195c10fb2bb982fc0218c730b43d1b92a355d61e68e3c5f3ac9d44c34f", size = 13946215, upload-time = "2026-04-13T11:29:08.672Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/ebe66bbe78125fc610f4fd415447a65349d94245950f3b3dfb31d028af02/duckdb-1.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e6495b00cad16888384119842797c49316a96ae1cb132bb03856d980d95afee1", size = 30064950, upload-time = "2026-04-13T11:29:11.468Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/8a/3e25b5d03bcf1fb99d189912f8ce92b1db4f9c8778e1b1f55745973a855a/duckdb-1.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d72b8856b1839d35648f38301b058f6232f4d36b463fe4dc8f4d3fdff2df1a2e", size = 15969113, upload-time = "2026-04-13T11:29:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/58001f0815002b1a93431bf907f77854085c7d049b83d521814a07b9db0b/duckdb-1.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2a1de4f4d454b8c97aec546c82003fc834d3422ce4bc6a19902f3462ef293bed", size = 14224774, upload-time = "2026-04-13T11:29:16.758Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2f/a7f0de9509d1cef35608aeb382919041cdd70f58c173865c3da6a0d87979/duckdb-1.5.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce0b8141a10d37ecef729c45bc41d334854013f4389f1488bd6035c5579aaac1", size = 19313510, upload-time = "2026-04-13T11:29:19.574Z" },
+    { url = "https://files.pythonhosted.org/packages/26/78/eb1e064ea8b9df3b87b167bfd7a407b2f615a4291e06cba756727adfa06c/duckdb-1.5.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c99ef73a277c8921bc0a1f16dee38d924484251d9cfd20951748c20fcd5ed855", size = 21429692, upload-time = "2026-04-13T11:29:22.575Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/12/05b0c47d14839925c5e35b79081d918ca82e3f236bb724a6f58409dd5291/duckdb-1.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:8d599758b4e48bf12e18c9b960cf491d219f0c4972d19a45489c05cc5ab36f83", size = 13107594, upload-time = "2026-04-13T11:29:25.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2c/80558a82b236e044330e84a154b96aacddb343316b479f3d49be03ea11cb/duckdb-1.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:fc85a5dbcbe6eccac1113c72370d1d3aacfdd49198d63950bdf7d8638a307f00", size = 13927537, upload-time = "2026-04-13T11:29:27.842Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f2/e3d742808f138d374be4bb516fade3d1f33749b813650810ab7885cdc363/duckdb-1.5.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4420b3f47027a7849d0e1815532007f377fa95ee5810b47ea717d35525c12f79", size = 30064879, upload-time = "2026-04-13T11:29:30.763Z" },
+    { url = "https://files.pythonhosted.org/packages/72/0d/f3dc1cf97e1267ca15e4307d456f96ce583961f0703fd75e62b2ad8d64fa/duckdb-1.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:bb42e6ed543902e14eae647850da24103a89f0bc2587dec5601b1c1f213bd2ed", size = 15969327, upload-time = "2026-04-13T11:29:33.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e0/d5418def53ae4e05a63075705ff44ed5af5a1a5932627eb2b600c5df1c93/duckdb-1.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98c0535cd6d901f61a5ea3c2e26a1fd28482953d794deb183daf568e3aa5dda6", size = 14225107, upload-time = "2026-04-13T11:29:35.882Z" },
+    { url = "https://files.pythonhosted.org/packages/16/a7/15aaa59dbecc35e9711980fcdbf525b32a52470b32d18ef678193a146213/duckdb-1.5.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:486c862bf7f163c0110b6d85b3e5c031d224a671cca468f12ebb1d3a348f6b39", size = 19313433, upload-time = "2026-04-13T11:29:38.367Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/21/d903cc63a5140c822b7b62b373a87dc557e60c29b321dfb435061c5e67cf/duckdb-1.5.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70631c847ca918ee710ec874241b00cf9d2e5be90762cbb2a0389f17823c08f7", size = 21429837, upload-time = "2026-04-13T11:29:41.135Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/0a/b770d1f60c70597302130d6247f418549b7094251a02348fbaf1c7e147ae/duckdb-1.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:52a21823f3fbb52f0f0e5425e20b07391ad882464b955879499b5ff0b45a376b", size = 13107699, upload-time = "2026-04-13T11:29:43.905Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cf/e200fe431d700962d1a908d2ce89f53ccee1cc8db260174ae663ba09686b/duckdb-1.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:411ad438bd4140f189a10e7f515781335962c5d18bd07837dc6d202e3985253d", size = 13927646, upload-time = "2026-04-13T11:29:46.598Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a1/f6286c67726cc1ea60a6e3c0d9fbc66527dde24ae089a51bbe298b13ca78/duckdb-1.5.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6b0fe75c148000f060aa1a27b293cacc0ea08cc1cad724fbf2143d56070a3785", size = 30078598, upload-time = "2026-04-13T11:29:49.828Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6a/59febb02f21a4a5c6b0b0099ef7c965fdd5e61e4904cf813809bb792e35f/duckdb-1.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:35579b8e3a064b5eaf15b0eafc558056a13f79a0a62e34cc4baf57119daecfec", size = 15975120, upload-time = "2026-04-13T11:29:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/09/70/ce750854d37bb5a45cccbb2c3cb04df4af56aea8fc30a2499bb643b4a9c0/duckdb-1.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ea58ff5b0880593a280cf5511734b17711b32ee1f58b47d726e8600848358160", size = 14227762, upload-time = "2026-04-13T11:29:55.564Z" },
+    { url = "https://files.pythonhosted.org/packages/28/dc/ad45ac3c0b6c4687dc649e8f6cf01af1c8b0443932a39b2abb4ebcb3babd/duckdb-1.5.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef461bca07313412dc09961c4a4757a851f56b95ac01c58fac6007632b7b94f2", size = 19315668, upload-time = "2026-04-13T11:29:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b1/1464f468d2e5813f5808de95df9d3113a645a5bfa2ffcaecbc542ddae272/duckdb-1.5.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be37680ddb380015cb37318e378c53511c45c4f0d8fac5599d22b7d092b9217a", size = 21434056, upload-time = "2026-04-13T11:30:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/32/6673607e024722473fa7aafdd29c0e3dd231dd528f6cd8b5797fbeeb229d/duckdb-1.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:0b291786014df1133f8f18b9df4d004484613146e858d71a21791e0fcca16cf4", size = 13633667, upload-time = "2026-04-13T11:30:04.05Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e3/9d34173ec068631faea3ea6e73050700729363e7e33306a9a3218e5cdc61/duckdb-1.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:c9f3e0b71b8a50fccfb42794899285d9d318ce2503782b9dd54868e5ecd0ad31", size = 14402513, upload-time = "2026-04-13T11:30:06.609Z" },
+]
+
+[[package]]
+name = "duckdb-engine"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "duckdb" },
+    { name = "packaging" },
+    { name = "sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/d5/c0d8d0a4ca3ffea92266f33d92a375e2794820ad89f9be97cf0c9a9697d0/duckdb_engine-0.17.0.tar.gz", hash = "sha256:396b23869754e536aa80881a92622b8b488015cf711c5a40032d05d2cf08f3cf", size = 48054, upload-time = "2025-03-29T09:49:17.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/a2/e90242f53f7ae41554419b1695b4820b364df87c8350aa420b60b20cab92/duckdb_engine-0.17.0-py3-none-any.whl", hash = "sha256:3aa72085e536b43faab635f487baf77ddc5750069c16a2f8d9c6c3cb6083e979", size = 49676, upload-time = "2025-03-29T09:49:15.564Z" },
+]
+
+[[package]]
 name = "editorconfig"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1941,6 +1991,7 @@ dev = [
     { name = "beanie" },
     { name = "beautifulsoup4" },
     { name = "daphne" },
+    { name = "duckdb-engine" },
     { name = "fsspec" },
     { name = "greenlet" },
     { name = "httpx-sse" },
@@ -2050,6 +2101,7 @@ dev = [
     { name = "beanie", specifier = ">=1.21.0" },
     { name = "beautifulsoup4" },
     { name = "daphne", specifier = ">=4.0.0" },
+    { name = "duckdb-engine" },
     { name = "fsspec", specifier = ">=2025" },
     { name = "greenlet" },
     { name = "httpx-sse" },


### PR DESCRIPTION
PR #4340 removed both `litestar.contrib.sqlalchemy` and `litestar.plugins.sqlalchemy` in favor of importing from `advanced_alchemy.extensions.litestar`, but a fair amount of residue survived.

This PR clears it:

- Drops the dead `nitpick_ignore` lines in `docs/conf.py` and demotes the two surviving `:class:` cross-refs in `2.x-changelog.rst` to literal backticks — same approach as #4730 (msgspec) and #4733 (pydantic).
- Removes the dead `pyproject.toml` patterns (mypy overrides, coverage `omit`, pyright exclude, ruff per-file-ignore) that all matched zero files on disk.
- Rewrites the 22 doc examples under `docs/examples/sqla/` from `litestar.plugins.sqlalchemy` to `advanced_alchemy.extensions.litestar`. Every symbol is a 1:1 re-export, so it's a single-line `from` clause per file, with ruff isort regrouping the imports as third-party.
- Adds `duckdb-engine` to the `dev` group so the bulk-operations tutorial example (built against `duckdb:///:memory:`) actually runs on a fresh checkout.

`make lint` and `make docs` are clean.

Closes #4724
Finishes #4225

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4734">https://litestar-org.github.io/litestar-docs-preview/4734</a> 
