### PR TITLE
fix(openapi): set security=  [ ] for routes not in from auth

### DIFF
--- a/litestar/_openapi/path_item.py
+++ b/litestar/_openapi/path_item.py
@@ -72,6 +72,14 @@ class PathItemFactory:
             self.context, route_handler, raises_validation_error=raises_validation_error
         )
 
+        exclude_keys = self.context.openapi_config.security_exclude_opt_keys
+        if exclude_keys and any(route_handler.opt.get(key) for key in exclude_keys):
+            security = []
+        elif route_handler.security:
+            security = list(route_handler.security)
+        else:
+            security = None
+
         return route_handler.operation_class(
             operation_id=operation_id,
             tags=sorted(route_handler.tags) if route_handler.tags else None,
@@ -81,7 +89,7 @@ class PathItemFactory:
             responses=responses,
             request_body=request_body,
             parameters=parameters or None,  # type: ignore[arg-type]
-            security=list(route_handler.security) if route_handler.security else None,
+            security=security,
         )
 
     def create_operation_id(self, route_handler: HTTPRouteHandler, http_method: HttpMethod) -> str:

--- a/litestar/openapi/config.py
+++ b/litestar/openapi/config.py
@@ -118,6 +118,7 @@ class OpenAPIConfig:
 
     def __post_init__(self) -> None:
         self.path = normalize_path(self.path)
+        self.security_exclude_opt_keys: set[str] = set()
 
         self.default_plugin: OpenAPIRenderPlugin | None = None
         for plugin in self.render_plugins:

--- a/litestar/security/base.py
+++ b/litestar/security/base.py
@@ -99,6 +99,8 @@ class AbstractSecurityConfig(ABC, Generic[UserType, AuthType]):
             else:
                 app_config.openapi_config.security = [self.security_requirement]
 
+            app_config.openapi_config.security_exclude_opt_keys.add(self.exclude_opt_key)
+
         if self.guards:
             app_config.guards.extend(self.guards)
 

--- a/tests/unit/test_security/test_security.py
+++ b/tests/unit/test_security/test_security.py
@@ -188,3 +188,72 @@ def test_abstract_security_config_setting_openapi_security_requirements(
             assert client.app.openapi_config.security == expected
         else:
             assert not client.app.openapi_config
+
+
+def test_excluded_route_gets_empty_security_in_openapi(
+    session_backend_config_memory: ServerSideSessionConfig,
+) -> None:
+    @get("/protected")
+    def protected_handler() -> dict:
+        return {"hello": "world"}
+
+    @get("/health", exclude_from_auth=True)
+    def health_handler() -> dict:
+        return {"status": "ok"}
+
+    security_config = SessionAuth[Any, ServerSideSessionBackend](
+        retrieve_user_handler=retrieve_user_handler,
+        exclude=["/health"],
+        session_backend_config=session_backend_config_memory,
+    )
+
+    with create_test_client(
+        [protected_handler, health_handler],
+        on_app_init=[security_config.on_app_init],
+        openapi_config=OpenAPIConfig(title="Test", version="1.0.0"),
+    ) as client:
+        schema = client.app.openapi_schema
+        assert schema and schema.paths
+
+        protected_op = schema.paths["/protected"].get
+        assert protected_op is not None
+        assert protected_op.security is None
+
+        health_op = schema.paths["/health"].get
+        assert health_op is not None
+        assert health_op.security == []
+
+
+def test_excluded_route_with_custom_opt_key(
+    session_backend_config_memory: ServerSideSessionConfig,
+) -> None:
+    @get("/protected")
+    def protected_handler() -> dict:
+        return {"hello": "world"}
+
+    @get("/public", skip_auth=True)
+    def public_handler() -> dict:
+        return {"status": "ok"}
+
+    security_config = SessionAuth[Any, ServerSideSessionBackend](
+        retrieve_user_handler=retrieve_user_handler,
+        exclude=["/public"],
+        exclude_opt_key="skip_auth",
+        session_backend_config=session_backend_config_memory,
+    )
+
+    with create_test_client(
+        [protected_handler, public_handler],
+        on_app_init=[security_config.on_app_init],
+        openapi_config=OpenAPIConfig(title="Test", version="1.0.0"),
+    ) as client:
+        schema = client.app.openapi_schema
+        assert schema and schema.paths
+
+        protected_op = schema.paths["/protected"].get
+        assert protected_op is not None
+        assert protected_op.security is None
+
+        public_op = schema.paths["/public"].get
+        assert public_op is not None
+        assert public_op.security == []


### PR DESCRIPTION
Closes  #3013

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
- follow [Litestar's AI Policy](https://github.com/litestar-org/.github/blob/main/AI_POLICY.md)

If the pull request is not yet ready for review (e.g. tests or other checks are still failing),
please submit it as a draft PR, to avoid noise for reviewers.
-->

## Description

We use both FastAPI and Litestar at work and noticed routes with `exclude_from_auth=True` were still showing auth in OpenAPI docs becuase security was being set at the root level and nothing was overriding it.

Fix was to pass `exclude_opt_key` into `OpenAPIConfig` during `on_app_init`, then while generating path items if that opt key is set on a handler it adds `security: []` to override the global one.

Also works for custom `exclude_opt_key` values not only `"exclude_from_auth"`.


<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4767">https://litestar-org.github.io/litestar-docs-preview/4767</a> 
