### PR TITLE
fix(core): Fix `Annotated` parmeters implicitly treated as query parameters (cherry-picked from #4805)

### DIFF
--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -494,7 +494,10 @@ class KwargsModel:
                 k
                 for k, f in field_definitions.items()
                 if isinstance(f.kwarg_definition, ParameterKwarg)
-                and (f.kwarg_definition.param_type in (ParamType.HEADER, ParamType.QUERY, ParamType.COOKIE))
+                and (
+                    f.kwarg_definition.param_type in (ParamType.HEADER, ParamType.QUERY, ParamType.COOKIE)
+                    and f.kwarg_definition.name is not None
+                )
             ),
             *list(layered_parameters.keys()),
         }

--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -511,7 +511,12 @@ class FieldDefinition:
                 )
             # if not, create a new KwargDefinition
             else:
-                model = BodyKwarg if kwargs.get("name") == "data" else ParameterKwarg
+                if (name := kwargs.get("name")) == "data":
+                    model: type[KwargDefinition] = BodyKwarg
+                elif name is None:
+                    model = KwargDefinition
+                else:
+                    model = ParameterKwarg
                 kwargs["kwarg_definition"] = model(**kwarg_definition_merge_args)
 
         kwargs.setdefault("annotation", unwrapped)

--- a/tests/unit/test_kwargs/test_param_markers.py
+++ b/tests/unit/test_kwargs/test_param_markers.py
@@ -3,6 +3,7 @@ import dataclasses
 import warnings
 from typing import Annotated, Any
 
+import annotated_types
 import pytest
 
 from litestar import Litestar, get
@@ -295,3 +296,47 @@ def test_deprecated_implicit_style_dependency() -> None:
         LitestarDeprecationWarning, match="path parameter 'path_param' declared using deprecated inferred"
     ):
         Litestar([path_handler])
+
+
+def test_annotated_metadata_does_not_shadow_dependency() -> None:
+    # https://github.com/litestar-org/litestar/issues/4804
+    async def provide_foo() -> str:
+        return "from-dependency"
+
+    @get("/", dependencies={"foo": provide_foo})
+    async def handler(foo: Annotated[str, "arbitrary metadata"]) -> str:
+        return foo
+
+    with create_test_client([handler]) as client:
+        res = client.get("/")
+        assert res.status_code == 200
+        assert res.text == "from-dependency"
+
+
+def test_constraint_metadata_does_not_shadow_dependency() -> None:
+    # https://github.com/litestar-org/litestar/issues/4804
+
+    async def provide_foo() -> int:
+        return 42
+
+    @get("/", dependencies={"foo": provide_foo})
+    async def handler(foo: Annotated[int, annotated_types.Gt(5)]) -> int:
+        return foo
+
+    with create_test_client([handler]) as client:
+        res = client.get("/")
+        assert res.status_code == 200
+        assert res.json() == 42
+
+
+def test_annotated_metadata_does_not_shadow_path_param() -> None:
+    # https://github.com/litestar-org/litestar/issues/4804
+
+    @get("/{foo:int}")
+    async def handler(foo: Annotated[int, "arbitrary metadata"]) -> int:
+        return foo
+
+    with create_test_client([handler]) as client:
+        res = client.get("/7")
+        assert res.status_code == 200
+        assert res.json() == 7


### PR DESCRIPTION
cherry-picked from #4805

<hr>

Fix a bug introduced in #4783, that would cause bare handler parameters wrapped in `Annotated` and not explicitly marked with the new parameter markers (`FromQuery[]` etc.) to be treated as a query parameter, causing validation issues.


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4806">https://litestar-org.github.io/litestar-docs-preview/4806</a> 
