### PR TITLE
refactor(repository): migrate in-tree callers to advanced_alchemy.filters

### DIFF
--- a/docs/examples/sqla/sqlalchemy_repository_bulk_operations.py
+++ b/docs/examples/sqla/sqlalchemy_repository_bulk_operations.py
@@ -3,11 +3,10 @@ from pathlib import Path
 from typing import Any
 
 from advanced_alchemy.extensions.litestar import base, repository
+from advanced_alchemy.filters import LimitOffset
 from rich import get_console
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Mapped, Session, sessionmaker
-
-from litestar.repository.filters import LimitOffset
 
 here = Path(__file__).parent
 console = get_console()

--- a/docs/examples/sqla/sqlalchemy_sync_repository.py
+++ b/docs/examples/sqla/sqlalchemy_sync_repository.py
@@ -10,6 +10,7 @@ from advanced_alchemy.extensions.litestar import (
     base,
     repository,
 )
+from advanced_alchemy.filters import LimitOffset
 from pydantic import BaseModel as _BaseModel
 from pydantic import TypeAdapter
 from sqlalchemy import ForeignKey, select
@@ -21,7 +22,6 @@ from litestar.di import Provide
 from litestar.handlers.http_handlers.decorators import delete, patch, post
 from litestar.pagination import OffsetPagination
 from litestar.params import Parameter
-from litestar.repository.filters import LimitOffset
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session

--- a/tests/e2e/test_advanced_alchemy.py
+++ b/tests/e2e/test_advanced_alchemy.py
@@ -1,7 +1,7 @@
 from advanced_alchemy.extensions.litestar.plugins import SQLAlchemyInitPlugin, SQLAlchemySyncConfig
+from advanced_alchemy.filters import LimitOffset
 
 from litestar import get
-from advanced_alchemy.filters import LimitOffset
 from litestar.testing import create_test_client
 
 

--- a/tests/e2e/test_advanced_alchemy.py
+++ b/tests/e2e/test_advanced_alchemy.py
@@ -1,7 +1,7 @@
 from advanced_alchemy.extensions.litestar.plugins import SQLAlchemyInitPlugin, SQLAlchemySyncConfig
 
 from litestar import get
-from litestar.repository.filters import LimitOffset
+from advanced_alchemy.filters import LimitOffset
 from litestar.testing import create_test_client
 
 


### PR DESCRIPTION
Three call sites in tests and examples still imported `LimitOffset` from `litestar.repository.filters` even though `advanced_alchemy.filters` has been the canonical home for those types. This swaps the imports so the package is warning-free against itself, plus a small isort follow-up to keep the grouped `advanced_alchemy` imports tidy.

The deprecation shim that originally lived on this branch has been split out into a follow-up PR targeting `v2` — that's where the `DeprecationWarning` belongs so 2.x users get a migration window before 3.0 GA removes the old path. This PR is now just the in-tree caller hygiene.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4735">https://litestar-org.github.io/litestar-docs-preview/4735</a> 
