### PR TITLE
feat(test client): Warn if not used as context manager

### DIFF
--- a/docs/usage/websockets.rst
+++ b/docs/usage/websockets.rst
@@ -396,7 +396,7 @@ To stream and receive data concurrently, the stream can be set up manually using
 
                 .. literalinclude:: ../../tests/examples/test_websockets.py
                     :language: python
-                    :lines: 28-35
+                    :lines: 26-33
 
 Transport modes
 ---------------

--- a/litestar/testing/client/async_client.py
+++ b/litestar/testing/client/async_client.py
@@ -85,6 +85,7 @@ class AsyncTestClient(AsyncClient, Generic[T]):
             self._session_backend = session_config._backend_class(config=session_config)
 
         self.exit_stack = contextlib.AsyncExitStack()
+        self._initialized = False
 
         super().__init__(
             base_url=base_url,
@@ -98,7 +99,6 @@ class AsyncTestClient(AsyncClient, Generic[T]):
             ),
             timeout=timeout,
         )
-        # warn on usafe if client not initialized
 
     async def __aenter__(self) -> Self:
         self._tg = await self.exit_stack.enter_async_context(anyio.create_task_group())
@@ -106,6 +106,7 @@ class AsyncTestClient(AsyncClient, Generic[T]):
         await self.exit_stack.enter_async_context(lifespan_handler)
         await super().__aenter__()
         self.exit_stack.push_async_exit(super().__aexit__)
+        self._initialized = True
 
         return self
 
@@ -117,6 +118,7 @@ class AsyncTestClient(AsyncClient, Generic[T]):
     ) -> None:
         try:
             await self.exit_stack.__aexit__(exc_type, exc_value, traceback)
+            self._initialized = False
         except Exception as exc:
             exc = _collapse_exception_groups(exc)
             raise exc

--- a/litestar/testing/client/sync_client.py
+++ b/litestar/testing/client/sync_client.py
@@ -87,6 +87,7 @@ class TestClient(Client, Generic[T]):
                 name="test_client",
             )
         )
+        self._initialized = False
 
         super().__init__(
             base_url=base_url,
@@ -100,12 +101,12 @@ class TestClient(Client, Generic[T]):
             ),
             timeout=timeout,
         )
-        # warn on usafe if client not initialized
 
     def __enter__(self) -> Self:
         self.exit_stack.enter_context(self.blocking_portal.wrap_async_context_manager(LifeSpanHandler(self.app)))
         super().__enter__()
         self.exit_stack.push(super().__exit__)
+        self._initialized = True
         return self
 
     def __exit__(
@@ -116,6 +117,7 @@ class TestClient(Client, Generic[T]):
     ) -> None:
         try:
             self.exit_stack.__exit__(exc_type, exc_value, traceback)
+            self._initialized = False
         except Exception as exc:
             exc = _collapse_exception_groups(exc)
             raise exc

--- a/litestar/testing/transport.py
+++ b/litestar/testing/transport.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from io import BytesIO
 from types import GeneratorType
 from typing import TYPE_CHECKING, Any, Generic, TypedDict, TypeVar, Union, cast
@@ -10,6 +11,7 @@ from urllib.parse import unquote
 import anyio
 from httpx import AsyncBaseTransport, BaseTransport, ByteStream, Response
 
+from litestar.exceptions import LitestarWarning
 from litestar.status_codes import HTTP_500_INTERNAL_SERVER_ERROR
 
 if TYPE_CHECKING:
@@ -140,6 +142,13 @@ class TestClientTransport(AsyncBaseTransport, Generic[T]):
         }
 
     async def handle_async_request(self, request: Request) -> Response:
+        if not self.client._initialized:
+            warnings.warn(
+                "AsyncTestClient not initialized. Was the client instance used as a context manager?",
+                LitestarWarning,
+                stacklevel=2,
+            )
+
         scope = self.parse_request(request=request)
         if scope["type"] == "websocket":
             scope.update(
@@ -208,4 +217,10 @@ class SyncTestClientTransport(BaseTransport):
         )
 
     def handle_request(self, request: Request) -> Response:
+        if not self.client._initialized:
+            warnings.warn(
+                "TestClient not initialized. Was the client instance used as a context manager?",
+                LitestarWarning,
+                stacklevel=2,
+            )
         return self.client.blocking_portal.call(self._async_transport.handle_async_request, request)

--- a/tests/e2e/test_dependency_injection/test_websocket_handler_dependency_injection.py
+++ b/tests/e2e/test_dependency_injection/test_websocket_handler_dependency_injection.py
@@ -71,14 +71,16 @@ class FirstController(Controller):
 
 
 def test_controller_dependency_injection() -> None:
-    client = create_test_client(
-        FirstController,
-        dependencies={
-            "second": Provide(router_first_dependency, sync_to_thread=False),
-            "third": Provide(router_second_dependency),
-        },
-    )
-    with client.websocket_connect(f"{test_path}/abcdef?query_param=12345") as ws:
+    with (
+        create_test_client(
+            FirstController,
+            dependencies={
+                "second": Provide(router_first_dependency, sync_to_thread=False),
+                "third": Provide(router_second_dependency),
+            },
+        ) as client,
+        client.websocket_connect(f"{test_path}/abcdef?query_param=12345") as ws,
+    ):
         ws.send_json({"data": "123"})
 
 
@@ -100,14 +102,16 @@ def test_function_dependency_injection() -> None:
         assert isinstance(third, str)
         await socket.close()
 
-    client = create_test_client(
-        test_function,
-        dependencies={
-            "first": Provide(router_first_dependency, sync_to_thread=False),
-            "second": Provide(router_second_dependency),
-        },
-    )
-    with client.websocket_connect(f"{test_path}/abcdef?query_param=12345") as ws:
+    with (
+        create_test_client(
+            test_function,
+            dependencies={
+                "first": Provide(router_first_dependency, sync_to_thread=False),
+                "second": Provide(router_second_dependency),
+            },
+        ) as client,
+        client.websocket_connect(f"{test_path}/abcdef?query_param=12345") as ws,
+    ):
         ws.send_json({"data": "123"})
 
 

--- a/tests/examples/test_middleware/test_abstract_middleware.py
+++ b/tests/examples/test_middleware/test_abstract_middleware.py
@@ -5,7 +5,7 @@ from litestar.testing import TestClient
 
 
 def test_base_middleware_example_websocket() -> None:
-    with TestClient(app).websocket_connect("/my-websocket") as ws:
+    with TestClient(app) as client, client.websocket_connect("/my-websocket") as ws:
         assert b"x-process-time" not in dict(ws.scope["headers"])
 
 

--- a/tests/examples/test_websockets.py
+++ b/tests/examples/test_websockets.py
@@ -7,9 +7,7 @@ from litestar.testing.client.sync_client import TestClient
 
 
 def test_custom_websocket_class():
-    client = TestClient(app=custom_websocket_class_app)
-
-    with client.websocket_connect("/") as ws:
+    with TestClient(app=custom_websocket_class_app) as client, client.websocket_connect("/") as ws:
         ws.send({"data": "I should not be in response"})
         data = ws.receive()
         assert data["text"] == "Fixed response"

--- a/tests/unit/test_connection/test_request.py
+++ b/tests/unit/test_connection/test_request.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 
 from collections.abc import Callable, Generator
 from typing import TYPE_CHECKING, Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from litestar import MediaType, Request, get, post
+from litestar import Request, asgi, get, post
 from litestar.connection.base import AuthT, StateT, UserT, empty_send
 from litestar.datastructures import Address, Cookie, State
 from litestar.exceptions import (
@@ -25,7 +25,7 @@ from litestar.middleware import MiddlewareProtocol
 from litestar.response.base import ASGIResponse
 from litestar.serialization import encode_json, encode_msgpack
 from litestar.status_codes import HTTP_400_BAD_REQUEST, HTTP_413_REQUEST_ENTITY_TOO_LARGE
-from litestar.testing import TestClient, create_test_client
+from litestar.testing import create_test_client
 
 if TYPE_CHECKING:
     from litestar.types import ASGIApp, Receive, Scope, Send
@@ -146,61 +146,69 @@ def test_custom_request_class() -> None:
 
 
 def test_request_url() -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        request = Request[Any, Any, State](scope, receive)
-        data = {"method": request.method, "url": str(request.url)}
-        response = ASGIResponse(body=encode_json(data))
-        await response(scope, receive, send)
+    mock = MagicMock()
 
-    client = TestClient(app)
-    response = client.get("/123?a=abc")
-    assert response.json() == {"method": "GET", "url": "http://testserver.local/123?a=abc"}
+    @get(["/", "123"])
+    def handler(request: Request) -> None:
+        mock({"method": request.method, "url": str(request.url)})
 
-    response = client.get("https://example.org:123/")
-    assert response.json() == {"method": "GET", "url": "https://example.org:123/"}
+    with create_test_client(handler, raise_server_exceptions=True) as client:
+        assert client.get("/").status_code == 200
+        assert client.get("/123?a=abc").status_code == 200
+
+    mock.assert_has_calls(
+        [
+            call({"method": "GET", "url": "http://testserver.local/"}),
+            call({"method": "GET", "url": "http://testserver.local/123?a=abc"}),
+        ]
+    )
 
 
 def test_request_query_params() -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        request = Request[Any, Any, State](scope, receive)
-        params = dict(request.query_params)
-        response = ASGIResponse(body=encode_json({"params": params}))
-        await response(scope, receive, send)
+    mock = MagicMock()
 
-    client = TestClient(app)
-    response = client.get("/?a=123&b=456")
-    assert response.json() == {"params": {"a": "123", "b": "456"}}
+    @get("/")
+    def handler(request: Request) -> None:
+        mock(dict(request.query_params))
+
+    with create_test_client(handler) as client:
+        client.get("/?a=123&b=456")
+
+    mock.assert_called_once_with({"a": "123", "b": "456"})
 
 
 def test_request_headers() -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        request = Request[Any, Any, State](scope, receive)
-        headers = dict(request.headers)
-        response = ASGIResponse(body=encode_json({"headers": headers}))
-        await response(scope, receive, send)
+    mock = MagicMock()
 
-    client = TestClient(app)
-    response = client.get("/", headers={"host": "example.org"})
-    assert response.json() == {
-        "headers": {
+    @get("/")
+    def handler(request: Request) -> None:
+        mock(dict(request.headers))
+
+    with create_test_client(handler) as client:
+        client.get("/", headers={"host": "example.org"})
+
+    mock.assert_called_once_with(
+        {
             "host": "example.org",
             "user-agent": "testclient",
             "accept-encoding": "gzip, deflate, br, zstd",
             "accept": "*/*",
             "connection": "keep-alive",
         }
-    }
+    )
 
 
 def test_request_accept_header() -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        request = Request[Any, Any, State](scope, receive)
-        response = ASGIResponse(body=encode_json({"accepted_types": list(request.accept)}))
-        await response(scope, receive, send)
+    mock = MagicMock()
 
-    client = TestClient(app)
-    response = client.get("/", headers={"Accept": "text/plain, application/xml;q=0.7, text/html;p=test"})
-    assert response.json() == {"accepted_types": ["text/html;p=test", "text/plain", "application/xml;q=0.7"]}
+    @get("/")
+    def handler(request: Request) -> None:
+        mock(list(request.accept))
+
+    with create_test_client(handler) as client:
+        client.get("/", headers={"Accept": "text/plain, application/xml;q=0.7, text/html;p=test"})
+
+    mock.assert_called_once_with(["text/html;p=test", "text/plain", "application/xml;q=0.7"])
 
 
 @pytest.mark.parametrize(
@@ -297,18 +305,6 @@ def test_request_body_then_stream() -> None:
 
 
 def test_request_stream_then_body() -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        request = Request[Any, Any, State](scope, receive)
-        chunks = b""
-        async for chunk in request.stream():
-            chunks += chunk
-        try:
-            body = await request.body()
-        except InternalServerException:
-            body = b"<stream consumed>"
-        response = ASGIResponse(body=encode_json({"body": body.decode(), "stream": chunks.decode()}))
-        await response(scope, receive, send)
-
     @post("/")
     async def handler(request: Request) -> bytes:
         chunks = b""
@@ -337,34 +333,18 @@ def test_request_json() -> None:
 
 
 def test_request_raw_path() -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        request = Request[Any, Any, State](scope, receive)
+    mock = MagicMock()
+
+    @get("/he/llo")
+    def handler(request: Request) -> None:
         path = str(request.scope["path"])
         raw_path = str(request.scope["raw_path"])
-        response = ASGIResponse(body=f"{path}, {raw_path}".encode(), media_type=MediaType.TEXT)
-        await response(scope, receive, send)
+        mock(f"{path}, {raw_path}")
 
-    client = TestClient(app)
-    response = client.get("/he%2Fllo")
-    assert response.text == "/he/llo, b'/he%2Fllo'"
+    with create_test_client(handler) as client:
+        client.get("/he%2Fllo")
 
-
-def test_request_without_setting_receive(create_scope: Callable[..., Scope]) -> None:
-    """If Request is instantiated without the 'receive' channel, then .body() is not available."""
-
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        scope.update(create_scope(route_handler=_route_handler))  # type: ignore[typeddict-item]
-        request = Request[Any, Any, State](scope)
-        try:
-            data = await request.json()
-        except RuntimeError:
-            data = "Receive channel not available"
-        response = ASGIResponse(body=encode_json({"json": data}))
-        await response(scope, receive, send)
-
-    client = TestClient(app)
-    response = client.post("/", json={"a": "123"})
-    assert response.json() == {"json": "Receive channel not available"}
+    mock.assert_called_once_with("/he/llo, b'/he%2Fllo'")
 
 
 async def test_request_disconnect(create_scope: Callable[..., Scope]) -> None:
@@ -398,25 +378,22 @@ def test_request_state() -> None:
 
 
 def test_request_cookies() -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        request = Request[Any, Any, State](scope, receive)
+    @get("/")
+    def handler(request: Request) -> ASGIResponse:
         mycookie = request.cookies.get("mycookie")
         if mycookie:
-            asgi_response = ASGIResponse(body=mycookie.encode("utf-8"), media_type="text/plain")
-        else:
-            asgi_response = ASGIResponse(
-                body=b"Hello, world!",
-                media_type="text/plain",
-                cookies=[Cookie(key="mycookie", value="Hello, cookies!")],
-            )
+            return ASGIResponse(body=mycookie.encode("utf-8"), media_type="text/plain")
+        return ASGIResponse(
+            body=b"Hello, world!",
+            media_type="text/plain",
+            cookies=[Cookie(key="mycookie", value="Hello, cookies!")],
+        )
 
-        await asgi_response(scope, receive, send)
-
-    client = TestClient(app)
-    response = client.get("/")
-    assert response.text == "Hello, world!"
-    response = client.get("/")
-    assert response.text == "Hello, cookies!"
+    with create_test_client(handler) as client:
+        response = client.get("/")
+        assert response.text == "Hello, world!"
+        response = client.get("/")
+        assert response.text == "Hello, cookies!"
 
 
 def test_chunked_encoding() -> None:
@@ -436,7 +413,8 @@ def test_chunked_encoding() -> None:
 
 
 def test_request_send_push_promise() -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+    @asgi("/")
+    async def handler(scope: Scope, receive: Receive, send: Send) -> None:
         # the server is push-enabled
         scope["extensions"]["http.response.push"] = {}  # type: ignore[index]
 
@@ -446,9 +424,9 @@ def test_request_send_push_promise() -> None:
         response = ASGIResponse(body=encode_json({"json": "OK"}))
         await response(scope, receive, send)
 
-    client = TestClient(app)
-    response = client.get("/")
-    assert response.json() == {"json": "OK"}
+    with create_test_client([handler]) as client:
+        response = client.get("/")
+        assert response.json() == {"json": "OK"}
 
 
 def test_request_send_push_promise_without_push_extension() -> None:
@@ -457,18 +435,15 @@ def test_request_send_push_promise_without_push_extension() -> None:
     .send_push_promise() does nothing.
     """
 
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        request = Request[Any, Any, State](scope)
-
+    @get("/")
+    async def handler(request: Request) -> str:
         with pytest.warns(LitestarWarning, match="Attempted to send a push promise"):
             await request.send_push_promise("/style.css")
+        return "Ok"
 
-        response = ASGIResponse(body=encode_json({"json": "OK"}))
-        await response(scope, receive, send)
-
-    client = TestClient(app)
-    response = client.get("/")
-    assert response.json() == {"json": "OK"}
+    with create_test_client([handler]) as client:
+        response = client.get("/")
+        assert response.text == "Ok"
 
 
 def test_request_send_push_promise_without_push_extension_raises() -> None:
@@ -477,40 +452,14 @@ def test_request_send_push_promise_without_push_extension_raises() -> None:
     .send_push_promise() does nothing.
     """
 
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        request = Request[Any, Any, State](scope)
+    @get("/")
+    async def handler(request: Request) -> str:
+        await request.send_push_promise("/style.css", raise_if_unavailable=True)
+        return "Ok"
 
+    with create_test_client([handler], raise_server_exceptions=True) as client:
         with pytest.raises(LitestarException, match="Attempted to send a push promise"):
-            await request.send_push_promise("/style.css", raise_if_unavailable=True)
-
-        response = ASGIResponse(body=encode_json({"json": "OK"}))
-        await response(scope, receive, send)
-
-    TestClient(app).get("/")
-
-
-def test_request_send_push_promise_without_setting_send() -> None:
-    """If Request is instantiated without the send channel, then.
-
-    .send_push_promise() is not available.
-    """
-
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        # the server is push-enabled
-        scope["extensions"]["http.response.push"] = {}  # type: ignore[index]
-
-        data = "OK"
-        request = Request[Any, Any, State](scope)
-        try:
-            await request.send_push_promise("/style.css")
-        except RuntimeError:
-            data = "Send channel not available"
-        response = ASGIResponse(body=encode_json({"json": data}))
-        await response(scope, receive, send)
-
-    client = TestClient(app)
-    response = client.get("/")
-    assert response.json() == {"json": "Send channel not available"}
+            client.get("/")
 
 
 class BeforeRequestMiddleWare(MiddlewareProtocol):

--- a/tests/unit/test_connection/test_websocket.py
+++ b/tests/unit/test_connection/test_websocket.py
@@ -49,7 +49,7 @@ def test_route_handler_property() -> None:
         value["handler"] = socket.route_handler
         await socket.close()
 
-    with create_test_client(route_handlers=[handler]).websocket_connect("/"):
+    with create_test_client(route_handlers=[handler]) as client, client.websocket_connect("/"):
         assert str(value["handler"]) == str(handler)
 
 
@@ -91,7 +91,10 @@ async def test_custom_websocket_class() -> None:
         await socket.accept()
         await socket.close()
 
-    with create_test_client(route_handlers=[handler], websocket_class=MyWebSocket).websocket_connect("/"):
+    with (
+        create_test_client(route_handlers=[handler], websocket_class=MyWebSocket) as client,
+        client.websocket_connect("/"),
+    ):
         assert value["called"]
 
 

--- a/tests/unit/test_contrib/test_opentelemetry.py
+++ b/tests/unit/test_contrib/test_opentelemetry.py
@@ -124,10 +124,11 @@ def test_open_telemetry_middleware_with_websocket_route(
         await socket.send_json({"hello": "world"})
         await socket.close()
 
-    with create_test_client(handler, middleware=app_config.middleware, plugins=app_config.plugins).websocket_connect(
-        "/"
-    ) as client:
-        data = client.receive_json()
+    with (
+        create_test_client(handler, middleware=app_config.middleware, plugins=app_config.plugins) as client,
+        client.websocket_connect("/") as ws_client,
+    ):
+        data = ws_client.receive_json()
         assert data == {"hello": "world"}
 
         first_span, second_span, third_span, fourth_span, fifth_span = cast(

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -79,9 +79,10 @@ def test_controller_with_websocket_handler() -> None:
             await socket.send_json({"data": "123"})
             await socket.close()
 
-    client = create_test_client(route_handlers=MyController)
-
-    with client.websocket_connect(f"{test_path}/socket") as ws:
+    with (
+        create_test_client(route_handlers=MyController) as client,
+        client.websocket_connect(f"{test_path}/socket") as ws,
+    ):
         ws.send_json({"data": "123"})
         data = ws.receive_json()
         assert data

--- a/tests/unit/test_guards.py
+++ b/tests/unit/test_guards.py
@@ -85,15 +85,14 @@ def test_guards_with_websocket_handler(local_guard: Guard) -> None:
         await socket.send_json({"data": "123"})
         await socket.close()
 
-    client = create_test_client(route_handlers=my_websocket_route_handler)
+    with create_test_client(route_handlers=my_websocket_route_handler) as client:
+        with pytest.RaisesGroup(pytest.RaisesExc(WebSocketDisconnect)), client.websocket_connect("/") as ws:
+            ws.send_json({"data": "123"})
 
-    with pytest.RaisesGroup(pytest.RaisesExc(WebSocketDisconnect)), client.websocket_connect("/") as ws:
-        ws.send_json({"data": "123"})
+        client.app.asgi_router.root_route_map_node.children["/"].asgi_handlers["websocket"][1].opt["allow_all"] = True
 
-    client.app.asgi_router.root_route_map_node.children["/"].asgi_handlers["websocket"][1].opt["allow_all"] = True
-
-    with client.websocket_connect("/") as ws:
-        ws.send_json({"data": "123"})
+        with client.websocket_connect("/") as ws:
+            ws.send_json({"data": "123"})
 
 
 def test_guard_ordering(local_guard: Guard, router_guard: Guard, app_guard: Guard) -> None:

--- a/tests/unit/test_handlers/test_websocket_handlers/test_handle_websocket.py
+++ b/tests/unit/test_handlers/test_websocket_handlers/test_handle_websocket.py
@@ -16,9 +16,7 @@ def test_handle_websocket() -> None:
         await socket.send_json({"data": "123"})
         await socket.close()
 
-    client = create_test_client(route_handlers=simple_websocket_handler)
-
-    with client.websocket_connect("/") as ws:
+    with create_test_client(route_handlers=simple_websocket_handler) as client, client.websocket_connect("/") as ws:
         ws.send_json({"data": "123"})
         data = ws.receive_json()
         assert data
@@ -46,9 +44,10 @@ def test_websocket_signature_namespace() -> None:
 
     router = Router("/", route_handlers=[MyController], signature_namespace={"b": str})
 
-    client = create_test_client(route_handlers=[router], signature_namespace={"a": int})
-
-    with client.websocket_connect("/ws?a=1&b=two&c=3.0&d=d") as ws:
+    with (
+        create_test_client(route_handlers=[router], signature_namespace={"a": int}) as client,
+        client.websocket_connect("/ws?a=1&b=two&c=3.0&d=d") as ws,
+    ):
         ws.send_json({"data": "123"})
         data = ws.receive_json()
         assert data == {"a": 1, "b": "two", "c": 3.0, "d": ["d"]}

--- a/tests/unit/test_handlers/test_websocket_handlers/test_handle_websocket_with_future_annotations.py
+++ b/tests/unit/test_handlers/test_websocket_handlers/test_handle_websocket_with_future_annotations.py
@@ -13,9 +13,7 @@ def test_handle_websocket() -> None:
         await socket.send_json({"data": "123"})
         await socket.close()
 
-    client = create_test_client(route_handlers=simple_websocket_handler)
-
-    with client.websocket_connect("/") as ws:
+    with create_test_client(route_handlers=simple_websocket_handler) as client, client.websocket_connect("/") as ws:
         ws.send_json({"data": "123"})
         data = ws.receive_json()
         assert data

--- a/tests/unit/test_handlers/test_websocket_handlers/test_kwarg_handling.py
+++ b/tests/unit/test_handlers/test_websocket_handlers/test_kwarg_handling.py
@@ -26,12 +26,11 @@ def test_handle_websocket_params_parsing() -> None:
         await socket.send_json({"data": "123"})
         await socket.close()
 
-    client = create_test_client(route_handlers=websocket_handler)
+    with create_test_client(route_handlers=websocket_handler) as client:
+        # Set cookies on the client to avoid warnings about per-request cookies.
+        client.cookies = {"cookie": "yum"}
 
-    # Set cookies on the client to avoid warnings about per-request cookies.
-    client.cookies = {"cookie": "yum"}
-
-    with client.websocket_connect("/1?qp=1", headers={"some-header": "abc"}) as ws:
-        ws.send_json({"data": "123"})
-        data = ws.receive_json()
-        assert data
+        with client.websocket_connect("/1?qp=1", headers={"some-header": "abc"}) as ws:
+            ws.send_json({"data": "123"})
+            data = ws.receive_json()
+            assert data

--- a/tests/unit/test_handlers/test_websocket_handlers/test_listeners.py
+++ b/tests/unit/test_handlers/test_websocket_handlers/test_listeners.py
@@ -60,8 +60,7 @@ def async_listener_callable(mock: MagicMock) -> WebsocketListenerRouteHandler:
 def test_basic_listener(
     mock: MagicMock, listener: Union[WebsocketListenerRouteHandler, type[WebsocketListener]]
 ) -> None:
-    client = create_test_client([listener])
-    with client.websocket_connect("/") as ws:
+    with create_test_client([listener]) as client, client.websocket_connect("/") as ws:
         ws.send_text("foo")
         assert ws.receive_text() == "foo"
         ws.send_text("bar")
@@ -124,8 +123,7 @@ def test_listener_receive_with_dto(receive_mode: WebSocketMode) -> None:
         nonlocal value
         value = data
 
-    client = create_test_client([handler], openapi_config=None)
-    with client.websocket_connect("/") as ws:
+    with create_test_client([handler], openapi_config=None) as client, client.websocket_connect("/") as ws:
         ws.send_json({"name": "litestar user", "hidden": "whoops"}, mode=receive_mode)
 
     assert isinstance(value, User)
@@ -287,8 +285,7 @@ def test_connection_callbacks() -> None:
     def handler(data: bytes) -> None:
         pass
 
-    client = create_test_client([handler])
-    with client.websocket_connect("/"):
+    with create_test_client([handler]) as client, client.websocket_connect("/"):
         pass
 
     on_accept_mock.assert_called_once()
@@ -311,8 +308,7 @@ def test_connection_lifespan() -> None:
     def handler(data: bytes) -> None:
         pass
 
-    client = create_test_client([handler])
-    with client.websocket_connect("/", timeout=1):
+    with create_test_client([handler]) as client, client.websocket_connect("/", timeout=1):
         pass
 
     on_accept.assert_called_once()

--- a/tests/unit/test_middleware/test_base_authentication_middleware.py
+++ b/tests/unit/test_middleware/test_base_authentication_middleware.py
@@ -58,13 +58,14 @@ def test_authentication_middleware_http_routes() -> None:
         assert isinstance(request.user, User)
         assert isinstance(request.auth, Auth)
 
-    client = create_test_client(route_handlers=[http_route_handler], middleware=[AuthMiddleware])
     token = "abc"
-    error_response = client.get("/", headers={"Authorization": token})
-    assert error_response.status_code == HTTP_403_FORBIDDEN
-    state[token] = AuthenticationResult(user=user, auth=auth)
-    success_response = client.get("/", headers={"Authorization": token})
-    assert success_response.status_code == HTTP_200_OK
+
+    with create_test_client(route_handlers=[http_route_handler], middleware=[AuthMiddleware]) as client:
+        error_response = client.get("/", headers={"Authorization": token})
+        assert error_response.status_code == HTTP_403_FORBIDDEN
+        state[token] = AuthenticationResult(user=user, auth=auth)
+        success_response = client.get("/", headers={"Authorization": token})
+        assert success_response.status_code == HTTP_200_OK
 
 
 def test_authentication_middleware_not_installed_raises_for_user_scope_http() -> None:
@@ -72,8 +73,8 @@ def test_authentication_middleware_not_installed_raises_for_user_scope_http() ->
     def http_route_handler_user_scope(request: Request[User, None, Any]) -> None:
         assert request.user
 
-    client = create_test_client(route_handlers=[http_route_handler_user_scope])
-    error_response = client.get("/", headers={"Authorization": "nope"})
+    with create_test_client(route_handlers=[http_route_handler_user_scope]) as client:
+        error_response = client.get("/", headers={"Authorization": "nope"})
     assert error_response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
 
 
@@ -82,8 +83,8 @@ def test_authentication_middleware_not_installed_raises_for_auth_scope_http() ->
     def http_route_handler_auth_scope(request: Request[None, Auth, Any]) -> None:
         assert request.auth
 
-    client = create_test_client(route_handlers=[http_route_handler_auth_scope])
-    error_response = client.get("/", headers={"Authorization": "nope"})
+    with create_test_client(route_handlers=[http_route_handler_auth_scope]) as client:
+        error_response = client.get("/", headers={"Authorization": "nope"})
     assert error_response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
 
 
@@ -99,14 +100,18 @@ async def websocket_route_handler(socket: WebSocket[User, Auth, Any]) -> None:
 
 def test_authentication_middleware_websocket_routes() -> None:
     token = "abc"
-    client = create_test_client(route_handlers=websocket_route_handler, middleware=[AuthMiddleware])
     with (
+        create_test_client(route_handlers=websocket_route_handler, middleware=[AuthMiddleware]) as client,
         pytest.RaisesGroup(pytest.RaisesExc(WebSocketDisconnect)),
         client.websocket_connect("/", headers={"Authorization": token}) as ws,
     ):
         assert ws.receive_json()
+
     state[token] = AuthenticationResult(user=user, auth=auth)
-    with client.websocket_connect("/", headers={"Authorization": token}) as ws:
+    with (
+        create_test_client(route_handlers=websocket_route_handler, middleware=[AuthMiddleware]) as client,
+        client.websocket_connect("/", headers={"Authorization": token}) as ws,
+    ):
         assert ws.receive_json()
 
 
@@ -116,8 +121,8 @@ def test_authentication_middleware_not_installed_raises_for_user_scope_websocket
         await socket.accept()
         assert isinstance(socket.user, User)
 
-    client = create_test_client(route_handlers=route_handler)
     with (
+        create_test_client(route_handlers=route_handler) as client,
         pytest.RaisesGroup(pytest.RaisesExc(WebSocketDisconnect)),
         client.websocket_connect("/", headers={"Authorization": "yep"}) as ws,
     ):
@@ -130,8 +135,8 @@ def test_authentication_middleware_not_installed_raises_for_auth_scope_websocket
         await socket.accept()
         assert isinstance(socket.auth, Auth)
 
-    client = create_test_client(route_handlers=route_handler)
     with (
+        create_test_client(route_handlers=route_handler) as client,
         pytest.RaisesGroup(pytest.RaisesExc(WebSocketDisconnect)),
         client.websocket_connect("/", headers={"Authorization": "yep"}) as ws,
     ):

--- a/tests/unit/test_middleware/test_compression_middleware.py
+++ b/tests/unit/test_middleware/test_compression_middleware.py
@@ -144,10 +144,13 @@ async def test_skips_for_websocket() -> None:
         await socket.send_json(data)
         await socket.close()
 
-    with create_test_client(
-        route_handlers=[websocket_handler],
-        compression_config=CompressionConfig(backend="brotli", brotli_gzip_fallback=False),
-    ).websocket_connect("/") as ws:
+    with (
+        create_test_client(
+            route_handlers=[websocket_handler],
+            compression_config=CompressionConfig(backend="brotli", brotli_gzip_fallback=False),
+        ) as client,
+        client.websocket_connect("/") as ws,
+    ):
         assert b"content-encoding" not in dict(ws.scope["headers"])
 
 

--- a/tests/unit/test_response/test_redirect_response.py
+++ b/tests/unit/test_response/test_redirect_response.py
@@ -13,55 +13,28 @@ import pytest
 from litestar import get
 from litestar.datastructures import MultiDict
 from litestar.exceptions import ImproperlyConfiguredException
-from litestar.response.base import ASGIResponse
 from litestar.response.redirect import ASGIRedirectResponse, Redirect
 from litestar.status_codes import HTTP_200_OK
-from litestar.testing import TestClient, create_test_client
+from litestar.testing import create_test_client
 
 if TYPE_CHECKING:
-    from litestar.types import Receive, Scope, Send
+    pass
 
 
 def test_redirect_response() -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["path"] == "/":
-            response = ASGIResponse(body=b"hello, world", media_type="text/plain")
-        else:
-            response = ASGIRedirectResponse(path="/")
-        await response(scope, receive, send)
+    @get("/redirect")
+    def redirect() -> Redirect:
+        return Redirect(path="/")
 
-    client = TestClient(app)
-    response = client.get("/redirect")
-    assert response.text == "hello, world"
-    assert response.url == "http://testserver.local/"
+    @get("/")
+    def index() -> str:
+        return "hello, world"
 
-
-def test_quoting_redirect_response() -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["path"] == "/test/":
-            response = ASGIResponse(body=b"hello, world", media_type="text/plain")
-        else:
-            response = ASGIRedirectResponse(path="/test/")
-        await response(scope, receive, send)
-
-    client = TestClient(app)
-    response = client.get("/redirect", follow_redirects=True)
-    assert response.text == "hello, world"
-    assert str(response.url) == "http://testserver.local/test/"
-
-
-def test_redirect_response_content_length_header() -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["path"] == "/":
-            response = ASGIResponse(body=b"hello", media_type="text/plain")
-        else:
-            response = ASGIRedirectResponse(path="/")
-        await response(scope, receive, send)
-
-    client: TestClient = TestClient(app)
-    response = client.request("GET", "/redirect", follow_redirects=False)
-    assert str(response.url) == "http://testserver.local/redirect"
-    assert "content-length" in response.headers
+    with create_test_client([redirect, index], raise_server_exceptions=True) as client:
+        response = client.get("/redirect")
+        assert response.text == "hello, world"
+        assert response.url == "http://testserver.local/"
+        assert "content-length" in response.headers
 
 
 def test_redirect_response_status_validation() -> None:
@@ -70,17 +43,18 @@ def test_redirect_response_status_validation() -> None:
 
 
 def test_redirect_response_html_media_type() -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["path"] == "/":
-            response = ASGIResponse(body=b"hello")
-        else:
-            response = ASGIRedirectResponse(path="/", media_type="text/html")
-        await response(scope, receive, send)
+    @get("/redirect")
+    def redirect() -> Redirect:
+        return Redirect(path="/", media_type="text/html")
 
-    client: TestClient = TestClient(app)
-    response = client.request("GET", "/redirect", follow_redirects=False)
-    assert str(response.url) == "http://testserver.local/redirect"
-    assert "text/html" in str(response.headers["Content-Type"])
+    @get("/")
+    def index() -> str:
+        return "hello"
+
+    with create_test_client([index, redirect]) as client:
+        response = client.request("GET", "/redirect", follow_redirects=False)
+        assert str(response.url) == "http://testserver.local/redirect"
+        assert "text/html" in str(response.headers["Content-Type"])
 
 
 def test_redirect_response_media_type_validation() -> None:

--- a/tests/unit/test_response/test_streaming_response.py
+++ b/tests/unit/test_response/test_streaming_response.py
@@ -12,26 +12,34 @@ from typing import TYPE_CHECKING
 
 import anyio
 
+from litestar import asgi, get
 from litestar.background_tasks import BackgroundTask
 from litestar.response.streaming import ASGIStreamingResponse
-from litestar.testing import TestClient
+from litestar.testing import create_test_client
 
 if TYPE_CHECKING:
     from litestar.types import Message, Receive, Scope, Send
 
 
 def test_streaming_response_unknown_size() -> None:
-    app = ASGIStreamingResponse(iterator=iter(["hello", "world"]))
-    client = TestClient(app)
-    response = client.get("/")
+    @get("/")
+    async def handler() -> ASGIStreamingResponse:
+        return ASGIStreamingResponse(iterator=iter(["hello", "world"]))
+
+    with create_test_client(handler) as client:
+        response = client.get("/")
+
     assert "content-length" not in response.headers
 
 
 def test_streaming_response_known_size() -> None:
-    app = ASGIStreamingResponse(iterator=iter(["hello", "world"]), headers={"content-length": "10"})
-    client = TestClient(app)
-    response = client.get("/")
-    assert response.headers["content-length"] == "10"
+    @get("/")
+    async def handler() -> ASGIStreamingResponse:
+        return ASGIStreamingResponse(iterator=iter(["hello", "world"]), headers={"content-length": "10"})
+
+    with create_test_client(handler) as client:
+        response = client.get("/")
+        assert response.headers["content-length"] == "10"
 
 
 async def test_streaming_response_stops_if_receiving_http_disconnect_with_async_iterator(anyio_backend: str) -> None:
@@ -91,7 +99,8 @@ async def test_streaming_response_stops_if_receiving_http_disconnect_with_sync_i
 def test_streaming_response() -> None:
     filled_by_bg_task = ""
 
-    async def app(scope: "Scope", receive: "Receive", send: "Send") -> None:
+    @asgi("/")
+    async def handler(scope: "Scope", receive: "Receive", send: "Send") -> None:
         async def numbers(minimum: int, maximum: int) -> AsyncIterator[str]:
             for i in range(minimum, maximum + 1):
                 yield str(i)
@@ -110,14 +119,15 @@ def test_streaming_response() -> None:
         await response(scope, receive, send)
 
     assert not filled_by_bg_task
-    client = TestClient(app)
-    response = client.get("/")
-    assert response.text == "1, 2, 3, 4, 5"
-    assert filled_by_bg_task == "6, 7, 8, 9"  # type: ignore[comparison-overlap]
+    with create_test_client([handler]) as client:
+        response = client.get("/")
+        assert response.text == "1, 2, 3, 4, 5"
+        assert filled_by_bg_task == "6, 7, 8, 9"  # type: ignore[comparison-overlap]
 
 
 def test_streaming_response_custom_iterator() -> None:
-    async def app(scope: "Scope", receive: "Receive", send: "Send") -> None:
+    @asgi("/")
+    async def handler(scope: "Scope", receive: "Receive", send: "Send") -> None:
         class CustomAsyncIterator:
             def __init__(self) -> None:
                 self._called = 0
@@ -134,13 +144,14 @@ def test_streaming_response_custom_iterator() -> None:
         response = ASGIStreamingResponse(iterator=CustomAsyncIterator(), media_type="text/plain")
         await response(scope, receive, send)
 
-    client = TestClient(app)
-    response = client.get("/")
-    assert response.text == "12345"
+    with create_test_client([handler]) as client:
+        response = client.get("/")
+        assert response.text == "12345"
 
 
 def test_streaming_response_custom_iterable() -> None:
-    async def app(scope: "Scope", receive: "Receive", send: "Send") -> None:
+    @asgi("/")
+    async def handler(scope: "Scope", receive: "Receive", send: "Send") -> None:
         class CustomAsyncIterable:
             async def __aiter__(self) -> AsyncIterator[str]:
                 for i in range(5):
@@ -149,13 +160,14 @@ def test_streaming_response_custom_iterable() -> None:
         response = ASGIStreamingResponse(iterator=CustomAsyncIterable(), media_type="text/plain")
         await response(scope, receive, send)
 
-    client = TestClient(app)
-    response = client.get("/")
-    assert response.text == "12345"
+    with create_test_client([handler]) as client:
+        response = client.get("/")
+        assert response.text == "12345"
 
 
 def test_sync_streaming_response() -> None:
-    async def app(scope: "Scope", receive: "Receive", send: "Send") -> None:
+    @asgi("/")
+    async def handler(scope: "Scope", receive: "Receive", send: "Send") -> None:
         def numbers(minimum: int, maximum: int) -> Iterator[str]:
             for i in range(minimum, maximum + 1):
                 yield str(i)
@@ -166,6 +178,6 @@ def test_sync_streaming_response() -> None:
         response = ASGIStreamingResponse(iterator=generator, media_type="text/plain")
         await response(scope, receive, send)
 
-    client = TestClient(app)
-    response = client.get("/")
-    assert response.text == "1, 2, 3, 4, 5"
+    with create_test_client([handler]) as client:
+        response = client.get("/")
+        assert response.text == "1, 2, 3, 4, 5"

--- a/tests/unit/test_testing/test_test_client.py
+++ b/tests/unit/test_testing/test_test_client.py
@@ -7,6 +7,7 @@ import anyio
 from _pytest.fixtures import FixtureRequest
 
 from litestar import Controller, Request, WebSocket, delete, head, patch, put, websocket
+from litestar.exceptions import LitestarWarning
 from litestar.middleware.session.base import BaseBackendConfig
 from litestar.status_codes import HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT
 from litestar.stores.base import Store
@@ -435,6 +436,12 @@ def test_websocket_connect(anyio_backend: "AnyIOBackend") -> None:
             assert data == {"data": "123"}
 
 
+def test_client_warns_not_initialized() -> None:
+    with pytest.warns(LitestarWarning, match="TestClient not initialized"):
+        client = create_test_client()
+        client.get("/")
+
+
 # ASYNC TESTS
 @pytest.mark.parametrize("block,exception", [(True, TimeoutError), (False, anyio.WouldBlock)])
 @pytest.mark.parametrize(
@@ -574,3 +581,9 @@ async def test_lifespan_uses_native_loop() -> None:
 
     async with create_async_test_client([], lifespan=[lifespan]) as client:
         assert client.app.state["loop"] is asyncio.get_running_loop()
+
+
+async def test_client_warns_not_initialized_async() -> None:
+    with pytest.warns(LitestarWarning, match="AsyncTestClient not initialized"):
+        client = create_async_test_client()
+        await client.get("/")


### PR DESCRIPTION
Raise a warning if instances of `TestClient` / `AsyncTestClient` aren't being used as context managers. Not doing this skips lifespan, which makes the client behave differently in tests than with a real ASGI server.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4743">https://litestar-org.github.io/litestar-docs-preview/4743</a> 
