### PR TITLE
docs(conf)!: fix Pygments code block contrast in light mode

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from functools import partial
 from typing import Any
 
+from shibuya._pygments import ShibuyaPygmentsBridge
 from sphinx.addnodes import document
 from sphinx.application import Sphinx
 from sqlalchemy.exc import SAWarning
@@ -294,7 +295,12 @@ suppress_warnings = [
 # -- Style configuration -----------------------------------------------------
 html_theme = "litestar_sphinx_theme"
 html_title = "Litestar Framework"
-pygments_style = "lightbulb"
+
+# Pygments theming.
+# Shibuya only reads `pygments_style` from conf.py; the dark companion lives on
+# `ShibuyaPygmentsBridge.dark_style_name` as a class attribute, so we set it here.
+pygments_style = "one-light"
+ShibuyaPygmentsBridge.dark_style_name = "one-dark-pro"
 
 html_static_path = ["_static"]
 templates_path = ["_templates"]


### PR DESCRIPTION
## Summary
- `pygments_style = "lightbulb"` was a dark-bg style (`#1d2331`) being used for light mode, so light-theme pages rendered dark-mode token colors on a light background and code was barely readable.
- Switch to the **One Light / One Dark Pro** pair. The dark companion is set via `ShibuyaPygmentsBridge.dark_style_name` because Shibuya has no `pygments_dark_style` config hook (`_patch.py:69-77`).

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4796">https://litestar-org.github.io/litestar-docs-preview/4796</a> 
