### PR TITLE
feat(minijinja): deprecate contrib module on v2

### DIFF
--- a/docs/reference/plugins/index.rst
+++ b/docs/reference/plugins/index.rst
@@ -12,6 +12,7 @@ plugins
     attrs
     flash_messages
     htmx
+    minijinja
     mako
     jinja
     opentelemetry

--- a/docs/reference/plugins/minijinja.rst
+++ b/docs/reference/plugins/minijinja.rst
@@ -1,0 +1,6 @@
+=========
+minijinja
+=========
+
+.. automodule:: litestar.plugins.minijinja
+    :members:

--- a/litestar/contrib/minijinja.py
+++ b/litestar/contrib/minijinja.py
@@ -1,217 +1,32 @@
 from __future__ import annotations
 
-import functools
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, Mapping, Protocol, TypeVar, cast
+from typing import TYPE_CHECKING
 
-from typing_extensions import ParamSpec
-
-from litestar.exceptions import ImproperlyConfiguredException, MissingDependencyException, TemplateNotFoundException
-from litestar.template.base import (
-    TemplateCallableType,
-    TemplateEngineProtocol,
-    TemplateProtocol,
-    csrf_token,
-    url_for,
-    url_for_static_asset,
-)
 from litestar.utils.deprecation import warn_deprecation
-
-try:
-    from minijinja import Environment
-    from minijinja import TemplateError as MiniJinjaTemplateNotFound
-except ImportError as e:
-    raise MissingDependencyException("minijinja") from e
-
-if TYPE_CHECKING:
-    from typing import Callable
-
-    C = TypeVar("C", bound="Callable")
-
-    def pass_state(func: C) -> C: ...
-
-else:
-    from minijinja import pass_state
 
 __all__ = (
     "MiniJinjaTemplateEngine",
     "StateProtocol",
 )
 
-P = ParamSpec("P")
-T = TypeVar("T")
+_FORWARDED = (*__all__, "MiniJinjaTemplate", "_transform_state")
 
 
-class StateProtocol(Protocol):
-    auto_escape: str | None
-    current_block: str | None
-    env: Environment
-    name: str
+def __getattr__(attr_name: str) -> object:
+    from litestar.plugins import minijinja
 
-    def lookup(self, key: str) -> Any | None: ...
+    if attr_name in _FORWARDED:
+        warn_deprecation(
+            deprecated_name=f"litestar.contrib.minijinja.{attr_name}",
+            version="2.22.0",
+            kind="import",
+            removal_in="3.0.0",
+            info=f"importing {attr_name} from 'litestar.contrib.minijinja' is deprecated, please "
+            f"import it from 'litestar.plugins.minijinja' instead",
+        )
+        return getattr(minijinja, attr_name)
 
-
-def _transform_state(func: TemplateCallableType[Mapping[str, Any], P, T]) -> TemplateCallableType[StateProtocol, P, T]:
-    """Transform a template callable to receive a ``StateProtocol`` instance as first argument.
-
-    This is for wrapping callables like ``url_for()`` that receive a mapping as first argument so they can be used
-    with minijinja which passes a ``StateProtocol`` instance as first argument.
-    """
-
-    @functools.wraps(func)
-    @pass_state
-    def wrapped(state: StateProtocol, /, *args: P.args, **kwargs: P.kwargs) -> T:
-        template_context = {"request": state.lookup("request"), "csrf_input": state.lookup("csrf_input")}
-        return func(template_context, *args, **kwargs)
-
-    return wrapped
-
-
-class MiniJinjaTemplate(TemplateProtocol):
-    """Initialize a template.
-
-    Args:
-        template: Base ``MiniJinjaTemplate`` used by the underlying minijinja engine
-    """
-
-    def __init__(self, engine: Environment, template_name: str) -> None:
-        super().__init__()
-        self.engine = engine
-        self.template_name = template_name
-
-    def render(self, *args: Any, **kwargs: Any) -> str:
-        """Render a template.
-
-        Args:
-            args: Positional arguments passed to the engines ``render`` function
-            kwargs: Keyword arguments passed to the engines ``render`` function
-
-        Returns:
-            Rendered template as a string
-        """
-        try:
-            return str(self.engine.render_template(self.template_name, *args, **kwargs))
-        except MiniJinjaTemplateNotFound as err:
-            raise TemplateNotFoundException(template_name=self.template_name) from err
-
-
-class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate", StateProtocol]):
-    """The engine instance."""
-
-    def __init__(self, directory: Path | list[Path] | None = None, engine_instance: Environment | None = None) -> None:
-        """Minijinja based TemplateEngine.
-
-        Args:
-            directory: Direct path or list of directory paths from which to serve templates.
-            engine_instance: A Minijinja Environment instance.
-        """
-        if directory and engine_instance:
-            raise ImproperlyConfiguredException(
-                "You must provide either a directory or a minijinja Environment instance."
-            )
-        if directory:
-
-            def _loader(name: str) -> str:
-                """Load a template from a directory.
-
-                Args:
-                    name: The name of the template
-
-                Returns:
-                    The template as a string
-
-                Raises:
-                    TemplateNotFoundException: if no template is found.
-                """
-                directories = directory if isinstance(directory, list) else [directory]
-
-                for d in directories:
-                    template_path = Path(d) / name  # pyright: ignore[reportGeneralTypeIssues]
-                    if template_path.exists():
-                        return template_path.read_text()
-                raise TemplateNotFoundException(template_name=name)
-
-            self.engine = Environment(loader=_loader)
-        elif engine_instance:
-            self.engine = engine_instance
-        else:
-            raise ImproperlyConfiguredException(
-                "You must provide either a directory or a minijinja Environment instance."
-            )
-
-        self.register_template_callable("url_for", _transform_state(url_for))
-        self.register_template_callable("csrf_token", _transform_state(csrf_token))
-        self.register_template_callable("url_for_static_asset", _transform_state(url_for_static_asset))
-
-    def get_template(self, template_name: str) -> MiniJinjaTemplate:
-        """Retrieve a template by matching its name (dotted path) with files in the directory or directories provided.
-
-        Args:
-            template_name: A dotted path
-
-        Returns:
-            MiniJinjaTemplate instance
-
-        Raises:
-            TemplateNotFoundException: if no template is found.
-        """
-        return MiniJinjaTemplate(self.engine, template_name)
-
-    def register_template_callable(
-        self,
-        key: str,
-        template_callable: TemplateCallableType[StateProtocol, P, T],
-    ) -> None:
-        """Register a callable on the template engine.
-
-        Args:
-            key: The callable key, i.e. the value to use inside the template to call the callable.
-            template_callable: A callable to register.
-
-        Returns:
-            None
-        """
-
-        def is_decorated(func: Callable) -> bool:
-            return hasattr(func, "__wrapped__") or func.__name__ not in globals()
-
-        if not is_decorated(template_callable):
-            template_callable = _transform_state(template_callable)  # type: ignore[arg-type] # pragma: no cover
-        self.engine.add_global(key, pass_state(template_callable))
-
-    def render_string(self, template_string: str, context: Mapping[str, Any]) -> str:
-        """Render a template from a string with the given context.
-
-        Args:
-            template_string: The template string to render.
-            context: A dictionary of variables to pass to the template.
-
-        Returns:
-            The rendered template as a string.
-        """
-        return self.engine.render_str(template_string, **context)
-
-    @classmethod
-    def from_environment(cls, minijinja_environment: Environment) -> MiniJinjaTemplateEngine:
-        """Create a MiniJinjaTemplateEngine from an existing minijinja Environment instance.
-
-        Args:
-            minijinja_environment (Environment): A minijinja Environment instance.
-
-        Returns:
-            MiniJinjaTemplateEngine instance
-        """
-        return cls(directory=None, engine_instance=minijinja_environment)
-
-
-@pass_state
-def _minijinja_from_state(func: Callable, state: StateProtocol, *args: Any, **kwargs: Any) -> str:  # pragma: no cover
-    template_context = {"request": state.lookup("request"), "csrf_input": state.lookup("csrf_input")}
-    return cast("str", func(template_context, *args, **kwargs))
-
-
-def __getattr__(name: str) -> Any:
-    if name == "minijinja_from_state":
+    if attr_name == "minijinja_from_state":
         warn_deprecation(
             "2.3.0",
             "minijinja_from_state",
@@ -219,5 +34,10 @@ def __getattr__(name: str) -> Any:
             removal_in="3.0.0",
             alternative="Use a callable that receives the minijinja State object as first argument.",
         )
-        return _minijinja_from_state
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+        return minijinja._minijinja_from_state
+
+    raise AttributeError(f"module {__name__!r} has no attribute {attr_name!r}")  # pragma: no cover
+
+
+if TYPE_CHECKING:
+    from litestar.plugins.minijinja import MiniJinjaTemplateEngine, StateProtocol

--- a/litestar/plugins/flash.py
+++ b/litestar/plugins/flash.py
@@ -59,7 +59,7 @@ class FlashPlugin(InitPlugin):
             raise litestar.exceptions.ImproperlyConfiguredException("Flash messages require a session middleware.")
         template_callable: Callable[[Any], Any] = get_flashes
         with suppress(MissingDependencyException):
-            from litestar.contrib.minijinja import MiniJinjaTemplateEngine, _transform_state
+            from litestar.plugins.minijinja import MiniJinjaTemplateEngine, _transform_state
 
             if isinstance(self.config.template_config.engine_instance, MiniJinjaTemplateEngine):
                 template_callable = _transform_state(get_flashes)

--- a/litestar/plugins/minijinja.py
+++ b/litestar/plugins/minijinja.py
@@ -35,6 +35,7 @@ else:
     from minijinja import pass_state
 
 __all__ = (
+    "MiniJinjaTemplate",
     "MiniJinjaTemplateEngine",
     "StateProtocol",
 )
@@ -75,7 +76,7 @@ class MiniJinjaTemplate(TemplateProtocol):
         template: Base ``MiniJinjaTemplate`` used by the underlying minijinja engine
     """
 
-    def __init__(self, engine: Environment, template_name: str) -> None:
+    def __init__(self, engine: Any, template_name: str) -> None:
         super().__init__()
         self.engine = engine
         self.template_name = template_name
@@ -99,7 +100,7 @@ class MiniJinjaTemplate(TemplateProtocol):
 class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate", StateProtocol]):
     """The engine instance."""
 
-    def __init__(self, directory: Path | list[Path] | None = None, engine_instance: Environment | None = None) -> None:
+    def __init__(self, directory: Path | list[Path] | None = None, engine_instance: Any | None = None) -> None:
         """Minijinja based TemplateEngine.
 
         Args:
@@ -193,7 +194,7 @@ class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate", StateP
         return self.engine.render_str(template_string, **context)
 
     @classmethod
-    def from_environment(cls, minijinja_environment: Environment) -> MiniJinjaTemplateEngine:
+    def from_environment(cls, minijinja_environment: Any) -> MiniJinjaTemplateEngine:
         """Create a MiniJinjaTemplateEngine from an existing minijinja Environment instance.
 
         Args:

--- a/litestar/plugins/minijinja.py
+++ b/litestar/plugins/minijinja.py
@@ -1,0 +1,211 @@
+"""MiniJinja template engine integration for Litestar."""
+
+from __future__ import annotations
+
+import functools
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Mapping, Protocol, TypeVar, cast
+
+from typing_extensions import ParamSpec
+
+from litestar.exceptions import ImproperlyConfiguredException, MissingDependencyException, TemplateNotFoundException
+from litestar.template.base import (
+    TemplateCallableType,
+    TemplateEngineProtocol,
+    TemplateProtocol,
+    csrf_token,
+    url_for,
+    url_for_static_asset,
+)
+
+try:
+    from minijinja import Environment
+    from minijinja import TemplateError as MiniJinjaTemplateNotFound
+except ImportError as e:
+    raise MissingDependencyException("minijinja") from e
+
+if TYPE_CHECKING:
+    from typing import Callable
+
+    C = TypeVar("C", bound="Callable")
+
+    def pass_state(func: C) -> C: ...
+
+else:
+    from minijinja import pass_state
+
+__all__ = (
+    "MiniJinjaTemplateEngine",
+    "StateProtocol",
+)
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+class StateProtocol(Protocol):
+    auto_escape: str | None
+    current_block: str | None
+    env: Environment
+    name: str
+
+    def lookup(self, key: str) -> Any | None: ...
+
+
+def _transform_state(func: TemplateCallableType[Mapping[str, Any], P, T]) -> TemplateCallableType[StateProtocol, P, T]:
+    """Transform a template callable to receive a ``StateProtocol`` instance as first argument.
+
+    This is for wrapping callables like ``url_for()`` that receive a mapping as first argument so they can be used
+    with minijinja which passes a ``StateProtocol`` instance as first argument.
+    """
+
+    @functools.wraps(func)
+    @pass_state
+    def wrapped(state: StateProtocol, /, *args: P.args, **kwargs: P.kwargs) -> T:
+        template_context = {"request": state.lookup("request"), "csrf_input": state.lookup("csrf_input")}
+        return func(template_context, *args, **kwargs)
+
+    return wrapped
+
+
+class MiniJinjaTemplate(TemplateProtocol):
+    """Initialize a template.
+
+    Args:
+        template: Base ``MiniJinjaTemplate`` used by the underlying minijinja engine
+    """
+
+    def __init__(self, engine: Environment, template_name: str) -> None:
+        super().__init__()
+        self.engine = engine
+        self.template_name = template_name
+
+    def render(self, *args: Any, **kwargs: Any) -> str:
+        """Render a template.
+
+        Args:
+            args: Positional arguments passed to the engines ``render`` function
+            kwargs: Keyword arguments passed to the engines ``render`` function
+
+        Returns:
+            Rendered template as a string
+        """
+        try:
+            return str(self.engine.render_template(self.template_name, *args, **kwargs))
+        except MiniJinjaTemplateNotFound as err:
+            raise TemplateNotFoundException(template_name=self.template_name) from err
+
+
+class MiniJinjaTemplateEngine(TemplateEngineProtocol["MiniJinjaTemplate", StateProtocol]):
+    """The engine instance."""
+
+    def __init__(self, directory: Path | list[Path] | None = None, engine_instance: Environment | None = None) -> None:
+        """Minijinja based TemplateEngine.
+
+        Args:
+            directory: Direct path or list of directory paths from which to serve templates.
+            engine_instance: A Minijinja Environment instance.
+        """
+        if directory and engine_instance:
+            raise ImproperlyConfiguredException(
+                "You must provide either a directory or a minijinja Environment instance."
+            )
+        if directory:
+
+            def _loader(name: str) -> str:
+                """Load a template from a directory.
+
+                Args:
+                    name: The name of the template
+
+                Returns:
+                    The template as a string
+
+                Raises:
+                    TemplateNotFoundException: if no template is found.
+                """
+                directories = directory if isinstance(directory, list) else [directory]
+
+                for d in directories:
+                    template_path = Path(d) / name  # pyright: ignore[reportGeneralTypeIssues]
+                    if template_path.exists():
+                        return template_path.read_text()
+                raise TemplateNotFoundException(template_name=name)
+
+            self.engine = Environment(loader=_loader)
+        elif engine_instance:
+            self.engine = engine_instance
+        else:
+            raise ImproperlyConfiguredException(
+                "You must provide either a directory or a minijinja Environment instance."
+            )
+
+        self.register_template_callable("url_for", _transform_state(url_for))
+        self.register_template_callable("csrf_token", _transform_state(csrf_token))
+        self.register_template_callable("url_for_static_asset", _transform_state(url_for_static_asset))
+
+    def get_template(self, template_name: str) -> MiniJinjaTemplate:
+        """Retrieve a template by matching its name (dotted path) with files in the directory or directories provided.
+
+        Args:
+            template_name: A dotted path
+
+        Returns:
+            MiniJinjaTemplate instance
+
+        Raises:
+            TemplateNotFoundException: if no template is found.
+        """
+        return MiniJinjaTemplate(self.engine, template_name)
+
+    def register_template_callable(
+        self,
+        key: str,
+        template_callable: TemplateCallableType[StateProtocol, P, T],
+    ) -> None:
+        """Register a callable on the template engine.
+
+        Args:
+            key: The callable key, i.e. the value to use inside the template to call the callable.
+            template_callable: A callable to register.
+
+        Returns:
+            None
+        """
+
+        def is_decorated(func: Callable) -> bool:
+            return hasattr(func, "__wrapped__") or func.__name__ not in globals()
+
+        if not is_decorated(template_callable):
+            template_callable = _transform_state(template_callable)  # type: ignore[arg-type] # pragma: no cover
+        self.engine.add_global(key, pass_state(template_callable))
+
+    def render_string(self, template_string: str, context: Mapping[str, Any]) -> str:
+        """Render a template from a string with the given context.
+
+        Args:
+            template_string: The template string to render.
+            context: A dictionary of variables to pass to the template.
+
+        Returns:
+            The rendered template as a string.
+        """
+        return self.engine.render_str(template_string, **context)
+
+    @classmethod
+    def from_environment(cls, minijinja_environment: Environment) -> MiniJinjaTemplateEngine:
+        """Create a MiniJinjaTemplateEngine from an existing minijinja Environment instance.
+
+        Args:
+            minijinja_environment (Environment): A minijinja Environment instance.
+
+        Returns:
+            MiniJinjaTemplateEngine instance
+        """
+        return cls(directory=None, engine_instance=minijinja_environment)
+
+
+@pass_state
+def _minijinja_from_state(func: Callable, state: StateProtocol, *args: Any, **kwargs: Any) -> str:  # pragma: no cover
+    template_context = {"request": state.lookup("request"), "csrf_input": state.lookup("csrf_input")}
+    return cast("str", func(template_context, *args, **kwargs))

--- a/tests/unit/test_contrib/test_minijinja.py
+++ b/tests/unit/test_contrib/test_minijinja.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import sys
+from importlib.util import cache_from_source
+from pathlib import Path
 
 import pytest
 from minijinja import Environment
 
-from litestar.contrib.minijinja import MiniJinjaTemplateEngine
 from litestar.exceptions import ImproperlyConfiguredException, TemplateNotFoundException
+from litestar.plugins.minijinja import MiniJinjaTemplateEngine
 
-if TYPE_CHECKING:
-    from pathlib import Path
+
+def purge_module(module_names: list[str], path: str | Path) -> None:
+    for name in module_names:
+        if name in sys.modules:
+            del sys.modules[name]
+    Path(cache_from_source(str(path))).unlink(missing_ok=True)
 
 
 def test_mini_jinja_template_engine_instantiation_error(tmp_path: Path) -> None:
@@ -44,3 +50,61 @@ def test_from_environment() -> None:
     engine = Environment()
     template_engine = MiniJinjaTemplateEngine.from_environment(engine)
     assert template_engine.engine is engine
+
+
+@pytest.mark.parametrize(
+    "attr_name",
+    ("MiniJinjaTemplateEngine", "StateProtocol", "MiniJinjaTemplate", "_transform_state"),
+)
+def test_deprecated_minijinja_imports(attr_name: str) -> None:
+    purge_module(["litestar.contrib.minijinja"], __file__)
+    with pytest.warns(
+        DeprecationWarning,
+        match=f"importing {attr_name} from 'litestar.contrib.minijinja' is deprecated",
+    ):
+        exec(f"from litestar.contrib.minijinja import {attr_name}", {})
+
+
+def test_contrib_imports_resolve_to_plugin_objects() -> None:
+    purge_module(["litestar.contrib.minijinja"], __file__)
+    with pytest.warns(DeprecationWarning):
+        from litestar.contrib.minijinja import MiniJinjaTemplateEngine as ContribMiniJinjaTemplateEngine
+        from litestar.contrib.minijinja import StateProtocol as ContribStateProtocol
+        from litestar.contrib.minijinja import _transform_state as contrib_transform_state
+
+    from litestar.plugins.minijinja import StateProtocol, _transform_state
+
+    assert ContribMiniJinjaTemplateEngine is MiniJinjaTemplateEngine
+    assert ContribStateProtocol is StateProtocol
+    assert contrib_transform_state is _transform_state
+
+
+def test_deprecated_minijinja_import_message_includes_version_and_removal() -> None:
+    purge_module(["litestar.contrib.minijinja"], __file__)
+    with pytest.warns(DeprecationWarning) as warning_records:
+        from litestar.contrib.minijinja import MiniJinjaTemplateEngine as ContribMiniJinjaTemplateEngine
+
+    message = str(warning_records[0].message)
+    assert ContribMiniJinjaTemplateEngine is MiniJinjaTemplateEngine
+    assert "litestar.contrib.minijinja.MiniJinjaTemplateEngine" in message
+    assert "Deprecated in litestar 2.22.0" in message
+    assert "removed in 3.0.0" in message
+    assert "litestar.plugins.minijinja" in message
+
+
+def test_existing_minijinja_from_state_deprecation_still_resolves() -> None:
+    purge_module(["litestar.contrib.minijinja"], __file__)
+    with pytest.warns(DeprecationWarning, match="minijinja_from_state"):
+        from litestar.contrib.minijinja import minijinja_from_state
+
+    from litestar.plugins.minijinja import _minijinja_from_state
+
+    assert minijinja_from_state is _minijinja_from_state
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    purge_module(["litestar.contrib.minijinja"], __file__)
+    import litestar.contrib.minijinja as contrib_minijinja
+
+    with pytest.raises(AttributeError):
+        contrib_minijinja.Nope


### PR DESCRIPTION
Summary:
- Add litestar.plugins.minijinja and deprecate litestar.contrib.minijinja imports.
- Add v2 deprecation tests in tests/unit/test_contrib/test_minijinja.py.
- Preserve v2 MiniJinja behavior, including url_for_static_asset.
- No manual changelog entry.

Tests:
- uv run --python 3.12 pytest tests/unit/test_contrib/test_minijinja.py -v
- uv run --python 3.12 ruff check litestar/plugins/minijinja.py litestar/contrib/minijinja.py tests/unit/test_contrib/test_minijinja.py
- uv run --python 3.12 ruff format --check litestar/plugins/minijinja.py litestar/contrib/minijinja.py tests/unit/test_contrib/test_minijinja.py
- uv run --python 3.12 pyright litestar/plugins/minijinja.py litestar/contrib/minijinja.py tests/unit/test_contrib/test_minijinja.py

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4775">https://litestar-org.github.io/litestar-docs-preview/4775</a> 
