### PR TITLE
feat(core): Deprecate request "reserved kwargs"

### DIFF
--- a/docs/examples/onboarding/fastapi/test_handler.py
+++ b/docs/examples/onboarding/fastapi/test_handler.py
@@ -1,10 +1,12 @@
+from typing import Dict
+
 from litestar import get
 from litestar.status_codes import HTTP_200_OK
 from litestar.testing import create_test_client
 
 
 @get("/", sync_to_thread=False)
-def hello() -> dict[str, str]:
+def hello() -> Dict[str, str]:
     return {"hello": "world"}
 
 

--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -55,7 +55,6 @@ if TYPE_CHECKING:
 _ExceptionGroup = get_exception_group()
 
 _DEPRECATED_RESERVED_KWARGS = {
-    "state",
     "scope",
     "headers",
     "cookies",
@@ -286,7 +285,7 @@ class KwargsModel:
         return param_definitions, expected_dependencies
 
     @classmethod
-    def create_for_signature_model(
+    def create_for_signature_model(  # noqa: C901
         cls,
         signature_model: type[SignatureModel],
         parsed_signature: ParsedSignature,

--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -54,12 +54,30 @@ if TYPE_CHECKING:
 
 _ExceptionGroup = get_exception_group()
 
+_DEPRECATED_RESERVED_KWARGS = {
+    "state",
+    "scope",
+    "headers",
+    "cookies",
+    "query",
+}
+
 
 @dataclasses.dataclass
 class HandlerContext:
     handler: str
     paths: list[str]
     dependencies: list[str] = dataclasses.field(default_factory=list)
+
+    def format(self, msg: str | None = None) -> str:
+        paths = ",".join(sorted(self.paths))
+        out = f"[paths={paths!r}, handler={self.handler!r}"
+        if self.dependencies:
+            out += f", dependencies={' -> '.join(self.dependencies[::-1])!r}"
+        out += "]"
+        if msg:
+            out = f"{out} {msg}"
+        return out
 
 
 class KwargsModel:
@@ -390,6 +408,19 @@ class KwargsModel:
             else False
         )
 
+        for reserved_kwarg in expected_reserved_kwargs.intersection(_DEPRECATED_RESERVED_KWARGS):
+            msg = (
+                f"Usage of deprecated reserved kwarg {reserved_kwarg!r}. It will be removed in "
+                f"Litestar 3.0. Use 'request.{reserved_kwarg}' instead"
+            )
+            if ctx is not None:
+                msg = ctx.format(msg)
+            warnings.warn(
+                msg,
+                stacklevel=2,
+                category=LitestarDeprecationWarning,
+            )
+
         return KwargsModel(
             expected_cookie_params=expected_cookie_parameters,
             expected_dependencies=expected_dependencies,
@@ -570,11 +601,6 @@ def _warn_deprecated_param_style(
             raise ValueError(f"Unknown style {style!r}")
 
     if ctx is not None:
-        paths = ",".join(sorted(ctx.paths))
-        out = f"[paths={paths!r}, handler={ctx.handler!r}"
-        if ctx.dependencies:
-            out += f", dependencies={' -> '.join(ctx.dependencies[::-1])!r}"
-        out += f"] {msg}"
-        msg = out
+        msg = ctx.format(msg)
 
     warnings.warn(msg, category=LitestarDeprecationWarning, stacklevel=stacklevel)

--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -411,7 +411,7 @@ class KwargsModel:
         for reserved_kwarg in expected_reserved_kwargs.intersection(_DEPRECATED_RESERVED_KWARGS):
             msg = (
                 f"Usage of deprecated reserved kwarg {reserved_kwarg!r}. It will be removed in "
-                f"Litestar 3.0. Use 'request.{reserved_kwarg}' instead"
+                f"Litestar 3.0. Use 'connection|request|socket.{reserved_kwarg}' instead"
             )
             if ctx is not None:
                 msg = ctx.format(msg)

--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -66,6 +66,7 @@ _DEPRECATED_RESERVED_KWARGS = {
 class HandlerContext:
     handler: str
     paths: list[str]
+    kind: str = "base"
     dependencies: list[str] = dataclasses.field(default_factory=list)
 
     def format(self, msg: str | None = None) -> str:
@@ -310,7 +311,7 @@ class KwargsModel:
         """
 
         if ctx is not None and not isinstance(ctx, HandlerContext):
-            ctx = HandlerContext(handler=ctx.name or ctx.handler_name, paths=sorted(ctx.paths))
+            ctx = HandlerContext(handler=ctx.name or ctx.handler_name, paths=sorted(ctx.paths), kind=ctx._kind)
 
         field_definitions = signature_model._fields
 
@@ -408,11 +409,21 @@ class KwargsModel:
         )
 
         for reserved_kwarg in expected_reserved_kwargs.intersection(_DEPRECATED_RESERVED_KWARGS):
-            msg = (
-                f"Usage of deprecated reserved kwarg {reserved_kwarg!r}. It will be removed in "
-                f"Litestar 3.0. Use 'connection|request|socket.{reserved_kwarg}' instead"
-            )
+            msg = f"Usage of deprecated reserved kwarg {reserved_kwarg!r}. It will be removed in Litestar 3.0."
             if ctx is not None:
+                handler_kind = ctx.kind
+                alternative = ""
+                if handler_kind == "http":
+                    alternative = f"request.{reserved_kwarg}"
+                elif handler_kind == "websocket":
+                    alternative = f"socket.{reserved_kwarg}"
+                elif handler_kind == "asgi":
+                    if reserved_kwarg == "scope":
+                        alternative = "scope"
+                    else:
+                        alternative = f'scope["{reserved_kwarg}"]'
+                if alternative:
+                    msg = msg + f" Use '{alternative}' instead"
                 msg = ctx.format(msg)
             warnings.warn(
                 msg,

--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -417,11 +417,6 @@ class KwargsModel:
                     alternative = f"request.{reserved_kwarg}"
                 elif handler_kind == "websocket":
                     alternative = f"socket.{reserved_kwarg}"
-                elif handler_kind == "asgi":
-                    if reserved_kwarg == "scope":
-                        alternative = "scope"
-                    else:
-                        alternative = f'scope["{reserved_kwarg}"]'
                 if alternative:
                     msg = msg + f" Use '{alternative}' instead"
                 msg = ctx.format(msg)

--- a/litestar/connection/base.py
+++ b/litestar/connection/base.py
@@ -9,6 +9,7 @@ from litestar.datastructures.state import State
 from litestar.datastructures.url import URL, Address, make_absolute_url
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types.empty import Empty
+from litestar.utils import deprecated, warn_deprecation
 from litestar.utils.empty import value_or_default
 from litestar.utils.scope.state import ScopeState
 
@@ -171,11 +172,13 @@ class ASGIConnection(Generic[HandlerT, UserT, AuthT, StateT]):
         return Headers.from_scope(self.scope)
 
     @property
-    def query_params(self) -> MultiDict[Any]:
+    def query(self) -> MultiDict[Any]:
         """Return the query parameters of this connection's ``Scope``.
 
         Returns:
             A normalized dict of query parameters. Multiple values for the same key are returned as a list.
+
+        .. versionadded:: 2.23.0
         """
         if self._parsed_query is Empty:
             if (parsed_query := self._connection_state.parsed_query) is not Empty:
@@ -185,6 +188,24 @@ class ASGIConnection(Generic[HandlerT, UserT, AuthT, StateT]):
                     self.scope.get("query_string", b"")
                 )
         return MultiDict(self._parsed_query)
+
+    @property
+    def query_params(self) -> MultiDict[Any]:
+        """Return the query parameters of this connection's ``Scope``.
+
+        Returns:
+            A normalized dict of query parameters. Multiple values for the same key are returned as a list.
+
+        .. deprecated:: 2.23.0
+        """
+        warn_deprecation(
+            "2.23.0",
+            removal_in="3.0",
+            alternative=".query",
+            kind="property",
+            deprecated_name="query_params",
+        )
+        return self.query
 
     @property
     def path_params(self) -> dict[str, Any]:

--- a/litestar/connection/base.py
+++ b/litestar/connection/base.py
@@ -9,7 +9,7 @@ from litestar.datastructures.state import State
 from litestar.datastructures.url import URL, Address, make_absolute_url
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types.empty import Empty
-from litestar.utils import deprecated, warn_deprecation
+from litestar.utils import warn_deprecation
 from litestar.utils.empty import value_or_default
 from litestar.utils.scope.state import ScopeState
 

--- a/litestar/handlers/asgi_handlers.py
+++ b/litestar/handlers/asgi_handlers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, ClassVar, Mapping, Sequence
 
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.handlers.base import BaseRouteHandler
@@ -27,6 +27,8 @@ class ASGIRouteHandler(BaseRouteHandler):
     """
 
     __slots__ = ("copy_scope", "is_mount", "is_static")
+
+    _kind: ClassVar[str] = "asgi"
 
     def __init__(
         self,

--- a/litestar/handlers/base.py
+++ b/litestar/handlers/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from copy import copy
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Mapping, Sequence, cast
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Mapping, Sequence, cast
 
 from litestar._signature import SignatureModel
 from litestar.di import Provide
@@ -75,6 +75,8 @@ class BaseRouteHandler:
         "type_decoders",
         "type_encoders",
     )
+
+    _kind: ClassVar[str] = "base"
 
     def __init__(
         self,

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import TYPE_CHECKING, AnyStr, Mapping, Sequence, TypedDict, cast
+from typing import TYPE_CHECKING, AnyStr, ClassVar, Mapping, Sequence, TypedDict, cast
 
 from litestar._layers.utils import narrow_response_cookies, narrow_response_headers
 from litestar.connection import Request
@@ -116,6 +116,8 @@ class HTTPRouteHandler(BaseRouteHandler):
         "tags",
         "template_name",
     )
+
+    _kind: ClassVar[str] = "http"
 
     has_sync_callable: bool
 

--- a/litestar/handlers/websocket_handlers/route_handler.py
+++ b/litestar/handlers/websocket_handlers/route_handler.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any, ClassVar, Mapping
 
 from litestar.connection import WebSocket
 from litestar.exceptions import ImproperlyConfiguredException
@@ -19,6 +19,8 @@ class WebsocketRouteHandler(BaseRouteHandler):
     """
 
     __slots__ = ("websocket_class",)
+
+    _kind: ClassVar[str] = "websocket"
 
     def __init__(
         self,

--- a/litestar/routes/http.py
+++ b/litestar/routes/http.py
@@ -221,11 +221,8 @@ class HTTPRoute(BaseRoute):
             An HTTP route handler for OPTIONS requests.
         """
 
-        def options_handler(scope: Scope) -> Response:
+        def options_handler() -> Response:
             """Handler function for OPTIONS requests.
-
-            Args:
-                scope: The ASGI Scope.
 
             Returns:
                 Response

--- a/tests/examples/test_contrib/test_sqlalchemy/plugins/test_example_apps.py
+++ b/tests/examples/test_contrib/test_sqlalchemy/plugins/test_example_apps.py
@@ -10,7 +10,12 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from litestar.plugins.sqlalchemy import EngineConfig
 from litestar.testing import TestClient
 
-pytestmark = pytest.mark.xdist_group("sqlalchemy_examples")
+pytestmark = [
+    pytest.mark.xdist_group("sqlalchemy_examples"),
+    pytest.mark.filterwarnings(
+        "ignore:.*Usage of deprecated reserved kwarg:litestar.exceptions.LitestarDeprecationWarning"
+    ),
+]
 
 
 @pytest.fixture

--- a/tests/examples/test_contrib/test_sqlalchemy/plugins/test_tutorial_example_apps.py
+++ b/tests/examples/test_contrib/test_sqlalchemy/plugins/test_tutorial_example_apps.py
@@ -2,23 +2,35 @@ from __future__ import annotations
 
 import importlib
 import sys
+import warnings
 
 import pytest
 from _pytest.fixtures import FixtureRequest
 from _pytest.monkeypatch import MonkeyPatch
-from docs.examples.contrib.sqlalchemy.plugins.tutorial import (
-    full_app_no_plugins,
-    full_app_with_init_plugin,
-    full_app_with_plugin,
-    full_app_with_serialization_plugin,
-    full_app_with_session_di,
-)
+
+from litestar.exceptions import LitestarDeprecationWarning
+
+with warnings.catch_warnings(category=LitestarDeprecationWarning):
+    warnings.simplefilter("ignore", LitestarDeprecationWarning)
+
+    from docs.examples.contrib.sqlalchemy.plugins.tutorial import (
+        full_app_no_plugins,
+        full_app_with_init_plugin,
+        full_app_with_plugin,
+        full_app_with_serialization_plugin,
+        full_app_with_session_di,
+    )
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from litestar import Litestar
 from litestar.testing import TestClient
 
-pytestmark = pytest.mark.xdist_group("sqlalchemy_examples")
+pytestmark = [
+    pytest.mark.xdist_group("sqlalchemy_examples"),
+    pytest.mark.filterwarnings(
+        "ignore:.*Usage of deprecated reserved kwarg:litestar.exceptions.LitestarDeprecationWarning"
+    ),
+]
 
 
 @pytest.fixture(

--- a/tests/examples/test_contrib/test_sqlalchemy/plugins/test_tutorial_example_apps.py
+++ b/tests/examples/test_contrib/test_sqlalchemy/plugins/test_tutorial_example_apps.py
@@ -10,7 +10,7 @@ from _pytest.monkeypatch import MonkeyPatch
 
 from litestar.exceptions import LitestarDeprecationWarning
 
-with warnings.catch_warnings(category=LitestarDeprecationWarning):
+with warnings.catch_warnings():
     warnings.simplefilter("ignore", LitestarDeprecationWarning)
 
     from docs.examples.contrib.sqlalchemy.plugins.tutorial import (

--- a/tests/examples/test_contrib/test_sqlalchemy/test_sqlalchemy_examples.py
+++ b/tests/examples/test_contrib/test_sqlalchemy/test_sqlalchemy_examples.py
@@ -8,7 +8,12 @@ from sqlalchemy.pool import NullPool
 from litestar.plugins.sqlalchemy import AsyncSessionConfig, SQLAlchemyAsyncConfig
 from litestar.testing import TestClient
 
-pytestmark = pytest.mark.xdist_group("sqlalchemy_examples")
+pytestmark = [
+    pytest.mark.xdist_group("sqlalchemy_examples"),
+    pytest.mark.filterwarnings(
+        "ignore:.*Usage of deprecated reserved kwarg:litestar.exceptions.LitestarDeprecationWarning"
+    ),
+]
 
 
 async def test_sqlalchemy_declarative_models(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:

--- a/tests/examples/test_plugins/test_sqlalchemy_init_plugin.py
+++ b/tests/examples/test_plugins/test_sqlalchemy_init_plugin.py
@@ -5,7 +5,12 @@ from _pytest.monkeypatch import MonkeyPatch
 
 from litestar.testing import TestClient
 
-pytestmark = pytest.mark.xdist_group("sqlalchemy_examples")
+pytestmark = [
+    pytest.mark.xdist_group("sqlalchemy_examples"),
+    pytest.mark.filterwarnings(
+        "ignore:.*Usage of deprecated reserved kwarg:litestar.exceptions.LitestarDeprecationWarning"
+    ),
+]
 
 
 def test_sync_app(monkeypatch: MonkeyPatch) -> None:

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -473,8 +473,8 @@ def test_from_scope() -> None:
     mock = MagicMock()
 
     @get()
-    def handler(scope: Scope) -> None:
-        mock(Litestar.from_scope(scope))
+    def handler(request: Request) -> None:
+        mock(Litestar.from_scope(request.scope))
         return
 
     app = Litestar(route_handlers=[handler])

--- a/tests/unit/test_connection/test_base.py
+++ b/tests/unit/test_connection/test_base.py
@@ -35,7 +35,7 @@ def test_connection_base_properties() -> None:
     assert connection.headers is not None
     assert connection_state.headers is not Empty
     assert connection_state.parsed_query is Empty
-    assert connection.query_params is not None
+    assert connection.query is not None
     assert connection_state.parsed_query is not Empty
     assert connection_state.cookies is Empty
     assert connection.cookies is not None

--- a/tests/unit/test_connection/test_request.py
+++ b/tests/unit/test_connection/test_request.py
@@ -185,7 +185,7 @@ def test_request_url() -> None:
 def test_request_query_params() -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         request = Request[Any, Any, State](scope, receive)
-        params = dict(request.query_params)
+        params = dict(request.query)
         response = ASGIResponse(body=encode_json({"params": params}))
         await response(scope, receive, send)
 

--- a/tests/unit/test_connection/test_websocket.py
+++ b/tests/unit/test_connection/test_websocket.py
@@ -123,7 +123,7 @@ def test_websocket_binary_json() -> None:
 def test_websocket_query_params() -> None:
     @websocket("/")
     async def handler(socket: WebSocket[Any, Any, State]) -> None:
-        query_params = dict(socket.query_params)
+        query_params = dict(socket.query)
         await socket.accept()
         await socket.send_json({"params": query_params})
         await socket.close()

--- a/tests/unit/test_data_extractors.py
+++ b/tests/unit/test_data_extractors.py
@@ -34,7 +34,7 @@ async def test_connection_data_extractor() -> None:
     assert extracted_data.get("path") == request.scope["path"]
     assert extracted_data.get("path") == request.scope["path"]
     assert extracted_data.get("path_params") == request.scope["path_params"]
-    assert extracted_data.get("query") == request.query_params.dict()
+    assert extracted_data.get("query") == request.query.dict()
     assert extracted_data.get("scheme") == request.scope["scheme"]
 
 
@@ -45,7 +45,7 @@ def test_parse_query() -> None:
     )
     parsed_extracted_data = ConnectionDataExtractor(parse_query=True)(request)
     unparsed_extracted_data = ConnectionDataExtractor()(request)
-    assert parsed_extracted_data.get("query") == request.query_params.dict()
+    assert parsed_extracted_data.get("query") == request.query.dict()
     assert unparsed_extracted_data.get("query") == request.scope["query_string"]
     # Close to avoid warnings about un-awaited coroutines.
     parsed_extracted_data.get("body").close()  # type: ignore[union-attr]

--- a/tests/unit/test_handlers/test_websocket_handlers/test_kwarg_handling.py
+++ b/tests/unit/test_handlers/test_websocket_handlers/test_kwarg_handling.py
@@ -1,6 +1,8 @@
+import pytest
 from typing_extensions import Annotated
 
 from litestar import WebSocket, websocket
+from litestar.exceptions import LitestarDeprecationWarning
 from litestar.params import FromPath, FromQuery, HeaderParameter
 from litestar.testing import create_test_client
 

--- a/tests/unit/test_handlers/test_websocket_handlers/test_kwarg_handling.py
+++ b/tests/unit/test_handlers/test_websocket_handlers/test_kwarg_handling.py
@@ -30,12 +30,13 @@ def test_handle_websocket_params_parsing() -> None:
         await socket.send_json({"data": "123"})
         await socket.close()
 
-    client = create_test_client(route_handlers=websocket_handler)
+    with pytest.warns(LitestarDeprecationWarning, match=".*Usage of deprecated reserved kwarg"), create_test_client(
+        route_handlers=websocket_handler
+    ) as client:
+        # Set cookies on the client to avoid warnings about per-request cookies.
+        client.cookies = {"cookie": "yum"}  # type: ignore[assignment]
 
-    # Set cookies on the client to avoid warnings about per-request cookies.
-    client.cookies = {"cookie": "yum"}  # type: ignore[assignment]
-
-    with client.websocket_connect("/1?qp=1", headers={"some-header": "abc"}) as ws:
-        ws.send_json({"data": "123"})
-        data = ws.receive_json()
-        assert data
+        with client.websocket_connect("/1?qp=1", headers={"some-header": "abc"}) as ws:
+            ws.send_json({"data": "123"})
+            data = ws.receive_json()
+            assert data

--- a/tests/unit/test_handlers/test_websocket_handlers/test_listeners.py
+++ b/tests/unit/test_handlers/test_websocket_handlers/test_listeners.py
@@ -8,7 +8,7 @@ from pytest_lazy_fixtures import lf
 
 from litestar import Controller, Litestar, Request, WebSocket
 from litestar.connection import ASGIConnection
-from litestar.datastructures import State
+from litestar.datastructures import MultiDict, State
 from litestar.di import Provide
 from litestar.dto import DataclassDTO, dto_field
 from litestar.exceptions import ImproperlyConfiguredException
@@ -338,7 +338,7 @@ def test_lifespan_dependencies() -> None:
 
     assert mock.call_args_list[0].kwargs["name"] == "foo"
     assert isinstance(mock.call_args_list[0].kwargs["state"], State)
-    assert isinstance(mock.call_args_list[0].kwargs["query"], dict)
+    assert isinstance(mock.call_args_list[0].kwargs["query"], MultiDict)
 
 
 def test_hook_dependencies() -> None:
@@ -367,13 +367,13 @@ def test_hook_dependencies() -> None:
     assert on_accept_kwargs["name"] == "foo"
     assert on_accept_kwargs["some"] == "hello"
     assert isinstance(on_accept_kwargs["state"], State)
-    assert isinstance(on_accept_kwargs["query"], dict)
+    assert isinstance(on_accept_kwargs["query"], MultiDict)
 
     on_disconnect_kwargs = on_disconnect_mock.call_args_list[0].kwargs
     assert on_disconnect_kwargs["name"] == "foo"
     assert on_disconnect_kwargs["some"] == "hello"
     assert isinstance(on_disconnect_kwargs["state"], State)
-    assert isinstance(on_disconnect_kwargs["query"], dict)
+    assert isinstance(on_disconnect_kwargs["query"], MultiDict)
 
 
 def test_websocket_listener_class_hook_dependencies() -> None:
@@ -404,13 +404,13 @@ def test_websocket_listener_class_hook_dependencies() -> None:
     assert on_accept_kwargs["name"] == "foo"
     assert on_accept_kwargs["some"] == "hello"
     assert isinstance(on_accept_kwargs["state"], State)
-    assert isinstance(on_accept_kwargs["query"], dict)
+    assert isinstance(on_accept_kwargs["query"], MultiDict)
 
     on_disconnect_kwargs = on_disconnect_mock.call_args_list[0].kwargs
     assert on_disconnect_kwargs["name"] == "foo"
     assert on_disconnect_kwargs["some"] == "hello"
     assert isinstance(on_disconnect_kwargs["state"], State)
-    assert isinstance(on_disconnect_kwargs["query"], dict)
+    assert isinstance(on_disconnect_kwargs["query"], MultiDict)
 
 
 @pytest.mark.parametrize("hook_name", ["on_accept", "on_disconnect", "connection_accept_handler"])

--- a/tests/unit/test_handlers/test_websocket_handlers/test_listeners.py
+++ b/tests/unit/test_handlers/test_websocket_handlers/test_listeners.py
@@ -325,8 +325,8 @@ def test_lifespan_dependencies() -> None:
     mock = MagicMock()
 
     @asynccontextmanager
-    async def lifespan(name: FromPath[str], state: State, query: dict) -> AsyncGenerator[None, None]:
-        mock(name=name, state=state, query=query)
+    async def lifespan(name: FromPath[str], state: State, request: Request) -> AsyncGenerator[None, None]:
+        mock(name=name, state=state, query=request.query)
         yield
 
     @websocket_listener("/{name:str}", connection_lifespan=lifespan)
@@ -348,11 +348,11 @@ def test_hook_dependencies() -> None:
     def some_dependency() -> str:
         return "hello"
 
-    def on_accept(name: FromPath[str], state: State, query: dict, some: str) -> None:
-        on_accept_mock(name=name, state=state, query=query, some=some)
+    def on_accept(name: FromPath[str], state: State, request: Request, some: str) -> None:  # pyright: ignore
+        on_accept_mock(name=name, state=state, query=request.query, some=some)
 
-    def on_disconnect(name: FromPath[str], state: State, query: dict, some: str) -> None:
-        on_disconnect_mock(name=name, state=state, query=query, some=some)
+    def on_disconnect(name: FromPath[str], state: State, request: Request, some: str) -> None:  # pyright: ignore
+        on_disconnect_mock(name=name, state=state, query=request.query, some=some)
 
     @websocket_listener("/{name: str}", on_accept=on_accept, on_disconnect=on_disconnect)
     def handler(data: bytes) -> None:
@@ -386,11 +386,11 @@ def test_websocket_listener_class_hook_dependencies() -> None:
     class Listener(WebsocketListener):
         path = "/{name: str}"
 
-        def on_accept(self, name: FromPath[str], state: State, query: dict, some: str) -> None:  # pyright: ignore
-            on_accept_mock(name=name, state=state, query=query, some=some)
+        def on_accept(self, name: FromPath[str], state: State, request: Request, some: str) -> None:  # pyright: ignore
+            on_accept_mock(name=name, state=state, query=request.query, some=some)
 
-        def on_disconnect(self, name: FromPath[str], state: State, query: dict, some: str) -> None:  # pyright: ignore
-            on_disconnect_mock(name=name, state=state, query=query, some=some)
+        def on_disconnect(self, name: FromPath[str], state: State, request: Request, some: str) -> None:  # pyright: ignore
+            on_disconnect_mock(name=name, state=state, query=request.query, some=some)
 
         def on_receive(self, data: bytes) -> None:  # pyright: ignore
             pass

--- a/tests/unit/test_kwargs/test_query_params.py
+++ b/tests/unit/test_kwargs/test_query_params.py
@@ -15,6 +15,7 @@ from typing_extensions import Annotated
 from litestar import MediaType, Request, get, post
 from litestar.datastructures import MultiDict
 from litestar.di import Provide
+from litestar.exceptions import LitestarDeprecationWarning
 from litestar.params import FromQuery, QueryParameter
 from litestar.status_codes import HTTP_200_OK, HTTP_400_BAD_REQUEST
 from litestar.testing import create_test_client
@@ -174,9 +175,10 @@ def test_query_kwarg() -> None:
         assert a == ["foo", "bar"]
         assert b == ["qux"]
 
-    with create_test_client(handler) as client:
-        response = client.get(f"{test_path}?{params}")
-        assert response.status_code == HTTP_200_OK, response.json()
+    with pytest.warns(LitestarDeprecationWarning, match=".*Usage of deprecated reserved kwarg 'query'"):
+        with create_test_client(handler) as client:
+            response = client.get(f"{test_path}?{params}")
+            assert response.status_code == HTTP_200_OK, response.json()
 
 
 @pytest.mark.parametrize(
@@ -197,7 +199,7 @@ def test_query_parsing_of_escaped_values(values: Tuple[Tuple[str, str], Tuple[st
     def handler(request: Request, first: FromQuery[str], second: FromQuery[str]) -> None:
         request_values["first"] = first
         request_values["second"] = second
-        request_values["query"] = request.query_params
+        request_values["query"] = request.query
 
     params = dict(values)
 

--- a/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
+++ b/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
@@ -1,7 +1,8 @@
-from typing import Annotated, Any, List, Optional, Type, cast
+from typing import Any, List, Optional, Type, cast
 
 import msgspec
 import pytest
+from typing_extensions import Annotated
 
 from litestar import (
     Controller,

--- a/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
+++ b/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
@@ -1,8 +1,7 @@
-from typing import Any, List, Optional, Type, cast
+from typing import Annotated, Any, List, Optional, Type, cast
 
 import msgspec
 import pytest
-from typing_extensions import Annotated
 
 from litestar import (
     Controller,
@@ -18,7 +17,7 @@ from litestar import (
 )
 from litestar.datastructures.state import ImmutableState, State
 from litestar.di import Provide
-from litestar.exceptions import ImproperlyConfiguredException
+from litestar.exceptions import ImproperlyConfiguredException, LitestarDeprecationWarning
 from litestar.params import Dependency, FromPath, FromQuery
 from litestar.status_codes import (
     HTTP_200_OK,
@@ -211,7 +210,9 @@ def test_header_params(decorator: Any, http_method: Any, expected_status_code: A
             for key, value in request_headers.items():
                 assert headers[key] == value
 
-    with create_test_client(MyController) as client:
+    with pytest.warns(
+        LitestarDeprecationWarning, match=".*Usage of deprecated reserved kwarg 'headers'"
+    ), create_test_client(MyController) as client:
         response = client.request(http_method, test_path, headers=request_headers)
         assert response.status_code == expected_status_code
 
@@ -261,7 +262,9 @@ def test_scope(decorator: Any, http_method: Any, expected_status_code: Any) -> N
         def test_method(self, scope: Scope) -> None:
             assert isinstance(scope, dict)
 
-    with create_test_client(MyController) as client:
+    with pytest.warns(
+        LitestarDeprecationWarning, match=".*Usage of deprecated reserved kwarg 'scope'"
+    ), create_test_client(MyController) as client:
         response = client.request(http_method, test_path)
         assert response.status_code == expected_status_code
 

--- a/tests/unit/test_middleware/test_logging_middleware.py
+++ b/tests/unit/test_middleware/test_logging_middleware.py
@@ -1,8 +1,9 @@
 from logging import INFO
-from typing import TYPE_CHECKING, Annotated, Any, Dict, Generator
+from typing import TYPE_CHECKING, Any, Dict, Generator
 
 import pytest
 from structlog.testing import capture_logs
+from typing_extensions import Annotated
 
 from litestar import Response, get, post
 from litestar.config.compression import CompressionConfig

--- a/tests/unit/test_middleware/test_logging_middleware.py
+++ b/tests/unit/test_middleware/test_logging_middleware.py
@@ -1,9 +1,8 @@
 from logging import INFO
-from typing import TYPE_CHECKING, Any, Dict, Generator
+from typing import TYPE_CHECKING, Annotated, Any, Dict, Generator
 
 import pytest
 from structlog.testing import capture_logs
-from typing_extensions import Annotated
 
 from litestar import Response, get, post
 from litestar.config.compression import CompressionConfig

--- a/tests/unit/test_openapi/conftest.py
+++ b/tests/unit/test_openapi/conftest.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import List, Optional, Type, Union
 
 import pytest
 from typing_extensions import Annotated
@@ -26,11 +26,11 @@ def create_person_controller() -> Type[Controller]:
         def get_persons(
             self,
             # expected to be ignored
-            headers: Any,
-            request: Any,
+            # headers: Any,
+            # request: Any,
             state: State,
-            query: Dict[str, Any],
-            cookies: Dict[str, Any],
+            # query: Dict[str, Any],
+            # cookies: Dict[str, Any],
             # path parameter
             service_id: FromPath[int],
             # required query parameters below

--- a/tests/unit/test_openapi/conftest.py
+++ b/tests/unit/test_openapi/conftest.py
@@ -26,11 +26,7 @@ def create_person_controller() -> Type[Controller]:
         def get_persons(
             self,
             # expected to be ignored
-            # headers: Any,
-            # request: Any,
             state: State,
-            # query: Dict[str, Any],
-            # cookies: Dict[str, Any],
             # path parameter
             service_id: FromPath[int],
             # required query parameters below

--- a/tests/unit/test_template/test_csrf_token.py
+++ b/tests/unit/test_template/test_csrf_token.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from litestar import MediaType, get
+from litestar import MediaType, Request, get
 from litestar.config.csrf import CSRFConfig
 from litestar.contrib.jinja import JinjaTemplateEngine
 from litestar.contrib.mako import MakoTemplateEngine
@@ -13,7 +13,6 @@ from litestar.middleware.csrf import generate_csrf_token
 from litestar.response.template import Template
 from litestar.template.config import TemplateConfig
 from litestar.testing import create_test_client
-from litestar.types import Scope
 from litestar.utils.empty import value_or_default
 from litestar.utils.scope.state import ScopeState
 
@@ -60,8 +59,8 @@ def test_csrf_input(engine: Any, template: str, tmp_path: Path) -> None:
     token = {"value": ""}
 
     @get(path="/", media_type=MediaType.HTML)
-    def handler(scope: Scope) -> Template:
-        connection_state = ScopeState.from_scope(scope)
+    def handler(request: Request) -> Template:
+        connection_state = ScopeState.from_scope(request.scope)
         token["value"] = value_or_default(connection_state.csrf_token, "")
         return Template(template_name="abc.html")
 

--- a/tests/unit/test_testing/test_request_factory.py
+++ b/tests/unit/test_testing/test_request_factory.py
@@ -120,7 +120,7 @@ def test_request_factory_create_with_default_params() -> None:
     assert request.url == request.base_url == _DEFAULT_REQUEST_FACTORY_URL
     assert request.method == HttpMethod.GET
     assert request.state.keys() == {"_ls_connection_state"}
-    assert not request.query_params
+    assert not request.query
     assert not request.path_params
     assert request.route_handler
     assert request.scope["http_version"] == "1.1"
@@ -165,7 +165,7 @@ def test_request_factory_create_with_params() -> None:
     assert request.base_url == f"{scheme}://{server}:{port}{root_path}/"
     assert request.url == f"{scheme}://{server}:{port}{root_path}{path}"
     assert request.method == HttpMethod.GET
-    assert request.query_params == MultiDict()
+    assert request.query == MultiDict()
     assert request.user == user
     assert request.auth == auth
     assert request.session == session


### PR DESCRIPTION
Deprecate the "reserved kwargs" for request data:

| deprecated  | use instead                 |
|-------------|-----------------------------|
| `query`     | `(request\|socket).query`   |
| `headers`   | `(request\|socket).headers` |
| `cookies`   | `(request\|socket).cookies` |
| `scope`     | `(request\|socket).scope`   |

Also deprecated:

`ASGIConnection.query_params`, in favour of `ASGIConnection.query`. This brings consistency with the naming of the deprecated `query` parameter, and the new `FromQuery` marker.

## Motivation

In lieu of the other refactorings done recently (#4750, #4801, #4808), promoting explicitness and readability, this is another step in that direction.

### Clarity

A bare `headers` does not immediately make clear where those headers come from, and how they got there. It's not communicated whether it's by DI or some other magic. `request.headers` makes this immediately obvious.

These also have been a point of confusion for many users, as these don't work the way they expect to; Typing something as e.g. `headers: MyHeaders`, where `MyHeaders` is a dataclass, does *not* take the usual validation route; Instead, `headers` must be typed as a `dict`.

### Low benefit

Receiving headers as `headers: dict[str, Any]` isn't really much more convenient than doing `request.headers`, so there's little benefit. Adding to that the reduced readability and surprising behaviour, this feature comes out as a net-negative.



<hr>

Intentionally not deprecated in this PR is `state`, as it works slightly different, and needs more tweaks. It will be addressed in a separate PR.


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4817">https://litestar-org.github.io/litestar-docs-preview/4817</a> 
