### PR TITLE
fix(openapi): set security=[] for routes excluded from auth

### DIFF
--- a/litestar/_openapi/datastructures.py
+++ b/litestar/_openapi/datastructures.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
-from typing import TYPE_CHECKING, _GenericAlias  # type: ignore[attr-defined]
+from typing import TYPE_CHECKING, Any, _GenericAlias  # type: ignore[attr-defined]
 
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.openapi.spec import Reference, Schema
@@ -229,11 +229,13 @@ class OpenAPIContext:
         self,
         openapi_config: OpenAPIConfig,
         plugins: Sequence[OpenAPISchemaPlugin],
+        middleware: Sequence[Any] | None = None,
     ) -> None:
         self.openapi_config = openapi_config
         self.plugins = plugins
         self.operation_ids: set[str] = set()
         self.schema_registry = SchemaRegistry()
+        self.middleware = middleware or []
 
     def add_operation_id(self, operation_id: str) -> None:
         """Add an operation ID to the context.

--- a/litestar/_openapi/path_item.py
+++ b/litestar/_openapi/path_item.py
@@ -16,6 +16,7 @@ from litestar.utils.helpers import unwrap_partial
 if TYPE_CHECKING:
     from litestar._openapi.datastructures import OpenAPIContext
     from litestar.handlers.http_handlers import HTTPRouteHandler
+    from litestar.openapi.spec import SecurityRequirement
     from litestar.routes import HTTPRoute
 
 __all__ = ("create_path_item_for_route", "merge_path_item_operations")
@@ -72,6 +73,18 @@ class PathItemFactory:
             self.context, route_handler, raises_validation_error=raises_validation_error
         )
 
+        security: list[SecurityRequirement] | None
+        if route_handler.opt.get("exclude_from_auth"):
+            # If the handler is excluded from auth, explicitly set security
+            # to an empty list. Per OpenAPI 3.1, this overrides root-level
+            # security and marks the operation as unsecured.
+            # See: https://github.com/litestar-org/litestar/issues/3013
+            security = []
+        elif route_handler.security:
+            security = list(route_handler.security)
+        else:
+            security = None
+
         return route_handler.operation_class(
             operation_id=operation_id,
             tags=sorted(route_handler.tags) if route_handler.tags else None,
@@ -81,7 +94,7 @@ class PathItemFactory:
             responses=responses,
             request_body=request_body,
             parameters=parameters or None,  # type: ignore[arg-type]
-            security=list(route_handler.security) if route_handler.security else None,
+            security=security,
         )
 
     def create_operation_id(self, route_handler: HTTPRouteHandler, http_method: HttpMethod) -> str:

--- a/litestar/_openapi/path_item.py
+++ b/litestar/_openapi/path_item.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 from inspect import cleandoc
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from litestar._openapi.parameters import create_parameters_for_handler
 from litestar._openapi.request_body import create_request_body
@@ -20,6 +20,28 @@ if TYPE_CHECKING:
     from litestar.routes import HTTPRoute
 
 __all__ = ("create_path_item_for_route", "merge_path_item_operations")
+
+
+def _get_security_exclude_opt_keys(middleware: list[Any]) -> set[str]:
+    """Extract all exclude_opt_key values from security middleware configs.
+
+    Args:
+        middleware: List of middleware configurations.
+
+    Returns:
+        A set of exclude_opt_key strings.
+    """
+    exclude_keys: set[str] = set()
+
+    for mw in middleware:
+        # DefineMiddleware stores kwargs including the config
+        if hasattr(mw, "kwargs") and "config" in mw.kwargs:
+            config = mw.kwargs["config"]
+            # Check if this is a security config with exclude_opt_key
+            if hasattr(config, "exclude_opt_key") and config.exclude_opt_key:
+                exclude_keys.add(config.exclude_opt_key)
+
+    return exclude_keys
 
 
 class PathItemFactory:
@@ -73,8 +95,13 @@ class PathItemFactory:
             self.context, route_handler, raises_validation_error=raises_validation_error
         )
 
+        # Check if the handler is excluded from security via any configured exclude_opt_key.
+        # Security middlewares can configure custom opt keys, so we need to check all of them.
+        exclude_opt_keys = _get_security_exclude_opt_keys(self.context.middleware)
+        is_excluded_from_auth = any(route_handler.opt.get(key) for key in exclude_opt_keys)
+
         security: list[SecurityRequirement] | None
-        if route_handler.opt.get("exclude_from_auth"):
+        if is_excluded_from_auth:
             # If the handler is excluded from auth, explicitly set security
             # to an empty list. Per OpenAPI 3.1, this overrides root-level
             # security and marks the operation as unsecured.

--- a/litestar/_openapi/plugin.py
+++ b/litestar/_openapi/plugin.py
@@ -76,7 +76,9 @@ class OpenAPIPlugin(InitPlugin, ReceiveRoutePlugin):
             ExampleFactory.seed_random(openapi_config.random_seed)
 
         openapi = openapi_config.to_openapi_schema()
-        context = OpenAPIContext(openapi_config=openapi_config, plugins=self.app.plugins.openapi)
+        context = OpenAPIContext(
+            openapi_config=openapi_config, plugins=self.app.plugins.openapi, middleware=self.app.middleware
+        )
         path_items: dict[str, PathItem] = {}
         for route in self.included_routes.values():
             path = route.path_format or "/"

--- a/tests/unit/test_security/test_security.py
+++ b/tests/unit/test_security/test_security.py
@@ -188,3 +188,49 @@ def test_abstract_security_config_setting_openapi_security_requirements(
             assert client.app.openapi_config.security == expected
         else:
             assert not client.app.openapi_config
+
+
+@pytest.mark.filterwarnings("ignore:Middleware 'SessionAuthMiddleware' exclude pattern")
+def test_excluded_route_has_no_security_in_openapi(
+    session_backend_config_memory: ServerSideSessionConfig,
+) -> None:
+    """Routes excluded from auth via exclude_opt_key should not show security
+    in OpenAPI spec. The handler opts out with opt={"exclude_from_auth": True},
+    and the OpenAPI generation should set security=[] on that operation.
+
+    Regression test for https://github.com/litestar-org/litestar/issues/3013.
+    """
+
+    @get("/protected")
+    def protected_handler() -> dict:
+        return {"hello": "world"}
+
+    @get("/health", opt={"exclude_from_auth": True})
+    def health_handler() -> dict:
+        return {"status": "ok"}
+
+    security_config = SessionAuth[Any, ServerSideSessionBackend](
+        retrieve_user_handler=retrieve_user_handler,
+        exclude=["/health"],
+        session_backend_config=session_backend_config_memory,
+    )
+
+    with create_test_client(
+        [protected_handler, health_handler],
+        on_app_init=[security_config.on_app_init],
+        openapi_config=OpenAPIConfig(title="Test", version="1.0.0"),
+    ) as client:
+        schema = client.app.openapi_schema
+        assert schema
+        assert schema.paths
+
+        # Protected route should NOT have per-operation security
+        # (it inherits from root-level security)
+        protected_op = schema.paths["/protected"].get
+        assert protected_op
+        assert protected_op.security is None
+
+        # Excluded route should have empty security, overriding root-level
+        health_op = schema.paths["/health"].get
+        assert health_op
+        assert health_op.security == []

--- a/tests/unit/test_security/test_security.py
+++ b/tests/unit/test_security/test_security.py
@@ -234,3 +234,51 @@ def test_excluded_route_has_no_security_in_openapi(
         health_op = schema.paths["/health"].get
         assert health_op
         assert health_op.security == []
+
+
+@pytest.mark.filterwarnings("ignore:Middleware 'SessionAuthMiddleware' exclude pattern")
+def test_excluded_route_with_custom_opt_key_in_openapi(
+    session_backend_config_memory: ServerSideSessionConfig,
+) -> None:
+    """Routes excluded from auth via a custom exclude_opt_key should not show
+    security in OpenAPI spec. This verifies that the OpenAPI generation handles
+    dynamically configured exclude_opt_key values.
+
+    Regression test for https://github.com/litestar-org/litestar/issues/3013.
+    """
+
+    @get("/protected")
+    def protected_handler() -> dict:
+        return {"hello": "world"}
+
+    @get("/health", opt={"skip_auth": True})
+    def health_handler() -> dict:
+        return {"status": "ok"}
+
+    # Use a custom exclude_opt_key instead of the default "exclude_from_auth"
+    security_config = SessionAuth[Any, ServerSideSessionBackend](
+        retrieve_user_handler=retrieve_user_handler,
+        exclude=["/health"],
+        exclude_opt_key="skip_auth",  # Custom key
+        session_backend_config=session_backend_config_memory,
+    )
+
+    with create_test_client(
+        [protected_handler, health_handler],
+        on_app_init=[security_config.on_app_init],
+        openapi_config=OpenAPIConfig(title="Test", version="1.0.0"),
+    ) as client:
+        schema = client.app.openapi_schema
+        assert schema
+        assert schema.paths
+
+        # Protected route should NOT have per-operation security
+        # (it inherits from root-level security)
+        protected_op = schema.paths["/protected"].get
+        assert protected_op
+        assert protected_op.security is None
+
+        # Excluded route should have empty security, overriding root-level
+        health_op = schema.paths["/health"].get
+        assert health_op
+        assert health_op.security == []


### PR DESCRIPTION
Fixes #3013.

Routes excluded from auth via `exclude_from_auth` still had root-level
security applied in the OpenAPI spec. Per OpenAPI 3.1, setting `security: []`
on an operation overrides the root-level requirement.

Check `route_handler.opt.get("exclude_from_auth")` in path item generation
and set `security=[]` on the operation when true.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4755">https://litestar-org.github.io/litestar-docs-preview/4755</a> 
