### PR TITLE
feat(jinja): deprecate contrib module on v2

### DIFF
--- a/docs/reference/contrib/jinja.rst
+++ b/docs/reference/contrib/jinja.rst
@@ -1,5 +1,8 @@
 jinja
 =====
 
+.. deprecated:: 2.22.0
+    Import from :mod:`litestar.plugins.jinja` instead. This module will be removed in 3.0.0.
+
 .. automodule:: litestar.contrib.jinja
     :members:

--- a/docs/reference/plugins/index.rst
+++ b/docs/reference/plugins/index.rst
@@ -12,6 +12,7 @@ plugins
     attrs
     flash_messages
     htmx
+    jinja
     opentelemetry
     problem_details
     prometheus

--- a/docs/reference/plugins/jinja.rst
+++ b/docs/reference/plugins/jinja.rst
@@ -1,0 +1,6 @@
+=====
+jinja
+=====
+
+.. automodule:: litestar.plugins.jinja
+    :members:

--- a/litestar/contrib/jinja.py
+++ b/litestar/contrib/jinja.py
@@ -1,113 +1,28 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Mapping, TypeVar
+from typing import TYPE_CHECKING
 
-from typing_extensions import ParamSpec
-
-from litestar.exceptions import ImproperlyConfiguredException, MissingDependencyException, TemplateNotFoundException
-from litestar.template.base import (
-    TemplateCallableType,
-    TemplateEngineProtocol,
-    csrf_token,
-    url_for,
-    url_for_static_asset,
-)
-
-try:
-    from jinja2 import Environment, FileSystemLoader, pass_context
-    from jinja2 import TemplateNotFound as JinjaTemplateNotFound
-except ImportError as e:
-    raise MissingDependencyException("jinja2", extra="jinja") from e
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-    from jinja2 import Template as JinjaTemplate
+from litestar.utils import warn_deprecation
 
 __all__ = ("JinjaTemplateEngine",)
 
-P = ParamSpec("P")
-T = TypeVar("T")
+
+def __getattr__(attr_name: str) -> object:
+    if attr_name in __all__:
+        from litestar.plugins import jinja
+
+        warn_deprecation(
+            deprecated_name=f"litestar.contrib.jinja.{attr_name}",
+            version="2.22.0",
+            kind="import",
+            removal_in="3.0.0",
+            info=f"importing {attr_name} from 'litestar.contrib.jinja' is deprecated, please "
+            f"import it from 'litestar.plugins.jinja' instead",
+        )
+        return getattr(jinja, attr_name)
+
+    raise AttributeError(f"module {__name__!r} has no attribute {attr_name!r}")  # pragma: no cover
 
 
-class JinjaTemplateEngine(TemplateEngineProtocol["JinjaTemplate", Mapping[str, Any]]):
-    """The engine instance."""
-
-    def __init__(
-        self,
-        directory: Path | list[Path] | None = None,
-        engine_instance: Environment | None = None,
-    ) -> None:
-        """Jinja-based TemplateEngine.
-
-        Args:
-            directory: Direct path or list of directory paths from which to serve templates.
-            engine_instance: A jinja Environment instance.
-        """
-
-        if directory and engine_instance:
-            raise ImproperlyConfiguredException("You must provide either a directory or a jinja2 Environment instance.")
-        if directory:
-            loader = FileSystemLoader(searchpath=directory)
-            self.engine = Environment(loader=loader, autoescape=True)
-        elif engine_instance:
-            self.engine = engine_instance
-        self.register_template_callable(key="url_for_static_asset", template_callable=url_for_static_asset)
-        self.register_template_callable(key="csrf_token", template_callable=csrf_token)
-        self.register_template_callable(key="url_for", template_callable=url_for)
-
-    def get_template(self, template_name: str) -> JinjaTemplate:
-        """Retrieve a template by matching its name (dotted path) with files in the directory or directories provided.
-
-        Args:
-            template_name: A dotted path
-
-        Returns:
-            JinjaTemplate instance
-
-        Raises:
-            TemplateNotFoundException: if no template is found.
-        """
-        try:
-            return self.engine.get_template(name=template_name)
-        except JinjaTemplateNotFound as exc:
-            raise TemplateNotFoundException(template_name=template_name) from exc
-
-    def register_template_callable(
-        self, key: str, template_callable: TemplateCallableType[Mapping[str, Any], P, T]
-    ) -> None:
-        """Register a callable on the template engine.
-
-        Args:
-            key: The callable key, i.e. the value to use inside the template to call the callable.
-            template_callable: A callable to register.
-
-        Returns:
-            None
-        """
-        self.engine.globals[key] = pass_context(template_callable)
-
-    def render_string(self, template_string: str, context: Mapping[str, Any]) -> str:
-        """Render a template from a string with the given context.
-
-        Args:
-            template_string: The template string to render.
-            context: A dictionary of variables to pass to the template.
-
-        Returns:
-            The rendered template as a string.
-        """
-        template = self.engine.from_string(template_string)
-        return template.render(context)
-
-    @classmethod
-    def from_environment(cls, jinja_environment: Environment) -> JinjaTemplateEngine:
-        """Create a JinjaTemplateEngine from an existing jinja Environment instance.
-
-        Args:
-            jinja_environment (jinja2.environment.Environment): A jinja Environment instance.
-
-        Returns:
-            JinjaTemplateEngine instance
-        """
-        return cls(directory=None, engine_instance=jinja_environment)
+if TYPE_CHECKING:
+    from litestar.plugins.jinja import JinjaTemplateEngine

--- a/litestar/plugins/jinja.py
+++ b/litestar/plugins/jinja.py
@@ -1,0 +1,115 @@
+"""Jinja2 template engine integration for Litestar."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping, TypeVar
+
+from typing_extensions import ParamSpec
+
+from litestar.exceptions import ImproperlyConfiguredException, MissingDependencyException, TemplateNotFoundException
+from litestar.template.base import (
+    TemplateCallableType,
+    TemplateEngineProtocol,
+    csrf_token,
+    url_for,
+    url_for_static_asset,
+)
+
+try:
+    from jinja2 import Environment, FileSystemLoader, pass_context
+    from jinja2 import TemplateNotFound as JinjaTemplateNotFound
+except ImportError as e:
+    raise MissingDependencyException("jinja2", extra="jinja") from e
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from jinja2 import Template as JinjaTemplate
+
+__all__ = ("JinjaTemplateEngine",)
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+class JinjaTemplateEngine(TemplateEngineProtocol["JinjaTemplate", Mapping[str, Any]]):
+    """The engine instance."""
+
+    def __init__(
+        self,
+        directory: Path | list[Path] | None = None,
+        engine_instance: Environment | None = None,
+    ) -> None:
+        """Jinja-based TemplateEngine.
+
+        Args:
+            directory: Direct path or list of directory paths from which to serve templates.
+            engine_instance: A jinja Environment instance.
+        """
+
+        if directory and engine_instance:
+            raise ImproperlyConfiguredException("You must provide either a directory or a jinja2 Environment instance.")
+        if directory:
+            loader = FileSystemLoader(searchpath=directory)
+            self.engine = Environment(loader=loader, autoescape=True)
+        elif engine_instance:
+            self.engine = engine_instance
+        self.register_template_callable(key="url_for_static_asset", template_callable=url_for_static_asset)
+        self.register_template_callable(key="csrf_token", template_callable=csrf_token)
+        self.register_template_callable(key="url_for", template_callable=url_for)
+
+    def get_template(self, template_name: str) -> JinjaTemplate:
+        """Retrieve a template by matching its name (dotted path) with files in the directory or directories provided.
+
+        Args:
+            template_name: A dotted path
+
+        Returns:
+            JinjaTemplate instance
+
+        Raises:
+            TemplateNotFoundException: if no template is found.
+        """
+        try:
+            return self.engine.get_template(name=template_name)
+        except JinjaTemplateNotFound as exc:
+            raise TemplateNotFoundException(template_name=template_name) from exc
+
+    def register_template_callable(
+        self, key: str, template_callable: TemplateCallableType[Mapping[str, Any], P, T]
+    ) -> None:
+        """Register a callable on the template engine.
+
+        Args:
+            key: The callable key, i.e. the value to use inside the template to call the callable.
+            template_callable: A callable to register.
+
+        Returns:
+            None
+        """
+        self.engine.globals[key] = pass_context(template_callable)
+
+    def render_string(self, template_string: str, context: Mapping[str, Any]) -> str:
+        """Render a template from a string with the given context.
+
+        Args:
+            template_string: The template string to render.
+            context: A dictionary of variables to pass to the template.
+
+        Returns:
+            The rendered template as a string.
+        """
+        template = self.engine.from_string(template_string)
+        return template.render(context)
+
+    @classmethod
+    def from_environment(cls, jinja_environment: Environment) -> JinjaTemplateEngine:
+        """Create a JinjaTemplateEngine from an existing jinja Environment instance.
+
+        Args:
+            jinja_environment (jinja2.environment.Environment): A jinja Environment instance.
+
+        Returns:
+            JinjaTemplateEngine instance
+        """
+        return cls(directory=None, engine_instance=jinja_environment)

--- a/tests/unit/test_contrib/test_jinja.py
+++ b/tests/unit/test_contrib/test_jinja.py
@@ -1,0 +1,53 @@
+# ruff: noqa: F401
+import sys
+from importlib.util import cache_from_source
+from pathlib import Path
+from typing import Union
+
+import pytest
+
+
+def purge_module(module_names: "list[str]", path: "Union[str, Path]") -> None:
+    for name in module_names:
+        if name in sys.modules:
+            del sys.modules[name]
+    Path(cache_from_source(str(path))).unlink(missing_ok=True)
+
+
+def test_deprecated_jinja_imports() -> None:
+    purge_module(["litestar.contrib.jinja"], __file__)
+    with pytest.warns(
+        DeprecationWarning,
+        match="importing JinjaTemplateEngine from 'litestar.contrib.jinja' is deprecated",
+    ):
+        from litestar.contrib.jinja import JinjaTemplateEngine
+
+
+def test_contrib_imports_resolve_to_plugin_objects() -> None:
+    purge_module(["litestar.contrib.jinja"], __file__)
+    with pytest.warns(DeprecationWarning):
+        from litestar.contrib.jinja import JinjaTemplateEngine as ContribJinjaTemplateEngine
+
+    from litestar.plugins.jinja import JinjaTemplateEngine
+
+    assert ContribJinjaTemplateEngine is JinjaTemplateEngine
+
+
+def test_deprecated_jinja_import_message_includes_version_and_removal() -> None:
+    purge_module(["litestar.contrib.jinja"], __file__)
+    with pytest.warns(DeprecationWarning) as warning_records:
+        from litestar.contrib.jinja import JinjaTemplateEngine
+
+    message = str(warning_records[0].message)
+    assert "litestar.contrib.jinja.JinjaTemplateEngine" in message
+    assert "Deprecated in litestar 2.22.0" in message
+    assert "removed in 3.0.0" in message
+    assert "litestar.plugins.jinja" in message
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    purge_module(["litestar.contrib.jinja"], __file__)
+    import litestar.contrib.jinja as contrib_jinja
+
+    with pytest.raises(AttributeError):
+        contrib_jinja.Nope


### PR DESCRIPTION
Summary:
- Add litestar.plugins.jinja and deprecate litestar.contrib.jinja imports.
- Add v2 deprecation tests in tests/unit/test_contrib/test_jinja.py.
- No manual changelog entry.

Tests:
- uv run --python 3.12 pytest tests/unit/test_contrib/test_jinja.py -v
- uv run --python 3.12 ruff check litestar/plugins/jinja.py litestar/contrib/jinja.py tests/unit/test_contrib/test_jinja.py
- uv run --python 3.12 ruff format --check litestar/plugins/jinja.py litestar/contrib/jinja.py tests/unit/test_contrib/test_jinja.py
- uv run --python 3.12 pyright litestar/plugins/jinja.py litestar/contrib/jinja.py tests/unit/test_contrib/test_jinja.py

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4773">https://litestar-org.github.io/litestar-docs-preview/4773</a> 
