### PR TITLE
fix(channels/backend/redis): reset cached PubSub state on shutdown

### DIFF
--- a/litestar/channels/backends/redis.py
+++ b/litestar/channels/backends/redis.py
@@ -100,6 +100,11 @@ class RedisChannelsPubSubBackend(RedisChannelsBackend):
 
     async def on_shutdown(self) -> None:
         await self._pub_sub.reset()
+        # the lazy `_pub_sub` property caches the PubSub object; clearing the
+        # cache here ensures a fresh PubSub is created on the next startup so
+        # the backend can be reused across multiple plugin lifecycles
+        self.__pub_sub = None
+        self._has_subscribed = _LazyEvent()
 
     async def subscribe(self, channels: Iterable[str]) -> None:
         """Subscribe to ``channels``, and enable publishing to them"""

--- a/tests/unit/test_channels/test_backends.py
+++ b/tests/unit/test_channels/test_backends.py
@@ -163,6 +163,7 @@ async def test_redis_pubsub_backend_reusable_across_plugin_lifecycles(
         async with ChannelsPlugin(backend=redis_pub_sub_backend, channels=["c"]) as plugin:
             subscriber = await plugin.subscribe("c")
             await plugin.wait_published(b"x", "c")
+
             async def _consume() -> list[bytes]:
                 items: list[bytes] = []
                 async for item in subscriber.iter_events():
@@ -170,6 +171,7 @@ async def test_redis_pubsub_backend_reusable_across_plugin_lifecycles(
                     if len(items) == 1:
                         break
                 return items
+
             assert await asyncio.wait_for(_consume(), timeout=2.0) == [b"x"]
 
 

--- a/tests/unit/test_channels/test_backends.py
+++ b/tests/unit/test_channels/test_backends.py
@@ -14,7 +14,7 @@ from litestar.channels import ChannelsBackend
 from litestar.channels.backends.asyncpg import AsyncPgChannelsBackend
 from litestar.channels.backends.memory import MemoryChannelsBackend
 from litestar.channels.backends.psycopg import PsycoPgChannelsBackend
-from litestar.channels.backends.redis import RedisChannelsStreamBackend
+from litestar.channels.backends.redis import RedisChannelsPubSubBackend, RedisChannelsStreamBackend
 from litestar.exceptions import ImproperlyConfiguredException
 
 
@@ -145,6 +145,32 @@ async def test_redis_streams_backend_flushall(redis_stream_backend: RedisChannel
     result = await redis_stream_backend.flush_all()
 
     assert result == 3
+
+
+@pytest.mark.xdist_group("redis")
+async def test_redis_pubsub_backend_reusable_across_plugin_lifecycles(
+    redis_pub_sub_backend: RedisChannelsPubSubBackend,
+) -> None:
+    """A pubsub backend instance must be reusable across multiple ``ChannelsPlugin`` lifecycles.
+
+    Regression test for a bug where ``on_shutdown`` closed the underlying
+    ``PubSub`` connection but the lazy ``_pub_sub`` cache kept the dead object,
+    breaking the next startup/subscribe cycle.
+    """
+    from litestar.channels import ChannelsPlugin
+
+    for _ in range(2):
+        async with ChannelsPlugin(backend=redis_pub_sub_backend, channels=["c"]) as plugin:
+            subscriber = await plugin.subscribe("c")
+            await plugin.wait_published(b"x", "c")
+            async def _consume() -> list[bytes]:
+                items: list[bytes] = []
+                async for item in subscriber.iter_events():
+                    items.append(item)
+                    if len(items) == 1:
+                        break
+                return items
+            assert await asyncio.wait_for(_consume(), timeout=2.0) == [b"x"]
 
 
 @pytest.mark.flaky(reruns=5)  # this should not really happen but just in case, we retry


### PR DESCRIPTION
While trying to find the root cause of the pin of redis ``<5.3`` found  that`RedisChannelsPubSubBackend.on_shutdown()` calls `self._pub_sub.reset()`, which closes the underlying `PubSub` connection, but the lazy `_pub_sub` property keeps the now-dead object cached in `__pub_sub`. The next startup/subscribe cycle on the same backend instance returns the same dead `PubSub`, and the subscriber worker fails on the first `get_message()` call:

RuntimeError: pubsub connection not set: did you forget to call subscribe() or psubscribe()?

This makes the documented "instantiate-once, share-across-app" usage pattern broken — any code that nests a `ChannelsPlugin` inside an `async with` block twice with the same `RedisChannelsPubSubBackend` instance hits the error on the second iteration.

The stream backend isn't affected because its `on_shutdown` is a no-op.

Added a test to cover the issue

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4784">https://litestar-org.github.io/litestar-docs-preview/4784</a> 
