### PR TITLE
fix(dto): reset transfer model names per app (#4699)

### DIFF
--- a/litestar/app.py
+++ b/litestar/app.py
@@ -434,6 +434,11 @@ class Litestar(Router):
         if self.pdb_on_exception:
             warn_pdb_on_exception()
 
+        # DTO transfer model names only need to be unique within a single application.
+        from litestar.dto._backend import DTOBackend
+
+        DTOBackend._seen_model_names.clear()
+
         try:
             from starlette.exceptions import HTTPException as StarletteHTTPException
 

--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -491,3 +491,21 @@ def test_components_schemas_in_alphabetical_order() -> None:
         "test_components_schemas_in_alphabetical_order.C",
     ]
     assert list(openapi.components.schemas.keys()) == expected_keys
+
+
+def test_dto_component_schema_names_are_stable_across_app_instances() -> None:
+    # https://github.com/litestar-org/litestar/issues/4699
+
+    @dataclass
+    class Item:
+        name: str
+
+    @get("/items", return_dto=DataclassDTO[Item], sync_to_thread=False)
+    def handler() -> Item:
+        return Item(name="item")
+
+    first_app_schemas = Litestar([handler], signature_types=[Item]).openapi_schema.to_schema()["components"]["schemas"]
+    second_app_schemas = Litestar([handler], signature_types=[Item]).openapi_schema.to_schema()["components"]["schemas"]
+
+    assert first_app_schemas.keys() == second_app_schemas.keys()
+    assert "HandlerItemResponseBody" in first_app_schemas


### PR DESCRIPTION
## Description

Fixes #4699.

`DTOBackend._seen_model_names` is process-global, so building a second `Litestar` app in the same process can inherit transfer model names from a previous app. That makes otherwise identical DTO OpenAPI component names drift between app instances.

This clears the DTO transfer-name registry when a new `Litestar` app is constructed, before route registration creates DTO backends for that app. Transfer model names still stay unique within the app being built, but a later app no longer inherits stale names from an earlier one.

## Tests

- `uv run --no-default-groups --group test --group dev pytest tests/unit/test_openapi/test_integration.py::test_dto_component_schema_names_are_stable_across_app_instances -q`
- `uv run --no-default-groups --group test --group dev pytest tests/unit/test_openapi/test_integration.py -q`
- `uv run --no-default-groups --group test --group dev pytest tests/unit/test_dto/test_factory/test_backends/test_backends.py::test_backend_model_name_uniqueness -q`
- `uv run --no-default-groups --group linting ruff format --check litestar/app.py tests/unit/test_openapi/test_integration.py`
- `uv run --no-default-groups --group linting ruff check litestar/app.py tests/unit/test_openapi/test_integration.py`
- `uv run --no-default-groups --group linting pyright litestar/app.py tests/unit/test_openapi/test_integration.py`


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4742">https://litestar-org.github.io/litestar-docs-preview/4742</a> 
