### PR TITLE
feat(opentelemetry): add after_exception list to OpenTelemetryConfig

### DIFF
--- a/litestar/contrib/opentelemetry/config.py
+++ b/litestar/contrib/opentelemetry/config.py
@@ -37,8 +37,19 @@ class OpenTelemetryConfig:
     Consult the [OpenTelemetry ASGI documentation](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/asgi/asgi.html) for more info about the configuration options.
     """
 
+    after_exception: list[AfterExceptionHookHandler] = field(default_factory=list)
+    """A list of callbacks that are called with the exception and the scope for every exception raised.
+
+    These handlers are added to the application-level ``after_exception`` hooks.
+
+    .. versionadded:: 2.16.0
+    """
     after_exception_hook_handler: AfterExceptionHookHandler | None = field(default=None)
-    """Callback which is called with the exception and the scope object for every exception raised."""
+    """Callback which is called with the exception and the scope object for every exception raised.
+
+    .. deprecated:: 2.16.0
+        Use :attr:`after_exception` instead.
+    """
 
     scope_span_details_extractor: Callable[[Scope], tuple[str, dict[str, Any]]] = field(
         default=get_route_details_from_scope

--- a/litestar/contrib/opentelemetry/plugin.py
+++ b/litestar/contrib/opentelemetry/plugin.py
@@ -30,6 +30,7 @@ class OpenTelemetryPlugin(InitPlugin):
 
     def on_app_init(self, app_config: AppConfig) -> AppConfig:
         app_config.middleware, _middleware = self._pop_otel_middleware(app_config.middleware)
+        app_config.after_exception.extend(self.config.after_exception)
         if self.config.after_exception_hook_handler:
             app_config.after_exception.append(self.config.after_exception_hook_handler)
         return app_config

--- a/tests/unit/test_contrib/test_opentelemetry.py
+++ b/tests/unit/test_contrib/test_opentelemetry.py
@@ -344,3 +344,109 @@ def test_after_exception_hook_handler_not_called_on_success(
 
         # Verify the hook was NOT called
         assert len(hook_calls) == 0
+
+
+def test_after_exception_list_called_on_exception(
+    resource: Resource, exporter: InMemorySpanExporter, meter_provider: MeterProvider, request: FixtureRequest
+) -> None:
+    """Test that after_exception list handlers are called when an exception occurs."""
+    hook_calls_1: list[tuple[Exception, Scope]] = []
+    hook_calls_2: list[tuple[Exception, Scope]] = []
+
+    def hook_one(exc: Exception, scope: Scope) -> None:
+        hook_calls_1.append((exc, scope))
+
+    def hook_two(exc: Exception, scope: Scope) -> None:
+        hook_calls_2.append((exc, scope))
+
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    meter = get_meter_provider().get_meter(f"litestar-test-{request.node.nodeid}")
+    config = OpenTelemetryConfig(tracer_provider=tracer_provider, meter=meter, after_exception=[hook_one, hook_two])
+
+    test_exception = ValueError("test error")
+
+    @get("/")
+    def handler() -> dict:
+        raise test_exception
+
+    with create_test_client(handler, plugins=[OpenTelemetryPlugin(config)]) as client:
+        response = client.get("/")
+        assert response.status_code == 500
+
+        # Both hooks should have been called
+        assert len(hook_calls_1) == 1
+        assert len(hook_calls_2) == 1
+
+        # Verify the exception is the one we raised
+        assert hook_calls_1[0][0] is test_exception
+        assert hook_calls_2[0][0] is test_exception
+
+        # Verify scope details
+        assert hook_calls_1[0][1]["type"] == ScopeType.HTTP
+        assert hook_calls_2[0][1]["type"] == ScopeType.HTTP
+
+
+def test_after_exception_list_not_called_on_success(
+    resource: Resource, exporter: InMemorySpanExporter, meter_provider: MeterProvider, request: FixtureRequest
+) -> None:
+    """Test that after_exception list handlers are not called when no exception occurs."""
+    hook_calls: list[tuple[Exception, Scope]] = []
+
+    def hook(exc: Exception, scope: Scope) -> None:
+        hook_calls.append((exc, scope))
+
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    meter = get_meter_provider().get_meter(f"litestar-test-{request.node.nodeid}")
+    config = OpenTelemetryConfig(tracer_provider=tracer_provider, meter=meter, after_exception=[hook])
+
+    @get("/")
+    def handler() -> dict:
+        return {"success": True}
+
+    with create_test_client(handler, plugins=[OpenTelemetryPlugin(config)]) as client:
+        response = client.get("/")
+        assert response.status_code == 200
+        assert len(hook_calls) == 0
+
+
+def test_after_exception_list_combined_with_hook_handler(
+    resource: Resource, exporter: InMemorySpanExporter, meter_provider: MeterProvider, request: FixtureRequest
+) -> None:
+    """Test that both after_exception list and deprecated after_exception_hook_handler work together."""
+    list_hook_calls: list[tuple[Exception, Scope]] = []
+    singular_hook_calls: list[tuple[Exception, Scope]] = []
+
+    def list_hook(exc: Exception, scope: Scope) -> None:
+        list_hook_calls.append((exc, scope))
+
+    def singular_hook(exc: Exception, scope: Scope) -> None:
+        singular_hook_calls.append((exc, scope))
+
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    meter = get_meter_provider().get_meter(f"litestar-test-{request.node.nodeid}")
+    config = OpenTelemetryConfig(
+        tracer_provider=tracer_provider,
+        meter=meter,
+        after_exception=[list_hook],
+        after_exception_hook_handler=singular_hook,
+    )
+
+    test_exception = ValueError("combined test")
+
+    @get("/")
+    def handler() -> dict:
+        raise test_exception
+
+    with create_test_client(handler, plugins=[OpenTelemetryPlugin(config)]) as client:
+        response = client.get("/")
+        assert response.status_code == 500
+
+        # Both the list hook and the singular hook should have been called
+        assert len(list_hook_calls) == 1
+        assert len(singular_hook_calls) == 1
+
+        assert list_hook_calls[0][0] is test_exception
+        assert singular_hook_calls[0][0] is test_exception


### PR DESCRIPTION
# [Improvement] – Add `after_exception` list to OpenTelemetry config

## Description

**Context:**  
The OTEL plugin only supported a single `after_exception_hook_handler`, making it impossible to register multiple exception hooks (e.g. recording exceptions on spans *and* logging them).

**Approach:**  
- Added `after_exception: list[AfterExceptionHookHandler]` field to `OpenTelemetryConfig`
- Updated `OpenTelemetryPlugin.on_app_init` to extend `app_config.after_exception` with the list
- Kept the existing singular `after_exception_hook_handler` for backward compatibility (marked deprecated)
- Added 3 new tests covering the list field

**Impact:**  
- **Functionality:** Users can now pass multiple after_exception handlers via the OTEL config
- **Developer Experience:** Aligns with how `AppConfig.after_exception` already works (list-based)
- **Coverage:** 3 new tests covering list handlers, no-op on success, and combined usage with deprecated field

---

## Tests
- [x] New tests added  
- [x] Existing tests pass (no regressions)

**Unit Tests Summary:**  
- `test_after_exception_list_called_on_exception` — verifies multiple list handlers are invoked
- `test_after_exception_list_not_called_on_success` — verifies handlers are skipped on success
- `test_after_exception_list_combined_with_hook_handler` — verifies list + deprecated singular field work together

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4739">https://litestar-org.github.io/litestar-docs-preview/4739</a> 
