### PR TITLE
refactor!: remove deprecated msgspec contrib namespace

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,7 +151,6 @@ nitpick_ignore = [
     # types in changelog that no longer exist
     (PY_ATTR, "litestar.dto.factory.DTOConfig.underscore_fields_private"),
     (PY_CLASS, "anyio.abc.BlockingPortal"),
-    (PY_CLASS, "litestar.contrib.msgspec.MsgspecDTO"),
     (PY_CLASS, "litestar.contrib.repository.filters.NotInCollectionFilter"),
     (PY_CLASS, "litestar.contrib.repository.filters.NotInSearchFilter"),
     (PY_CLASS, "litestar.contrib.repository.filters.OnBeforeAfter"),

--- a/docs/migration_guide_3.rst
+++ b/docs/migration_guide_3.rst
@@ -1,0 +1,19 @@
+:orphan:
+
+Removal of Deprecated msgspec Contrib Namespace
+===============================================
+
+The deprecated msgspec contrib namespace has been removed in this release.
+
+How to Migrate
+--------------
+
+Existing code that imports ``MsgspecDTO`` from the deprecated contrib namespace must be updated to use the new canonical location.
+
+The canonical replacement for ``MsgspecDTO`` is now located at ``litestar.dto.MsgspecDTO``.
+
+You can import it directly from ``litestar.dto``:
+
+.. code-block:: python
+
+    from litestar.dto import MsgspecDTO

--- a/docs/release-notes/2.x-changelog.rst
+++ b/docs/release-notes/2.x-changelog.rst
@@ -2703,7 +2703,7 @@
         DTO factories for `msgspec <https://jcristharif.com/msgspec/>`_ and
         `Pydantic <https://docs.pydantic.dev/latest/>`_ have been added:
 
-        - :class:`~litestar.contrib.msgspec.MsgspecDTO`
+        - :class:`~litestar.dto.MsgspecDTO`
         - ``PydanticDTO``
 
     .. change:: DTOs: Arbitrary generic wrappers

--- a/docs/release-notes/whats-new-3.rst
+++ b/docs/release-notes/whats-new-3.rst
@@ -344,3 +344,9 @@ startup.
 .. seealso::
 
     :ref:`usage/middleware/creating-middleware:Configuration constraints`
+
+
+Removal of ``litestar.contrib.msgspec``
+---------------------------------------
+
+The deprecated ``litestar.contrib.msgspec`` namespace has been removed. ``MsgspecDTO`` can now be imported directly from its new canonical location at ``litestar.dto``.

--- a/tests/unit/test_dto/test_msgspec_dto.py
+++ b/tests/unit/test_dto/test_msgspec_dto.py
@@ -18,6 +18,11 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
+def int_factory() -> Callable[[], int]:
+    return lambda: 2
+
+
+@pytest.fixture
 def expected_field_defs(int_factory: Callable[[], int]) -> list[DTOFieldDefinition]:
     return [
         DTOFieldDefinition.from_field_definition(


### PR DESCRIPTION

## Description

This PR finalizes the removal of the deprecated `litestar.contrib.msgspec` namespace, completing the migration of `MsgspecDTO` into the core `litestar.dto` module. 

Since `MsgspecDTO` is fully supported natively, the old contrib namespace is no longer necessary and has been safely purged. 

### Changes Included:
* **Test Migration**: Moved `tests/unit/test_contrib/test_msgspec.py` to `tests/unit/test_dto/test_msgspec_dto.py` to correctly test the canonical DTO class without relying on the deprecated path.
* **Documentation**:
  * Removed stale `nitpick_ignore` references in `docs/conf.py`.
  * Added clear upgrade instructions in `docs/migration_guide_3.rst`.
  * Added a summary of the removal to the release notes in `docs/release-notes/whats-new-3.rst`.

## Breaking Change
**Yes** – Users who are still importing `MsgspecDTO` from `litestar.contrib.msgspec` will experience `ImportError`s.

**Migration path:**
Update imports to use the canonical location:
```python
# Before
from litestar.contrib.msgspec import MsgspecDTO

# After
from litestar.dto import MsgspecDTO
