### PR TITLE
feat(mako): deprecate contrib module on v2

### DIFF
--- a/docs/reference/contrib/mako.rst
+++ b/docs/reference/contrib/mako.rst
@@ -1,5 +1,8 @@
 mako
 ====
 
+.. deprecated:: 2.22.0
+    Import from :mod:`litestar.plugins.mako` instead. This module will be removed in 3.0.0.
+
 .. automodule:: litestar.contrib.mako
     :members:

--- a/docs/reference/plugins/index.rst
+++ b/docs/reference/plugins/index.rst
@@ -12,6 +12,7 @@ plugins
     attrs
     flash_messages
     htmx
+    mako
     jinja
     opentelemetry
     problem_details

--- a/docs/reference/plugins/mako.rst
+++ b/docs/reference/plugins/mako.rst
@@ -1,0 +1,6 @@
+====
+mako
+====
+
+.. automodule:: litestar.plugins.mako
+    :members:

--- a/litestar/contrib/mako.py
+++ b/litestar/contrib/mako.py
@@ -1,145 +1,28 @@
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING, Any, Mapping, TypeVar
+from typing import TYPE_CHECKING
 
-from typing_extensions import ParamSpec
-
-from litestar.exceptions import ImproperlyConfiguredException, MissingDependencyException, TemplateNotFoundException
-from litestar.template.base import (
-    TemplateCallableType,
-    TemplateEngineProtocol,
-    TemplateProtocol,
-    csrf_token,
-    url_for,
-    url_for_static_asset,
-)
-
-try:
-    from mako.exceptions import TemplateLookupException as MakoTemplateNotFound  # type: ignore[import-untyped]
-    from mako.lookup import TemplateLookup  # type: ignore[import-untyped]
-    from mako.template import Template as _MakoTemplate  # type: ignore[import-untyped]
-except ImportError as e:
-    raise MissingDependencyException("mako") from e
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from litestar.utils import warn_deprecation
 
 __all__ = ("MakoTemplate", "MakoTemplateEngine")
 
-P = ParamSpec("P")
-T = TypeVar("T")
+
+def __getattr__(attr_name: str) -> object:
+    if attr_name in __all__:
+        from litestar.plugins import mako
+
+        warn_deprecation(
+            deprecated_name=f"litestar.contrib.mako.{attr_name}",
+            version="2.22.0",
+            kind="import",
+            removal_in="3.0.0",
+            info=f"importing {attr_name} from 'litestar.contrib.mako' is deprecated, please "
+            f"import it from 'litestar.plugins.mako' instead",
+        )
+        return getattr(mako, attr_name)
+
+    raise AttributeError(f"module {__name__!r} has no attribute {attr_name!r}")  # pragma: no cover
 
 
-class MakoTemplate(TemplateProtocol):
-    """Mako template, implementing ``TemplateProtocol``"""
-
-    def __init__(self, template: _MakoTemplate, template_callables: list[tuple[str, TemplateCallableType]]) -> None:
-        """Initialize a template.
-
-        Args:
-            template: Base ``MakoTemplate`` used by the underlying mako-engine
-            template_callables: List of callables passed to the template
-        """
-        super().__init__()
-        self.template = template
-        self.template_callables = template_callables
-
-    def render(self, *args: Any, **kwargs: Any) -> str:
-        """Render a template.
-
-        Args:
-            args: Positional arguments passed to the engines ``render`` function
-            kwargs: Keyword arguments passed to the engines ``render`` function
-
-        Returns:
-            Rendered template as a string
-        """
-        for callable_key, template_callable in self.template_callables:
-            kwargs_copy = {**kwargs}
-            kwargs[callable_key] = partial(template_callable, kwargs_copy)
-
-        return str(self.template.render(*args, **kwargs))
-
-
-class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate, Mapping[str, Any]]):
-    """Mako-based TemplateEngine."""
-
-    def __init__(self, directory: Path | list[Path] | None = None, engine_instance: Any | None = None) -> None:
-        """Initialize template engine.
-
-        Args:
-            directory: Direct path or list of directory paths from which to serve templates.
-            engine_instance: A mako TemplateLookup instance.
-        """
-        if directory and engine_instance:
-            raise ImproperlyConfiguredException("You must provide either a directory or a mako TemplateLookup.")
-        if directory:
-            self.engine = TemplateLookup(
-                directories=directory if isinstance(directory, (list, tuple)) else [directory], default_filters=["h"]
-            )
-        elif engine_instance:
-            self.engine = engine_instance
-
-        self._template_callables: list[tuple[str, TemplateCallableType]] = []
-        self.register_template_callable(key="url_for_static_asset", template_callable=url_for_static_asset)
-        self.register_template_callable(key="csrf_token", template_callable=csrf_token)
-        self.register_template_callable(key="url_for", template_callable=url_for)
-
-    def get_template(self, template_name: str) -> MakoTemplate:
-        """Retrieve a template by matching its name (dotted path) with files in the directory or directories provided.
-
-        Args:
-            template_name: A dotted path
-
-        Returns:
-            MakoTemplate instance
-
-        Raises:
-            TemplateNotFoundException: if no template is found.
-        """
-        try:
-            return MakoTemplate(
-                template=self.engine.get_template(template_name), template_callables=self._template_callables
-            )
-        except MakoTemplateNotFound as exc:
-            raise TemplateNotFoundException(template_name=template_name) from exc
-
-    def register_template_callable(
-        self, key: str, template_callable: TemplateCallableType[Mapping[str, Any], P, T]
-    ) -> None:
-        """Register a callable on the template engine.
-
-        Args:
-            key: The callable key, i.e. the value to use inside the template to call the callable.
-            template_callable: A callable to register.
-
-        Returns:
-            None
-        """
-        self._template_callables.append((key, template_callable))
-
-    def render_string(self, template_string: str, context: Mapping[str, Any]) -> str:  # pyright: ignore
-        """Render a template from a string with the given context.
-
-        Args:
-            template_string: The template string to render.
-            context: A dictionary of variables to pass to the template.
-
-        Returns:
-            The rendered template as a string.
-        """
-        template = _MakoTemplate(template_string)  # noqa: S702
-        return template.render(**context)  # type: ignore[no-any-return]
-
-    @classmethod
-    def from_template_lookup(cls, template_lookup: TemplateLookup) -> MakoTemplateEngine:
-        """Create a template engine from an existing mako TemplateLookup instance.
-
-        Args:
-            template_lookup: A mako TemplateLookup instance.
-
-        Returns:
-            MakoTemplateEngine instance
-        """
-        return cls(directory=None, engine_instance=template_lookup)
+if TYPE_CHECKING:
+    from litestar.plugins.mako import MakoTemplate, MakoTemplateEngine

--- a/litestar/plugins/mako.py
+++ b/litestar/plugins/mako.py
@@ -1,0 +1,147 @@
+"""Mako template engine integration for Litestar."""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import TYPE_CHECKING, Any, Mapping, TypeVar
+
+from typing_extensions import ParamSpec
+
+from litestar.exceptions import ImproperlyConfiguredException, MissingDependencyException, TemplateNotFoundException
+from litestar.template.base import (
+    TemplateCallableType,
+    TemplateEngineProtocol,
+    TemplateProtocol,
+    csrf_token,
+    url_for,
+    url_for_static_asset,
+)
+
+try:
+    from mako.exceptions import TemplateLookupException as MakoTemplateNotFound  # type: ignore[import-untyped]
+    from mako.lookup import TemplateLookup  # type: ignore[import-untyped]
+    from mako.template import Template as _MakoTemplate  # type: ignore[import-untyped]
+except ImportError as e:
+    raise MissingDependencyException("mako") from e
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = ("MakoTemplate", "MakoTemplateEngine")
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+class MakoTemplate(TemplateProtocol):
+    """Mako template, implementing ``TemplateProtocol``"""
+
+    def __init__(self, template: _MakoTemplate, template_callables: list[tuple[str, TemplateCallableType]]) -> None:
+        """Initialize a template.
+
+        Args:
+            template: Base ``MakoTemplate`` used by the underlying mako-engine
+            template_callables: List of callables passed to the template
+        """
+        super().__init__()
+        self.template = template
+        self.template_callables = template_callables
+
+    def render(self, *args: Any, **kwargs: Any) -> str:
+        """Render a template.
+
+        Args:
+            args: Positional arguments passed to the engines ``render`` function
+            kwargs: Keyword arguments passed to the engines ``render`` function
+
+        Returns:
+            Rendered template as a string
+        """
+        for callable_key, template_callable in self.template_callables:
+            kwargs_copy = {**kwargs}
+            kwargs[callable_key] = partial(template_callable, kwargs_copy)
+
+        return str(self.template.render(*args, **kwargs))
+
+
+class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate, Mapping[str, Any]]):
+    """Mako-based TemplateEngine."""
+
+    def __init__(self, directory: Path | list[Path] | None = None, engine_instance: Any | None = None) -> None:
+        """Initialize template engine.
+
+        Args:
+            directory: Direct path or list of directory paths from which to serve templates.
+            engine_instance: A mako TemplateLookup instance.
+        """
+        if directory and engine_instance:
+            raise ImproperlyConfiguredException("You must provide either a directory or a mako TemplateLookup.")
+        if directory:
+            self.engine = TemplateLookup(
+                directories=directory if isinstance(directory, (list, tuple)) else [directory], default_filters=["h"]
+            )
+        elif engine_instance:
+            self.engine = engine_instance
+
+        self._template_callables: list[tuple[str, TemplateCallableType]] = []
+        self.register_template_callable(key="url_for_static_asset", template_callable=url_for_static_asset)
+        self.register_template_callable(key="csrf_token", template_callable=csrf_token)
+        self.register_template_callable(key="url_for", template_callable=url_for)
+
+    def get_template(self, template_name: str) -> MakoTemplate:
+        """Retrieve a template by matching its name (dotted path) with files in the directory or directories provided.
+
+        Args:
+            template_name: A dotted path
+
+        Returns:
+            MakoTemplate instance
+
+        Raises:
+            TemplateNotFoundException: if no template is found.
+        """
+        try:
+            return MakoTemplate(
+                template=self.engine.get_template(template_name), template_callables=self._template_callables
+            )
+        except MakoTemplateNotFound as exc:
+            raise TemplateNotFoundException(template_name=template_name) from exc
+
+    def register_template_callable(
+        self, key: str, template_callable: TemplateCallableType[Mapping[str, Any], P, T]
+    ) -> None:
+        """Register a callable on the template engine.
+
+        Args:
+            key: The callable key, i.e. the value to use inside the template to call the callable.
+            template_callable: A callable to register.
+
+        Returns:
+            None
+        """
+        self._template_callables.append((key, template_callable))
+
+    def render_string(self, template_string: str, context: Mapping[str, Any]) -> str:  # pyright: ignore
+        """Render a template from a string with the given context.
+
+        Args:
+            template_string: The template string to render.
+            context: A dictionary of variables to pass to the template.
+
+        Returns:
+            The rendered template as a string.
+        """
+        template = _MakoTemplate(template_string)  # noqa: S702
+        return template.render(**context)  # type: ignore[no-any-return]
+
+    @classmethod
+    def from_template_lookup(cls, template_lookup: TemplateLookup) -> MakoTemplateEngine:
+        """Create a template engine from an existing mako TemplateLookup instance.
+
+        Args:
+            template_lookup: A mako TemplateLookup instance.
+
+        Returns:
+            MakoTemplateEngine instance
+        """
+        return cls(directory=None, engine_instance=template_lookup)

--- a/litestar/plugins/mako.py
+++ b/litestar/plugins/mako.py
@@ -36,7 +36,7 @@ T = TypeVar("T")
 class MakoTemplate(TemplateProtocol):
     """Mako template, implementing ``TemplateProtocol``"""
 
-    def __init__(self, template: _MakoTemplate, template_callables: list[tuple[str, TemplateCallableType]]) -> None:
+    def __init__(self, template: Any, template_callables: list[tuple[str, Any]]) -> None:
         """Initialize a template.
 
         Args:
@@ -135,7 +135,7 @@ class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate, Mapping[str, Any]]
         return template.render(**context)  # type: ignore[no-any-return]
 
     @classmethod
-    def from_template_lookup(cls, template_lookup: TemplateLookup) -> MakoTemplateEngine:
+    def from_template_lookup(cls, template_lookup: Any) -> MakoTemplateEngine:
         """Create a template engine from an existing mako TemplateLookup instance.
 
         Args:

--- a/tests/unit/test_contrib/test_mako.py
+++ b/tests/unit/test_contrib/test_mako.py
@@ -1,0 +1,56 @@
+# ruff: noqa: F401
+import sys
+from importlib.util import cache_from_source
+from pathlib import Path
+from typing import Union
+
+import pytest
+
+
+def purge_module(module_names: "list[str]", path: "Union[str, Path]") -> None:
+    for name in module_names:
+        if name in sys.modules:
+            del sys.modules[name]
+    Path(cache_from_source(str(path))).unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize("attr_name", ("MakoTemplate", "MakoTemplateEngine"))
+def test_deprecated_mako_imports(attr_name: str) -> None:
+    purge_module(["litestar.contrib.mako"], __file__)
+    with pytest.warns(
+        DeprecationWarning,
+        match=f"importing {attr_name} from 'litestar.contrib.mako' is deprecated",
+    ):
+        exec(f"from litestar.contrib.mako import {attr_name}", {})
+
+
+def test_contrib_imports_resolve_to_plugin_objects() -> None:
+    purge_module(["litestar.contrib.mako"], __file__)
+    with pytest.warns(DeprecationWarning):
+        from litestar.contrib.mako import MakoTemplate as ContribMakoTemplate
+        from litestar.contrib.mako import MakoTemplateEngine as ContribMakoTemplateEngine
+
+    from litestar.plugins.mako import MakoTemplate, MakoTemplateEngine
+
+    assert ContribMakoTemplate is MakoTemplate
+    assert ContribMakoTemplateEngine is MakoTemplateEngine
+
+
+def test_deprecated_mako_import_message_includes_version_and_removal() -> None:
+    purge_module(["litestar.contrib.mako"], __file__)
+    with pytest.warns(DeprecationWarning) as warning_records:
+        from litestar.contrib.mako import MakoTemplateEngine
+
+    message = str(warning_records[0].message)
+    assert "litestar.contrib.mako.MakoTemplateEngine" in message
+    assert "Deprecated in litestar 2.22.0" in message
+    assert "removed in 3.0.0" in message
+    assert "litestar.plugins.mako" in message
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    purge_module(["litestar.contrib.mako"], __file__)
+    import litestar.contrib.mako as contrib_mako
+
+    with pytest.raises(AttributeError):
+        contrib_mako.Nope


### PR DESCRIPTION
Summary:
- Add litestar.plugins.mako and deprecate litestar.contrib.mako imports.
- Add v2 deprecation tests in tests/unit/test_contrib/test_mako.py.
- No manual changelog entry.

Tests:
- uv run --python 3.12 pytest tests/unit/test_contrib/test_mako.py -v
- uv run --python 3.12 ruff check litestar/plugins/mako.py litestar/contrib/mako.py tests/unit/test_contrib/test_mako.py
- uv run --python 3.12 ruff format --check litestar/plugins/mako.py litestar/contrib/mako.py tests/unit/test_contrib/test_mako.py
- uv run --python 3.12 pyright litestar/plugins/mako.py litestar/contrib/mako.py tests/unit/test_contrib/test_mako.py

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4774">https://litestar-org.github.io/litestar-docs-preview/4774</a> 
