### PR TITLE
docs(openapi): document default schema file endpoints (#3941)

### DIFF
--- a/docs/usage/openapi/ui_plugins.rst
+++ b/docs/usage/openapi/ui_plugins.rst
@@ -151,6 +151,56 @@ In the following example, we configure the OpenAPI root path to be ``/docs``:
 This will result in any of the OpenAPI endpoints being served at ``/docs`` instead of ``/schema``, e.g.,
 ``/docs/openapi.json``.
 
+Serving the OpenAPI schema as a downloadable file
+-------------------------------------------------
+
+In addition to the UI rendered at the OpenAPI root path, Litestar can also serve the raw OpenAPI schema document at
+predictable URLs underneath that root path. These endpoints are what tools like Scalar API Client, Postman, Insomnia,
+and CI validators consume when they import or validate an API contract.
+
+Default endpoints
+~~~~~~~~~~~~~~~~~
+
+With the default ``OpenAPIConfig`` (no custom ``render_plugins``), Litestar serves:
+
+- ``/<openapi_path>/`` — the configured UI (Scalar by default)
+- ``/<openapi_path>/openapi.json`` — the schema as JSON, always available
+
+The JSON endpoint is registered automatically even when ``render_plugins`` does not include
+:class:`JsonRenderPlugin <litestar.openapi.plugins.JsonRenderPlugin>`, because UI plugins need a JSON document to point
+at. With the default ``path``, the JSON file lives at ``/schema/openapi.json``.
+
+Enabling YAML output
+~~~~~~~~~~~~~~~~~~~~
+
+YAML is not served by default. To expose ``/schema/openapi.yaml`` and ``/schema/openapi.yml``, add
+:class:`YamlRenderPlugin <litestar.openapi.plugins.YamlRenderPlugin>` to ``render_plugins``:
+
+.. code-block:: python
+
+   from litestar import Litestar
+   from litestar.openapi import OpenAPIConfig
+   from litestar.openapi.plugins import ScalarRenderPlugin, YamlRenderPlugin
+
+   app = Litestar(
+       route_handlers=[...],
+       openapi_config=OpenAPIConfig(
+           title="My API",
+           version="1.0.0",
+           render_plugins=[ScalarRenderPlugin(), YamlRenderPlugin()],
+       ),
+   )
+
+The YAML plugin requires the ``PyYAML`` library, which can be installed via the ``litestar[yaml]`` package extra.
+
+Importing the schema into other tools
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For tools that consume an OpenAPI document by URL (Scalar API Client's collection import, Postman, Insomnia, Bruno,
+``openapi-typescript``, ``oasdiff``, and similar), point them at the JSON or YAML endpoint described above. With the
+default configuration this is ``/schema/openapi.json``. If you customized the root path to ``/docs``, the file is at
+``/docs/openapi.json``.
+
 Building your own OpenAPI UI Plugin
 -----------------------------------
 


### PR DESCRIPTION
## Summary

Closes #3941.

Adds a dedicated section to `docs/usage/openapi/ui_plugins.rst` covering where the OpenAPI schema is actually served, since the current docs only gloss over it.

What the section now documents:

- The auto-registered `/<openapi_path>/openapi.json` endpoint. It's always available even when `render_plugins` does not explicitly include `JsonRenderPlugin`, because UI plugins need a JSON document to point at. This behavior lives in `litestar/_openapi/plugin.py` and was not previously called out.
- How to enable `/<openapi_path>/openapi.yaml` and `/<openapi_path>/openapi.yml` by adding `YamlRenderPlugin` to `render_plugins`, plus the `litestar[yaml]` extra requirement.
- Concrete guidance for users importing the schema into external tools (Scalar API Client, Postman, Insomnia, Bruno, `openapi-typescript`, `oasdiff`), which is the use case the issue specifically called out.

The section sits right after "Configuring the OpenAPI Root Path" so the path resolution context flows naturally into "and here is what lives under that path."

## Test plan

- [x] Section renders as valid RST (verified against `docutils` parser, no new errors introduced)
- [x] Confirmed against source: `litestar/openapi/plugins.py` for the JSON/YAML default paths and `litestar/_openapi/plugin.py:178-179` for the auto-registration of `JsonRenderPlugin` when no other plugin claims `/openapi.json`
- [x] No code changes, so no existing tests are affected