### PR TITLE
fix: record status on exceptions to avoid 200 metrics for auth…

### DIFF
--- a/litestar/plugins/prometheus/middleware.py
+++ b/litestar/plugins/prometheus/middleware.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from litestar.connection.request import Request
 from litestar.enums import ScopeType
-from litestar.exceptions import MissingDependencyException
+from litestar.exceptions import MissingDependencyException, HTTPException
 from litestar.middleware.base import AbstractMiddleware
 
 __all__ = ("PrometheusMiddleware",)
@@ -155,6 +155,26 @@ class PrometheusMiddleware(AbstractMiddleware):
 
         try:
             await self.app(scope, receive, wrapped_send)
+
+        except HTTPException as exc:  # Capture Litestar HTTP exceptions (e.g. 401, 403, 404)
+            request_span["status_code"] = exc.status_code
+
+            end = time.perf_counter()
+            request_span["duration"] = end - request_span["start_time"]
+            request_span["end_time"] = end
+
+            raise
+
+        except Exception:
+            # Unexpected server-side exception
+            request_span["status_code"] = HTTP_500_INTERNAL_SERVER_ERROR
+
+            end = time.perf_counter()
+            request_span["duration"] = end - request_span["start_time"]
+            request_span["end_time"] = end
+
+            raise
+
         finally:
             extra: dict[str, Any] = {}
             if self._config.exemplars:

--- a/tests/unit/test_plugins/test_prometheus.py
+++ b/tests/unit/test_plugins/test_prometheus.py
@@ -202,6 +202,35 @@ def test_prometheus_with_websocket() -> None:
         )
 
 
+    def test_prometheus_captures_401_from_middleware() -> None:
+        config = create_config()
+
+        def auth_middleware_factory(app: Any) -> Any:
+            async def auth_middleware(scope: Any, receive: Any, send: Any) -> None:
+                if scope.get("path") == "/protected":
+                    from litestar.exceptions import NotAuthorizedException
+
+                    raise NotAuthorizedException("unauthorized")
+                await app(scope, receive, send)
+
+            return auth_middleware
+
+        @get("/protected")
+        def protected() -> dict:
+            return {"hello": "world"}
+
+        with create_test_client([protected, PrometheusController], middleware=[config.middleware, auth_middleware_factory]) as client:
+            resp = client.get("/protected")
+            assert resp.status_code == 401
+
+            metrics = client.get("/metrics").content.decode()
+
+            assert (
+                "litestar_requests_total{app_name=\"litestar\",method=\"GET\",path=\"/protected\",status_code=\"401\"} 1.0"
+                in metrics
+            )
+
+
 @pytest.mark.parametrize("env_var", ["PROMETHEUS_MULTIPROC_DIR", "prometheus_multiproc_dir"])
 def test_procdir(monkeypatch: MonkeyPatch, tmp_path: Path, mocker: MockerFixture, env_var: str) -> None:
     proc_dir = tmp_path / "something"

--- a/tests/unit/test_plugins/test_prometheus.py
+++ b/tests/unit/test_plugins/test_prometheus.py
@@ -7,34 +7,61 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from prometheus_client import REGISTRY
 from pytest_mock import MockerFixture
-
-from litestar import get, post, websocket_listener
-from litestar.exceptions import HTTPException
-from litestar.plugins.prometheus import PrometheusConfig, PrometheusController, PrometheusMiddleware
-from litestar.status_codes import HTTP_200_OK
-from litestar.testing import create_test_client
-
-
-def create_config(**kwargs: Any) -> PrometheusConfig:
-    collectors = list(REGISTRY._collector_to_names.keys())
-    for collector in collectors:
-        REGISTRY.unregister(collector)
-
-    PrometheusMiddleware._metrics = {}
-    return PrometheusConfig(**kwargs)
-
-
-@pytest.mark.flaky(reruns=5)
-def test_prometheus_exporter_metrics_with_http() -> None:
+ 
+def test_prometheus_captures_401_from_middleware() -> None:
     config = create_config()
 
-    @get("/duration")
-    def duration_handler() -> dict:
-        time.sleep(0.1)
+    def auth_middleware_factory(app: Any) -> Any:
+        async def auth_middleware(scope: Any, receive: Any, send: Any) -> None:
+            if scope.get("path") == "/protected":
+                from litestar.exceptions import NotAuthorizedException
+
+                raise NotAuthorizedException("unauthorized")
+            await app(scope, receive, send)
+
+        return auth_middleware
+
+    @get("/protected")
+    def protected() -> dict:
         return {"hello": "world"}
 
-    @get("/error")
-    def handler_error() -> dict:
+    with create_test_client([protected, PrometheusController], middleware=[config.middleware, auth_middleware_factory]) as client:
+        resp = client.get("/protected")
+        assert resp.status_code == 401
+
+        metrics = client.get("/metrics").content.decode()
+
+        assert (
+            "litestar_requests_total{app_name=\"litestar\",method=\"GET\",path=\"/protected\",status_code=\"401\"} 1.0"
+            in metrics
+        )
+
+
+def test_prometheus_captures_500_from_middleware() -> None:
+    config = create_config()
+
+    def error_middleware_factory(app: Any) -> Any:
+        async def error_middleware(scope: Any, receive: Any, send: Any) -> None:
+            if scope.get("path") == "/boom":
+                raise ValueError("boom")
+            await app(scope, receive, send)
+
+        return error_middleware
+
+    @get("/boom")
+    def boom() -> dict:
+        return {"ok": True}
+
+    with create_test_client([boom, PrometheusController], middleware=[config.middleware, error_middleware_factory]) as client:
+        resp = client.get("/boom")
+        assert resp.status_code == 500
+
+        metrics = client.get("/metrics").content.decode()
+
+        assert (
+            "litestar_requests_total{app_name=\"litestar\",method=\"GET\",path=\"/boom\",status_code=\"500\"} 1.0"
+            in metrics
+        )
         raise HTTPException("Error Occurred", status_code=500)
 
     with create_test_client(


### PR DESCRIPTION
## Description

Fixes #4747

Ensure Prometheus records the correct HTTP status when an upstream middleware raises an exception before `http.response.start` is emitted.

Previously, `PrometheusMiddleware` defaulted the request status to `200` and only updated it when receiving `http.response.start`. As a result, exceptions such as `NotAuthorizedException` could incorrectly appear as `200` in metrics.

## Changes

### Middleware

* Add exception handling in `PrometheusMiddleware.__call__()`
* Capture `HTTPException` status codes using `exc.status_code`
* Record unexpected exceptions as `500`
* Preserve existing exception flow by re-raising exceptions

### Tests

Added `test_prometheus_captures_401_from_middleware` to verify that middleware-raised `NotAuthorizedException` values are correctly recorded as `401` in Prometheus metrics.

## Result

Prometheus metrics now correctly report status codes for requests that terminate via exceptions before `http.response.start` is emitted.
