### PR TITLE
docs: remove STOK from sponsors

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -134,15 +134,6 @@ A huge thank you to our current sponsors:
 
          `Telemetry Sports <https://telemetrysports.com/>`_
 
-      .. grid-item-card::
-         :link: https://www.stok.kr/
-
-         .. image:: https://avatars.githubusercontent.com/u/144093421
-            :alt: Stok
-            :class: sponsor
-
-         `Stok <https://www.stok.kr/>`_
-
 We invite organizations and individuals to join our sponsorship program.
 By becoming a sponsor on platforms like `Polar <sponsor-polar_>`_, `GitHub <sponsor-github_>`_
 and `Open Collective <sponsor-oc_>`_, you can play a pivotal role in our project's growth.


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
- follow [Litestar's AI Policy](https://github.com/litestar-org/.github/blob/main/AI_POLICY.md)

If the pull request is not yet ready for review (e.g. tests or other checks are still failing),
please submit it as a draft PR, to avoid noise for reviewers.
-->

## Description
- `STOK` is no longer an active sponsor.
- Originally removed in #3915, but reintroduced in #4012 during the landing page rewrite.


<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4779">https://litestar-org.github.io/litestar-docs-preview/4779</a> 
