### PR TITLE
feat(openapi): add $dynamicRef and $dynamicAnchor to Schema dataclass

### DIFF
--- a/litestar/openapi/spec/schema.py
+++ b/litestar/openapi/spec/schema.py
@@ -647,6 +647,24 @@ class Schema(BaseSchemaObject):
     discouraged, and later versions of this specification may remove it.
     """
 
+    dynamic_ref: str | None = field(default=None, metadata={"alias": "$dynamicRef"})
+    """The value of ``$dynamicRef`` MUST be a string, in the form of a URI-reference.
+
+    This keyword is used to reference a dynamically-anchored schema. At runtime, the URI reference is resolved against
+    the base URI of the current schema, and the resolved URI is used to locate the schema to be applied.
+
+    See `JSON Schema 2020-12 §7.7.1 <https://json-schema.org/draft/2020-12/json-schema-core#section-7.7.1>`_.
+    """
+
+    dynamic_anchor: str | None = field(default=None, metadata={"alias": "$dynamicAnchor"})
+    """The value of ``$dynamicAnchor`` MUST be a string.
+
+    This keyword is used to create a dynamic anchor in the schema. A dynamic anchor can be referenced by a
+    ``$dynamicRef`` in another schema, allowing for dynamic schema composition.
+
+    See `JSON Schema 2020-12 §7.7.2 <https://json-schema.org/draft/2020-12/json-schema-core#section-7.7.2>`_.
+    """
+
     def __hash__(self) -> int:
         return _recursive_hash(self)
 

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -774,3 +774,57 @@ def test_decimal_schema_type() -> None:
 
     schema = create_schema_for_annotation(Decimal)
     assert schema.type == OpenAPIType.STRING
+
+def test_schema_dynamic_ref_and_anchor() -> None:
+    """Test that Schema supports $dynamicRef and $dynamicAnchor fields."""
+    schema = Schema(
+        type=OpenAPIType.OBJECT,
+        dynamic_ref="#/components/schemas/Pet",
+        dynamic_anchor="petAnchor",
+    )
+
+    assert schema.dynamic_ref == "#/components/schemas/Pet"
+    assert schema.dynamic_anchor == "petAnchor"
+
+    # Test serialization to dict
+    schema_dict = schema.to_schema()
+    assert schema_dict["$dynamicRef"] == "#/components/schemas/Pet"
+    assert schema_dict["$dynamicAnchor"] == "petAnchor"
+
+
+def test_schema_dynamic_ref_and_anchor_optional() -> None:
+    """Test that dynamic_ref and dynamic_anchor are optional."""
+    schema = Schema(type=OpenAPIType.STRING)
+
+    assert schema.dynamic_ref is None
+    assert schema.dynamic_anchor is None
+
+    schema_dict = schema.to_schema()
+    assert "$dynamicRef" not in schema_dict
+    assert "$dynamicAnchor" not in schema_dict
+
+
+def test_schema_dynamic_ref_and_anchor_with_other_fields() -> None:
+    """Test that dynamic_ref and dynamic_anchor work with other schema fields."""
+    schema = Schema(
+        type=OpenAPIType.OBJECT,
+        title="TestSchema",
+        description="A test schema",
+        dynamic_ref="#/components/schemas/Base",
+        dynamic_anchor="testAnchor",
+        properties={"name": Schema(type=OpenAPIType.STRING)},
+        required=["name"],
+    )
+
+    assert schema.dynamic_ref == "#/components/schemas/Base"
+    assert schema.dynamic_anchor == "testAnchor"
+    assert schema.title == "TestSchema"
+    assert schema.description == "A test schema"
+
+    schema_dict = schema.to_schema()
+    assert schema_dict["$dynamicRef"] == "#/components/schemas/Base"
+    assert schema_dict["$dynamicAnchor"] == "testAnchor"
+    assert schema_dict["title"] == "TestSchema"
+    assert schema_dict["description"] == "A test schema"
+    assert "name" in schema_dict.get("properties", {})
+    assert schema_dict.get("required") == ["name"]


### PR DESCRIPTION
## Summary

Adds support for JSON Schema 2020-12's `$dynamicRef` and `$dynamicAnchor` keywords to the `Schema` dataclass in `litestar/openapi/spec/schema.py`.

Litestar's `Schema` dataclass claims comprehensive OAS 3.1 / JSON Schema 2020-12 coverage but was missing these two applicator keywords. This change completes the vocabulary by adding both fields, enabling users to represent dynamic schema composition through the official `Schema` API.

## Changes

- Added `dynamic_ref: str | None` field with `$dynamicRef` alias
- Added `dynamic_anchor: str | None` field with `$dynamicAnchor` alias  
- Both use the same `field(default=None, metadata={"alias": "..."})` pattern as existing fields

## Tests

All 244 existing OpenAPI tests pass:
```
tests/unit/test_openapi/ — 244 passed, 1 skipped
```

## Example

```python
from litestar.openapi.spec import Schema

schema = Schema(
    dynamic_anchor="itemType",
    properties={
        "items": Schema(
            type="array",
            items=Schema(dynamic_ref="#itemType")
        )
    }
)

print(schema.to_schema())
```

Fixes #4789

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4809">https://litestar-org.github.io/litestar-docs-preview/4809</a> 
