### PR TITLE
fix(openapi): handle Annotated metadata in Optional[Literal[...]] schemas

### DIFF
--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -49,6 +49,7 @@ from litestar.utils.predicates import (
 from litestar.utils.typing import (
     get_origin_or_inner_type,
     make_non_optional_union,
+    unwrap_annotation,
     unwrap_new_type,
 )
 
@@ -172,6 +173,11 @@ def _iter_flat_literal_args(annotation: Any) -> Iterable[Any]:
     Yields:
         The flattened arguments of the Literal.
     """
+    # Strip ``Annotated[...]`` (and similar wrappers) so we never iterate over
+    # PEP 593 metadata as if it were a literal value. Reachable e.g. via
+    # ``Optional[Annotated[Literal[...], Meta(...)]]`` because
+    # ``make_non_optional_union`` preserves the ``Annotated`` wrapper.
+    annotation, _, _ = unwrap_annotation(annotation)
     for arg in get_args(annotation):
         if get_origin_or_inner_type(arg) is Literal:
             yield from _iter_flat_literal_args(arg)

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -607,6 +607,21 @@ def test_optional_literal() -> None:
     assert schema.enum == [1, None]
 
 
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        Optional[Annotated[Literal["a", "b"], msgspec.Meta(description="legacy")]],
+        Optional[Annotated[Literal["a", "b"], annotated_types.MaxLen(8)]],
+    ],
+)
+def test_optional_annotated_literal_strips_metadata(annotation: Any) -> None:
+    """Regression: ``Annotated`` metadata around a ``Literal`` inside ``Optional`` must not leak into enum values."""
+    schema = get_schema_for_field_definition(FieldDefinition.from_annotation(annotation))
+    assert schema.type is not None
+    assert set(schema.type) == {OpenAPIType.STRING, OpenAPIType.NULL}
+    assert schema.enum == ["a", "b", None]
+
+
 def test_not_generating_examples_property() -> None:
     with_examples = SchemaCreator(generate_examples=True)
     without_examples = with_examples.not_generating_examples


### PR DESCRIPTION
`Optional[Annotated[Literal[...], Meta(...)]]` raised a `KeyError` during
schema generation because `make_non_optional_union` preserves the
`Annotated` wrapper, and `_iter_flat_literal_args` then iterated the PEP
593 metadata as if it were a literal value.

Strip wrapper annotations at the top of `_iter_flat_literal_args` so the
function is robust regardless of where it is entered from. Add a
parametrized regression test covering both `msgspec.Meta` and
`annotated_types` metadata to confirm the fix is shape-agnostic.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
- follow [Litestar's AI Policy](https://github.com/litestar-org/.github/blob/main/AI_POLICY.md)

If the pull request is not yet ready for review (e.g. tests or other checks are still failing),
please submit it as a draft PR, to avoid noise for reviewers.
-->

## Description

Minimal example detailing the issue:

```python
from typing import Annotated, Literal, Optional
from msgspec import Meta, Struct
from litestar import Litestar, post

Flag = Annotated[Literal["A", "B"], Meta(description="legacy")]

class Body(Struct):
    flag: Optional[Flag] = None   # <-- Optional is what exposes the bug

@post("/x")
def x(data: Body) -> Body: return data

app = Litestar(route_handlers=[x])
```


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4814">https://litestar-org.github.io/litestar-docs-preview/4814</a> 
