### PR TITLE
feat(middleware): add W3C Trace Context correlation middleware

### DIFF
--- a/docs/reference/middleware/correlation.rst
+++ b/docs/reference/middleware/correlation.rst
@@ -1,0 +1,5 @@
+correlation
+===========
+
+.. automodule:: litestar.middleware.correlation
+    :members:

--- a/docs/reference/middleware/index.rst
+++ b/docs/reference/middleware/index.rst
@@ -10,6 +10,7 @@ middleware
     allowed_hosts
     authentication
     compression
+    correlation
     csrf
     logging
     rate_limit

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -25,6 +25,20 @@
         sends SSE comment keepalive pings at the specified interval to prevent connection timeouts from reverse proxies
         or clients.
 
+    .. change:: Add W3C Trace Context correlation middleware
+        :type: feature
+        :issue: 4719
+
+        Added :class:`~litestar.middleware.correlation.CorrelationMiddleware`, an ASGI middleware that reads a
+        distributed-trace correlation ID from a configurable list of request headers (W3C ``traceparent`` plus
+        cloud-vendor and generic fallbacks) and propagates it via :class:`~contextvars.ContextVar` so handlers and
+        loggers can access it through :class:`~litestar.middleware.correlation.CorrelationContext`. A fresh UUID4 is
+        generated when no header matches; malformed ``traceparent`` values are stored as-is rather than raising.
+
+        The :class:`~litestar.contrib.opentelemetry.OpenTelemetryPlugin` can auto-inject the middleware ahead of its
+        instrumentation when :attr:`~litestar.contrib.opentelemetry.OpenTelemetryConfig.enable_correlation_middleware`
+        is true. The middleware itself has no OpenTelemetry dependency and works standalone.
+
     .. change:: Remove logging config and related constructs
         :type: feature
         :breaking:

--- a/docs/usage/metrics/open-telemetry.rst
+++ b/docs/usage/metrics/open-telemetry.rst
@@ -34,3 +34,18 @@ exporter to use these (see the
 
 You can also pass con figuration to the ``OpenTelemetryConfig`` telling it which providers to use. Consult
 :class:`reference docs <litestar.contrib.opentelemetry.OpenTelemetryConfig>` regarding the configuration options you can use.
+
+Trace context correlation
+-------------------------
+
+Set
+:attr:`OpenTelemetryConfig.enable_correlation_middleware <litestar.contrib.opentelemetry.OpenTelemetryConfig.enable_correlation_middleware>`
+to ``True`` and the plugin will inject
+:class:`~litestar.middleware.correlation.CorrelationMiddleware` ahead of its
+instrumentation. The middleware reads a W3C ``traceparent`` (or one of a
+configurable list of cloud-vendor / generic fallback headers) and exposes
+the value to handlers and loggers via
+:class:`~litestar.middleware.correlation.CorrelationContext`. It works
+standalone as well — see
+:doc:`/usage/middleware/correlation` for usage patterns, the logging-filter
+recipe, and the full configuration surface.

--- a/docs/usage/middleware/builtin-middleware.rst
+++ b/docs/usage/middleware/builtin-middleware.rst
@@ -162,6 +162,21 @@ list of domains to :class:`~litestar.app.Litestar`:
     domain name, not in the middle or end. Doing so will result in a validation exception being raised.
 
 
+Correlation IDs
+---------------
+
+:class:`~litestar.middleware.correlation.CorrelationMiddleware` reads a
+distributed-trace correlation ID from W3C ``traceparent`` (or one of a
+configurable list of cloud-vendor / generic fallback headers) and propagates
+the value through a :class:`~contextvars.ContextVar` so handlers, dependencies,
+and loggers can access it for the duration of a request. When no header
+matches, a fresh W3C-compliant ``traceparent`` is generated.
+
+See :doc:`/usage/middleware/correlation` for usage patterns including
+standalone wiring, the logging-filter recipe, and integration with the
+:class:`~litestar.contrib.opentelemetry.OpenTelemetryPlugin`.
+
+
 Compression
 -----------
 

--- a/docs/usage/middleware/correlation.rst
+++ b/docs/usage/middleware/correlation.rst
@@ -1,0 +1,165 @@
+Correlation IDs
+===============
+
+:class:`~litestar.middleware.correlation.CorrelationMiddleware` reads a
+distributed-trace correlation ID from a configurable list of request headers
+and propagates it through a :class:`~contextvars.ContextVar` so handlers,
+dependencies, and loggers can read it for the duration of a request.
+
+The middleware is a *propagation primitive*: it stores the **entire raw
+header value** unchanged. For W3C ``traceparent`` that means the full
+``version-trace_id-parent_id-flags`` quadruple — preserving the parent-span
+ID and the sample-flag bit so downstream services can forward the value
+verbatim. For cloud-vendor headers (AWS, GCP, …) the raw vendor format is
+preserved as-is.
+
+When no recognised header is present, the middleware **generates a fresh
+W3C-compliant** ``traceparent`` value (``00-<32 hex>-<16 hex>-01``) so that
+the contextvar value is always something downstream services can parse.
+
+
+Header lookup order
+-------------------
+
+By default the middleware tries the W3C ``traceparent`` header first, then
+the entries of
+:data:`~litestar.middleware.correlation.TRACE_CONTEXT_FALLBACK_HEADERS`:
+
+* ``traceparent`` — W3C Trace Context
+* ``x-amzn-trace-id`` — AWS X-Ray
+* ``x-cloud-trace-context`` — Google Cloud Trace
+* ``x-correlation-id`` — generic
+* ``x-request-id`` — generic / Kubernetes
+
+The first present header wins. To pick a different primary header, pass
+``header=``. To disable the fallback list and only consult the primary
+header, pass ``auto_trace_headers=False``. A custom fallback list can be
+provided via ``fallback_headers=``.
+
+The resolved header lookup order is computed once at construction time —
+not on every request — to keep the per-request hot path to a single header
+dict lookup and a contextvar ``set``/``reset`` pair.
+
+
+Standalone usage
+----------------
+
+The middleware lives in ``litestar.middleware`` and has no OpenTelemetry
+dependency, so it can be used in any Litestar app:
+
+.. code-block:: python
+
+    from litestar import Litestar, get
+    from litestar.middleware.correlation import CorrelationContext, CorrelationMiddleware
+
+
+    @get("/")
+    def index() -> dict[str, str | None]:
+        return {"correlation_id": CorrelationContext.get()}
+
+
+    app = Litestar(route_handlers=[index], middleware=[CorrelationMiddleware()])
+
+
+Reading the correlation ID
+--------------------------
+
+From inside a handler, dependency, or any code running on the request task,
+call :meth:`~litestar.middleware.correlation.CorrelationContext.get`:
+
+.. code-block:: python
+
+    from litestar.middleware.correlation import CorrelationContext
+
+    correlation_id = CorrelationContext.get()  # str | None
+
+Outside of a request scope (e.g. during application startup) the call
+returns ``None``.
+
+If you need only the 32-character W3C trace ID — for example to attach it
+to log records — use the public helper:
+
+.. code-block:: python
+
+    from litestar.middleware.correlation import (
+        CorrelationContext,
+        trace_id_from_traceparent,
+    )
+
+    raw = CorrelationContext.get() or ""
+    trace_id = trace_id_from_traceparent(raw)  # str | None
+
+
+Logging integration
+-------------------
+
+Because the value lives in a ``ContextVar``, a tiny logging filter is enough
+to inject it into every log record:
+
+.. code-block:: python
+
+    import logging
+
+    from litestar.middleware.correlation import CorrelationContext
+
+
+    class CorrelationIdFilter(logging.Filter):
+        def filter(self, record: logging.LogRecord) -> bool:
+            record.correlation_id = CorrelationContext.get() or "-"
+            return True
+
+
+    handler = logging.StreamHandler()
+    handler.addFilter(CorrelationIdFilter())
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s [%(correlation_id)s] %(levelname)s %(message)s")
+    )
+
+For ``structlog`` users, ``CorrelationContext.get()`` can be wired into a
+``contextvars.bind_contextvars`` call or a custom processor.
+
+
+OpenTelemetry integration
+-------------------------
+
+When using the
+:class:`~litestar.contrib.opentelemetry.OpenTelemetryPlugin`, set
+:attr:`~litestar.contrib.opentelemetry.OpenTelemetryConfig.enable_correlation_middleware`
+to ``True`` and the plugin will inject the correlation middleware ahead of
+its instrumentation:
+
+.. code-block:: python
+
+    from litestar import Litestar
+    from litestar.contrib.opentelemetry import OpenTelemetryConfig, OpenTelemetryPlugin
+
+    plugin = OpenTelemetryPlugin(
+        OpenTelemetryConfig(enable_correlation_middleware=True),
+    )
+    app = Litestar(route_handlers=[...], plugins=[plugin])
+
+The OpenTelemetry config exposes the same knobs as the middleware
+constructor (``correlation_header``, ``correlation_headers``,
+``auto_trace_headers``) so you can adjust behaviour without manually
+constructing the middleware.
+
+
+Defensive parsing
+-----------------
+
+A malformed ``traceparent`` value (one that fails W3C validation — wrong
+length, non-hex characters, the reserved ``ff`` version, or an all-zeros
+trace ID or parent ID) is logged at ``DEBUG`` level and stored *as-is*.
+The middleware never raises on bad input — request handling proceeds
+normally with whatever the client sent.
+
+
+.. seealso::
+
+    * :class:`~litestar.middleware.correlation.CorrelationMiddleware` — full API
+    * :class:`~litestar.middleware.correlation.CorrelationContext`
+    * :func:`~litestar.middleware.correlation.trace_id_from_traceparent`
+    * :data:`~litestar.middleware.correlation.TRACE_CONTEXT_FALLBACK_HEADERS`
+    * :doc:`/usage/metrics/open-telemetry` and the
+      :class:`~litestar.contrib.opentelemetry.OpenTelemetryPlugin` for
+      span-level integration

--- a/docs/usage/middleware/index.rst
+++ b/docs/usage/middleware/index.rst
@@ -19,4 +19,5 @@ See :doc:`the documentation regarding these </usage/middleware/builtin-middlewar
 
     using-middleware
     builtin-middleware
+    correlation
     creating-middleware

--- a/litestar/contrib/opentelemetry/config.py
+++ b/litestar/contrib/opentelemetry/config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -10,6 +10,7 @@ from litestar.contrib.opentelemetry.middleware import (
 )
 from litestar.exceptions import MissingDependencyException
 from litestar.middleware.base import DefineMiddleware
+from litestar.middleware.correlation import TRACE_CONTEXT_FALLBACK_HEADERS
 
 __all__ = ("OpenTelemetryConfig",)
 
@@ -92,6 +93,24 @@ class OpenTelemetryConfig:
 
     Should be a subclass of OpenTelemetry
     InstrumentationMiddleware][litestar.contrib.opentelemetry.OpenTelemetryInstrumentationMiddleware].
+    """
+    enable_correlation_middleware: bool = False
+    """If true, the :class:`OpenTelemetryPlugin` injects
+    :class:`~litestar.middleware.correlation.CorrelationMiddleware` ahead of the
+    OpenTelemetry instrumentation middleware so that the W3C trace context is
+    captured into a context variable for handlers and loggers.
+    """
+    correlation_header: str = "traceparent"
+    """Primary header read by the correlation middleware when it is enabled."""
+    correlation_headers: Sequence[str] = TRACE_CONTEXT_FALLBACK_HEADERS
+    """Fallback header list, in priority order, scanned by the correlation
+    middleware after :attr:`correlation_header` when :attr:`auto_trace_headers`
+    is true.
+    """
+    auto_trace_headers: bool = True
+    """If true, the correlation middleware scans :attr:`correlation_headers`
+    after :attr:`correlation_header`. If false, only :attr:`correlation_header`
+    is consulted.
     """
 
     @property

--- a/litestar/contrib/opentelemetry/plugin.py
+++ b/litestar/contrib/opentelemetry/plugin.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from litestar.contrib.opentelemetry.config import OpenTelemetryConfig
 from litestar.contrib.opentelemetry.middleware import OpenTelemetryInstrumentationMiddleware
 from litestar.middleware.base import DefineMiddleware
+from litestar.middleware.correlation import CorrelationMiddleware
 from litestar.plugins import InitPlugin
 
 if TYPE_CHECKING:
@@ -30,6 +31,15 @@ class OpenTelemetryPlugin(InitPlugin):
 
     def on_app_init(self, app_config: AppConfig) -> AppConfig:
         app_config.middleware, _middleware = self._pop_otel_middleware(app_config.middleware)
+        if self.config.enable_correlation_middleware:
+            app_config.middleware.insert(
+                0,
+                CorrelationMiddleware(
+                    header=self.config.correlation_header,
+                    fallback_headers=self.config.correlation_headers,
+                    auto_trace_headers=self.config.auto_trace_headers,
+                ),
+            )
         if self.config.after_exception_hook_handler:
             app_config.after_exception.append(self.config.after_exception_hook_handler)
         return app_config

--- a/litestar/middleware/__init__.py
+++ b/litestar/middleware/__init__.py
@@ -8,12 +8,22 @@ from litestar.middleware.base import (
     DefineMiddleware,
     MiddlewareProtocol,
 )
+from litestar.middleware.correlation import (
+    TRACE_CONTEXT_FALLBACK_HEADERS,
+    CorrelationContext,
+    CorrelationMiddleware,
+    trace_id_from_traceparent,
+)
 
 __all__ = (
+    "TRACE_CONTEXT_FALLBACK_HEADERS",
     "ASGIMiddleware",
     "AbstractAuthenticationMiddleware",
     "AbstractMiddleware",
     "AuthenticationResult",
+    "CorrelationContext",
+    "CorrelationMiddleware",
     "DefineMiddleware",
     "MiddlewareProtocol",
+    "trace_id_from_traceparent",
 )

--- a/litestar/middleware/correlation.py
+++ b/litestar/middleware/correlation.py
@@ -1,0 +1,211 @@
+"""W3C Trace Context correlation middleware.
+
+Reads a correlation/trace ID from a configurable list of request headers
+(W3C ``traceparent`` first, then cloud-vendor and generic fallbacks), generates
+a W3C-compliant ``traceparent`` value when none match, and propagates the
+result through a :class:`contextvars.ContextVar` so handlers and loggers can
+read it.
+
+The middleware is a *propagation primitive*. It stores the **entire raw header
+value** in the context — including the W3C ``version-trace_id-parent_id-flags``
+quadruple, or the full vendor format (e.g. AWS ``Root=...;Parent=...;Sampled=...``).
+This keeps downstream services able to forward the value verbatim and preserves
+the sample-flag bit. Users who want only the 32-character trace ID for log
+records can call :func:`trace_id_from_traceparent` themselves.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextvars import ContextVar, Token
+from typing import TYPE_CHECKING, Final
+from uuid import uuid4
+
+from litestar.datastructures import Headers
+from litestar.enums import ScopeType
+from litestar.middleware.base import ASGIMiddleware
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from litestar.types.asgi_types import ASGIApp, Receive, Scope, Send
+
+__all__ = (
+    "TRACE_CONTEXT_FALLBACK_HEADERS",
+    "CorrelationContext",
+    "CorrelationMiddleware",
+    "trace_id_from_traceparent",
+)
+
+logger = logging.getLogger("litestar")
+
+TRACE_CONTEXT_FALLBACK_HEADERS: Final[tuple[str, ...]] = (
+    "traceparent",
+    "x-amzn-trace-id",
+    "x-cloud-trace-context",
+    "x-correlation-id",
+    "x-request-id",
+)
+"""Priority-ordered fallback header list scanned when ``auto_trace_headers`` is enabled."""
+
+_W3C_TRACEPARENT_HEADER: Final[str] = "traceparent"
+_W3C_TRACE_ID_HEX_LEN: Final[int] = 32
+_W3C_PARENT_ID_HEX_LEN: Final[int] = 16
+_W3C_VERSION_HEX_LEN: Final[int] = 2
+_W3C_FLAGS_HEX_LEN: Final[int] = 2
+_W3C_INVALID_VERSION: Final[str] = "ff"
+"""Per W3C Trace Context spec section 3.2.1, version ``ff`` is reserved as invalid."""
+
+
+_correlation_id_var: ContextVar[str | None] = ContextVar("litestar_correlation_id", default=None)
+
+
+class CorrelationContext:
+    """Static accessor over the per-request correlation ID context variable.
+
+    Use :meth:`get` from inside a route handler, dependency, or logger filter to
+    read the correlation ID set by :class:`CorrelationMiddleware` for the
+    current request. Outside of a request scope, :meth:`get` returns ``None``.
+    """
+
+    @staticmethod
+    def get() -> str | None:
+        """Return the correlation ID for the current request, or ``None`` if unset."""
+        return _correlation_id_var.get()
+
+    @staticmethod
+    def set(value: str) -> Token[str | None]:
+        """Set the correlation ID. Returns a token usable with :meth:`reset`."""
+        return _correlation_id_var.set(value)
+
+    @staticmethod
+    def reset(token: Token[str | None]) -> None:
+        """Reset the correlation ID to its prior value using a token from :meth:`set`."""
+        _correlation_id_var.reset(token)
+
+
+def _is_valid_traceparent(value: str) -> bool:
+    """Return ``True`` if ``value`` matches the W3C ``traceparent`` format.
+
+    Format: ``<version>-<trace_id>-<parent_id>-<flags>`` where each part is
+    lowercase hex of length 2/32/16/2. Version ``ff`` is reserved as invalid
+    per the spec, and trace ID and parent ID must not be all zeros. Never
+    raises.
+    """
+    parts = value.split("-")
+    if len(parts) != 4:
+        return False
+    version, trace_id, parent_id, flags = parts
+    if (
+        len(version) != _W3C_VERSION_HEX_LEN
+        or len(trace_id) != _W3C_TRACE_ID_HEX_LEN
+        or len(parent_id) != _W3C_PARENT_ID_HEX_LEN
+        or len(flags) != _W3C_FLAGS_HEX_LEN
+    ):
+        return False
+    if version.lower() == _W3C_INVALID_VERSION:
+        return False
+    try:
+        int(version, 16)
+        int(trace_id, 16)
+        int(parent_id, 16)
+        int(flags, 16)
+    except ValueError:
+        return False
+    if int(trace_id, 16) == 0 or int(parent_id, 16) == 0:
+        return False
+    return True
+
+
+def trace_id_from_traceparent(value: str) -> str | None:
+    """Extract the 32-character trace ID from a W3C ``traceparent`` value.
+
+    Returns the trace-ID hex string if ``value`` is a well-formed traceparent,
+    otherwise ``None``. Never raises. Useful for log records that want only the
+    trace ID without the parent-span and flags suffix.
+    """
+    if not _is_valid_traceparent(value):
+        return None
+    return value.split("-", 2)[1]
+
+
+def _generate_w3c_traceparent() -> str:
+    """Generate a fresh W3C-compliant ``traceparent`` string.
+
+    Returned in the form ``00-<32 hex>-<16 hex>-01`` so it can be forwarded
+    verbatim as a ``traceparent`` header to downstream services. The sampled
+    flag is set so the trace is recorded.
+    """
+    return f"00-{uuid4().hex}-{uuid4().hex[:_W3C_PARENT_ID_HEX_LEN]}-01"
+
+
+class CorrelationMiddleware(ASGIMiddleware):
+    """ASGI middleware that propagates a W3C trace context / correlation ID.
+
+    On each request the middleware scans, in order, ``header`` and then (if
+    ``auto_trace_headers`` is true) the entries of ``fallback_headers``. The
+    first present header's value is stored verbatim in :class:`CorrelationContext`
+    for the duration of the request. If no header is present, a fresh
+    W3C-compliant ``traceparent`` string is generated.
+
+    A malformed ``traceparent`` (one that fails W3C validation) is logged at
+    DEBUG level and stored as-is — the middleware never raises on bad input.
+
+    The stored value is the **entire raw header**, preserving everything needed
+    for downstream propagation. Use :func:`trace_id_from_traceparent` if you
+    need only the 32-character trace ID portion.
+    """
+
+    scopes = (ScopeType.HTTP, ScopeType.WEBSOCKET)
+
+    def __init__(
+        self,
+        header: str = _W3C_TRACEPARENT_HEADER,
+        fallback_headers: Sequence[str] = TRACE_CONTEXT_FALLBACK_HEADERS,
+        auto_trace_headers: bool = True,
+    ) -> None:
+        """Initialize the middleware.
+
+        Args:
+            header: Primary header to read the correlation ID from.
+            fallback_headers: Additional headers to consult, in priority order,
+                when ``auto_trace_headers`` is true and ``header`` is absent.
+            auto_trace_headers: If true, scan ``fallback_headers`` after
+                ``header``. If false, only ``header`` is consulted.
+        """
+        self.header = header.lower()
+        self.fallback_headers = tuple(h.lower() for h in fallback_headers)
+        self.auto_trace_headers = auto_trace_headers
+        # Pre-compute the deduplicated header lookup order once at construction
+        # time. ASGI middleware runs on every request, so doing this in
+        # ``handle`` would be wasteful.
+        self._resolved_headers: tuple[str, ...] = self._compute_resolved_headers()
+
+    def _compute_resolved_headers(self) -> tuple[str, ...]:
+        if not self.auto_trace_headers:
+            return (self.header,)
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for name in (self.header, *self.fallback_headers):
+            if name not in seen:
+                seen.add(name)
+                ordered.append(name)
+        return tuple(ordered)
+
+    def _extract_value(self, headers: Headers) -> str:
+        for name in self._resolved_headers:
+            value = headers.get(name)
+            if value is None:
+                continue
+            if name == _W3C_TRACEPARENT_HEADER and not _is_valid_traceparent(value):
+                logger.debug("Malformed traceparent header %r; storing raw value", value)
+            return value
+        return _generate_w3c_traceparent()
+
+    async def handle(self, scope: Scope, receive: Receive, send: Send, next_app: ASGIApp) -> None:
+        value = self._extract_value(Headers.from_scope(scope))
+        token = CorrelationContext.set(value)
+        try:
+            await next_app(scope, receive, send)
+        finally:
+            CorrelationContext.reset(token)

--- a/tests/unit/test_middleware/test_correlation.py
+++ b/tests/unit/test_middleware/test_correlation.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+
+from litestar import get
+from litestar.middleware.correlation import (
+    TRACE_CONTEXT_FALLBACK_HEADERS,
+    CorrelationContext,
+    CorrelationMiddleware,
+    _generate_w3c_traceparent,
+    _is_valid_traceparent,
+    trace_id_from_traceparent,
+)
+from litestar.status_codes import HTTP_200_OK
+from litestar.testing import create_async_test_client, create_test_client
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from litestar.handlers import HTTPRouteHandler
+    from litestar.types.asgi_types import Receive, Scope, Send
+
+
+VALID_TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+"""Canonical W3C Trace Context example (https://www.w3.org/TR/trace-context/#examples-of-http-traceparent-headers)."""
+
+W3C_TRACEPARENT_RE = re.compile(r"^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$")
+"""Pattern for a valid W3C ``traceparent`` value generated as a fallback."""
+
+
+@pytest.fixture
+def correlation_handler() -> Iterator[HTTPRouteHandler]:
+    @get("/")
+    def handler() -> dict[str, str | None]:
+        return {"id": CorrelationContext.get()}
+
+    yield handler
+
+
+def test_traceparent_is_stored_whole(correlation_handler: HTTPRouteHandler) -> None:
+    """Valid traceparent must be stored verbatim so downstream services can propagate it intact."""
+    with create_test_client(route_handlers=[correlation_handler], middleware=[CorrelationMiddleware()]) as client:
+        response = client.get("/", headers={"traceparent": VALID_TRACEPARENT})
+        assert response.status_code == HTTP_200_OK
+        assert response.json() == {"id": VALID_TRACEPARENT}
+
+
+def test_malformed_traceparent_falls_back_to_raw(correlation_handler: HTTPRouteHandler) -> None:
+    """A traceparent that fails W3C validation is stored as-is — never raises."""
+    with create_test_client(route_handlers=[correlation_handler], middleware=[CorrelationMiddleware()]) as client:
+        response = client.get("/", headers={"traceparent": "garbage"})
+        assert response.status_code == HTTP_200_OK
+        assert response.json() == {"id": "garbage"}
+
+
+def test_fallback_value_is_w3c_compliant_traceparent(correlation_handler: HTTPRouteHandler) -> None:
+    """When no header matches, the generated fallback must be a valid W3C traceparent.
+
+    A bare UUID hex would break downstream services that parse the value as a
+    traceparent — they need the version + trace-id + parent-id + flags shape.
+    """
+    with create_test_client(route_handlers=[correlation_handler], middleware=[CorrelationMiddleware()]) as client:
+        response = client.get("/")
+        assert response.status_code == HTTP_200_OK
+        value = response.json()["id"]
+        assert isinstance(value, str)
+        assert W3C_TRACEPARENT_RE.fullmatch(value), value
+        # And the generated value must round-trip through the validator.
+        assert _is_valid_traceparent(value)
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        ("x-amzn-trace-id", "Root=1-5759e988-bd862e3fe1be46a994272793"),
+        ("x-cloud-trace-context", "105445aa7843bc8bf206b12000100000/0;o=1"),
+        ("x-correlation-id", "abc-123"),
+        ("x-request-id", "req-xyz-789"),
+    ],
+)
+def test_each_fallback_header_is_picked_up(correlation_handler: HTTPRouteHandler, header: tuple[str, str]) -> None:
+    name, value = header
+    with create_test_client(route_handlers=[correlation_handler], middleware=[CorrelationMiddleware()]) as client:
+        response = client.get("/", headers={name: value})
+        assert response.json() == {"id": value}
+
+
+def test_primary_header_wins_over_fallback(correlation_handler: HTTPRouteHandler) -> None:
+    with create_test_client(route_handlers=[correlation_handler], middleware=[CorrelationMiddleware()]) as client:
+        response = client.get(
+            "/",
+            headers={"traceparent": VALID_TRACEPARENT, "x-request-id": "should-not-win"},
+        )
+        assert response.json() == {"id": VALID_TRACEPARENT}
+
+
+def test_auto_trace_headers_disabled_skips_fallbacks(correlation_handler: HTTPRouteHandler) -> None:
+    with create_test_client(
+        route_handlers=[correlation_handler],
+        middleware=[CorrelationMiddleware(auto_trace_headers=False)],
+    ) as client:
+        response = client.get("/", headers={"x-request-id": "ignored"})
+        # No traceparent and fallbacks disabled → generated W3C traceparent.
+        assert W3C_TRACEPARENT_RE.fullmatch(response.json()["id"])
+
+
+def test_custom_primary_header(correlation_handler: HTTPRouteHandler) -> None:
+    with create_test_client(
+        route_handlers=[correlation_handler],
+        middleware=[CorrelationMiddleware(header="X-Custom-Trace")],
+    ) as client:
+        response = client.get("/", headers={"x-custom-trace": "custom-value"})
+        assert response.json() == {"id": "custom-value"}
+
+
+def test_token_reset_between_sequential_requests(correlation_handler: HTTPRouteHandler) -> None:
+    with create_test_client(route_handlers=[correlation_handler], middleware=[CorrelationMiddleware()]) as client:
+        first = client.get("/", headers={"x-request-id": "first"}).json()["id"]
+        second = client.get("/", headers={"x-request-id": "second"}).json()["id"]
+        third = client.get("/").json()["id"]  # no header → generated W3C traceparent
+        assert first == "first"
+        assert second == "second"
+        assert W3C_TRACEPARENT_RE.fullmatch(third)
+
+
+async def test_concurrent_requests_are_isolated() -> None:
+    @get("/")
+    async def handler(req_id: str) -> dict[str, str | None]:
+        # Force a context switch to give parallel requests a chance to clobber state if isolation is broken.
+        await asyncio.sleep(0)
+        return {"sent": req_id, "seen": CorrelationContext.get()}
+
+    async with create_async_test_client(route_handlers=[handler], middleware=[CorrelationMiddleware()]) as client:
+        ids = [f"req-{i}" for i in range(50)]
+        responses = await asyncio.gather(
+            *(client.get("/", params={"req_id": rid}, headers={"x-request-id": rid}) for rid in ids)
+        )
+        for rid, response in zip(ids, responses):
+            assert response.status_code == HTTP_200_OK
+            payload = response.json()
+            assert payload["sent"] == rid
+            assert payload["seen"] == rid
+
+
+def test_correlation_context_get_returns_none_outside_request() -> None:
+    assert CorrelationContext.get() is None
+
+
+def test_correlation_context_set_and_reset_round_trip() -> None:
+    assert CorrelationContext.get() is None
+    token = CorrelationContext.set("abc")
+    try:
+        assert CorrelationContext.get() == "abc"
+    finally:
+        CorrelationContext.reset(token)
+    assert CorrelationContext.get() is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (VALID_TRACEPARENT, True),
+        ("00-" + "a" * 32 + "-" + "b" * 16 + "-01", True),
+        ("garbage", False),
+        ("", False),
+        ("00-tooshort-b7ad6b7169203331-01", False),
+        ("00-" + "a" * 32 + "-" + "b" * 16, False),  # missing flags
+        ("00-" + "a" * 32 + "-" + "b" * 16 + "-01-extra", False),
+        ("zz-" + "a" * 32 + "-" + "b" * 16 + "-01", False),  # non-hex version
+        ("00-" + "0" * 32 + "-" + "b" * 16 + "-01", False),  # all-zero trace id
+        ("00-" + "a" * 32 + "-" + "0" * 16 + "-01", False),  # all-zero parent id
+        ("ff-" + "a" * 32 + "-" + "b" * 16 + "-01", False),  # version "ff" reserved as invalid (W3C 3.2.1)
+        ("FF-" + "a" * 32 + "-" + "b" * 16 + "-01", False),  # case-insensitive ff rejection
+    ],
+)
+def test_is_valid_traceparent(value: str, expected: bool) -> None:
+    assert _is_valid_traceparent(value) is expected
+
+
+def test_trace_id_from_traceparent_extracts_trace_id() -> None:
+    assert trace_id_from_traceparent(VALID_TRACEPARENT) == "0af7651916cd43dd8448eb211c80319c"
+
+
+def test_trace_id_from_traceparent_returns_none_for_invalid() -> None:
+    assert trace_id_from_traceparent("garbage") is None
+    assert trace_id_from_traceparent("") is None
+    # ``ff`` version is invalid per W3C even though it parses as hex, so the
+    # extractor should return ``None`` rather than the trace-id chunk.
+    assert trace_id_from_traceparent("ff-" + "a" * 32 + "-" + "b" * 16 + "-01") is None
+
+
+def test_generated_w3c_traceparent_is_valid() -> None:
+    """Generated fallback values must round-trip through the validator."""
+    for _ in range(100):
+        generated = _generate_w3c_traceparent()
+        assert W3C_TRACEPARENT_RE.fullmatch(generated), generated
+        assert _is_valid_traceparent(generated), generated
+
+
+def test_resolved_headers_are_precomputed_at_construction() -> None:
+    """ASGI middleware runs per-request — resolution must happen once in __init__."""
+    middleware = CorrelationMiddleware()
+    # Snapshot. Mutating the public attributes after construction must NOT
+    # change the order used at request time, proving the list is precomputed.
+    snapshot = middleware._resolved_headers
+    assert isinstance(snapshot, tuple)
+    middleware.fallback_headers = ("x-completely-different",)
+    middleware.header = "x-also-different"
+    assert middleware._resolved_headers is snapshot
+
+    # Single-header mode dedupes correctly too.
+    only = CorrelationMiddleware(auto_trace_headers=False)
+    assert only._resolved_headers == ("traceparent",)
+
+
+def test_fallback_header_list_contents() -> None:
+    """Lock the public default header list — changes here are user-visible."""
+    assert TRACE_CONTEXT_FALLBACK_HEADERS == (
+        "traceparent",
+        "x-amzn-trace-id",
+        "x-cloud-trace-context",
+        "x-correlation-id",
+        "x-request-id",
+    )
+
+
+def test_standalone_without_opentelemetry(correlation_handler: HTTPRouteHandler) -> None:
+    """Middleware works with no OTEL plugin, no OTEL imports, plain Litestar app."""
+    with create_test_client(route_handlers=[correlation_handler], middleware=[CorrelationMiddleware()]) as client:
+        response = client.get("/", headers={"traceparent": VALID_TRACEPARENT})
+        assert response.json() == {"id": VALID_TRACEPARENT}
+
+
+# ---------------------------------------------------------------------------
+# OpenTelemetry plugin auto-injection
+# ---------------------------------------------------------------------------
+
+
+def test_otel_plugin_injects_correlation_middleware_when_enabled() -> None:
+    from litestar.contrib.opentelemetry import OpenTelemetryConfig, OpenTelemetryPlugin
+
+    @get("/")
+    def handler() -> dict[str, str | None]:
+        return {"id": CorrelationContext.get()}
+
+    plugin = OpenTelemetryPlugin(OpenTelemetryConfig(enable_correlation_middleware=True))
+    with create_test_client(route_handlers=[handler], plugins=[plugin]) as client:
+        response = client.get("/", headers={"traceparent": VALID_TRACEPARENT})
+        assert response.status_code == HTTP_200_OK
+        assert response.json() == {"id": VALID_TRACEPARENT}
+
+
+def test_otel_plugin_does_not_inject_correlation_middleware_when_disabled() -> None:
+    from litestar.contrib.opentelemetry import OpenTelemetryConfig, OpenTelemetryPlugin
+
+    @get("/")
+    def handler() -> dict[str, str | None]:
+        return {"id": CorrelationContext.get()}
+
+    plugin = OpenTelemetryPlugin(OpenTelemetryConfig())  # default: disabled
+    with create_test_client(route_handlers=[handler], plugins=[plugin]) as client:
+        response = client.get("/", headers={"traceparent": VALID_TRACEPARENT})
+        # Without the middleware the contextvar is never set
+        assert response.json() == {"id": None}
+
+
+def test_otel_instrumentation_and_correlation_run_together() -> None:
+    """Coexistence: OTel must still emit spans AND the correlation contextvar must be set.
+
+    OTel is wrapped at the asgi-handler level by ``Litestar._create_asgi_handler``
+    (``app.py`` looks up the plugin and wraps via ``otel_plugin.middleware(app=...)``),
+    while the correlation middleware is injected at index 0 of
+    ``app_config.middleware`` by ``OpenTelemetryPlugin.on_app_init``. This test
+    proves both run in the same request — a regression that disabled OTel via
+    the plugin's middleware-pop logic would surface here.
+    """
+    from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    from litestar.contrib.opentelemetry import OpenTelemetryConfig, OpenTelemetryPlugin
+
+    exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider(resource=Resource(attributes={SERVICE_NAME: "litestar-correlation-test"}))
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    seen_correlation: list[str | None] = []
+
+    @get("/")
+    def handler() -> dict[str, str | None]:
+        seen_correlation.append(CorrelationContext.get())
+        return {"id": CorrelationContext.get()}
+
+    plugin = OpenTelemetryPlugin(
+        OpenTelemetryConfig(tracer_provider=tracer_provider, enable_correlation_middleware=True)
+    )
+    with create_test_client(route_handlers=[handler], plugins=[plugin]) as client:
+        response = client.get("/", headers={"traceparent": VALID_TRACEPARENT})
+
+    assert response.status_code == HTTP_200_OK
+    assert response.json() == {"id": VALID_TRACEPARENT}
+    # The correlation contextvar was set during the handler (proves the
+    # middleware ran).
+    assert seen_correlation == [VALID_TRACEPARENT]
+    # And OTel emitted at least one span (proves the OTel wrap survived
+    # ``on_app_init``'s middleware-list manipulation).
+    spans = exporter.get_finished_spans()
+    assert spans, "expected at least one OTel span to be exported"
+
+
+# ---------------------------------------------------------------------------
+# Performance smoke
+# ---------------------------------------------------------------------------
+
+
+async def test_middleware_overhead_is_bounded() -> None:
+    """Smoke check that the middleware's per-request overhead is small.
+
+    The hot path is a single dict lookup over a precomputed header list and a
+    contextvar set/reset. We bench at the ASGI layer (skipping TestClient
+    entirely so the measurement isolates the middleware's own work) and assert
+    the *per-call* overhead stays well under 100µs. That's far looser than the
+    issue's <5% target measured against a real handler, but tight enough to
+    catch a catastrophic regression — e.g. someone reintroducing an O(N)
+    header rebuild inside ``handle``.
+    """
+    iterations = 10_000
+
+    async def noop_app(scope: Scope, receive: Receive, send: Send) -> None:  # pragma: no cover - trivial
+        return None
+
+    middleware = CorrelationMiddleware()
+    wrapped = middleware(noop_app)
+
+    # Bench stubs — minimal scope and never-invoked receive/send. These don't
+    # need to be a fully populated ``HTTPScope``/``Receive``/``Send`` since the
+    # middleware only reads the headers, sets the context, and forwards.
+    async def _receive() -> Any:  # pragma: no cover - never awaited
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def _send(message: Any) -> None:  # pragma: no cover - never invoked
+        return None
+
+    scope = cast(
+        "Scope",
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [(b"traceparent", VALID_TRACEPARENT.encode("latin-1"))],
+            "query_string": b"",
+        },
+    )
+    receive = cast("Receive", _receive)
+    send = cast("Send", _send)
+
+    # Warm up so import-time / first-call costs don't pollute the bench.
+    for _ in range(200):
+        await wrapped(scope, receive, send)
+
+    start = time.perf_counter()
+    for _ in range(iterations):
+        await wrapped(scope, receive, send)
+    middleware_elapsed = time.perf_counter() - start
+
+    start = time.perf_counter()
+    for _ in range(iterations):
+        await noop_app(scope, receive, send)
+    baseline_elapsed = time.perf_counter() - start
+
+    overhead_per_call = max(0.0, (middleware_elapsed - baseline_elapsed) / iterations)
+    # Generous threshold leaves CI noise headroom while catching anything pathological.
+    assert overhead_per_call < 100e-6, (
+        f"correlation middleware overhead too high: {overhead_per_call * 1e6:.1f}µs/call "
+        f"(middleware {middleware_elapsed:.3f}s vs baseline {baseline_elapsed:.3f}s "
+        f"over {iterations} iterations)"
+    )


### PR DESCRIPTION
## Description

Resolves #4719 

Introduces `CorrelationMiddleware` to read and propagate distributed-trace correlation IDs from a priority-ordered list of headers (W3C `traceparent` default, plus cloud-vendor fallbacks). Exposes `CorrelationContext` for contextvar-based access in handlers and loggers.

Key additions:
- Precomputes header resolution in `__init__` to eliminate O(N) per-request overhead.
- Generates fully compliant W3C traceparents on UUID fallback.
- Strictly rejects `ff` version specifier per W3C specification.
- Integrates with `OpenTelemetryPlugin` via `enable_correlation_middleware` config, auto-injecting ahead of OTel instrumentation.
- Adds comprehensive test suite (100% coverage) handling concurrent request isolation.
- Adds usage and reference documentation.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4748">https://litestar-org.github.io/litestar-docs-preview/4748</a> 
