### PR TITLE
feat: allow custom OpenAPI error response schemas

### DIFF
--- a/litestar/_openapi/responses.py
+++ b/litestar/_openapi/responses.py
@@ -98,7 +98,7 @@ class ResponseFactory:
             exceptions.append(ValidationException)
 
         error_response_creator = self.context.openapi_config.error_response_creator or create_error_responses
-        for status_code, response in error_response_creator(exceptions=exceptions):
+        for status_code, response in error_response_creator(exceptions):
             responses[status_code] = response
 
         for status_code, response in self.create_additional_responses():

--- a/litestar/_openapi/responses.py
+++ b/litestar/_openapi/responses.py
@@ -97,7 +97,8 @@ class ResponseFactory:
         if raises_validation_error and ValidationException not in exceptions:
             exceptions.append(ValidationException)
 
-        for status_code, response in create_error_responses(exceptions=exceptions):
+        error_response_creator = self.context.openapi_config.error_response_creator or create_error_responses
+        for status_code, response in error_response_creator(exceptions=exceptions):
             responses[status_code] = response
 
         for status_code, response in self.create_additional_responses():

--- a/litestar/app.py
+++ b/litestar/app.py
@@ -442,6 +442,9 @@ class Litestar(Router):
             config.exception_handlers.setdefault(StarletteHTTPException, _starlette_exception_handler)
         except ImportError:
             pass
+
+        self._validate_exception_handlers(config.exception_handlers)
+
         super().__init__(
             after_request=config.after_request,
             after_response=config.after_response,
@@ -504,6 +507,36 @@ class Litestar(Router):
         except ImportError:
             pass
         return config
+
+    @staticmethod
+    def _validate_exception_handlers(exception_handlers: ExceptionHandlersMap) -> None:
+        """Warn if a non-Litestar HTTPException class is registered as an exception handler key.
+
+        A common mistake is to accidentally import ``HTTPException`` from ``http.client``
+        (Python stdlib) instead of ``litestar.exceptions``. When the stdlib class is used
+        as a key, the handler will silently fail to match any Litestar HTTP exceptions.
+
+        See: https://github.com/litestar-org/litestar/issues/4434
+        """
+        from litestar.exceptions import HTTPException as LitestarHTTPException
+
+        for key in exception_handlers:
+            if isinstance(key, int):
+                continue
+            if (
+                key.__name__ == "HTTPException"
+                and key is not LitestarHTTPException
+                and not key.__module__.startswith("starlette.")
+            ):
+                warnings.warn(
+                    f"An 'HTTPException' class from '{key.__module__}' was registered as an exception "
+                    f"handler key. This is likely an incorrect import. Did you mean "
+                    f"'litestar.exceptions.HTTPException'? Handlers keyed to non-Litestar HTTPException "
+                    f"classes will not catch Litestar HTTP exceptions. "
+                    f"See: https://github.com/litestar-org/litestar/issues/4434",
+                    category=LitestarWarning,
+                    stacklevel=2,
+                )
 
     @staticmethod
     def _get_default_plugins(plugins: list[PluginProtocol]) -> list[PluginProtocol]:

--- a/litestar/contrib/opentelemetry/config.py
+++ b/litestar/contrib/opentelemetry/config.py
@@ -37,8 +37,19 @@ class OpenTelemetryConfig:
     Consult the [OpenTelemetry ASGI documentation](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/asgi/asgi.html) for more info about the configuration options.
     """
 
+    after_exception: list[AfterExceptionHookHandler] = field(default_factory=list)
+    """A list of callbacks that are called with the exception and the scope for every exception raised.
+
+    These handlers are added to the application-level ``after_exception`` hooks.
+
+    .. versionadded:: 2.16.0
+    """
     after_exception_hook_handler: AfterExceptionHookHandler | None = field(default=None)
-    """Callback which is called with the exception and the scope object for every exception raised."""
+    """Callback which is called with the exception and the scope object for every exception raised.
+
+    .. deprecated:: 2.16.0
+        Use :attr:`after_exception` instead.
+    """
 
     scope_span_details_extractor: Callable[[Scope], tuple[str, dict[str, Any]]] = field(
         default=get_route_details_from_scope

--- a/litestar/contrib/opentelemetry/plugin.py
+++ b/litestar/contrib/opentelemetry/plugin.py
@@ -30,6 +30,7 @@ class OpenTelemetryPlugin(InitPlugin):
 
     def on_app_init(self, app_config: AppConfig) -> AppConfig:
         app_config.middleware, _middleware = self._pop_otel_middleware(app_config.middleware)
+        app_config.after_exception.extend(self.config.after_exception)
         if self.config.after_exception_hook_handler:
             app_config.after_exception.append(self.config.after_exception_hook_handler)
         return app_config

--- a/litestar/openapi/config.py
+++ b/litestar/openapi/config.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
     from litestar.openapi.plugins import OpenAPIRenderPlugin
     from litestar.router import Router
-    from litestar.types.callable_types import OperationIDCreator
+    from litestar.types.callable_types import ErrorResponsesCreator, OperationIDCreator
 
 __all__ = ("OpenAPIConfig",)
 
@@ -90,6 +90,12 @@ class OpenAPIConfig:
     """
     operation_id_creator: OperationIDCreator = default_operation_id_creator
     """A callable that generates unique operation ids"""
+    error_response_creator: ErrorResponsesCreator | None = field(default=None)
+    """A callable that generates OpenAPI schemas for error responses.
+
+    When ``None``, the default schema matching ``HTTPException`` is used.
+    Useful when error responses are customized via exception handlers or plugins (e.g. ``ProblemDetailsPlugin``).
+    """
     path: str = "/schema"
     """Base path for the OpenAPI documentation endpoints.
 

--- a/litestar/types/callable_types.py
+++ b/litestar/types/callable_types.py
@@ -55,4 +55,3 @@ OperationIDCreator: TypeAlias = "Callable[[HTTPRouteHandler, Method, list[str | 
 Serializer: TypeAlias = Callable[[Any], Any]
 HTTPHandlerDecorator: TypeAlias = "Callable[..., Callable[[AnyCallable], HTTPRouteHandler]]"
 ErrorResponsesCreator: TypeAlias = "Callable[[list[type[HTTPException]]], Iterator[tuple[str, OpenAPIResponse]]]"
-

--- a/litestar/types/callable_types.py
+++ b/litestar/types/callable_types.py
@@ -4,14 +4,17 @@ from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
 from typing import TYPE_CHECKING, Any, TypeVar
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from typing import TypeAlias
 
     from litestar.app import Litestar
     from litestar.config.app import AppConfig
     from litestar.connection.base import ASGIConnection
     from litestar.connection.request import Request
+    from litestar.exceptions.http_exceptions import HTTPException
     from litestar.handlers.base import BaseRouteHandler
     from litestar.handlers.http_handlers import HTTPRouteHandler
+    from litestar.openapi.spec import OpenAPIResponse
     from litestar.response.base import Response
     from litestar.types.asgi_types import ASGIApp, Message, Method, Scope
     from litestar.types.helper_types import SyncOrAsyncUnion
@@ -51,3 +54,5 @@ OnAppInitHandler: TypeAlias = "Callable[[AppConfig], AppConfig]"
 OperationIDCreator: TypeAlias = "Callable[[HTTPRouteHandler, Method, list[str | PathParameterDefinition]], str]"
 Serializer: TypeAlias = Callable[[Any], Any]
 HTTPHandlerDecorator: TypeAlias = "Callable[..., Callable[[AnyCallable], HTTPRouteHandler]]"
+ErrorResponsesCreator: TypeAlias = "Callable[[list[type[HTTPException]]], Iterator[tuple[str, OpenAPIResponse]]]"
+

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import warnings
 from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
 from dataclasses import fields
@@ -447,3 +448,38 @@ def test_handler_registration_on_registration_called_only_once(mocker: MockerFix
         )
         == 1
     )
+
+
+def test_warn_on_stdlib_http_exception_in_exception_handlers() -> None:
+    """Test that a warning is emitted when http.client.HTTPException is used as an exception handler key."""
+    from http.client import HTTPException as StdlibHTTPException
+
+    def handler(_: Request, exc: Exception) -> Response:
+        return Response(content="error", status_code=500)
+
+    with pytest.warns(LitestarWarning, match="http.client"):
+        Litestar(exception_handlers={StdlibHTTPException: handler})
+
+
+def test_no_warn_on_litestar_http_exception_in_exception_handlers() -> None:
+    """Test that no warning is emitted when litestar.exceptions.HTTPException is used."""
+    from litestar.exceptions import HTTPException
+
+    def handler(_: Request, exc: Exception) -> Response:
+        return Response(content="error", status_code=500)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", LitestarWarning)
+        # Should not raise any LitestarWarning
+        Litestar(exception_handlers={HTTPException: handler})
+
+
+def test_no_warn_on_int_key_in_exception_handlers() -> None:
+    """Test that no warning is emitted for integer status code keys."""
+
+    def handler(_: Request, exc: Exception) -> Response:
+        return Response(content="error", status_code=500)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", LitestarWarning)
+        Litestar(exception_handlers={500: handler})

--- a/tests/unit/test_contrib/test_opentelemetry.py
+++ b/tests/unit/test_contrib/test_opentelemetry.py
@@ -344,3 +344,109 @@ def test_after_exception_hook_handler_not_called_on_success(
 
         # Verify the hook was NOT called
         assert len(hook_calls) == 0
+
+
+def test_after_exception_list_called_on_exception(
+    resource: Resource, exporter: InMemorySpanExporter, meter_provider: MeterProvider, request: FixtureRequest
+) -> None:
+    """Test that after_exception list handlers are called when an exception occurs."""
+    hook_calls_1: list[tuple[Exception, Scope]] = []
+    hook_calls_2: list[tuple[Exception, Scope]] = []
+
+    def hook_one(exc: Exception, scope: Scope) -> None:
+        hook_calls_1.append((exc, scope))
+
+    def hook_two(exc: Exception, scope: Scope) -> None:
+        hook_calls_2.append((exc, scope))
+
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    meter = get_meter_provider().get_meter(f"litestar-test-{request.node.nodeid}")
+    config = OpenTelemetryConfig(tracer_provider=tracer_provider, meter=meter, after_exception=[hook_one, hook_two])
+
+    test_exception = ValueError("test error")
+
+    @get("/")
+    def handler() -> dict:
+        raise test_exception
+
+    with create_test_client(handler, plugins=[OpenTelemetryPlugin(config)]) as client:
+        response = client.get("/")
+        assert response.status_code == 500
+
+        # Both hooks should have been called
+        assert len(hook_calls_1) == 1
+        assert len(hook_calls_2) == 1
+
+        # Verify the exception is the one we raised
+        assert hook_calls_1[0][0] is test_exception
+        assert hook_calls_2[0][0] is test_exception
+
+        # Verify scope details
+        assert hook_calls_1[0][1]["type"] == ScopeType.HTTP
+        assert hook_calls_2[0][1]["type"] == ScopeType.HTTP
+
+
+def test_after_exception_list_not_called_on_success(
+    resource: Resource, exporter: InMemorySpanExporter, meter_provider: MeterProvider, request: FixtureRequest
+) -> None:
+    """Test that after_exception list handlers are not called when no exception occurs."""
+    hook_calls: list[tuple[Exception, Scope]] = []
+
+    def hook(exc: Exception, scope: Scope) -> None:
+        hook_calls.append((exc, scope))
+
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    meter = get_meter_provider().get_meter(f"litestar-test-{request.node.nodeid}")
+    config = OpenTelemetryConfig(tracer_provider=tracer_provider, meter=meter, after_exception=[hook])
+
+    @get("/")
+    def handler() -> dict:
+        return {"success": True}
+
+    with create_test_client(handler, plugins=[OpenTelemetryPlugin(config)]) as client:
+        response = client.get("/")
+        assert response.status_code == 200
+        assert len(hook_calls) == 0
+
+
+def test_after_exception_list_combined_with_hook_handler(
+    resource: Resource, exporter: InMemorySpanExporter, meter_provider: MeterProvider, request: FixtureRequest
+) -> None:
+    """Test that both after_exception list and deprecated after_exception_hook_handler work together."""
+    list_hook_calls: list[tuple[Exception, Scope]] = []
+    singular_hook_calls: list[tuple[Exception, Scope]] = []
+
+    def list_hook(exc: Exception, scope: Scope) -> None:
+        list_hook_calls.append((exc, scope))
+
+    def singular_hook(exc: Exception, scope: Scope) -> None:
+        singular_hook_calls.append((exc, scope))
+
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    meter = get_meter_provider().get_meter(f"litestar-test-{request.node.nodeid}")
+    config = OpenTelemetryConfig(
+        tracer_provider=tracer_provider,
+        meter=meter,
+        after_exception=[list_hook],
+        after_exception_hook_handler=singular_hook,
+    )
+
+    test_exception = ValueError("combined test")
+
+    @get("/")
+    def handler() -> dict:
+        raise test_exception
+
+    with create_test_client(handler, plugins=[OpenTelemetryPlugin(config)]) as client:
+        response = client.get("/")
+        assert response.status_code == 500
+
+        # Both the list hook and the singular hook should have been called
+        assert len(list_hook_calls) == 1
+        assert len(singular_hook_calls) == 1
+
+        assert list_hook_calls[0][0] is test_exception
+        assert singular_hook_calls[0][0] is test_exception

--- a/tests/unit/test_openapi/test_responses.py
+++ b/tests/unit/test_openapi/test_responses.py
@@ -578,3 +578,175 @@ def test_file_response_media_type(content_media_type: Any, expected: Any, create
 
     response = create_factory(handler).create_success_response()
     assert next(iter(response.content.values())).schema.content_media_type == expected  # type: ignore[union-attr]
+
+
+def test_create_responses_with_custom_error_response_creator() -> None:
+    from collections.abc import Iterator
+
+    def custom_error_responses(exceptions: list[type[HTTPException]]) -> Iterator[tuple[str, OpenAPIResponse]]:
+        for exc in exceptions:
+            yield (
+                str(exc.status_code),
+                OpenAPIResponse(
+                    description="Custom error",
+                    content={
+                        MediaType.JSON: OpenAPIMediaType(
+                            schema=Schema(
+                                type=OpenAPIType.OBJECT,
+                                required=["custom_field"],
+                                properties={"custom_field": Schema(type=OpenAPIType.STRING)},
+                            )
+                        )
+                    },
+                ),
+            )
+
+    @get("/test", name="test", raises=[PetException])
+    def handler() -> dict:
+        return {}
+
+    app = Litestar(route_handlers=[handler])
+    route_handler = app.asgi_router.route_handler_index["test"]
+
+    factory = ResponseFactory(
+        context=OpenAPIContext(
+            openapi_config=OpenAPIConfig(
+                title="test",
+                version="1.0.0",
+                error_response_creator=custom_error_responses,
+            ),
+            plugins=openapi_schema_plugins,
+        ),
+        route_handler=route_handler,
+    )
+
+    responses = factory.create_responses(raises_validation_error=False)
+    assert responses is not None
+    assert str(PetException.status_code) in responses
+
+    error_response = responses[str(PetException.status_code)]
+    assert error_response.description == "Custom error"
+    assert error_response.content is not None
+    schema = error_response.content[MediaType.JSON].schema
+    assert isinstance(schema, Schema)
+    assert schema.required == ["custom_field"]
+    assert "custom_field" in schema.properties  # type: ignore[operator]
+
+
+def test_create_responses_with_default_error_response_creator() -> None:
+
+    @get("/test", name="test", raises=[PetException])
+    def handler() -> dict:
+        return {}
+
+    app = Litestar(route_handlers=[handler])
+    route_handler = app.asgi_router.route_handler_index["test"]
+
+    factory = ResponseFactory(
+        context=OpenAPIContext(
+            openapi_config=OpenAPIConfig(title="test", version="1.0.0"),
+            plugins=openapi_schema_plugins,
+        ),
+        route_handler=route_handler,
+    )
+
+    responses = factory.create_responses(raises_validation_error=False)
+    assert responses is not None
+    assert str(PetException.status_code) in responses
+
+    error_response = responses[str(PetException.status_code)]
+    assert error_response.content is not None
+    schema = error_response.content[MediaType.JSON].schema
+    assert isinstance(schema, Schema)
+
+    assert schema.required == ["detail", "status_code"]
+    assert "status_code" in schema.properties  # type: ignore[operator]
+    assert "detail" in schema.properties  # type: ignore[operator]
+
+
+def test_custom_error_response_creator_problem_details_style() -> None:
+    import contextlib
+    from collections.abc import Iterator
+
+    def problem_details_error_responses(
+        exceptions: list[type[HTTPException]],
+    ) -> Iterator[tuple[str, OpenAPIResponse]]:
+
+        grouped: dict[int, list[type[HTTPException]]] = {}
+        for exc in exceptions:
+            grouped.setdefault(exc.status_code, []).append(exc)
+
+        for status_code, group in grouped.items():
+            schemas = []
+            description = ""
+            for exc in group:
+                example_title = ""
+                example_detail = ""
+                if hasattr(exc, "detail") and exc.detail:
+                    description = exc.detail
+                    example_detail = exc.detail
+                if not example_title:
+                    with contextlib.suppress(Exception):
+                        example_title = HTTPStatus(status_code).phrase
+                schemas.append(
+                    Schema(
+                        type=OpenAPIType.OBJECT,
+                        required=["title", "status"],
+                        properties={
+                            "status": Schema(type=OpenAPIType.INTEGER),
+                            "title": Schema(type=OpenAPIType.STRING),
+                            "detail": Schema(type=OpenAPIType.STRING),
+                        },
+                        examples=[{"status": status_code, "title": example_title, "detail": example_detail}],
+                    )
+                )
+            schema = Schema(one_of=schemas) if len(schemas) > 1 else schemas[0]
+            if not description:
+                with contextlib.suppress(Exception):
+                    description = HTTPStatus(status_code).description
+
+            yield (
+                str(status_code),
+                OpenAPIResponse(
+                    description=description,
+                    content={"application/problem+json": OpenAPIMediaType(schema=schema)},
+                ),
+            )
+
+    @get("/test", name="test", raises=[PetException, ValidationException])
+    def handler() -> dict:
+        return {}
+
+    app = Litestar(route_handlers=[handler])
+    route_handler = app.asgi_router.route_handler_index["test"]
+
+    factory = ResponseFactory(
+        context=OpenAPIContext(
+            openapi_config=OpenAPIConfig(
+                title="test",
+                version="1.0.0",
+                error_response_creator=problem_details_error_responses,
+            ),
+            plugins=openapi_schema_plugins,
+        ),
+        route_handler=route_handler,
+    )
+
+    responses = factory.create_responses(raises_validation_error=False)
+    assert responses is not None
+
+
+    pet_response = responses[str(PetException.status_code)]
+    assert pet_response.content is not None
+    assert "application/problem+json" in pet_response.content
+    schema = pet_response.content["application/problem+json"].schema
+    assert isinstance(schema, Schema)
+    assert schema.required == ["title", "status"]
+    assert "status" in schema.properties  # type: ignore[operator]
+    assert "title" in schema.properties  # type: ignore[operator]
+
+
+    validation_response = responses[str(ValidationException.status_code)]
+    assert validation_response.content is not None
+    assert "application/problem+json" in validation_response.content
+

--- a/tests/unit/test_openapi/test_responses.py
+++ b/tests/unit/test_openapi/test_responses.py
@@ -734,7 +734,6 @@ def test_custom_error_response_creator_problem_details_style() -> None:
     responses = factory.create_responses(raises_validation_error=False)
     assert responses is not None
 
-
     pet_response = responses[str(PetException.status_code)]
     assert not isinstance(pet_response, Reference)
     assert pet_response.content is not None
@@ -744,7 +743,6 @@ def test_custom_error_response_creator_problem_details_style() -> None:
     assert schema.required == ["title", "status"]
     assert "status" in schema.properties  # type: ignore[operator]
     assert "title" in schema.properties  # type: ignore[operator]
-
 
     validation_response = responses[str(ValidationException.status_code)]
     assert not isinstance(validation_response, Reference)

--- a/tests/unit/test_openapi/test_responses.py
+++ b/tests/unit/test_openapi/test_responses.py
@@ -605,8 +605,7 @@ def test_create_responses_with_custom_error_response_creator() -> None:
     def handler() -> dict:
         return {}
 
-    app = Litestar(route_handlers=[handler])
-    route_handler = app.asgi_router.route_handler_index["test"]
+    route_handler = get_registered_route_handler(handler, "test")
 
     factory = ResponseFactory(
         context=OpenAPIContext(
@@ -625,6 +624,7 @@ def test_create_responses_with_custom_error_response_creator() -> None:
     assert str(PetException.status_code) in responses
 
     error_response = responses[str(PetException.status_code)]
+    assert not isinstance(error_response, Reference)
     assert error_response.description == "Custom error"
     assert error_response.content is not None
     schema = error_response.content[MediaType.JSON].schema
@@ -639,8 +639,7 @@ def test_create_responses_with_default_error_response_creator() -> None:
     def handler() -> dict:
         return {}
 
-    app = Litestar(route_handlers=[handler])
-    route_handler = app.asgi_router.route_handler_index["test"]
+    route_handler = get_registered_route_handler(handler, "test")
 
     factory = ResponseFactory(
         context=OpenAPIContext(
@@ -655,6 +654,7 @@ def test_create_responses_with_default_error_response_creator() -> None:
     assert str(PetException.status_code) in responses
 
     error_response = responses[str(PetException.status_code)]
+    assert not isinstance(error_response, Reference)
     assert error_response.content is not None
     schema = error_response.content[MediaType.JSON].schema
     assert isinstance(schema, Schema)
@@ -717,8 +717,7 @@ def test_custom_error_response_creator_problem_details_style() -> None:
     def handler() -> dict:
         return {}
 
-    app = Litestar(route_handlers=[handler])
-    route_handler = app.asgi_router.route_handler_index["test"]
+    route_handler = get_registered_route_handler(handler, "test")
 
     factory = ResponseFactory(
         context=OpenAPIContext(
@@ -737,6 +736,7 @@ def test_custom_error_response_creator_problem_details_style() -> None:
 
 
     pet_response = responses[str(PetException.status_code)]
+    assert not isinstance(pet_response, Reference)
     assert pet_response.content is not None
     assert "application/problem+json" in pet_response.content
     schema = pet_response.content["application/problem+json"].schema
@@ -747,6 +747,6 @@ def test_custom_error_response_creator_problem_details_style() -> None:
 
 
     validation_response = responses[str(ValidationException.status_code)]
+    assert not isinstance(validation_response, Reference)
     assert validation_response.content is not None
     assert "application/problem+json" in validation_response.content
-


### PR DESCRIPTION
# Improvement – Allow custom OpenAPI error response schemas

## Description

**Context:**  
Litestar generated OpenAPI error responses using the default `HTTPException` schema, which did not match apps that return custom error payloads such as `problem_details`. This made the generated schema inaccurate for users with customized exception handling.

**Approach:**  
- Added `OpenAPIConfig.error_response_creator`
- Updated `ResponseFactory.create_responses()` to use the configured error response creator
- Added a dedicated `ErrorResponsesCreator` type alias
- Preserved the existing default behavior when no custom creator is provided
- Added tests for:
  - custom error schema generation
  - default error schema fallback
  - `application/problem+json` / problem-details-style responses

**Impact:**  
- **Functionality:** users can now customize generated OpenAPI error response schemas to match their actual error payload format
- **Developer Experience:** provides a clean extension point instead of requiring downstream workarounds
- **Coverage/Robustness:** verifies both backward compatibility and custom-schema generation paths

---

## Tests
- [x] New tests added  
- [x] Existing tests updated  

**Unit Tests Summary:**  
- `test_create_responses_with_custom_error_response_creator`
- `test_create_responses_with_default_error_response_creator`
- `test_custom_error_response_creator_problem_details_style`

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4741">https://litestar-org.github.io/litestar-docs-preview/4741</a> 
