### PR TITLE
feat(core): Introduce generic request body markers

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -16,23 +16,23 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title;
-            
+
             const types = [
                 "build",
                 "chore",
-                "ci", 
-                "docs", 
-                "feat", 
-                "fix", 
-                "perf", 
-                "refactor", 
-                "revert", 
-                "style", 
+                "ci",
+                "docs",
+                "feat",
+                "fix",
+                "perf",
+                "refactor",
+                "revert",
+                "style",
                 "test",
             ];
-            
+
             const pattern = new RegExp(`^(${types.join("|")})(\\([^)]+\\))?!?: .+`);
-            
+
             if (!pattern.test(title)) {
                 core.setFailed(
                     `PR title ${JSON.stringify(title)} is not a valid Conventional Commit.\n\n` +
@@ -41,6 +41,5 @@ jobs:
                 );
                 return;
             }
-            
-            console.log(`PR title ${JSON.stringify(title)} is valid.`);
 
+            console.log(`PR title ${JSON.stringify(title)} is valid.`);

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -37,7 +37,7 @@ jobs:
                 core.setFailed(
                     `PR title ${JSON.stringify(title)} is not a valid Conventional Commit.\n\n` +
                     `Expected format: <type>(<optional scope>): <subject>\n` +
-                    `Allowed types: ${types.join(", ")}\n\n` +
+                    `Allowed types: ${types.join(", ")}\n\n`
                 );
                 return;
             }

--- a/docs/examples/request_data/custom_request.py
+++ b/docs/examples/request_data/custom_request.py
@@ -19,8 +19,8 @@ class CustomRequest(Request):
         self.kitten_name = KITTEN_NAMES_MAP.get(scope["method"], "Mittens")
 
 
-@get(path="/kitten-name", sync_to_thread=False)
-def get_kitten_name(request: CustomRequest) -> str:
+@get(path="/kitten-name")
+async def get_kitten_name(request: CustomRequest) -> str:
     """Get kitten name based on the HTTP method."""
     return request.kitten_name
 

--- a/docs/examples/request_data/msgpack_request.py
+++ b/docs/examples/request_data/msgpack_request.py
@@ -1,15 +1,12 @@
 from typing import Any, Dict
 
-from typing_extensions import Annotated
-
 from litestar import Litestar, post
-from litestar.enums import RequestEncodingType
-from litestar.params import Body
+from litestar.params import MsgPackBody
 
 
-@post(path="/", sync_to_thread=False)
-def msgpack_handler(
-    data: Annotated[Dict[str, Any], Body(media_type=RequestEncodingType.MESSAGEPACK)],
+@post(path="/")
+async def msgpack_handler(
+    data: MsgPackBody[Dict[str, Any]],
 ) -> Dict[str, Any]:
     # This will try to parse the request body as `MessagePack` regardless of the
     # `Content-Type`

--- a/docs/examples/request_data/request_data_10.py
+++ b/docs/examples/request_data/request_data_10.py
@@ -1,16 +1,13 @@
 from typing import Any, Dict, List, Tuple
 
-from typing_extensions import Annotated
-
 from litestar import Litestar, post
 from litestar.datastructures import UploadFile
-from litestar.enums import RequestEncodingType
-from litestar.params import Body
+from litestar.params import MultipartBody
 
 
 @post(path="/")
 async def handle_file_upload(
-    data: Annotated[List[UploadFile], Body(media_type=RequestEncodingType.MULTI_PART)],
+    data: MultipartBody[List[UploadFile]],
 ) -> Dict[str, Tuple[str, str, Any]]:
     result = {}
 

--- a/docs/examples/request_data/request_data_4.py
+++ b/docs/examples/request_data/request_data_4.py
@@ -1,10 +1,7 @@
 from dataclasses import dataclass
 
-from typing_extensions import Annotated
-
 from litestar import Litestar, post
-from litestar.enums import RequestEncodingType
-from litestar.params import Body
+from litestar.params import URLEncodedBody
 
 
 @dataclass
@@ -14,9 +11,7 @@ class User:
 
 
 @post(path="/")
-async def create_user(
-    data: Annotated[User, Body(media_type=RequestEncodingType.URL_ENCODED)],
-) -> User:
+async def create_user(data: URLEncodedBody[User]) -> User:
     return data
 
 

--- a/docs/examples/request_data/request_data_5.py
+++ b/docs/examples/request_data/request_data_5.py
@@ -14,7 +14,7 @@ class User:
 
 
 @post(path="/")
-async def create_user(data: MultipartBody[User]) -> Dict[str, str | int]:
+async def create_user(data: MultipartBody[User]) -> Dict[str, str]:
     content = await data.form_input_name.read()
     filename = data.form_input_name.filename
     return {"id": data.id, "name": data.name, "filename": filename, "size": len(content)}

--- a/docs/examples/request_data/request_data_5.py
+++ b/docs/examples/request_data/request_data_5.py
@@ -1,12 +1,9 @@
 from dataclasses import dataclass
 from typing import Dict
 
-from typing_extensions import Annotated
-
 from litestar import Litestar, post
 from litestar.datastructures import UploadFile
-from litestar.enums import RequestEncodingType
-from litestar.params import Body
+from litestar.params import MultipartBody
 
 
 @dataclass
@@ -17,9 +14,7 @@ class User:
 
 
 @post(path="/")
-async def create_user(
-    data: Annotated[User, Body(media_type=RequestEncodingType.MULTI_PART)],
-) -> Dict[str, str]:
+async def create_user(data: MultipartBody[User]) -> Dict[str, str | int]:
     content = await data.form_input_name.read()
     filename = data.form_input_name.filename
     return {"id": data.id, "name": data.name, "filename": filename, "size": len(content)}

--- a/docs/examples/request_data/request_data_6.py
+++ b/docs/examples/request_data/request_data_6.py
@@ -1,15 +1,10 @@
-from typing_extensions import Annotated
-
 from litestar import Litestar, MediaType, post
 from litestar.datastructures import UploadFile
-from litestar.enums import RequestEncodingType
-from litestar.params import Body
+from litestar.params import MultipartBody
 
 
 @post(path="/", media_type=MediaType.TEXT)
-async def handle_file_upload(
-    data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)],
-) -> str:
+async def handle_file_upload(data: MultipartBody[UploadFile]) -> str:
     content = await data.read()
     filename = data.filename
     return f"{filename},length: {len(content)}"

--- a/docs/examples/request_data/request_data_7.py
+++ b/docs/examples/request_data/request_data_7.py
@@ -1,15 +1,10 @@
-from typing_extensions import Annotated
-
 from litestar import Litestar, MediaType, post
 from litestar.datastructures import UploadFile
-from litestar.enums import RequestEncodingType
-from litestar.params import Body
+from litestar.params import MultipartBody
 
 
-@post(path="/", media_type=MediaType.TEXT, sync_to_thread=False)
-def handle_file_upload(
-    data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)],
-) -> str:
+@post(path="/", media_type=MediaType.TEXT)
+async def handle_file_upload(data: MultipartBody[UploadFile]) -> str:
     content = data.file.read()
     filename = data.filename
     return f"{filename},length: {len(content)}"

--- a/docs/examples/request_data/request_data_8.py
+++ b/docs/examples/request_data/request_data_8.py
@@ -1,23 +1,20 @@
+import dataclasses
 from typing import Dict
-
-from pydantic import BaseModel, ConfigDict
-from typing_extensions import Annotated
 
 from litestar import Litestar, post
 from litestar.datastructures import UploadFile
-from litestar.enums import RequestEncodingType
-from litestar.params import Body
+from litestar.params import MultipartBody
 
 
-class FormData(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+@dataclasses.dataclass()
+class FormData:
     cv: UploadFile
     diploma: UploadFile
 
 
 @post(path="/")
 async def handle_file_upload(
-    data: Annotated[FormData, Body(media_type=RequestEncodingType.MULTI_PART)],
+    data: MultipartBody[FormData],
 ) -> Dict[str, str]:
     cv_content = await data.cv.read()
     diploma_content = await data.diploma.read()

--- a/docs/examples/request_data/request_data_9.py
+++ b/docs/examples/request_data/request_data_9.py
@@ -1,16 +1,13 @@
 from typing import Dict
 
-from typing_extensions import Annotated
-
 from litestar import Litestar, post
 from litestar.datastructures import UploadFile
-from litestar.enums import RequestEncodingType
-from litestar.params import Body
+from litestar.params import MultipartBody
 
 
 @post(path="/")
 async def handle_file_upload(
-    data: Annotated[Dict[str, UploadFile], Body(media_type=RequestEncodingType.MULTI_PART)],
+    data: MultipartBody[Dict[str, UploadFile]],
 ) -> Dict[str, str]:
     file_contents = {}
     for name, file in data.items():

--- a/docs/usage/requests.rst
+++ b/docs/usage/requests.rst
@@ -59,8 +59,8 @@ URL Encoded Form Data
 ^^^^^^^^^^^^^^^^^^^^^
 
 To access data sent as `url-encoded form data <https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST>`_,
-i.e. ``application/x-www-form-urlencoded`` Content-Type header, use :class:`Body <litestar.params.Body>` and specify
-:class:`RequestEncodingType.URL_ENCODED <litestar.enums.RequestEncodingType>` as the ``media_type``:
+i.e. ``application/x-www-form-urlencoded`` Content-Type header, wrap the ``data``
+annotation with :data:`~litestar.params.URLEncodedBody`:
 
 .. tab-set::
 
@@ -81,12 +81,19 @@ i.e. ``application/x-www-form-urlencoded`` Content-Type header, use :class:`Body
     dictionaries and deeply nested data. It should only be used for simple data structures.
 
 
+.. tip::
+    ``URLEncodedBody[<type>]`` is a shorthand for
+    ``Annotated[<type>, Body(media_type=RequestEncodingType.URL_ENCODED)]``. If you want
+    to pass additional OpenAPI metadata or constraints, use the
+    :class:`~typing.Annotated` form
+
+
 MultiPart Form Data
 ^^^^^^^^^^^^^^^^^^^
 
 You can access data uploaded using a request with a
 `multipart/form-data <https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST>`_
-Content-Type header by specifying it in the :class:`Body <litestar.params.Body>` function:
+Content-Type header by specifying the data with :data:`~litestar.params.MultipartBody`:
 
 .. tab-set::
 
@@ -100,6 +107,13 @@ Content-Type header by specifying it in the :class:`Body <litestar.params.Body>`
         .. literalinclude:: ../../tests/examples/test_request_data.py
             :language: python
             :lines: 51-64
+
+
+.. tip::
+    ``MultipartBody[<type>]`` is a shorthand for
+    ``Annotated[<type>, Body(media_type=RequestEncodingType.MULTI_PART)]``. If you want
+    to pass additional OpenAPI metadata or constraints, use the
+    :class:`~typing.Annotated` form
 
 
 File uploads
@@ -156,7 +170,7 @@ To access a single file simply type ``data`` as :class:`UploadFile <.datastructu
 Multiple files
 ^^^^^^^^^^^^^^
 
-To access multiple files with known filenames, you can use a pydantic model:
+To access multiple files with known filenames, you can use any structured type:
 
 
 .. tab-set::
@@ -213,8 +227,8 @@ Finally, you can also access the files as a list without the filenames:
 MessagePack data
 ----------------
 
-To receive `MessagePack <https://msgpack.org/>`_ data, specify the appropriate ``Content-Type``
-for ``Body``\ , by using :class:`RequestEncodingType.MESSAGEPACK <.enums.RequestEncodingType>`:
+To receive `MessagePack <https://msgpack.org/>`_ data, annotate ``data`` with
+:data:`~litestar.params.MsgPackBody`:
 
 .. tab-set::
 
@@ -228,6 +242,14 @@ for ``Body``\ , by using :class:`RequestEncodingType.MESSAGEPACK <.enums.Request
         .. literalinclude:: ../../tests/examples/test_request_data.py
             :language: python
             :lines: 136-141
+
+.. tip::
+    ``MsgPackBody[<type>]`` is a shorthand for
+    ``Annotated[<type>, Body(media_type=RequestEncodingType.MESSAGEPACK)]``. If you want
+    to pass additional OpenAPI metadata or constraints, use the
+    :class:`~typing.Annotated` form
+
+
 
 Custom Request
 --------------

--- a/litestar/params.py
+++ b/litestar/params.py
@@ -20,11 +20,15 @@ __all__ = (
     "FromPath",
     "FromQuery",
     "HeaderParameter",
+    "JSONBody",
     "KwargDefinition",
+    "MsgPackBody",
+    "MultipartBody",
     "Parameter",
     "ParameterKwarg",
     "PathParameter",
     "QueryParameter",
+    "URLEncodedBody",
 )
 
 if TYPE_CHECKING:
@@ -401,6 +405,19 @@ class BodyKwarg(KwargDefinition):
             A hash
         """
         return sum(hash(v) for v in asdict(self) if isinstance(v, Hashable))
+
+
+JSONBody: TypeAlias = Annotated[T, BodyKwarg(media_type=RequestEncodingType.JSON)]
+"""Declare a 'application/json request body"""
+
+MsgPackBody: TypeAlias = Annotated[T, BodyKwarg(media_type=RequestEncodingType.MESSAGEPACK)]
+"""Declare a 'application/x-msgpack' request body"""
+
+MultipartBody: TypeAlias = Annotated[T, BodyKwarg(media_type=RequestEncodingType.MULTI_PART)]
+"""Declare a 'multipart/form-data' request body"""
+
+URLEncodedBody: TypeAlias = Annotated[T, BodyKwarg(media_type=RequestEncodingType.URL_ENCODED)]
+"""Declare a 'application/x-www-form-urlencoded' request body"""
 
 
 def Body(

--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -11,6 +11,8 @@ from typing import Any, AnyStr, Callable, Collection, ForwardRef, Literal, Mappi
 
 from typing_extensions import Annotated as te_Annotated
 
+from litestar.enums import RequestEncodingType
+
 try:
     from typing import Annotated  # pyright: ignore
 
@@ -48,7 +50,7 @@ try:
 except ImportError:
     TypeAliasTypes = (TeTypeAliasType,)  # type: ignore[assignment]
 
-from litestar.exceptions import ImproperlyConfiguredException, LitestarWarning
+from litestar.exceptions import ImproperlyConfiguredException, LitestarDeprecationWarning, LitestarWarning
 from litestar.params import BodyKwarg, DependencyKwarg, KwargDefinition, ParameterKwarg
 from litestar.types.builtin_types import NoneType, UnionTypes
 from litestar.utils.predicates import (
@@ -431,7 +433,7 @@ class FieldDefinition:
         return get_type_hints(self.annotation, include_extras=include_extras)
 
     @classmethod
-    def from_annotation(cls, annotation: Any, **kwargs: Any) -> FieldDefinition:
+    def from_annotation(cls, annotation: Any, **kwargs: Any) -> FieldDefinition:  # noqa: C901
         """Initialize FieldDefinition.
 
         Args:
@@ -451,7 +453,27 @@ class FieldDefinition:
 
         if not kwargs.get("kwarg_definition"):
             if isinstance(kwargs.get("default"), (KwargDefinition, DependencyKwarg)):
-                kwargs["kwarg_definition"] = kwargs.pop("default")
+                kwarg_definition = kwargs["kwarg_definition"] = kwargs.pop("default")
+                if isinstance(kwarg_definition, BodyKwarg):
+                    can_use_marker = (
+                        not kwarg_definition.is_constrained and kwarg_definition.multipart_form_part_limit is None
+                    )
+                    if can_use_marker:
+                        alternative = {
+                            RequestEncodingType.JSON: "JSONBody[<type>]",
+                            RequestEncodingType.MESSAGEPACK: "MsgPackBody[<type>]",
+                            RequestEncodingType.MULTI_PART: "MultiPartBody[<type>]",
+                            RequestEncodingType.URL_ENCODED: "URLEncodedBBody[<type>]",
+                        }[RequestEncodingType(kwarg_definition.media_type)]
+                    else:
+                        alternative = "Annotated[<type>, Body(...)]"
+                    warnings.warn(
+                        "Deprecated use of 'Body()' as a default value. This will be removed"
+                        f"in Litestar 3.0. Use 'data: {alternative}' instead of "
+                        "'data: <type> = Body(...)'",
+                        stacklevel=2,
+                        category=LitestarDeprecationWarning,
+                    )
             elif kwarg_definition := next(
                 (v for v in metadata if isinstance(v, (KwargDefinition, DependencyKwarg))), None
             ):

--- a/tests/unit/test_datastructures/test_upload_file.py
+++ b/tests/unit/test_datastructures/test_upload_file.py
@@ -4,8 +4,7 @@ from typing import Optional
 
 from litestar import post
 from litestar.datastructures import UploadFile
-from litestar.enums import RequestEncodingType
-from litestar.params import Body
+from litestar.params import MultipartBody
 from litestar.status_codes import HTTP_201_CREATED
 from litestar.testing import create_test_client
 
@@ -45,7 +44,7 @@ def test_cleanup_is_being_performed(tmpdir: Path) -> None:
     upload_file: Optional[UploadFile] = None
 
     @post("/form", sync_to_thread=False)
-    def handler(data: UploadFile = Body(media_type=RequestEncodingType.MULTI_PART)) -> None:
+    def handler(data: MultipartBody[UploadFile]) -> None:
         nonlocal upload_file
         upload_file = data
         assert not upload_file.file.closed

--- a/tests/unit/test_dto/test_factory/test_integration.py
+++ b/tests/unit/test_dto/test_factory/test_integration.py
@@ -17,11 +17,11 @@ from litestar.connection.request import Request
 from litestar.datastructures import UploadFile
 from litestar.dto import DataclassDTO, DTOConfig, DTOData, MsgspecDTO, dto_field
 from litestar.dto.types import RenameStrategy
-from litestar.enums import MediaType, RequestEncodingType
+from litestar.enums import MediaType
 from litestar.openapi.spec.response import OpenAPIResponse
 from litestar.openapi.spec.schema import Schema
 from litestar.pagination import ClassicPagination, CursorPagination, OffsetPagination
-from litestar.params import Body
+from litestar.params import MultipartBody, URLEncodedBody
 from litestar.serialization import encode_json
 from litestar.testing import create_test_client
 from tests.helpers import not_none
@@ -43,7 +43,7 @@ def test_url_encoded_form_data(use_experimental_dto_backend: bool) -> None:
         config = DTOConfig(experimental_codegen_backend=use_experimental_dto_backend)
 
     @post(dto=UserDTO, signature_types=[User])
-    def handler(data: User = Body(media_type=RequestEncodingType.URL_ENCODED)) -> User:
+    def handler(data: URLEncodedBody[User]) -> User:
         return data
 
     with create_test_client(route_handlers=[handler]) as client:
@@ -70,7 +70,7 @@ async def test_multipart_encoded_form_data(use_experimental_dto_backend: bool) -
         config = DTOConfig(experimental_codegen_backend=use_experimental_dto_backend)
 
     @post(dto=PayloadDTO, return_dto=None, signature_types=[Payload], media_type=MediaType.TEXT)
-    async def handler(data: Payload = Body(media_type=RequestEncodingType.MULTI_PART)) -> bytes:
+    async def handler(data: MultipartBody[Payload]) -> bytes:
         return await data.forbidden.read()
 
     with create_test_client(route_handlers=[handler]) as client:
@@ -271,7 +271,7 @@ def test_dto_data_with_url_encoded_form_data(use_experimental_dto_backend: bool)
     config = DTOConfig(experimental_codegen_backend=use_experimental_dto_backend)
 
     @post(dto=DataclassDTO[Annotated[User, config]])
-    def handler(data: DTOData[User] = Body(media_type=RequestEncodingType.URL_ENCODED)) -> User:
+    def handler(data: URLEncodedBody[DTOData[User]]) -> User:
         return data.create_instance()
 
     with create_test_client(route_handlers=[handler]) as client:
@@ -426,7 +426,7 @@ def test_url_encoded_form_data_patch_request(use_experimental_dto_backend: bool)
     ]
 
     @post(dto=dto, return_dto=None, signature_types=[User])
-    def handler(data: DTOData[User] = Body(media_type=RequestEncodingType.URL_ENCODED)) -> Dict[str, Any]:
+    def handler(data: URLEncodedBody[DTOData[User]]) -> Dict[str, Any]:
         return data.as_builtins()  # type:ignore[no-any-return]
 
     with create_test_client(route_handlers=[handler]) as client:

--- a/tests/unit/test_kwargs/test_body_markers.py
+++ b/tests/unit/test_kwargs/test_body_markers.py
@@ -1,0 +1,14 @@
+import pytest
+
+from litestar import Litestar, post
+from litestar.exceptions import LitestarDeprecationWarning
+from litestar.params import Body
+
+
+def test_deprecated_default_warns() -> None:
+    @post("/")
+    async def handler(data: dict = Body()) -> None:
+        pass
+
+    with pytest.raises(LitestarDeprecationWarning, match=r"Deprecated use of 'Body\(\)' as a default value"):
+        Litestar([handler])

--- a/tests/unit/test_kwargs/test_json_data.py
+++ b/tests/unit/test_kwargs/test_json_data.py
@@ -3,7 +3,6 @@ from dataclasses import asdict
 from msgspec import Struct
 
 from litestar import post
-from litestar.params import Body
 from litestar.status_codes import HTTP_201_CREATED
 from litestar.testing import create_test_client
 
@@ -12,7 +11,7 @@ from . import Form
 
 def test_request_body_json() -> None:
     @post(path="/test")
-    def test_method(data: Form = Body()) -> None:
+    def test_method(data: Form) -> None:
         assert isinstance(data, Form)
 
     with create_test_client(test_method) as client:

--- a/tests/unit/test_kwargs/test_msgpack_data.py
+++ b/tests/unit/test_kwargs/test_msgpack_data.py
@@ -1,9 +1,7 @@
 from msgspec import Struct
-from typing_extensions import Annotated
 
 from litestar import post
-from litestar.enums import RequestEncodingType
-from litestar.params import Body
+from litestar.params import MsgPackBody
 from litestar.serialization import encode_msgpack
 from litestar.status_codes import HTTP_201_CREATED
 from litestar.testing import create_test_client
@@ -18,7 +16,7 @@ def test_request_body_msgpack() -> None:
         assert data == test_data
 
     @post(path="/annotated")
-    def test_annotated(data: dict = Body(media_type=RequestEncodingType.MESSAGEPACK)) -> None:
+    def test_annotated(data: MsgPackBody[dict]) -> None:
         assert isinstance(data, dict)
         assert data == test_data
 
@@ -34,7 +32,7 @@ def test_no_body_with_default() -> None:
     default = Test(name="default")
 
     @post(path="/test", signature_types=[Test])
-    def test_method(data: Annotated[Test, Body(media_type=RequestEncodingType.MESSAGEPACK)] = default) -> Test:
+    def test_method(data: MsgPackBody[Test] = default) -> Test:
         return data
 
     with create_test_client(test_method) as client:

--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -1,6 +1,3 @@
-# ruff: noqa: UP006, UP007
-from __future__ import annotations
-
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from os import path
@@ -15,7 +12,7 @@ from typing_extensions import Annotated
 from litestar import Request, post
 from litestar.datastructures.upload_file import UploadFile
 from litestar.enums import RequestEncodingType
-from litestar.params import Body
+from litestar.params import Body, MultipartBody
 from litestar.status_codes import HTTP_201_CREATED, HTTP_400_BAD_REQUEST
 from litestar.testing import create_test_client
 
@@ -104,7 +101,7 @@ def test_request_body_multi_part_mixed_field_content_types() -> None:
         tags: List[int]
 
     @post(path="/form", signature_types=[MultiPartFormWithMixedFields])
-    async def test_method(data: MultiPartFormWithMixedFields = Body(media_type=RequestEncodingType.MULTI_PART)) -> None:
+    async def test_method(data: MultipartBody[MultiPartFormWithMixedFields]) -> None:
         file_data = await data.image.read()
         assert file_data == b"data"
         assert data.tags == [1, 2, 3]
@@ -387,7 +384,7 @@ def test_postman_multipart_form_data() -> None:
 
 def test_image_upload() -> None:
     @post("/", signature_types=[UploadFile])
-    async def hello_world(data: UploadFile = Body(media_type=RequestEncodingType.MULTI_PART)) -> None:
+    async def hello_world(data: MultipartBody[UploadFile]) -> None:
         await data.read()
 
     with open(join(dirname(realpath(__file__)), "flower.jpeg"), "rb") as f, create_test_client(
@@ -406,7 +403,7 @@ def test_upload_multiple_files(file_count: int, optional: bool) -> None:
         annotation = Optional[annotation]  # type: ignore[misc, assignment]
 
     @post("/", signature_namespace={"annotation": annotation})
-    async def handler(data: annotation = Body(media_type=RequestEncodingType.MULTI_PART)) -> None:  # pyright: ignore
+    async def handler(data: MultipartBody[annotation]) -> None:  # pyright: ignore
         assert len(data) == file_count
 
         for file in data:
@@ -434,7 +431,7 @@ class OptionalFiles:
 @pytest.mark.parametrize("file_count", (1, 2))
 def test_upload_multiple_files_in_model(file_count: int, file_model: Type[Union[Files, OptionalFiles]]) -> None:
     @post("/", signature_namespace={"file_model": file_model})
-    async def handler(data: file_model = Body(media_type=RequestEncodingType.MULTI_PART)) -> None:  # type: ignore[valid-type]
+    async def handler(data: MultipartBody[file_model]) -> None:  # type: ignore[valid-type]
         assert len(data.file_list) == file_count  # type: ignore[attr-defined]
 
         for file in data.file_list:  # type: ignore[attr-defined]
@@ -449,7 +446,7 @@ def test_upload_multiple_files_in_model(file_count: int, file_model: Type[Union[
 
 def test_optional_formdata() -> None:
     @post("/", signature_types=[UploadFile])
-    async def hello_world(data: Optional[UploadFile] = Body(media_type=RequestEncodingType.MULTI_PART)) -> None:
+    async def hello_world(data: MultipartBody[Optional[UploadFile]]) -> None:
         if data is not None:
             await data.read()
 
@@ -461,7 +458,7 @@ def test_optional_formdata() -> None:
 @pytest.mark.parametrize("limit", (1000, 100, 10))
 def test_multipart_form_part_limit(limit: int) -> None:
     @post("/", signature_types=[UploadFile])
-    async def hello_world(data: List[UploadFile] = Body(media_type=RequestEncodingType.MULTI_PART)) -> dict:
+    async def hello_world(data: MultipartBody[List[UploadFile]]) -> dict:
         return {"limit": len(data)}
 
     with create_test_client(route_handlers=[hello_world], multipart_form_part_limit=limit) as client:
@@ -482,7 +479,9 @@ def test_multipart_form_part_limit_body_param_precedence() -> None:
 
     @post("/", signature_types=[UploadFile])
     async def hello_world(
-        data: List[UploadFile] = Body(media_type=RequestEncodingType.MULTI_PART, multipart_form_part_limit=route_limit),
+        data: Annotated[
+            List[UploadFile], Body(media_type=RequestEncodingType.MULTI_PART, multipart_form_part_limit=route_limit)
+        ],
     ) -> None:
         assert len(data) == route_limit
 

--- a/tests/unit/test_kwargs/test_url_encoded_data.py
+++ b/tests/unit/test_kwargs/test_url_encoded_data.py
@@ -2,8 +2,7 @@ from dataclasses import asdict
 from typing import Optional
 
 from litestar import post
-from litestar.enums import RequestEncodingType
-from litestar.params import Body
+from litestar.params import URLEncodedBody
 from litestar.status_codes import HTTP_201_CREATED
 from litestar.testing import create_test_client
 
@@ -12,7 +11,7 @@ from . import Form
 
 def test_request_body_url_encoded() -> None:
     @post(path="/test")
-    def test_method(data: Form = Body(media_type=RequestEncodingType.URL_ENCODED)) -> None:
+    def test_method(data: URLEncodedBody[Form]) -> None:
         assert isinstance(data, Form)
 
     with create_test_client(test_method) as client:
@@ -22,7 +21,7 @@ def test_request_body_url_encoded() -> None:
 
 def test_optional_request_body_url_encoded() -> None:
     @post(path="/test")
-    def test_method(data: Optional[Form] = Body(media_type=RequestEncodingType.URL_ENCODED)) -> None:
+    def test_method(data: URLEncodedBody[Optional[Form]]) -> None:
         assert data is None
 
     with create_test_client(test_method) as client:

--- a/tests/unit/test_kwargs/test_validations.py
+++ b/tests/unit/test_kwargs/test_validations.py
@@ -6,9 +6,15 @@ from typing_extensions import Annotated
 from litestar import Litestar, get, post, websocket
 from litestar.constants import RESERVED_KWARGS
 from litestar.di import Provide
-from litestar.enums import RequestEncodingType
 from litestar.exceptions import ImproperlyConfiguredException
-from litestar.params import Body, BodyKwarg, CookieParameter, HeaderParameter, QueryParameter
+from litestar.params import (
+    BodyKwarg,
+    CookieParameter,
+    HeaderParameter,
+    MultipartBody,
+    QueryParameter,
+    URLEncodedBody,
+)
 
 _PARAM_TYPES = {"query": QueryParameter, "header": HeaderParameter, "cookie": CookieParameter}
 
@@ -70,51 +76,51 @@ def test_raises_when_reserved_kwargs_are_misused(reserved_kwarg: str) -> None:
         Litestar(route_handlers=[handler_with_aliased_param])
 
 
-def url_encoded_dependency(data: Dict[str, Any] = Body(media_type=RequestEncodingType.URL_ENCODED)) -> Dict[str, Any]:
+def url_encoded_dependency(data: URLEncodedBody[Dict[str, Any]]) -> Dict[str, Any]:
     assert data
     return data
 
 
-def multi_part_dependency(data: Dict[str, Any] = Body(media_type=RequestEncodingType.MULTI_PART)) -> Dict[str, Any]:
+def multi_part_dependency(data: MultipartBody[Dict[str, Any]]) -> Dict[str, Any]:
     assert data
     return data
 
 
-def json_dependency(data: Dict[str, Any] = Body()) -> Dict[str, Any]:
+def json_dependency(data: Dict[str, Any]) -> Dict[str, Any]:
     assert data
     return data
 
 
 @pytest.mark.parametrize(
-    "body, dependency",
+    "body_annotation, dependency",
     [
-        (Body(), json_dependency),
-        (Body(media_type=RequestEncodingType.MULTI_PART), multi_part_dependency),
-        (Body(media_type=RequestEncodingType.URL_ENCODED), url_encoded_dependency),
+        (Any, json_dependency),
+        (MultipartBody[Any], multi_part_dependency),  # type: ignore[misc]
+        (URLEncodedBody[Any], url_encoded_dependency),  # type: ignore[misc]
     ],
 )
-def test_dependency_data_kwarg_validation_success_scenarios(body: BodyKwarg, dependency: Callable) -> None:
+def test_dependency_data_kwarg_validation_success_scenarios(body_annotation: Any, dependency: Callable) -> None:
     @post("/", dependencies={"first": Provide(dependency)})
-    def handler(first: Dict[str, Any], data: Any = body) -> None:
+    def handler(first: Dict[str, Any], data: body_annotation) -> None:
         pass
 
     Litestar(route_handlers=[handler])
 
 
 @pytest.mark.parametrize(
-    "body, dependency",
+    "body_annotation, dependency",
     [
-        [Body(), url_encoded_dependency],
-        [Body(), multi_part_dependency],
-        [Body(media_type=RequestEncodingType.URL_ENCODED), json_dependency],
-        [Body(media_type=RequestEncodingType.URL_ENCODED), multi_part_dependency],
-        [Body(media_type=RequestEncodingType.MULTI_PART), json_dependency],
-        [Body(media_type=RequestEncodingType.MULTI_PART), url_encoded_dependency],
+        [Any, url_encoded_dependency],
+        [Any, multi_part_dependency],
+        [URLEncodedBody[Any], json_dependency],  # type: ignore[misc]
+        [URLEncodedBody[Any], multi_part_dependency],  # type: ignore[misc]
+        [MultipartBody[Any], json_dependency],  # type: ignore[misc]
+        [MultipartBody[Any], url_encoded_dependency],  # type: ignore[misc]
     ],
 )
-def test_dependency_data_kwarg_validation_failure_scenarios(body: BodyKwarg, dependency: Callable) -> None:
+def test_dependency_data_kwarg_validation_failure_scenarios(body_annotation: BodyKwarg, dependency: Callable) -> None:
     @post("/", dependencies={"first": Provide(dependency, sync_to_thread=False)})
-    def handler(first: Dict[str, Any], data: Any = body) -> None:
+    def handler(first: Dict[str, Any], data: body_annotation) -> None:  # type: ignore[valid-type]
         assert first
         assert data
 

--- a/tests/unit/test_middleware/test_csrf_middleware.py
+++ b/tests/unit/test_middleware/test_csrf_middleware.py
@@ -10,9 +10,8 @@ from litestar import MediaType, WebSocket, delete, get, patch, post, put, websoc
 from litestar.config.csrf import CSRFConfig
 from litestar.contrib.jinja import JinjaTemplateEngine
 from litestar.contrib.mako import MakoTemplateEngine
-from litestar.enums import RequestEncodingType
 from litestar.handlers import HTTPRouteHandler
-from litestar.params import Body
+from litestar.params import URLEncodedBody
 from litestar.response.template import Template
 from litestar.status_codes import HTTP_200_OK, HTTP_201_CREATED, HTTP_403_FORBIDDEN
 from litestar.template.config import TemplateConfig
@@ -181,7 +180,7 @@ def test_csrf_form_parsing(engine: Any, template: str, tmp_path: Path) -> None:
         return Template(template_name="abc.html")
 
     @post("/")
-    def form_handler(data: dict = Body(media_type=RequestEncodingType.URL_ENCODED)) -> dict:
+    def form_handler(data: URLEncodedBody[dict]) -> dict:
         return data
 
     with create_test_client(
@@ -207,7 +206,7 @@ def test_csrf_form_parsing(engine: Any, template: str, tmp_path: Path) -> None:
 
 def test_csrf_middleware_exclude_from_check_via_opts() -> None:
     @post("/", exclude_from_csrf=True)
-    def post_handler(data: dict = Body(media_type=RequestEncodingType.URL_ENCODED)) -> dict:
+    def post_handler(data: URLEncodedBody[dict]) -> dict:
         return data
 
     with create_test_client(
@@ -222,11 +221,11 @@ def test_csrf_middleware_exclude_from_check_via_opts() -> None:
 
 def test_csrf_middleware_exclude_from_check() -> None:
     @post("/protected-handler")
-    def post_handler(data: dict = Body(media_type=RequestEncodingType.URL_ENCODED)) -> dict:
+    def post_handler(data: URLEncodedBody[dict]) -> dict:
         return data
 
     @post("/unprotected-handler")
-    def post_handler2(data: dict = Body(media_type=RequestEncodingType.URL_ENCODED)) -> dict:
+    def post_handler2(data: URLEncodedBody[dict]) -> dict:
         return data
 
     with create_test_client(
@@ -269,11 +268,11 @@ def test_csrf_middleware_exclude_from_set_cookies() -> None:
 
 def test_csrf_middleware_configure_name_for_exclude_from_check_via_opts() -> None:
     @post("/handler", exclude_from_csrf=True)
-    def post_handler(data: dict = Body(media_type=RequestEncodingType.URL_ENCODED)) -> dict:
+    def post_handler(data: URLEncodedBody[dict]) -> dict:
         return data
 
     @post("/handler2", custom_exclude_from_csrf=True)
-    def post_handler2(data: dict = Body(media_type=RequestEncodingType.URL_ENCODED)) -> dict:
+    def post_handler2(data: URLEncodedBody[dict]) -> dict:
         return data
 
     with create_test_client(

--- a/tests/unit/test_openapi/test_request_body.py
+++ b/tests/unit/test_openapi/test_request_body.py
@@ -10,11 +10,10 @@ from litestar._openapi.datastructures import OpenAPIContext
 from litestar._openapi.request_body import create_request_body
 from litestar.datastructures.upload_file import UploadFile
 from litestar.dto import AbstractDTO
-from litestar.enums import RequestEncodingType
 from litestar.handlers import BaseRouteHandler
 from litestar.openapi.config import OpenAPIConfig
 from litestar.openapi.spec import RequestBody
-from litestar.params import Body
+from litestar.params import Body, MultipartBody
 from litestar.typing import FieldDefinition
 
 
@@ -84,9 +83,7 @@ def test_request_body_schema_extra() -> None:
 
 def test_upload_single_file_schema_generation() -> None:
     @post(path="/file-upload")
-    async def handle_file_upload(
-        data: UploadFile = Body(media_type=RequestEncodingType.MULTI_PART),
-    ) -> None:
+    async def handle_file_upload(data: MultipartBody[UploadFile]) -> None:
         return None
 
     app = Litestar([handle_file_upload])
@@ -100,9 +97,7 @@ def test_upload_single_file_schema_generation() -> None:
 
 def test_upload_list_of_files_schema_generation() -> None:
     @post(path="/file-list-upload")
-    async def handle_file_list_upload(
-        data: List[UploadFile] = Body(media_type=RequestEncodingType.MULTI_PART),
-    ) -> None:
+    async def handle_file_list_upload(data: MultipartBody[List[UploadFile]]) -> None:
         return None
 
     app = Litestar([handle_file_list_upload])
@@ -122,7 +117,7 @@ def test_upload_list_of_files_schema_generation() -> None:
 def test_upload_file_dict_schema_generation() -> None:
     @post(path="/file-dict-upload")
     async def handle_file_list_upload(
-        data: Dict[str, UploadFile] = Body(media_type=RequestEncodingType.MULTI_PART),
+        data: MultipartBody[Dict[str, UploadFile]],
     ) -> None:
         return None
 
@@ -142,9 +137,7 @@ def test_upload_file_dict_schema_generation() -> None:
 
 def test_upload_file_model_schema_generation() -> None:
     @post(path="/form-upload")
-    async def handle_form_upload(
-        data: FormData = Body(media_type=RequestEncodingType.MULTI_PART),
-    ) -> None:
+    async def handle_form_upload(data: MultipartBody[FormData]) -> None:
         return None
 
     app = Litestar([handle_form_upload])

--- a/tests/unit/test_plugins/test_opentelemetry.py
+++ b/tests/unit/test_plugins/test_opentelemetry.py
@@ -378,7 +378,6 @@ def test_client_request_hook_receives_three_params(
     that reads the request body to trigger it.
     """
     from litestar import post
-    from litestar.params import Body
 
     hook_calls: list[tuple] = []
 
@@ -395,7 +394,7 @@ def test_client_request_hook_receives_three_params(
     )
 
     @post("/")
-    async def handler(data: dict = Body()) -> dict:
+    async def handler(data: dict) -> dict:
         return data
 
     with create_test_client(handler, plugins=[OpenTelemetryPlugin(config)]) as client:


### PR DESCRIPTION
Introduce generic request body markers, following the pattern established in #4750.

Add:

- `JSONBody`
- `MsgPackBody`
- `MultipartBody`
- `URLEncodedBody`

They can be used just like request parameter markers, and replace the more clunky `Annotated[T, Body(media_type=RequestEncodingType.MULTI_PART))]` form.

For example

```python
@post("/")
async def handler(data: Annotated[dict, Body(media_type=RequestEncodingType.MULTI_PART))]) -> None:
    pass
``` 
can be replaced with

```python
@post("/")
async def handler(data: MultipartData[dict]) -> None:
    pass
```

## Migrating

Replace

- `Annotated[T, Body(media_type=RequestEncodingType.JSON))]` with `JSONBody[T]`
- `Annotated[T, Body(media_type=RequestEncodingType.MESSAGEPACK))]` with `MsgPackBody[T]`
- `Annotated[T, Body(media_type=RequestEncodingType.MULTI_PART))]` with `MultipartBody[T]`
- `Annotated[T, Body(media_type=RequestEncodingType.URL_ENCODED))]` with `URLEncodedBody[T]`


## Open questions

Currently not implemented is *required* `data` marking. A bare `data:` parameter will be inferred to be JSON. Do we want to change this, for the sake of being more explicit, or do we allow this affordance? 

My personal feeling is that, if we want to move away from the magic parameters like `data`, we should require explicit marking in all cases. That is, the request body will always be injected into a parameter marked with `Body()`.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4801">https://litestar-org.github.io/litestar-docs-preview/4801</a> 
