### PR TITLE
fix: Allow empty template_str

### DIFF
--- a/litestar/response/template.py
+++ b/litestar/response/template.py
@@ -50,7 +50,7 @@ class Template(Response[bytes]):
 
         Args:
             template_name: Path-like name for the template to be rendered, e.g. ``index.html``.
-            template_str: A string representing the template, e.g. ``tmpl = "Hello <strong>World</strong>"``.
+            template_str: A string representing the template, e.g. ``template_str = "Hello <strong>World</strong>"``.
             background: A :class:`BackgroundTask <.background_tasks.BackgroundTask>` instance or
                 :class:`BackgroundTasks <.background_tasks.BackgroundTasks>` to execute after the response is finished.
                 Defaults to ``None``.
@@ -63,10 +63,10 @@ class Template(Response[bytes]):
                 the media type based on the template name. If this fails, fall back to ``text/plain``.
             status_code: A value for the response HTTP status code.
         """
-        if not (template_name or template_str):
+        if template_name is None and template_str is None:
             raise ValueError("Either template_name or template_str must be provided.")
 
-        if template_name and template_str:
+        if template_name is not None and template_str is not None:
             raise ValueError("Either template_name or template_str must be provided, not both.")
 
         super().__init__(

--- a/tests/unit/test_template/test_template.py
+++ b/tests/unit/test_template/test_template.py
@@ -155,6 +155,7 @@ test_cases = [
     {"name": "none", "template_name": None, "template_str": None, "status_code": 500},
     {"name": "name_only", "template_name": "dummy.html", "template_str": None, "status_code": 200},
     {"name": "str_only", "template_name": None, "template_str": "Dummy", "status_code": 200},
+    {"name": "str_empty", "template_name": None, "template_str": "", "status_code": 200},
 ]
 
 
@@ -184,7 +185,7 @@ def test_template_scenarios(tmp_path: Path, engine: TemplateEngineProtocol, test
             assert response.status_code == test_case["status_code"]
 
             if test_case["status_code"] == 200:
-                if test_case["template_str"]:
+                if test_case["template_str"] is not None:
                     assert response.text == test_case["template_str"]
                 else:
                     assert response.text == "Test content for template"


### PR DESCRIPTION
## Description

It's currently impossible to pass an empty template string to `Template`, i.e.

```
Template(template_str="")
```

because internally, the checks are testing the parameters for `Truth`-ness, and not for `None`-ness. This makes it impossible to return a "proper" empty-string-response for HTMX-requests, e.g. when deleting table rows.

This PR fixes that by comparing the parameters to `None`, therfore allowing `""` to be a valid value.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4797">https://litestar-org.github.io/litestar-docs-preview/4797</a> 
