### PR TITLE
chore: clean up leftover Python 3.9/3.10 references

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -7,8 +7,8 @@ Getting Started
 Supported Python Versions
 +++++++++++++++++++++++++
 
-The lowest currently supported version is Python 3.9.
-At a minimum you will need Python 3.9 for code changes and 3.13 if you plan on doing documentation building / changes.
+The lowest currently supported version is Python 3.11.
+At a minimum you will need Python 3.11 for code changes and 3.13 if you plan on doing documentation building / changes.
 
 You can use various tools to manage multiple Python versions on your system including:
 
@@ -142,7 +142,7 @@ enforce type safety. You can run them with:
 - ``make type-check`` to run both
 - ``make lint`` to run pre-commit hooks and type checkers.
 
-Our type checkers are run on Python 3.9 in CI, so you should make sure to run them on the same version locally as well.
+Our type checkers are run on Python 3.11 in CI, so you should make sure to run them on the same version locally as well.
 
 Project documentation
 ---------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,6 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Natural Language :: English",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
- follow [Litestar's AI Policy](https://github.com/litestar-org/.github/blob/main/AI_POLICY.md)

If the pull request is not yet ready for review (e.g. tests or other checks are still failing),
please submit it as a draft PR, to avoid noise for reviewers.
-->

## Description
Follow-up to #4644.

- `pyproject.toml`: drop the now-obsolete `:: 3.9` and `:: 3.10`
  classifiers (other version metadata was already updated in #4644).
- `CONTRIBUTING.rst`: bump the minimum Python version mentioned in the
  contributor guide from 3.9 to 3.11.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4777">https://litestar-org.github.io/litestar-docs-preview/4777</a> 
