### PR TITLE
perf(serialization): optimize default_serializer to avoid unnecessary…

### DIFF
--- a/litestar/serialization/msgspec_hooks.py
+++ b/litestar/serialization/msgspec_hooks.py
@@ -82,14 +82,10 @@ def default_serializer(value: Any, type_encoders: Mapping[Any, Callable[[Any], A
     Raises:
         TypeError: if value is not supported
     """
-    type_encoders = {**DEFAULT_TYPE_ENCODERS, **(type_encoders or {})}
+    encoders = DEFAULT_TYPE_ENCODERS if not type_encoders else {**DEFAULT_TYPE_ENCODERS, **type_encoders}
 
     for base in value.__class__.__mro__[:-1]:
-        try:
-            encoder = type_encoders[base]
-        except KeyError:
-            continue
-        else:
+        if (encoder := encoders.get(base)) is not None:
             return encoder(value)
 
     raise TypeError(f"Unsupported type: {type(value)!r}")


### PR DESCRIPTION
perf(serialization): optimize default_serializer to avoid unnecessary dict copy

Avoid creating a full copy of DEFAULT_TYPE_ENCODERS on every call when no custom type_encoders are provided. This reduces heap allocation and GC pressure during serialization of non-native types.

Also replace try/except KeyError with dict.get() for cleaner code.

Fixes #4701

<!-- 
By submitting this pull request, you agree to: 
- follow `https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md` 
- follow `https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md` 
- follow the `https://www.python.org/psf/conduct/` 
- follow `https://github.com/litestar-org/.github/blob/main/AI_POLICY.md` 

If the pull request is not yet ready for review (e.g. tests or other checks are still failing), 
please submit it as a draft PR, to avoid noise for reviewers. 
--> 

## Description 

<!-- 
Please add in issue numbers this pull request will close, if applicable 
Examples: Fixes #4321 or Closes #1234 

Ensure you are using a supported keyword to properly link an issue: 
`https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword` 
--> 

Fixes #4701

This PR optimizes the `default_serializer` function in `litestar/serialization/msgspec_hooks.py` to avoid unnecessary dictionary copying on every serialization call.

### Changes

- **Avoid unnecessary dict copy**: When no custom `type_encoders` are provided, use `DEFAULT_TYPE_ENCODERS` directly instead of creating a merged copy
- **Cleaner code**: Replace `try/except KeyError` pattern with `dict.get()` for better readability

### Performance Impact

Before this change, every call to `default_serializer` would create a new dictionary by merging `DEFAULT_TYPE_ENCODERS` with the provided `type_encoders` (or an empty dict). This caused unnecessary heap allocation and GC pressure, especially when serializing responses containing many non-native types (datetime, Decimal, UUID, etc.).

After this change, when no custom type encoders are provided, the function reuses `DEFAULT_TYPE_ENCODERS` directly, eliminating the dictionary copy overhead.

### Testing

- All existing tests pass
- The optimization is backward compatible and does not change any behavior

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4826">https://litestar-org.github.io/litestar-docs-preview/4826</a> 
