### PR TITLE
chore(deps): bump redis and exclude 5.3 version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ piccolo = ["piccolo", "litestar-piccolo"]
 polyfactory = ["polyfactory>=2.6.3"]
 prometheus = ["prometheus-client"]
 pydantic = ["pydantic>=2", "email-validator", "pydantic-extra-types"]
-redis = ["redis[hiredis]>=7"]
+redis = ["redis[hiredis]>=4.4.4,!=5.3.*"]  # 5.3.0 introduced some issues with the channels plugin; need to investigate
 sqlalchemy = ["advanced-alchemy>=1.1.0"]
 standard = [
   "jinja2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ piccolo = ["piccolo", "litestar-piccolo"]
 polyfactory = ["polyfactory>=2.6.3"]
 prometheus = ["prometheus-client"]
 pydantic = ["pydantic>=2", "email-validator", "pydantic-extra-types"]
-redis = ["redis[hiredis]>=4.4.4,<5.3"]  # 5.3.0 introduced some issues with the channels plugin; need to investigate
+redis = ["redis[hiredis]>=7"]
 sqlalchemy = ["advanced-alchemy>=1.1.0"]
 standard = [
   "jinja2",

--- a/uv.lock
+++ b/uv.lock
@@ -2166,7 +2166,7 @@ requires-dist = [
     { name = "pydantic-extra-types", marker = "extra == 'pydantic'" },
     { name = "pyjwt", marker = "extra == 'jwt'", specifier = ">=2.9.0" },
     { name = "pyyaml", marker = "extra == 'yaml'" },
-    { name = "redis", extras = ["hiredis"], marker = "extra == 'redis'", specifier = ">=4.4.4,<5.3" },
+    { name = "redis", extras = ["hiredis"], marker = "extra == 'redis'", specifier = ">=7" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "rich-click", specifier = "<1.9" },
     { name = "sniffio", specifier = ">=1.3.1" },
@@ -3642,14 +3642,14 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "5.2.1"
+version = "7.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/da/d283a37303a995cd36f8b92db85135153dc4f7a8e4441aa827721b442cfb/redis-5.2.1.tar.gz", hash = "sha256:16f2e22dff21d5125e8481515e386711a34cbec50f0e44413dd7d9c060a54e0f", size = 4608355, upload-time = "2024-12-06T09:50:41.956Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/5f/fa26b9b2672cbe30e07d9a5bdf39cf16e3b80b42916757c5f92bca88e4ba/redis-5.2.1-py3-none-any.whl", hash = "sha256:ee7e1056b9aea0f04c6c2ed59452947f34c4940ee025f5dd83e6a6418b6989e4", size = 261502, upload-time = "2024-12-06T09:50:39.656Z" },
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2166,7 +2166,7 @@ requires-dist = [
     { name = "pydantic-extra-types", marker = "extra == 'pydantic'" },
     { name = "pyjwt", marker = "extra == 'jwt'", specifier = ">=2.9.0" },
     { name = "pyyaml", marker = "extra == 'yaml'" },
-    { name = "redis", extras = ["hiredis"], marker = "extra == 'redis'", specifier = ">=7" },
+    { name = "redis", extras = ["hiredis"], marker = "extra == 'redis'", specifier = ">=4.4.4,!=5.3.*" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "rich-click", specifier = "<1.9" },
     { name = "sniffio", specifier = ">=1.3.1" },


### PR DESCRIPTION
It updates redis to >7.0

Could not reproduce the specific issue with the pinned version of redis but found that:
https://github.com/redis/redis-py/issues/3640

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4785">https://litestar-org.github.io/litestar-docs-preview/4785</a> 
