### PR TITLE
feat(di): Deprecate `params.Dependency`, introduce `di.NamedDependency` and `params.SkipValidation`

### DIFF
--- a/docs/examples/dependency_injection/dependency_non_optional_not_provided.py
+++ b/docs/examples/dependency_injection/dependency_non_optional_not_provided.py
@@ -1,13 +1,11 @@
 from typing import Any
 
-from typing_extensions import Annotated
-
 from litestar import Litestar, get
-from litestar.params import Dependency
+from litestar.di import NamedDependency
 
 
 @get("/")
-def hello_world(non_optional_dependency: Annotated[int, Dependency()]) -> dict[str, Any]:
+async def hello_world(non_optional_dependency: NamedDependency[int]) -> dict[str, Any]:
     """Notice we haven't provided the dependency to the route.
 
     This is not great, however by explicitly marking dependencies, Litestar won't let the app start.

--- a/docs/examples/dependency_injection/dependency_skip_validation.py
+++ b/docs/examples/dependency_injection/dependency_skip_validation.py
@@ -15,4 +15,4 @@ async def hello_world(injected: SkipValidation[int]) -> Dict[str, Any]:
     return {"hello": injected}
 
 
-app = Litestar(route_handlers=[hello_world])
+app = Litestar(route_handlers=[hello_world], debug=True)

--- a/docs/examples/dependency_injection/dependency_skip_validation.py
+++ b/docs/examples/dependency_injection/dependency_skip_validation.py
@@ -1,10 +1,7 @@
 from typing import Any, Dict
 
-from typing_extensions import Annotated
-
 from litestar import Litestar, get
-from litestar.di import Provide
-from litestar.params import Dependency
+from litestar.params import SkipValidation
 
 
 async def provide_str() -> str:
@@ -12,8 +9,8 @@ async def provide_str() -> str:
     return "whoops"
 
 
-@get("/", dependencies={"injected": Provide(provide_str)}, sync_to_thread=False)
-def hello_world(injected: Annotated[int, Dependency(skip_validation=True)]) -> Dict[str, Any]:
+@get("/", dependencies={"injected": provide_str})
+async def hello_world(injected: SkipValidation[int]) -> Dict[str, Any]:
     """Handler expects an `int`, but we've provided a `str`."""
     return {"hello": injected}
 

--- a/docs/examples/dependency_injection/dependency_skip_validation.py
+++ b/docs/examples/dependency_injection/dependency_skip_validation.py
@@ -15,4 +15,4 @@ async def hello_world(injected: SkipValidation[int]) -> Dict[str, Any]:
     return {"hello": injected}
 
 
-app = Litestar(route_handlers=[hello_world], debug=True)
+app = Litestar(route_handlers=[hello_world])

--- a/docs/examples/dependency_injection/dependency_with_dependency_fn_and_default.py
+++ b/docs/examples/dependency_injection/dependency_with_dependency_fn_and_default.py
@@ -1,13 +1,11 @@
 from typing import Any, Dict
 
-from typing_extensions import Annotated
-
 from litestar import Litestar, get
-from litestar.params import Dependency
+from litestar.di import NamedDependency
 
 
-@get("/", sync_to_thread=False)
-def hello_world(optional_dependency: Annotated[int, Dependency()] = 3) -> Dict[str, Any]:
+@get("/")
+async def hello_world(optional_dependency: NamedDependency[int] = 3) -> Dict[str, Any]:
     """Notice we haven't provided the dependency to the route.
 
     This is OK, because of the default value, and now the parameter is excluded from the docs.

--- a/docs/usage/dependency-injection.rst
+++ b/docs/usage/dependency-injection.rst
@@ -372,3 +372,21 @@ Litestar fail at application boot rather than at request time:
    :caption: Dependency not provided error
    :language: python
 
+
+
+Bypassing validation
+~~~~~~~~~~~~~~~~~~~~
+
+By default, injected dependency values are validated by Litestar, for example, this
+application will raise an internal server error:
+
+.. literalinclude:: /examples/dependency_injection/dependency_validation_error.py
+    :caption: Dependency validation error
+    :language: python
+
+
+This validation can be bypassed using the :data:`~litestar.params.SkipValidation` marker:
+
+.. literalinclude:: /examples/dependency_injection/dependency_skip_validation.py
+    :caption: Dependency validation error
+    :language: python

--- a/docs/usage/dependency-injection.rst
+++ b/docs/usage/dependency-injection.rst
@@ -359,7 +359,7 @@ Early detection if a dependency isn't provided
 ***********************************************
 
 The other side of the same coin is when a dependency isn't provided, and no default is
-specified. Without the :data:`~litestar.di.NamedDependency`marker, the parameter is
+specified. Without the :data:`~litestar.di.NamedDependency` marker, the parameter is
 treated like any other unmarked handler kwarg, i.e. it raises a
 :class:`~.exceptions.LitestarDeprecationWarning` about a missing explicit parameter
 marker, and the route will then fail at request time because no matching query parameter

--- a/docs/usage/dependency-injection.rst
+++ b/docs/usage/dependency-injection.rst
@@ -297,7 +297,8 @@ it in ``Provide``:
 Dependencies within dependencies
 --------------------------------
 
-You can inject dependencies into other dependencies - exactly like you would into regular functions.
+You can inject dependencies into other dependencies, exactly like you would into handler
+functions:
 
 .. code-block:: python
 
@@ -306,24 +307,24 @@ You can inject dependencies into other dependencies - exactly like you would int
    from random import randint
 
 
-   def first_dependency() -> int:
+   async def first_dependency() -> int:
        return randint(1, 10)
 
 
-   def second_dependency(injected_integer: int) -> bool:
+   async def second_dependency(injected_integer: int) -> bool:
        return injected_integer % 2 == 0
 
 
    @get("/true-or-false")
    def true_or_false_handler(injected_bool: bool) -> str:
-       return "its true!" if injected_bool else "nope, its false..."
+       return "it's true!" if injected_bool else "nope, it's false..."
 
 
    app = Litestar(
        route_handlers=[true_or_false_handler],
        dependencies={
-           "injected_integer": Provide(first_dependency),
-           "injected_bool": Provide(second_dependency),
+           "injected_integer": first_dependency,
+           "injected_bool": second_dependency,
        },
    )
 
@@ -332,34 +333,13 @@ You can inject dependencies into other dependencies - exactly like you would int
    The rules for `dependency overrides`_ apply here as well.
 
 
-The ``Dependency`` function
-----------------------------
+Explicitly marking dependencies
+-------------------------------
 
-Dependency validation
-~~~~~~~~~~~~~~~~~~~~~
+Normally, dependencies are inferred. That means, Litestar will try to match a dependency
+provider to a function parameter. However, this process can also be made explicit by
+using the :data:`~litestar.di.NamedDependency` generic.
 
-By default, injected dependency values are validated by Litestar, for example, this application will raise an
-internal server error:
-
-.. literalinclude:: /examples/dependency_injection/dependency_validation_error.py
-    :caption: Dependency validation error
-    :language: python
-
-
-Dependency validation can be toggled using the :class:`Dependency <litestar.params.Dependency>` function.
-
-.. literalinclude:: /examples/dependency_injection/dependency_skip_validation.py
-    :caption: Dependency validation error
-    :language: python
-
-
-This may be useful for reasons of efficiency, or if pydantic cannot validate a certain type, but use with caution!
-
-Dependency function as a marker
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The :class:`Dependency <litestar.params.Dependency>` function can also be used as a marker that gives us a bit more detail
-about your application.
 
 Exclude dependencies with default values from OpenAPI docs
 ***********************************************************
@@ -379,15 +359,16 @@ Early detection if a dependency isn't provided
 ***********************************************
 
 The other side of the same coin is when a dependency isn't provided, and no default is
-specified. Without the :class:`~.params.Dependency` marker, the parameter is treated
-like any other unmarked handler kwarg, i.e. it raises a
+specified. Without the :data:`~litestar.di.NamedDependency`marker, the parameter is
+treated like any other unmarked handler kwarg, i.e. it raises a
 :class:`~.exceptions.LitestarDeprecationWarning` about a missing explicit parameter
 marker, and the route will then fail at request time because no matching query parameter
 was supplied.
 
-Adding :class:`~.params.Dependency` makes the contract explicit and lets Litestar fail
-at application boot rather than at request time:
+Adding :data:`~litestar.di.NamedDependency` makes the contract explicit and lets
+Litestar fail at application boot rather than at request time:
 
 .. literalinclude:: /examples/dependency_injection/dependency_non_optional_not_provided.py
    :caption: Dependency not provided error
    :language: python
+

--- a/docs/usage/dependency-injection.rst
+++ b/docs/usage/dependency-injection.rst
@@ -388,5 +388,5 @@ application will raise an internal server error:
 This validation can be bypassed using the :data:`~litestar.params.SkipValidation` marker:
 
 .. literalinclude:: /examples/dependency_injection/dependency_skip_validation.py
-    :caption: Dependency validation error
+    :caption: Bypassing dependency validation
     :language: python

--- a/docs/usage/dependency-injection.rst
+++ b/docs/usage/dependency-injection.rst
@@ -334,7 +334,7 @@ functions:
 
 
 Explicitly marking dependencies
--------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Normally, dependencies are inferred. That means, Litestar will try to match a dependency
 provider to a function parameter. However, this process can also be made explicit by
@@ -342,7 +342,7 @@ using the :data:`~litestar.di.NamedDependency` generic.
 
 
 Exclude dependencies with default values from OpenAPI docs
-***********************************************************
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Depending on your application design, it is possible to have a dependency declared in a handler or
 :class:`Provide <.di.Provide>` function that has a default value. If the dependency isn't provided for the route, the
@@ -356,7 +356,7 @@ By declaring the parameter to be a dependency, Litestar knows to exclude it from
 
 
 Early detection if a dependency isn't provided
-***********************************************
+++++++++++++++++++++++++++++++++++++++++++++++
 
 The other side of the same coin is when a dependency isn't provided, and no default is
 specified. Without the :data:`~litestar.di.NamedDependency` marker, the parameter is
@@ -375,7 +375,7 @@ Litestar fail at application boot rather than at request time:
 
 
 Bypassing validation
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 By default, injected dependency values are validated by Litestar, for example, this
 application will raise an internal server error:

--- a/litestar/_kwargs/dependencies.py
+++ b/litestar/_kwargs/dependencies.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from litestar.utils.compat import async_next
 
-__all__ = ("Dependency", "create_dependency_batches", "map_dependencies_recursively", "resolve_dependency")
+__all__ = ("DependencyContainer", "create_dependency_batches", "map_dependencies_recursively", "resolve_dependency")
 
 
 if TYPE_CHECKING:
@@ -13,12 +13,12 @@ if TYPE_CHECKING:
     from litestar.di import Provide
 
 
-class Dependency:
+class DependencyContainer:
     """Dependency graph of a given combination of ``Route`` + ``RouteHandler``"""
 
     __slots__ = ("dependencies", "key", "provide")
 
-    def __init__(self, key: str, provide: Provide, dependencies: list[Dependency]) -> None:
+    def __init__(self, key: str, provide: Provide, dependencies: list[DependencyContainer]) -> None:
         """Initialize a dependency.
 
         Args:
@@ -39,7 +39,7 @@ class Dependency:
 
 
 async def resolve_dependency(
-    dependency: Dependency,
+    dependency: DependencyContainer,
     connection: ASGIConnection,
     kwargs: dict[str, Any],
     cleanup_group: DependencyCleanupGroup,
@@ -74,7 +74,7 @@ async def resolve_dependency(
     kwargs[dependency.key] = value
 
 
-def create_dependency_batches(expected_dependencies: set[Dependency]) -> list[set[Dependency]]:
+def create_dependency_batches(expected_dependencies: set[DependencyContainer]) -> list[set[DependencyContainer]]:
     """Calculate batches for all dependencies, recursively.
 
     Args:
@@ -83,7 +83,7 @@ def create_dependency_batches(expected_dependencies: set[Dependency]) -> list[se
     Returns:
         A list of batches.
     """
-    dependencies_to: dict[Dependency, set[Dependency]] = {}
+    dependencies_to: dict[DependencyContainer, set[DependencyContainer]] = {}
     for dependency in expected_dependencies:
         if dependency not in dependencies_to:
             map_dependencies_recursively(dependency, dependencies_to)
@@ -106,7 +106,9 @@ def create_dependency_batches(expected_dependencies: set[Dependency]) -> list[se
     return batches
 
 
-def map_dependencies_recursively(dependency: Dependency, dependencies_to: dict[Dependency, set[Dependency]]) -> None:
+def map_dependencies_recursively(
+    dependency: DependencyContainer, dependencies_to: dict[DependencyContainer, set[DependencyContainer]]
+) -> None:
     """Recursively map dependencies to their sub dependencies.
 
     Args:

--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -8,7 +8,7 @@ from anyio import create_task_group
 
 from litestar._kwargs.cleanup import DependencyCleanupGroup
 from litestar._kwargs.dependencies import (
-    Dependency,
+    DependencyContainer,
     create_dependency_batches,
     resolve_dependency,
 )
@@ -89,7 +89,7 @@ class KwargsModel:
         *,
         expected_cookie_params: set[ParameterDefinition],
         expected_data_dto: type[AbstractDTO] | None,
-        expected_dependencies: set[Dependency],
+        expected_dependencies: set[DependencyContainer],
         expected_form_data: tuple[RequestEncodingType | str, FieldDefinition] | None,
         expected_header_params: set[ParameterDefinition],
         expected_msgpack_data: FieldDefinition | None,
@@ -203,7 +203,7 @@ class KwargsModel:
         layered_parameters: dict[str, FieldDefinition],
         dependencies: dict[str, Provide],
         field_definitions: dict[str, FieldDefinition],
-    ) -> tuple[set[ParameterDefinition], set[Dependency]]:
+    ) -> tuple[set[ParameterDefinition], set[DependencyContainer]]:
         """Get parameter_definitions for the construction of KwargsModel instance.
 
         Args:
@@ -445,13 +445,13 @@ class KwargsModel:
         return cleanup_group
 
     @classmethod
-    def _create_dependency_graph(cls, key: str, dependencies: dict[str, Provide]) -> Dependency:
+    def _create_dependency_graph(cls, key: str, dependencies: dict[str, Provide]) -> DependencyContainer:
         """Create a graph like structure of dependencies, with each dependency including its own dependencies as a
         list.
         """
         provide = dependencies[key]
         sub_dependency_keys = [k for k in provide.signature_model._fields if k in dependencies]
-        return Dependency(
+        return DependencyContainer(
             key=key,
             provide=provide,
             dependencies=[cls._create_dependency_graph(key=k, dependencies=dependencies) for k in sub_dependency_keys],

--- a/litestar/_kwargs/parameter_definition.py
+++ b/litestar/_kwargs/parameter_definition.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 from litestar.enums import ParamType
-from litestar.params import DependencyKwarg, ParameterKwarg
+from litestar.params import ParameterKwarg
 
 if TYPE_CHECKING:
     from litestar.typing import FieldDefinition
@@ -59,7 +59,7 @@ def create_parameter_definition(
         field_alias = (kwarg_definition.name or field_name) if kwarg_definition is not None else field_name
         param_type = ParamType.PATH
 
-    if isinstance(field_definition.kwarg_definition, DependencyKwarg):
+    if field_definition.is_di_field:
         param_type = ParamType.DEPENDENCY
         if field_definition.is_annotated:
             legacy_style = None

--- a/litestar/_openapi/parameters.py
+++ b/litestar/_openapi/parameters.py
@@ -9,7 +9,7 @@ from litestar.enums import ParamType
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.openapi.spec.parameter import Parameter
 from litestar.openapi.spec.schema import Schema
-from litestar.params import DependencyKwarg, ParameterKwarg
+from litestar.params import ParameterKwarg
 from litestar.types import Empty
 from litestar.typing import FieldDefinition
 
@@ -188,7 +188,7 @@ class ParameterFactory:
 
         for field_name, field_definition in unique_handler_fields:
             kwarg_definition = field_definition.kwarg_definition
-            if isinstance(kwarg_definition, DependencyKwarg) and field_name not in self.dependency_providers:
+            if field_definition.is_di_field and field_name not in self.dependency_providers:
                 # never document explicit dependencies
                 continue
 

--- a/litestar/_signature/utils.py
+++ b/litestar/_signature/utils.py
@@ -31,7 +31,7 @@ def _validate_signature_dependencies(
     dependency_names: set[str] = set(dependency_name_set)
 
     for parameter in parsed_signature.parameters.values():
-        if isinstance(parameter.kwarg_definition, DependencyKwarg) and parameter.name not in dependency_name_set:
+        if parameter.is_di_field and parameter.name not in dependency_name_set:
             if not parameter.is_optional and parameter.default is Empty:
                 raise ImproperlyConfiguredException(
                     f"Explicit dependency '{parameter.name}' for '{fn_name}' has no default value, "

--- a/litestar/_signature/utils.py
+++ b/litestar/_signature/utils.py
@@ -48,7 +48,7 @@ def _normalize_annotation(field_definition: FieldDefinition) -> Any:
     ):
         return Any
 
-    if any(m is SkipValidationMarker for m in field_definition.metadata):
+    if field_definition.has_metadata(SkipValidationMarker):
         return Any
 
     return field_definition.annotation

--- a/litestar/_signature/utils.py
+++ b/litestar/_signature/utils.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from litestar.constants import SKIP_VALIDATION_NAMES
 from litestar.exceptions import ImproperlyConfiguredException
-from litestar.params import DependencyKwarg
+from litestar.params import DependencyKwarg, SkipValidationMarker
 from litestar.types import Empty, TypeDecodersSequence
 
 if TYPE_CHECKING:
@@ -46,6 +46,9 @@ def _normalize_annotation(field_definition: FieldDefinition) -> Any:
         isinstance(field_definition.kwarg_definition, DependencyKwarg)
         and field_definition.kwarg_definition.skip_validation
     ):
+        return Any
+
+    if any(m is SkipValidationMarker for m in field_definition.metadata):
         return Any
 
     return field_definition.annotation

--- a/litestar/di.py
+++ b/litestar/di.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from inspect import isasyncgenfunction, isclass, isfunction, isgeneratorfunction, ismethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
+
+from typing_extensions import Annotated
 
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types import Empty
@@ -18,7 +20,26 @@ if TYPE_CHECKING:
     from litestar.types import AnyCallable
     from litestar.utils.signature import ParsedSignature
 
-__all__ = ("Provide",)
+__all__ = (
+    "NamedDependency",
+    "Provide",
+)
+
+
+T = TypeVar("T")
+
+
+class Dependency:
+    def __init__(self, kind: Literal["param"] = "param") -> None:
+        self.kind = kind
+
+
+NamedDependency = Annotated[T, Dependency(kind="param")]
+"""
+Mark a parameter for name-based dependency injection.
+
+The name of the function parameter name will be used as the name for the dependency to inject.
+"""
 
 
 class Provide:

--- a/litestar/di.py
+++ b/litestar/di.py
@@ -30,15 +30,17 @@ T = TypeVar("T")
 
 
 class Dependency:
-    def __init__(self, kind: Literal["param"] = "param") -> None:
+    def __init__(self, kind: Literal["named"] = "named") -> None:
+        # currently only 'named' kind is supported, and this value isn't used. 3.0 will
+        # introduce the 'type' kind
         self.kind = kind
 
 
-NamedDependency = Annotated[T, Dependency(kind="param")]
+NamedDependency = Annotated[T, Dependency(kind="named")]
 """
 Mark a parameter for name-based dependency injection.
 
-The name of the function parameter name will be used as the name for the dependency to inject.
+The name of the function parameter will be used as the name for the dependency to inject.
 """
 
 

--- a/litestar/params.py
+++ b/litestar/params.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Hashable, Sequence, TypeVar
 from typing_extensions import Annotated, TypeAlias
 
 from litestar.enums import ParamType, RequestEncodingType
+from litestar.exceptions import LitestarDeprecationWarning
 from litestar.types import Empty
 
 __all__ = (
@@ -28,8 +29,12 @@ __all__ = (
     "ParameterKwarg",
     "PathParameter",
     "QueryParameter",
+    "SkipValidation",
+    "SkipValidationMarker",
     "URLEncodedBody",
 )
+
+from litestar.utils import deprecated
 
 if TYPE_CHECKING:
     from litestar.openapi.spec.example import Example
@@ -529,7 +534,29 @@ class DependencyKwarg:
         """
         return sum(hash(v) for v in asdict(self) if isinstance(v, Hashable))
 
+    def __post_init__(self) -> None:
+        if self.skip_validation:
+            warnings.warn(
+                "Deprecated parameter 'skip_validation'. This will be removed in "
+                "Litestar 3.0. To skip validation of a dependency parameter, annotate "
+                "it as 'SkipValidation[<type>]' instead",
+                category=LitestarDeprecationWarning,
+                stacklevel=2,
+            )
+        else:
+            object.__setattr__(self, "skip_validation", False)
 
+        if self.default is not Empty:
+            warnings.warn(
+                "Deprecated default in 'Dependency' annotation. This will be removed "
+                "in Litestar 3.0. To set a default for a dependency, specify it as a "
+                "function parameter default.",
+                category=LitestarDeprecationWarning,
+                stacklevel=2,
+            )
+
+
+@deprecated("2.23.0", removal_in="3.0", alternative="di.NamedDependency")
 def Dependency(*, default: Any = Empty, skip_validation: bool = False) -> Any:
     """Create a dependency kwarg definition.
 
@@ -538,3 +565,11 @@ def Dependency(*, default: Any = Empty, skip_validation: bool = False) -> Any:
         skip_validation: If `True` provided dependency values are not validated by signature model.
     """
     return DependencyKwarg(default=default, skip_validation=skip_validation)
+
+
+class SkipValidationMarker:
+    pass
+
+
+SkipValidation: TypeAlias = Annotated[T, SkipValidationMarker]
+"""Exclude a dependency from signature validation"""

--- a/litestar/params.py
+++ b/litestar/params.py
@@ -568,8 +568,10 @@ def Dependency(*, default: Any = Empty, skip_validation: bool = False) -> Any:
 
 
 class SkipValidationMarker:
-    pass
+    """Singleton indicating that a type annotated with this as metadata should be
+    treated as 'Any'
+    """
 
 
 SkipValidation: TypeAlias = Annotated[T, SkipValidationMarker]
-"""Exclude a dependency from signature validation"""
+"""Exclude 'T' from validation, effectively treating it as 'Any'"""

--- a/litestar/params.py
+++ b/litestar/params.py
@@ -34,7 +34,7 @@ __all__ = (
     "URLEncodedBody",
 )
 
-from litestar.utils import deprecated
+from litestar.utils import deprecated, warn_deprecation
 
 if TYPE_CHECKING:
     from litestar.openapi.spec.example import Example
@@ -518,7 +518,6 @@ def Body(
 
 
 @dataclass(frozen=True)
-@deprecated("2.23.0", removal_in="3.0", alternative="di.NamedDependency")
 class DependencyKwarg:
     """Data container representing a dependency."""
 
@@ -536,6 +535,14 @@ class DependencyKwarg:
         return sum(hash(v) for v in asdict(self) if isinstance(v, Hashable))
 
     def __post_init__(self) -> None:
+        warn_deprecation(
+            "2.23.0",
+            removal_in="3.0",
+            alternative="di.NamedDependency",
+            kind="class",
+            deprecated_name="DependencyKwarg",
+        )
+
         if self.skip_validation:
             warnings.warn(
                 "Deprecated parameter 'skip_validation'. This will be removed in "
@@ -558,10 +565,10 @@ def Dependency(*, default: Any = Empty, skip_validation: bool = False) -> Any:
 
 
 class SkipValidationMarker:
-    """Singleton indicating that a type annotated with this as metadata should be
+    """Indicate that a type annotated with this as metadata should be
     treated as 'Any'
     """
 
 
-SkipValidation: TypeAlias = Annotated[T, SkipValidationMarker]
+SkipValidation: TypeAlias = Annotated[T, SkipValidationMarker()]
 """Exclude 'T' from validation, effectively treating it as 'Any'"""

--- a/litestar/params.py
+++ b/litestar/params.py
@@ -518,6 +518,7 @@ def Body(
 
 
 @dataclass(frozen=True)
+@deprecated("2.23.0", removal_in="3.0", alternative="di.NamedDependency")
 class DependencyKwarg:
     """Data container representing a dependency."""
 
@@ -540,17 +541,6 @@ class DependencyKwarg:
                 "Deprecated parameter 'skip_validation'. This will be removed in "
                 "Litestar 3.0. To skip validation of a dependency parameter, annotate "
                 "it as 'SkipValidation[<type>]' instead",
-                category=LitestarDeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            object.__setattr__(self, "skip_validation", False)
-
-        if self.default is not Empty:
-            warnings.warn(
-                "Deprecated default in 'Dependency' annotation. This will be removed "
-                "in Litestar 3.0. To set a default for a dependency, specify it as a "
-                "function parameter default.",
                 category=LitestarDeprecationWarning,
                 stacklevel=2,
             )

--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -11,6 +11,7 @@ from typing import Any, AnyStr, Callable, Collection, ForwardRef, Literal, Mappi
 
 from typing_extensions import Annotated as te_Annotated
 
+from litestar import di
 from litestar.enums import RequestEncodingType
 
 try:
@@ -179,6 +180,18 @@ class FieldDefinition:
 
     def __hash__(self) -> int:
         return hash((self.name, self.raw, self.annotation, self.origin, self.inner_types))
+
+    def get_from_metadata(self, type_: type[T]) -> T | None:
+        """Return the next instance of ``type_`` in the field's metadata"""
+        return next((m for m in self.metadata if isinstance(m, type_)), None)
+
+    def has_metadata(self, type_: Any) -> bool:
+        """Whether the field has any ``type_`` in its metadata"""
+        return self.get_from_metadata(type_) is not None
+
+    @property
+    def is_di_field(self) -> bool:
+        return self.has_metadata(di.Dependency) or isinstance(self.kwarg_definition, DependencyKwarg)
 
     @property
     def has_default(self) -> bool:

--- a/tests/examples/test_dependency_injection/test_dependency_default_value_with_dependency_fn.py
+++ b/tests/examples/test_dependency_injection/test_dependency_default_value_with_dependency_fn.py
@@ -6,6 +6,6 @@ from litestar.testing import TestClient
 
 def test_optional_dependency_not_in_openapi_schema() -> None:
     with TestClient(app=dependency_with_dependency_fn_and_default.app) as client:
-        r = client.get("/schema/openapi.json")
-    assert r.status_code == HTTP_200_OK
-    assert r.json()["paths"]["/"]["get"].get("parameters") is None
+        res = client.get("/schema/openapi.json")
+    assert res.status_code == HTTP_200_OK
+    assert res.json()["paths"]["/"]["get"].get("parameters") is None

--- a/tests/unit/test_kwargs/test_dependency_batches.py
+++ b/tests/unit/test_kwargs/test_dependency_batches.py
@@ -2,7 +2,7 @@ from typing import List, Set
 
 import pytest
 
-from litestar._kwargs.dependencies import Dependency, create_dependency_batches
+from litestar._kwargs.dependencies import DependencyContainer, create_dependency_batches
 from litestar.di import Provide
 from litestar.exceptions import HTTPException, ValidationException
 from litestar.handlers import get
@@ -14,11 +14,11 @@ async def dummy() -> None:
     pass
 
 
-DEPENDENCY_A = Dependency("A", Provide(dummy), [])
-DEPENDENCY_B = Dependency("B", Provide(dummy), [])
-DEPENDENCY_C1 = Dependency("C1", Provide(dummy), [])
-DEPENDENCY_C2 = Dependency("C2", Provide(dummy), [DEPENDENCY_C1])
-DEPENDENCY_ALL_EXCEPT_A = Dependency("D", Provide(dummy), [DEPENDENCY_B, DEPENDENCY_C1, DEPENDENCY_C2])
+DEPENDENCY_A = DependencyContainer("A", Provide(dummy), [])
+DEPENDENCY_B = DependencyContainer("B", Provide(dummy), [])
+DEPENDENCY_C1 = DependencyContainer("C1", Provide(dummy), [])
+DEPENDENCY_C2 = DependencyContainer("C2", Provide(dummy), [DEPENDENCY_C1])
+DEPENDENCY_ALL_EXCEPT_A = DependencyContainer("D", Provide(dummy), [DEPENDENCY_B, DEPENDENCY_C1, DEPENDENCY_C2])
 
 
 @pytest.mark.parametrize(
@@ -57,7 +57,9 @@ DEPENDENCY_ALL_EXCEPT_A = Dependency("D", Provide(dummy), [DEPENDENCY_B, DEPENDE
         ),
     ],
 )
-def test_dependency_batches(dependency_tree: Set[Dependency], expected_batches: List[Set[Dependency]]) -> None:
+def test_dependency_batches(
+    dependency_tree: Set[DependencyContainer], expected_batches: List[Set[DependencyContainer]]
+) -> None:
     calculated_batches = create_dependency_batches(dependency_tree)
     assert calculated_batches == expected_batches
 

--- a/tests/unit/test_kwargs/test_param_markers.py
+++ b/tests/unit/test_kwargs/test_param_markers.py
@@ -7,6 +7,7 @@ import pytest
 from typing_extensions import Annotated
 
 from litestar import Litestar, get
+from litestar.di import NamedDependency
 from litestar.enums import ParamType
 from litestar.exceptions.base_exceptions import LitestarDeprecationWarning
 from litestar.openapi.spec import Parameter as OpenAPIParameter
@@ -351,3 +352,18 @@ def test_deprecated_dependency_marker() -> None:
             pass
 
         Litestar([handler])
+
+
+def test_named_dependency_explicit_marker() -> None:
+
+    @get("/")
+    async def handler(foo: NamedDependency[int] = 1) -> int:
+        return foo
+
+    with create_test_client([handler]) as client:
+        # uses parameter default
+        assert client.get("/").json() == 1
+
+        # isn't implicitly treated as a query parameter
+        schema = client.get("/schema/openapi.json").json()
+        assert schema["paths"]["/"]["get"].get("parameters") is None

--- a/tests/unit/test_kwargs/test_param_markers.py
+++ b/tests/unit/test_kwargs/test_param_markers.py
@@ -12,6 +12,7 @@ from litestar.exceptions.base_exceptions import LitestarDeprecationWarning
 from litestar.openapi.spec import Parameter as OpenAPIParameter
 from litestar.params import (
     CookieParameter,
+    Dependency,
     FromCookie,
     FromHeader,
     FromPath,
@@ -340,3 +341,13 @@ def test_annotated_metadata_does_not_shadow_path_param() -> None:
         res = client.get("/7")
         assert res.status_code == 200
         assert res.json() == 7
+
+
+def test_deprecated_dependency_marker() -> None:
+    with pytest.warns(LitestarDeprecationWarning, match="Call to deprecated function 'Dependency'"):
+
+        @get("/")
+        async def handler(foo: Annotated[int, Dependency()] = 1) -> None:
+            pass
+
+        Litestar([handler])

--- a/tests/unit/test_kwargs/test_validations.py
+++ b/tests/unit/test_kwargs/test_validations.py
@@ -1,4 +1,5 @@
 from typing import Any, Callable, Dict
+from unittest.mock import MagicMock
 
 import pytest
 from typing_extensions import Annotated
@@ -10,11 +11,14 @@ from litestar.exceptions import ImproperlyConfiguredException
 from litestar.params import (
     BodyKwarg,
     CookieParameter,
+    FromQuery,
     HeaderParameter,
     MultipartBody,
     QueryParameter,
+    SkipValidation,
     URLEncodedBody,
 )
+from litestar.testing import create_test_client
 
 _PARAM_TYPES = {"query": QueryParameter, "header": HeaderParameter, "cookie": CookieParameter}
 
@@ -126,3 +130,34 @@ def test_dependency_data_kwarg_validation_failure_scenarios(body_annotation: Bod
 
     with pytest.raises(ImproperlyConfiguredException):
         Litestar(route_handlers=[handler])
+
+
+def test_skip_validation() -> None:
+    mock = MagicMock()
+
+    @get("/")
+    def handler(foo: SkipValidation[FromQuery[int]]) -> None:
+        mock(foo)
+        return
+
+    with create_test_client([handler]) as client:
+        client.get("/?foo=1")
+
+    mock.assert_called_once_with("1")
+
+
+def test_skip_validation_dependency() -> None:
+    mock = MagicMock()
+
+    async def provide_foo() -> str:
+        return "1"
+
+    @get("/", dependencies={"foo": provide_foo})
+    def handler(foo: SkipValidation[int]) -> None:
+        mock(foo)
+        return
+
+    with create_test_client([handler]) as client:
+        client.get("/")
+
+    mock.assert_called_once_with("1")

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -10,7 +10,7 @@ from litestar._openapi.datastructures import OpenAPIContext
 from litestar._openapi.parameters import ParameterFactory
 from litestar._openapi.schema_generation.examples import ExampleFactory
 from litestar._openapi.typescript_converter.schema_parsing import is_schema_value
-from litestar.di import Provide
+from litestar.di import NamedDependency, Provide
 from litestar.enums import ParamType
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.handlers import HTTPRouteHandler
@@ -206,12 +206,26 @@ def test_raise_for_multiple_parameters_of_same_name_and_differing_types() -> Non
         app.openapi_schema
 
 
-def test_dependency_params_in_docs_if_dependency_provided() -> None:
+def test_dependency_params_in_docs_if_dependency_provided_deprecated() -> None:
     async def produce_dep(param: FromQuery[str]) -> int:
         return 13
 
     @get(dependencies={"dep": Provide(produce_dep)})
     def handler(dep: Optional[int] = Dependency()) -> None:
+        return None
+
+    app = Litestar(route_handlers=[handler])
+    param_name_set = {p.name for p in cast("OpenAPI", app.openapi_schema).paths["/"].get.parameters}  # type: ignore[index, redundant-cast, union-attr]
+    assert "dep" not in param_name_set
+    assert "param" in param_name_set
+
+
+def test_dependency_params_in_docs_if_dependency_provided() -> None:
+    async def produce_dep(param: FromQuery[str]) -> int:
+        return 13
+
+    @get(dependencies={"dep": Provide(produce_dep)})
+    def handler(dep: NamedDependency[Optional[int]]) -> None:
         return None
 
     app = Litestar(route_handlers=[handler])

--- a/tests/unit/test_params.py
+++ b/tests/unit/test_params.py
@@ -201,9 +201,28 @@ def test_dependency_provided_on_controller() -> None:
     assert resp.json() == {"value": 13}
 
 
+def test_dependency_skip_validation_deprecated() -> None:
+    @get("/validated")
+    def validated(value: NamedDependency[int]) -> Dict[str, int]:
+        return {"value": value}
+
+    @get("/skipped")
+    def skipped(value: Annotated[int, Dependency(skip_validation=True)]) -> Dict[str, int]:
+        return {"value": value}
+
+    with create_test_client(
+        route_handlers=[validated, skipped], dependencies={"value": Provide(lambda: "str", sync_to_thread=False)}
+    ) as client:
+        validated_resp = client.get("/validated")
+        assert validated_resp.status_code == HTTP_500_INTERNAL_SERVER_ERROR
+        skipped_resp = client.get("/skipped")
+        assert skipped_resp.status_code == HTTP_200_OK
+        assert skipped_resp.json() == {"value": "str"}
+
+
 def test_dependency_skip_validation() -> None:
     @get("/validated")
-    def validated(value: int = Dependency()) -> Dict[str, int]:
+    def validated(value: NamedDependency[int]) -> Dict[str, int]:
         return {"value": value}
 
     @get("/skipped")

--- a/tests/unit/test_params.py
+++ b/tests/unit/test_params.py
@@ -4,9 +4,9 @@ import pytest
 from typing_extensions import Annotated
 
 from litestar import Controller, Litestar, MediaType, get, post
-from litestar.di import Provide
-from litestar.exceptions import ImproperlyConfiguredException
-from litestar.params import Body, Dependency, FromQuery, Parameter, QueryParameter
+from litestar.di import NamedDependency, Provide
+from litestar.exceptions import ImproperlyConfiguredException, LitestarDeprecationWarning
+from litestar.params import Body, Dependency, FromQuery, Parameter, QueryParameter, SkipValidation
 from litestar.status_codes import HTTP_200_OK, HTTP_201_CREATED, HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
 from litestar.testing import TestClient, create_test_client
 
@@ -65,9 +65,19 @@ def test_parsing_of_body_as_default() -> None:
         assert response.status_code == HTTP_201_CREATED
 
 
+def test_parsing_of_dependency_as_annotated_deprecated() -> None:
+    @get(path="/", dependencies={"dep": Provide(lambda: None, sync_to_thread=False)})
+    def handler(dep: Annotated[None, Dependency()]) -> None:
+        return dep
+
+    with create_test_client(handler) as client:
+        response = client.get("/")
+        assert response.text == "null"
+
+
 def test_parsing_of_dependency_as_annotated() -> None:
     @get(path="/", dependencies={"dep": Provide(lambda: None, sync_to_thread=False)})
-    def handler(dep: Annotated[int, Dependency(skip_validation=True)]) -> int:
+    def handler(dep: NamedDependency[None]) -> None:
         return dep
 
     with create_test_client(handler) as client:
@@ -77,7 +87,7 @@ def test_parsing_of_dependency_as_annotated() -> None:
 
 def test_parsing_of_dependency_as_default() -> None:
     @get(path="/", dependencies={"dep": Provide(lambda: None, sync_to_thread=False)})
-    def handler(dep: int = Dependency(skip_validation=True)) -> int:
+    def handler(dep: None = Dependency()) -> None:
         return dep
 
     with create_test_client(handler) as client:
@@ -86,14 +96,17 @@ def test_parsing_of_dependency_as_default() -> None:
 
 
 @pytest.mark.parametrize(
-    "dependency, expected",
+    "dependency_default, expected",
     [
-        (Dependency(), None),
-        (Dependency(default=None), None),
-        (Dependency(default=13), 13),
+        (..., None),
+        (None, None),
+        (13, 13),
     ],
 )
-def test_dependency_defaults(dependency: Any, expected: Optional[int]) -> None:
+def test_dependency_defaults_deprecated(dependency_default: Any, expected: Optional[int]) -> None:
+    with pytest.warns(LitestarDeprecationWarning):
+        dependency = Dependency(default=dependency_default) if dependency_default is not ... else Dependency()
+
     @get("/")
     def handler(value: Optional[int] = dependency) -> Dict[str, Optional[int]]:
         return {"value": value}
@@ -103,7 +116,25 @@ def test_dependency_defaults(dependency: Any, expected: Optional[int]) -> None:
         assert resp.json() == {"value": expected}
 
 
-def test_dependency_non_optional_with_default() -> None:
+@pytest.mark.parametrize(
+    "dependency_default, expected",
+    [
+        (..., None),
+        (None, None),
+        (13, 13),
+    ],
+)
+def test_dependency_defaults(dependency_default: Any, expected: Optional[int]) -> None:
+    @get("/")
+    def handler(value: Optional[int] = dependency_default) -> Dict[str, Optional[int]]:
+        return {"value": value}
+
+    with create_test_client(route_handlers=[handler]) as client:
+        resp = client.get("/")
+        assert resp.json() == {"value": expected}
+
+
+def test_dependency_non_optional_with_default_deprecated() -> None:
     @get("/")
     def handler(value: int = Dependency(default=13)) -> Dict[str, int]:
         return {"value": value}
@@ -113,7 +144,17 @@ def test_dependency_non_optional_with_default() -> None:
         assert resp.json() == {"value": 13}
 
 
-def test_dependency_no_default() -> None:
+def test_dependency_non_optional_with_default() -> None:
+    @get("/")
+    def handler(value: int = 13) -> Dict[str, int]:
+        return {"value": value}
+
+    with create_test_client(route_handlers=[handler]) as client:
+        resp = client.get("/")
+        assert resp.json() == {"value": 13}
+
+
+def test_dependency_no_default_deprecated() -> None:
     @get(dependencies={"value": Provide(lambda: 13, sync_to_thread=False)})
     def test(value: int = Dependency()) -> Dict[str, int]:
         return {"value": value}
@@ -123,9 +164,19 @@ def test_dependency_no_default() -> None:
     assert resp.json() == {"value": 13}
 
 
+def test_dependency_no_default() -> None:
+    @get(dependencies={"value": Provide(lambda: 13, sync_to_thread=False)})
+    def test(value: int) -> Dict[str, int]:
+        return {"value": value}
+
+    with create_test_client(route_handlers=[test]) as client:
+        resp = client.get("/")
+    assert resp.json() == {"value": 13}
+
+
 def test_dependency_not_provided_and_no_default() -> None:
     @get()
-    def test(value: int = Dependency()) -> Dict[str, int]:
+    def test(value: NamedDependency[int]) -> Dict[str, int]:
         return {"value": value}
 
     with pytest.raises(ImproperlyConfiguredException):
@@ -142,7 +193,7 @@ def test_dependency_provided_on_controller() -> None:
         dependencies = {"value": Provide(lambda: 13, sync_to_thread=False)}
 
         @get()
-        def test(self, value: int = Dependency()) -> Dict[str, int]:
+        def test(self, value: int) -> Dict[str, int]:
             return {"value": value}
 
     with create_test_client(route_handlers=[C]) as client:
@@ -156,7 +207,7 @@ def test_dependency_skip_validation() -> None:
         return {"value": value}
 
     @get("/skipped")
-    def skipped(value: int = Dependency(skip_validation=True)) -> Dict[str, int]:
+    def skipped(value: SkipValidation[int]) -> Dict[str, int]:
         return {"value": value}
 
     with create_test_client(
@@ -171,7 +222,7 @@ def test_dependency_skip_validation() -> None:
 
 def test_dependency_skip_validation_with_default() -> None:
     @get("/skipped")
-    def skipped(value: int = Dependency(default=1, skip_validation=True)) -> Dict[str, int]:
+    def skipped(value: SkipValidation[int] = 1) -> Dict[str, int]:
         return {"value": value}
 
     with create_test_client(route_handlers=[skipped]) as client:

--- a/tests/unit/test_signature/test_validation.py
+++ b/tests/unit/test_signature/test_validation.py
@@ -7,7 +7,7 @@ from typing_extensions import Annotated, TypedDict
 
 from litestar import get, post
 from litestar._signature import SignatureModel
-from litestar.di import Provide
+from litestar.di import NamedDependency, Provide
 from litestar.enums import ParamType
 from litestar.exceptions import ImproperlyConfiguredException, ValidationException
 from litestar.params import CookieParameter, Dependency, FromQuery, HeaderParameter, PathParameter, QueryParameter
@@ -99,7 +99,7 @@ def test_client_backend_error_precedence_over_server_error() -> None:
     }
 
     @get("/")
-    def test(dep: int, param: FromQuery[int], optional_dep: Optional[int] = Dependency()) -> None: ...
+    def test(dep: int, param: FromQuery[int], optional_dep: NamedDependency[Optional[int]]) -> None: ...
 
     with create_test_client(route_handlers=[test], dependencies=dependencies) as client:
         response = client.get("/?param=thirteen")


### PR DESCRIPTION
Add a new `NamedDependency` marker, building upon the work of #4750 and #4801. This completes the move to generic parameter markers to indicate the value source.

`NamedDependency` is also a preparation for the overhauled di that will be introduced in version 3, which supports typed-based DI alongside the current name-based DI, and will feature its counterpart `TypeDependency`.

<hr>

- Add `di.NamedDependency` generic, replacing `Annotated[<type>, Depenency()]` as a marker
- Deprecate `params.Dependency`
- Introduce `params.SkipValidation` generic. `Dependency(skip_validation=True)` can be cleanly migrated to this. In addition, `SkipValidation` works on all parameters, not just dependencies

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4808">https://litestar-org.github.io/litestar-docs-preview/4808</a> 
