### PR TITLE
fix(openapi): propagate msgspec.Meta on Optional[Annotated[...]] struct fields

### DIFF
--- a/litestar/plugins/core/_msgspec.py
+++ b/litestar/plugins/core/_msgspec.py
@@ -34,11 +34,27 @@ class MsgspecDIPlugin(DIPlugin):
         return inspect.Signature(parameters), type_hints
 
 
+def _unwrap_optional(field_type: Any) -> Any:
+    """Return the inner arm of ``Optional[X]`` so downstream isinstance checks see ``X`` directly.
+
+    msgspec wraps it as ``UnionType((<inner>, NoneType))`` where ``<inner>`` is either a
+    ``Metadata`` wrapper (for description/examples) or the bare constraint-bearing type
+    (e.g. ``IntType(gt=1, ...)``) - Meta-derived constraints are hoisted onto the type.
+    Heterogeneous unions are left alone.
+    """
+    if isinstance(field_type, msgspec.inspect.UnionType):
+        non_none = [t for t in field_type.types if not isinstance(t, msgspec.inspect.NoneType)]
+        if len(non_none) == 1:
+            return non_none[0]
+    return field_type
+
+
 def kwarg_definition_from_field(field: msgspec.inspect.Field) -> tuple[ParameterKwarg | None, dict[str, Any]]:
     extra: dict[str, Any] = {}
     kwargs: dict[str, Any] = {}
-    if isinstance(field.type, msgspec.inspect.Metadata):
-        meta = field.type
+    field_type = _unwrap_optional(field.type)
+    if isinstance(field_type, msgspec.inspect.Metadata):
+        meta = field_type
         field_type = meta.type
         if extra_json_schema := meta.extra_json_schema:
             kwargs["title"] = extra_json_schema.get("title")
@@ -47,8 +63,6 @@ def kwarg_definition_from_field(field: msgspec.inspect.Field) -> tuple[Parameter
                 kwargs["examples"] = [Example(value=e) for e in examples]
             kwargs["schema_extra"] = extra_json_schema.get("extra")
         extra = meta.extra or {}
-    else:
-        field_type = field.type
 
     if isinstance(
         field_type,

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -343,6 +343,42 @@ def test_create_schema_from_msgspec_annotated_type() -> None:
     assert schema.properties["set_field"].min_items == 2  # type: ignore[index, union-attr]
 
 
+def test_msgspec_optional_annotated_meta_propagates() -> None:
+    """Regression: ``Optional[Annotated[T, msgspec.Meta(...)]]`` must propagate description, examples, and constraints."""
+
+    class Body(msgspec.Struct):
+        required_field: Annotated[str, msgspec.Meta(description="d", examples=["ex"])]
+        optional_field: Optional[Annotated[str, msgspec.Meta(description="d2", examples=["ex2"])]] = None
+        optional_int: Optional[Annotated[int, msgspec.Meta(gt=1, le=100)]] = None
+        optional_str: Optional[Annotated[str, msgspec.Meta(min_length=2, max_length=8, pattern="^[a-z]+$")]] = None
+
+    schema = get_schema_for_field_definition(FieldDefinition.from_kwarg(name="Body", annotation=Body))
+    props = schema.properties  # type: ignore[union-attr]
+
+    assert props["required_field"].description == "d"
+    assert props["required_field"].examples == ["ex"]
+    assert props["optional_field"].description == "d2"
+    assert props["optional_field"].examples == ["ex2"]
+    assert props["optional_int"].exclusive_minimum == 1
+    assert props["optional_int"].maximum == 100
+    assert props["optional_str"].min_length == 2
+    assert props["optional_str"].max_length == 8
+    assert props["optional_str"].pattern == "^[a-z]+$"
+
+
+def test_msgspec_union_with_metadata_arm_is_not_unwrapped() -> None:
+    """Heterogeneous unions must not have a single arm's ``Meta`` lifted onto the whole field."""
+
+    class Body(msgspec.Struct):
+        mixed: Union[Annotated[str, msgspec.Meta(description="only-str", min_length=5)], int] = ""
+
+    schema = get_schema_for_field_definition(FieldDefinition.from_kwarg(name="Body", annotation=Body))
+    mixed = schema.properties["mixed"]  # type: ignore[index, union-attr]
+
+    assert mixed.description is None
+    assert mixed.min_length is None
+
+
 def test_annotated_types() -> None:
     historical_date = date(year=1980, day=1, month=1)
     today = date.today()

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -354,9 +354,9 @@ def test_msgspec_optional_annotated_meta_propagates() -> None:
 
     schema = get_schema_for_field_definition(FieldDefinition.from_kwarg(name="Body", annotation=Body))
 
-    assert schema.properties["required_field"].description == "d"  # type: ignore[index, union-attr]
+    assert schema.properties["required_field"].description == "d"  # type: ignore[index]
     assert schema.properties["required_field"].examples == ["ex"]  # type: ignore[index, union-attr]
-    assert schema.properties["optional_field"].description == "d2"  # type: ignore[index, union-attr]
+    assert schema.properties["optional_field"].description == "d2"  # type: ignore[index]
     assert schema.properties["optional_field"].examples == ["ex2"]  # type: ignore[index, union-attr]
     assert schema.properties["optional_int"].exclusive_minimum == 1  # type: ignore[index, union-attr]
     assert schema.properties["optional_int"].maximum == 100  # type: ignore[index, union-attr]
@@ -373,7 +373,7 @@ def test_msgspec_union_with_metadata_arm_is_not_unwrapped() -> None:
 
     schema = get_schema_for_field_definition(FieldDefinition.from_kwarg(name="Body", annotation=Body))
 
-    assert schema.properties["mixed"].description is None  # type: ignore[index, union-attr]
+    assert schema.properties["mixed"].description is None  # type: ignore[index]
     assert schema.properties["mixed"].min_length is None  # type: ignore[index, union-attr]
 
 

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -353,17 +353,16 @@ def test_msgspec_optional_annotated_meta_propagates() -> None:
         optional_str: Optional[Annotated[str, msgspec.Meta(min_length=2, max_length=8, pattern="^[a-z]+$")]] = None
 
     schema = get_schema_for_field_definition(FieldDefinition.from_kwarg(name="Body", annotation=Body))
-    props = schema.properties  # type: ignore[union-attr]
 
-    assert props["required_field"].description == "d"
-    assert props["required_field"].examples == ["ex"]
-    assert props["optional_field"].description == "d2"
-    assert props["optional_field"].examples == ["ex2"]
-    assert props["optional_int"].exclusive_minimum == 1
-    assert props["optional_int"].maximum == 100
-    assert props["optional_str"].min_length == 2
-    assert props["optional_str"].max_length == 8
-    assert props["optional_str"].pattern == "^[a-z]+$"
+    assert schema.properties["required_field"].description == "d"  # type: ignore[index, union-attr]
+    assert schema.properties["required_field"].examples == ["ex"]  # type: ignore[index, union-attr]
+    assert schema.properties["optional_field"].description == "d2"  # type: ignore[index, union-attr]
+    assert schema.properties["optional_field"].examples == ["ex2"]  # type: ignore[index, union-attr]
+    assert schema.properties["optional_int"].exclusive_minimum == 1  # type: ignore[index, union-attr]
+    assert schema.properties["optional_int"].maximum == 100  # type: ignore[index, union-attr]
+    assert schema.properties["optional_str"].min_length == 2  # type: ignore[index, union-attr]
+    assert schema.properties["optional_str"].max_length == 8  # type: ignore[index, union-attr]
+    assert schema.properties["optional_str"].pattern == "^[a-z]+$"  # type: ignore[index, union-attr]
 
 
 def test_msgspec_union_with_metadata_arm_is_not_unwrapped() -> None:
@@ -373,10 +372,9 @@ def test_msgspec_union_with_metadata_arm_is_not_unwrapped() -> None:
         mixed: Union[Annotated[str, msgspec.Meta(description="only-str", min_length=5)], int] = ""
 
     schema = get_schema_for_field_definition(FieldDefinition.from_kwarg(name="Body", annotation=Body))
-    mixed = schema.properties["mixed"]  # type: ignore[index, union-attr]
 
-    assert mixed.description is None
-    assert mixed.min_length is None
+    assert schema.properties["mixed"].description is None  # type: ignore[index, union-attr]
+    assert schema.properties["mixed"].min_length is None  # type: ignore[index, union-attr]
 
 
 def test_annotated_types() -> None:

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -377,6 +377,24 @@ def test_msgspec_union_with_metadata_arm_is_not_unwrapped() -> None:
     assert schema.properties["mixed"].min_length is None  # type: ignore[index, union-attr]
 
 
+def test_unwrap_optional_branches() -> None:
+    """Direct branch coverage for the ``_unwrap_optional`` helper."""
+    from litestar.plugins.core._msgspec import _unwrap_optional
+
+    # Not a UnionType: returned as-is.
+    int_type = msgspec.inspect.IntType(gt=None, ge=None, lt=None, le=None, multiple_of=None)
+    assert _unwrap_optional(int_type) is int_type
+
+    # Optional[X]: single non-None arm is returned.
+    optional_int = msgspec.inspect.UnionType(types=(int_type, msgspec.inspect.NoneType()))
+    assert _unwrap_optional(optional_int) is int_type
+
+    # Heterogeneous union: returned as-is.
+    str_type = msgspec.inspect.StrType(min_length=None, max_length=None, pattern=None)
+    hetero = msgspec.inspect.UnionType(types=(int_type, str_type))
+    assert _unwrap_optional(hetero) is hetero
+
+
 def test_annotated_types() -> None:
     historical_date = date(year=1980, day=1, month=1)
     today = date.today()


### PR DESCRIPTION
# Summary

`msgspec.Meta` placed inside an `Optional` on a `Struct` field - `Optional[Annotated[T, Meta(...)]]` - was silently dropped from the generated OpenAPI schema. `description`, `examples`, `title`, and every numeric/string constraint (`gt`, `ge`, `lt`, `le`, `min_length`, `max_length`, `pattern`, …) went missing. The non-Optional form worked, which made this look like a serialization quirk, but the cause was a missing case in `kwarg_definition_from_field`: it checks `isinstance(field.type, Metadata)`, while msgspec exposes the optional shape as `UnionType(types=(Metadata(...), NoneType()))` - one level deeper than the check.

# Root cause

`msgspec.inspect` presents `Optional[Annotated[T, Meta(...)]]` as `UnionType((<inner>, NoneType))` where `<inner>` is one of two shapes depending on what `Meta` carries:

- a `Metadata` wrapper, when `Meta` carries description/examples/title, or
- the bare constraint-bearing type (e.g. `IntType(gt=1, ...)`) - msgspec hoists constraint metadata directly onto the type.

Both shapes are buried inside the `UnionType`, so the existing `isinstance(field.type, Metadata)` check misses them and the Optional path falls through without producing a `ParameterKwarg`.

# Fix

A small helper at the top of `kwarg_definition_from_field` peeks inside a single-non-None `UnionType` and returns the inner arm, letting the existing isinstance ladder handle both shapes. Heterogeneous unions (multiple non-None arms) are left alone - no single `Meta` semantically applies to the whole union.

Note:
- Applies to both struct OpenAPI generation (`StructSchemaPlugin`) and msgspec DTOs (`MsgspecDTO._generate_field_definitions`) - same helper, same effect.
- Not a request hot path: runs once per struct field at OpenAPI build / DTO class creation.
- Heterogeneous unions (`Union[Annotated[str, Meta], int]`) intentionally left as-is and pinned by a regression test.

# Minimal reproduction

```python
from typing import Annotated, Optional
import msgspec
from litestar import Litestar, post

class Body(msgspec.Struct):
    name:  Annotated[str, msgspec.Meta(description="works", min_length=2)]
    alias: Optional[Annotated[str, msgspec.Meta(description="dropped", min_length=2)]] = None

@post("/")
def handler(data: Body) -> Body:
    return data

app = Litestar(route_handlers=[handler])

schema = app.openapi_schema.to_schema()
props = schema["components"]["schemas"]["Body"]["properties"]

print(props["name"])
# {'type': 'string', 'description': 'works', 'minLength': 2}

print(props["alias"])
# Before: {'oneOf': [{'type': 'string'}, {'type': 'null'}]}                <-- description & minLength gone
# After:  {'oneOf': [{'type': 'string'}, {'type': 'null'}],
#          'description': 'dropped', 'minLength': 2}
```


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4815">https://litestar-org.github.io/litestar-docs-preview/4815</a> 
