### PR TITLE
test: simplify test_recursive_schema_generation

### DIFF
--- a/tests/unit/test_openapi/test_spec_generation.py
+++ b/tests/unit/test_openapi/test_spec_generation.py
@@ -1,4 +1,3 @@
-import sys
 from collections.abc import Callable
 from types import ModuleType
 from typing import Any
@@ -104,9 +103,7 @@ def test_msgspec_schema() -> None:
         }
 
 
-@pytest.fixture()
-def py_310_module_content() -> str:
-    return """
+MODULE_CONTENT = """
 from __future__ import annotations
 
 from msgspec import Struct
@@ -135,23 +132,8 @@ async def test() -> A:
 """
 
 
-@pytest.mark.parametrize(
-    ("fixture_name",),
-    [
-        pytest.param(
-            "py_310_module_content",
-            marks=pytest.mark.skipif(
-                sys.version_info < (3, 10),
-                reason="requires python 3.10",
-            ),
-        ),
-    ],
-)
-def test_recursive_schema_generation(
-    fixture_name: str, create_module: Callable[[str], ModuleType], request: pytest.FixtureRequest
-) -> None:
-    module_content = request.getfixturevalue(fixture_name)
-    module = create_module(module_content)
+def test_recursive_schema_generation(create_module: Callable[[str], ModuleType]) -> None:
+    module = create_module(MODULE_CONTENT)
     with create_test_client(module.test, debug=True) as client:
         schema = client.app.openapi_schema
         assert schema


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
- follow [Litestar's AI Policy](https://github.com/litestar-org/.github/blob/main/AI_POLICY.md)

If the pull request is not yet ready for review (e.g. tests or other checks are still failing),
please submit it as a draft PR, to avoid noise for reviewers.
-->

## Description
Follow-up to #4644 (Python 3.9/3.10 drop).

The enclosing `parametrize` originally ran two syntax variants (#2869); when the 3.8 variant was removed in #4010, the remaining variant stayed under `skipif(sys.version_info < (3, 10))`. With 3.11+ as the minimum, the skipif is dead — and once removed, the `parametrize` wraps a single unconditional entry.

- Remove the `skipif` and `parametrize`.
- Replace the fixture with a module-level constant.
- Remove `import sys` and the `request` fixture parameter.
 
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4778">https://litestar-org.github.io/litestar-docs-preview/4778</a> 
