### PR TITLE
chore(core)!: Remove deprecated `params.Dependency` and `params.DependencyKwarg`

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -6,6 +6,22 @@
 .. changelog:: 3.0.0
     :date: 2364-01-27
 
+    .. change:: Remove deprecated ``params.Dependency`` and ``params.DependencyKwarg``
+        :type: feature
+        :pr: 4818
+        :breaking:
+
+        Remove ``params.Dependency`` and ``params.DependencyKwarg`` that were deprecated
+        in ``2.23.0``.
+
+        **Migration**
+
+        - Replace ``foo: int = Dependency()`` with ``foo: NamedDependency[int]``
+        - Replace ``foo: Annotated[int, Dependency(default=1)]`` by hoisting the
+          default into the parameter default: ``foo: NamedDependency[int] = 1``
+        - Replace ``foo: Annotated[int, Dependency(skip_validation=True)`` with
+          ``foo: NamedDependency[SkipValidation[int]]``
+
     .. change:: Fix OpenAPI schema incorrectly marking nullable required fields as not required
         :type: bugfix
         :pr: 4687

--- a/litestar/_signature/utils.py
+++ b/litestar/_signature/utils.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from litestar.constants import SKIP_VALIDATION_NAMES
 from litestar.exceptions import ImproperlyConfiguredException
-from litestar.params import DependencyKwarg, SkipValidationMarker
+from litestar.params import SkipValidationMarker
 from litestar.types import Empty, TypeDecodersSequence
 
 if TYPE_CHECKING:
@@ -44,10 +44,7 @@ def _validate_signature_dependencies(
 
 
 def _normalize_annotation(field_definition: FieldDefinition) -> Any:
-    if field_definition.name in SKIP_VALIDATION_NAMES or (
-        isinstance(field_definition.kwarg_definition, DependencyKwarg)
-        and field_definition.kwarg_definition.skip_validation
-    ):
+    if field_definition.name in SKIP_VALIDATION_NAMES:
         return Any
 
     if field_definition.has_metadata(SkipValidationMarker):

--- a/litestar/dto/dataclass_dto.py
+++ b/litestar/dto/dataclass_dto.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 from litestar.dto.base_dto import AbstractDTO
 from litestar.dto.data_structures import DTOFieldDefinition
 from litestar.dto.field import DTOField, extract_dto_field
-from litestar.params import DependencyKwarg, KwargDefinition
+from litestar.params import KwargDefinition
 from litestar.types.empty import Empty
 
 if TYPE_CHECKING:
@@ -51,7 +51,7 @@ class DataclassDTO(AbstractDTO[T], Generic[T]):
 
             yield (
                 replace(field_definition, default=Empty, kwarg_definition=default)
-                if isinstance(default, (KwargDefinition, DependencyKwarg))
+                if isinstance(default, KwargDefinition)
                 else field_definition
             )
 

--- a/litestar/params.py
+++ b/litestar/params.py
@@ -6,15 +6,12 @@ from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar, TypeAlias, TypeVar
 
 from litestar.enums import ParamType, RequestEncodingType
-from litestar.exceptions import LitestarDeprecationWarning
 from litestar.types import Empty
 
 __all__ = (
     "Body",
     "BodyKwarg",
     "CookieParameter",
-    "Dependency",
-    "DependencyKwarg",
     "FromCookie",
     "FromHeader",
     "FromPath",
@@ -32,8 +29,6 @@ __all__ = (
     "SkipValidationMarker",
     "URLEncodedBody",
 )
-
-from litestar.utils import deprecated, warn_deprecation
 
 if TYPE_CHECKING:
     from litestar.openapi.spec.example import Example
@@ -514,53 +509,6 @@ def Body(
         schema_extra=schema_extra,
         schema_component_key=schema_component_key,
     )
-
-
-@dataclass(frozen=True)
-class DependencyKwarg:
-    """Data container representing a dependency."""
-
-    default: Any = field(default=Empty)
-    """A default value."""
-    skip_validation: bool = field(default=False)
-    """Flag dictating whether to skip validation."""
-
-    def __hash__(self) -> int:
-        """Hash the dataclass in a safe way.
-
-        Returns:
-            A hash
-        """
-        return sum(hash(v) for v in asdict(self) if isinstance(v, Hashable))
-
-    def __post_init__(self) -> None:
-        warn_deprecation(
-            "2.23.0",
-            removal_in="3.0",
-            alternative="di.NamedDependency",
-            kind="class",
-            deprecated_name="DependencyKwarg",
-        )
-
-        if self.skip_validation:
-            warnings.warn(
-                "Deprecated parameter 'skip_validation'. This will be removed in "
-                "Litestar 3.0. To skip validation of a dependency parameter, annotate "
-                "it as 'SkipValidation[<type>]' instead",
-                category=LitestarDeprecationWarning,
-                stacklevel=2,
-            )
-
-
-@deprecated("2.23.0", removal_in="3.0", alternative="di.NamedDependency")
-def Dependency(*, default: Any = Empty, skip_validation: bool = False) -> Any:
-    """Create a dependency kwarg definition.
-
-    Args:
-        default: A default value to use in case a dependency is not provided.
-        skip_validation: If `True` provided dependency values are not validated by signature model.
-    """
-    return DependencyKwarg(default=default, skip_validation=skip_validation)
 
 
 class SkipValidationMarker:

--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -47,7 +47,7 @@ except ImportError:
     TypeAliasTypes = (TeTypeAliasType,)  # type: ignore[assignment]
 
 from litestar.exceptions import ImproperlyConfiguredException, LitestarDeprecationWarning, LitestarWarning
-from litestar.params import BodyKwarg, DependencyKwarg, KwargDefinition, ParameterKwarg
+from litestar.params import BodyKwarg, KwargDefinition, ParameterKwarg
 from litestar.types.builtin_types import NoneType, UnionTypes
 from litestar.utils.predicates import (
     is_any,
@@ -156,7 +156,7 @@ class FieldDefinition:
     """Default value of the field."""
     extra: dict[str, Any]
     """A mapping of extra values."""
-    kwarg_definition: KwargDefinition | DependencyKwarg | None
+    kwarg_definition: KwargDefinition | None
     """Kwarg Parameter."""
     name: str
     """Field name."""
@@ -185,7 +185,7 @@ class FieldDefinition:
     def is_di_field(self) -> bool:
         from litestar.di import Dependency
 
-        return self.has_metadata(Dependency) or isinstance(self.kwarg_definition, DependencyKwarg)
+        return self.has_metadata(Dependency)
 
     @property
     def has_default(self) -> bool:
@@ -459,7 +459,7 @@ class FieldDefinition:
         annotation_args = () if origin is abc.Callable else get_args(unwrapped)
 
         if not kwargs.get("kwarg_definition"):
-            if isinstance(kwargs.get("default"), (KwargDefinition, DependencyKwarg)):
+            if isinstance(kwargs.get("default"), KwargDefinition):
                 kwarg_definition = kwargs["kwarg_definition"] = kwargs.pop("default")
                 if isinstance(kwarg_definition, BodyKwarg):
                     can_use_marker = (
@@ -481,9 +481,7 @@ class FieldDefinition:
                         stacklevel=2,
                         category=LitestarDeprecationWarning,
                     )
-            elif kwarg_definition := next(
-                (v for v in metadata if isinstance(v, (KwargDefinition, DependencyKwarg))), None
-            ):
+            elif kwarg_definition := next((v for v in metadata if isinstance(v, KwargDefinition)), None):
                 kwargs["kwarg_definition"] = kwarg_definition
 
                 if kwarg_definition.default is not Empty:
@@ -505,7 +503,7 @@ class FieldDefinition:
                             stacklevel=2,
                         )
 
-                metadata = tuple(v for v in metadata if not isinstance(v, (KwargDefinition, DependencyKwarg)))
+                metadata = tuple(v for v in metadata if not isinstance(v, KwargDefinition))
             elif (extra := kwargs.get("extra", {})) and "kwarg_definition" in extra:
                 kwargs["kwarg_definition"] = extra.pop("kwarg_definition")
 
@@ -560,7 +558,7 @@ class FieldDefinition:
         name: str,
         default: Any = Empty,
         inner_types: tuple[FieldDefinition, ...] | None = None,
-        kwarg_definition: KwargDefinition | DependencyKwarg | None = None,
+        kwarg_definition: KwargDefinition | None = None,
         extra: dict[str, Any] | None = None,
     ) -> FieldDefinition:
         """Create a new FieldDefinition instance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ polyfactory = ["polyfactory>=2.6.3"]
 prometheus = ["prometheus-client"]
 pydantic = ["pydantic>=2", "email-validator", "pydantic-extra-types"]
 redis = ["redis[hiredis]>=4.4.4,!=5.3.*"]  # 5.3.0 introduced some issues with the channels plugin; need to investigate
-sqlalchemy = ["advanced-alchemy>=1.1.0"]
+sqlalchemy = ["advanced-alchemy @ git+https://github.com/litestar-org/advanced-alchemy.git@remove-litestar-deprecated-request-params"]
 standard = [
   "jinja2",
   "jsbeautifier",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ polyfactory = ["polyfactory>=2.6.3"]
 prometheus = ["prometheus-client"]
 pydantic = ["pydantic>=2", "email-validator", "pydantic-extra-types"]
 redis = ["redis[hiredis]>=4.4.4,!=5.3.*"]  # 5.3.0 introduced some issues with the channels plugin; need to investigate
-sqlalchemy = ["advanced-alchemy @ git+https://github.com/litestar-org/advanced-alchemy.git@remove-litestar-deprecated-request-params"]
+sqlalchemy = ["advanced-alchemy @ git+https://github.com/litestar-org/advanced-alchemy.git@main"]
 standard = [
   "jinja2",
   "jsbeautifier",

--- a/tests/unit/test_kwargs/test_param_markers.py
+++ b/tests/unit/test_kwargs/test_param_markers.py
@@ -13,7 +13,6 @@ from litestar.exceptions.base_exceptions import LitestarDeprecationWarning
 from litestar.openapi.spec import Parameter as OpenAPIParameter
 from litestar.params import (
     CookieParameter,
-    Dependency,
     FromCookie,
     FromHeader,
     FromPath,
@@ -342,16 +341,6 @@ def test_annotated_metadata_does_not_shadow_path_param() -> None:
         res = client.get("/7")
         assert res.status_code == 200
         assert res.json() == 7
-
-
-def test_deprecated_dependency_marker() -> None:
-    with pytest.warns(LitestarDeprecationWarning, match="Call to deprecated function 'Dependency'"):
-
-        @get("/")
-        async def handler(foo: Annotated[int, Dependency()] = 1) -> None:
-            pass
-
-        Litestar([handler])
 
 
 def test_named_dependency_explicit_marker() -> None:

--- a/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
+++ b/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
@@ -18,9 +18,9 @@ from litestar import (
     put,
 )
 from litestar.datastructures.state import ImmutableState, State
-from litestar.di import Provide
+from litestar.di import NamedDependency, Provide
 from litestar.exceptions import ImproperlyConfiguredException
-from litestar.params import Dependency, FromPath, FromQuery
+from litestar.params import FromPath, FromQuery
 from litestar.status_codes import (
     HTTP_200_OK,
     HTTP_201_CREATED,
@@ -313,7 +313,6 @@ def test_improper_use_of_state_kwarg_with_annotated_metadata() -> None:
     caused the subclass check to crash with ``TypeError`` before we could raise the
     configuration error.
     """
-    from typing import Annotated
 
     from litestar.params import QueryParameter
 
@@ -350,7 +349,7 @@ def test_data_kwarg_in_dependency(decorator: Any, http_method: Any, expected_sta
         path = test_path
 
         @decorator(dependencies={"person_name": Provide(dependency_with_data)})
-        async def test_method(self, data: DataclassPerson, person_name: Annotated[str, Dependency()]) -> None:
+        async def test_method(self, data: DataclassPerson, person_name: NamedDependency[str]) -> None:
             assert data == person_instance
             assert person_name == f"{person_instance.first_name} {person_instance.last_name}"
 

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -18,7 +18,6 @@ from litestar.openapi.spec import Example, OpenAPI, Reference, Schema
 from litestar.openapi.spec.enums import OpenAPIType
 from litestar.params import (
     CookieParameter,
-    Dependency,
     FromCookie,
     FromHeader,
     FromPath,
@@ -205,20 +204,6 @@ def test_raise_for_multiple_parameters_of_same_name_and_differing_types() -> Non
         app.openapi_schema
 
 
-def test_dependency_params_in_docs_if_dependency_provided_deprecated() -> None:
-    async def produce_dep(param: FromQuery[str]) -> int:
-        return 13
-
-    @get(dependencies={"dep": Provide(produce_dep)})
-    def handler(dep: Optional[int] = Dependency()) -> None:
-        return None
-
-    app = Litestar(route_handlers=[handler])
-    param_name_set = {p.name for p in cast("OpenAPI", app.openapi_schema).paths["/"].get.parameters}  # type: ignore[index, redundant-cast, union-attr]
-    assert "dep" not in param_name_set
-    assert "param" in param_name_set
-
-
 def test_dependency_params_in_docs_if_dependency_provided() -> None:
     async def produce_dep(param: FromQuery[str]) -> int:
         return 13
@@ -235,7 +220,7 @@ def test_dependency_params_in_docs_if_dependency_provided() -> None:
 
 def test_dependency_not_in_doc_params_if_not_provided() -> None:
     @get()
-    def handler(dep: Annotated[Optional[int], Dependency()]) -> None:
+    def handler(dep: NamedDependency[Optional[int]]) -> None:
         return None
 
     app = Litestar(route_handlers=[handler])

--- a/tests/unit/test_params.py
+++ b/tests/unit/test_params.py
@@ -5,8 +5,8 @@ import pytest
 
 from litestar import Controller, Litestar, MediaType, get, post
 from litestar.di import NamedDependency, Provide
-from litestar.exceptions import ImproperlyConfiguredException, LitestarDeprecationWarning
-from litestar.params import Body, Dependency, FromQuery, Parameter, QueryParameter, SkipValidation
+from litestar.exceptions import ImproperlyConfiguredException
+from litestar.params import Body, FromQuery, Parameter, QueryParameter, SkipValidation
 from litestar.status_codes import HTTP_200_OK, HTTP_201_CREATED, HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
 from litestar.testing import TestClient, create_test_client
 
@@ -65,16 +65,6 @@ def test_parsing_of_body_as_default() -> None:
         assert response.status_code == HTTP_201_CREATED
 
 
-def test_parsing_of_dependency_as_annotated_deprecated() -> None:
-    @get(path="/", dependencies={"dep": Provide(lambda: None, sync_to_thread=False)})
-    def handler(dep: Annotated[None, Dependency()]) -> None:
-        return dep
-
-    with create_test_client(handler) as client:
-        response = client.get("/")
-        assert response.text == "null"
-
-
 def test_parsing_of_dependency_as_annotated() -> None:
     @get(path="/", dependencies={"dep": Provide(lambda: None, sync_to_thread=False)})
     def handler(dep: NamedDependency[None]) -> None:
@@ -83,30 +73,6 @@ def test_parsing_of_dependency_as_annotated() -> None:
     with create_test_client(handler) as client:
         response = client.get("/")
         assert response.text == "null"
-
-
-def test_parsing_of_dependency_as_default() -> None:
-    @get(path="/", dependencies={"dep": Provide(lambda: None, sync_to_thread=False)})
-    def handler(dep: None = Dependency()) -> None:
-        return dep
-
-    with create_test_client(handler) as client:
-        response = client.get("/")
-        assert response.text == "null"
-
-
-@pytest.mark.parametrize("dependency_default", [None, 13])
-def test_dependency_defaults_deprecated(dependency_default: Any) -> None:
-    with pytest.warns(LitestarDeprecationWarning):
-        dependency = Dependency(default=dependency_default) if dependency_default is not ... else Dependency()
-
-    @get("/")
-    def handler(value: Optional[int] = dependency) -> dict[str, Optional[int]]:
-        return {"value": value}
-
-    with create_test_client(route_handlers=[handler]) as client:
-        resp = client.get("/")
-        assert resp.json() == {"value": dependency_default}
 
 
 @pytest.mark.parametrize("dependency_default", [None, 13])
@@ -120,16 +86,6 @@ def test_dependency_defaults(dependency_default: Any) -> None:
         assert resp.json() == {"value": dependency_default}
 
 
-def test_dependency_non_optional_with_default_deprecated() -> None:
-    @get("/")
-    def handler(value: int = Dependency(default=13)) -> dict[str, int]:
-        return {"value": value}
-
-    with create_test_client(route_handlers=[handler]) as client:
-        resp = client.get("/")
-        assert resp.json() == {"value": 13}
-
-
 def test_dependency_non_optional_with_default() -> None:
     @get("/")
     def handler(value: int = 13) -> dict[str, int]:
@@ -138,16 +94,6 @@ def test_dependency_non_optional_with_default() -> None:
     with create_test_client(route_handlers=[handler]) as client:
         resp = client.get("/")
         assert resp.json() == {"value": 13}
-
-
-def test_dependency_no_default_deprecated() -> None:
-    @get(dependencies={"value": Provide(lambda: 13, sync_to_thread=False)})
-    def test(value: int = Dependency()) -> dict[str, int]:
-        return {"value": value}
-
-    with create_test_client(route_handlers=[test]) as client:
-        resp = client.get("/")
-    assert resp.json() == {"value": 13}
 
 
 def test_dependency_no_default() -> None:
@@ -187,32 +133,13 @@ def test_dependency_provided_on_controller() -> None:
     assert resp.json() == {"value": 13}
 
 
-def test_dependency_skip_validation_deprecated() -> None:
-    @get("/validated")
-    def validated(value: NamedDependency[int]) -> dict[str, int]:
-        return {"value": value}
-
-    @get("/skipped")
-    def skipped(value: Annotated[int, Dependency(skip_validation=True)]) -> dict[str, int]:
-        return {"value": value}
-
-    with create_test_client(
-        route_handlers=[validated, skipped], dependencies={"value": Provide(lambda: "str", sync_to_thread=False)}
-    ) as client:
-        validated_resp = client.get("/validated")
-        assert validated_resp.status_code == HTTP_500_INTERNAL_SERVER_ERROR
-        skipped_resp = client.get("/skipped")
-        assert skipped_resp.status_code == HTTP_200_OK
-        assert skipped_resp.json() == {"value": "str"}
-
-
 def test_dependency_skip_validation() -> None:
     @get("/validated")
     def validated(value: NamedDependency[int]) -> dict[str, int]:
         return {"value": value}
 
     @get("/skipped")
-    def skipped(value: SkipValidation[int]) -> dict[str, int]:
+    def skipped(value: NamedDependency[SkipValidation[int]]) -> dict[str, int]:
         return {"value": value}
 
     with create_test_client(
@@ -227,7 +154,7 @@ def test_dependency_skip_validation() -> None:
 
 def test_dependency_skip_validation_with_default() -> None:
     @get("/skipped")
-    def skipped(value: SkipValidation[int] = 1) -> dict[str, int]:
+    def skipped(value: NamedDependency[SkipValidation[int]] = 1) -> dict[str, int]:
         return {"value": value}
 
     with create_test_client(route_handlers=[skipped]) as client:
@@ -238,7 +165,7 @@ def test_dependency_skip_validation_with_default() -> None:
 
 def test_dependency_default_is_not_treated_as_query_parameter() -> None:
     @get("/")
-    def handler(value: int = Dependency(default=42)) -> dict[str, int]:
+    def handler(value: NamedDependency[int] = 42) -> dict[str, int]:
         return {"value": value}
 
     with create_test_client(route_handlers=[handler]) as client:
@@ -255,7 +182,7 @@ def test_dependency_default_does_not_collide_with_query_param_of_same_name() -> 
     the handler's query parameter.
     """
 
-    def provide_value(value: int = Dependency(default=7)) -> int:
+    def provide_value(value: NamedDependency[int] = 7) -> int:
         return value * 10
 
     @get("/", dependencies={"computed": Provide(provide_value, sync_to_thread=False)})

--- a/tests/unit/test_plugins/test_base.py
+++ b/tests/unit/test_plugins/test_base.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-from advanced_alchemy.extensions.litestar import SQLAlchemySerializationPlugin
 from click import Group
 
 from litestar import Litestar, MediaType, get
 from litestar.constants import UNDEFINED_SENTINELS
+from litestar.dto import AbstractDTO
 from litestar.file_system import FileSystemRegistry
-from litestar.plugins import CLIPlugin, InitPlugin, OpenAPISchemaPlugin, PluginRegistry
+from litestar.plugins import CLIPlugin, InitPlugin, OpenAPISchemaPlugin, PluginRegistry, SerializationPlugin
 from litestar.plugins.attrs import AttrsSchemaPlugin
 from litestar.plugins.core import MsgspecDIPlugin
 from litestar.plugins.pydantic import PydanticDIPlugin, PydanticInitPlugin, PydanticPlugin, PydanticSchemaPlugin
@@ -52,8 +52,15 @@ def test_plugin_registry() -> None:
         def on_cli_init(self, cli: Group) -> None:
             pass
 
+    class MySerializationPlugin(SerializationPlugin):
+        def supports_type(self, field_definition: FieldDefinition) -> bool:
+            return False
+
+        def create_dto_for_type(self, field_definition: FieldDefinition) -> type[AbstractDTO]:
+            raise NotImplementedError()
+
     cli_plugin = MyCLIPlugin()
-    serialization_plugin = SQLAlchemySerializationPlugin()
+    serialization_plugin = MySerializationPlugin()
     openapi_plugin = PydanticSchemaPlugin()
     init_plugin = PydanticInitPlugin()
 

--- a/tests/unit/test_signature/test_validation.py
+++ b/tests/unit/test_signature/test_validation.py
@@ -12,7 +12,7 @@ from litestar._signature import SignatureModel
 from litestar.di import NamedDependency, Provide
 from litestar.enums import ParamType
 from litestar.exceptions import ImproperlyConfiguredException, ValidationException
-from litestar.params import CookieParameter, Dependency, FromQuery, HeaderParameter, PathParameter, QueryParameter
+from litestar.params import CookieParameter, FromQuery, HeaderParameter, PathParameter, QueryParameter
 from litestar.status_codes import HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
 from litestar.testing import RequestFactory, create_test_client
 from litestar.utils.signature import ParsedSignature
@@ -52,7 +52,7 @@ def test_dependency_validation_failure_raises_500() -> None:
     dependencies = {"dep": Provide(lambda: "thirteen", sync_to_thread=False)}
 
     @get("/")
-    def test(dep: int, param: FromQuery[int], optional_dep: Annotated[Optional[int], Dependency()]) -> None: ...
+    def test(dep: int, param: FromQuery[int], optional_dep: NamedDependency[Optional[int]]) -> None: ...
 
     with create_test_client(
         route_handlers=[test],
@@ -68,7 +68,7 @@ def test_validation_failure_raises_400() -> None:
     dependencies = {"dep": Provide(lambda: 13, sync_to_thread=False)}
 
     @get("/")
-    def test(dep: int, param: FromQuery[int], optional_dep: Annotated[Optional[int], Dependency()] = None) -> None: ...
+    def test(dep: int, param: FromQuery[int], optional_dep: NamedDependency[Optional[int]] = None) -> None: ...
 
     with create_test_client(route_handlers=[test], dependencies=dependencies) as client:
         response = client.get("/?param=thirteen")

--- a/tests/unit/test_typing.py
+++ b/tests/unit/test_typing.py
@@ -24,7 +24,7 @@ except ImportError:
 
 from litestar import get
 from litestar.exceptions import LitestarWarning
-from litestar.params import DependencyKwarg, KwargDefinition, ParameterKwarg, QueryParameter
+from litestar.params import KwargDefinition, ParameterKwarg, QueryParameter
 from litestar.typing import FieldDefinition
 from tests.unit.test_utils.test_signature import T, _check_field_definition, field_definition_int, test_type_hints
 
@@ -167,8 +167,8 @@ def test_field_definition_kwarg_definition_from_extras() -> None:
     )
 
 
-@pytest.mark.parametrize("kwarg_definition", [KwargDefinition(), DependencyKwarg()])
-def test_field_definition_kwarg_definition_from_kwargs(kwarg_definition: KwargDefinition | DependencyKwarg) -> None:
+def test_field_definition_kwarg_definition_from_kwargs() -> None:
+    kwarg_definition = KwargDefinition()
     assert FieldDefinition.from_annotation(int, kwarg_definition=kwarg_definition).kwarg_definition is kwarg_definition
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -9,17 +9,13 @@ resolution-markers = [
 
 [[package]]
 name = "advanced-alchemy"
-version = "1.9.1"
-source = { registry = "https://pypi.org/simple" }
+version = "1.10.0"
+source = { git = "https://github.com/litestar-org/advanced-alchemy.git?rev=cadc841d7c38d65081a311b56980c2cd1731d8bd#cadc841d7c38d65081a311b56980c2cd1731d8bd" }
 dependencies = [
     { name = "alembic" },
     { name = "greenlet" },
     { name = "sqlalchemy" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/fb/5d629e83e7e93bbd9c3e77c17fbdf34f79e2b2c0365238565b9afbd047aa/advanced_alchemy-1.9.1.tar.gz", hash = "sha256:c2f2025875bc582fb13aa511af79b189dc80ae2fd70a7f590ed0d0db8634d097", size = 1143288, upload-time = "2026-03-26T01:39:08.185Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/af/0d8cfa503c9818ad9fe9eed2c89108aa0d0f3c7c967015951b1780a16061/advanced_alchemy-1.9.1-py3-none-any.whl", hash = "sha256:270f710793842f70c75d1f383367ebb23e3c1ca78dab0610f2d4301fcf8c188e", size = 315022, upload-time = "2026-03-26T01:39:06.558Z" },
 ]
 
 [[package]]
@@ -2138,7 +2134,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "advanced-alchemy", marker = "extra == 'sqlalchemy'", specifier = ">=1.1.0" },
+    { name = "advanced-alchemy", marker = "extra == 'sqlalchemy'", git = "https://github.com/litestar-org/advanced-alchemy.git?rev=cadc841d7c38d65081a311b56980c2cd1731d8bd" },
     { name = "annotated-types", marker = "extra == 'annotated-types'" },
     { name = "anyio", specifier = ">=3" },
     { name = "attrs", marker = "extra == 'attrs'" },

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 [[package]]
 name = "advanced-alchemy"
 version = "1.10.0"
-source = { git = "https://github.com/litestar-org/advanced-alchemy.git?rev=cadc841d7c38d65081a311b56980c2cd1731d8bd#cadc841d7c38d65081a311b56980c2cd1731d8bd" }
+source = { git = "https://github.com/litestar-org/advanced-alchemy.git?rev=main#bbe68ddd3a8dd32618c5117a98cf74d269b480fc" }
 dependencies = [
     { name = "alembic" },
     { name = "greenlet" },
@@ -2134,7 +2134,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "advanced-alchemy", marker = "extra == 'sqlalchemy'", git = "https://github.com/litestar-org/advanced-alchemy.git?rev=cadc841d7c38d65081a311b56980c2cd1731d8bd" },
+    { name = "advanced-alchemy", marker = "extra == 'sqlalchemy'", git = "https://github.com/litestar-org/advanced-alchemy.git?rev=main" },
     { name = "annotated-types", marker = "extra == 'annotated-types'" },
     { name = "anyio", specifier = ">=3" },
     { name = "attrs", marker = "extra == 'attrs'" },


### PR DESCRIPTION
Remove `params.Dependency` and `params.DependencyKwarg` that were deprecated in #4808.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4818">https://litestar-org.github.io/litestar-docs-preview/4818</a> 
