### PR TITLE
fix: `data` declared in dependency only not included in OpenAPI schema

### DIFF
--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -61,6 +61,14 @@ class HandlerContext:
     paths: list[str]
     dependencies: list[str] = dataclasses.field(default_factory=list)
 
+    def format(self, msg: str) -> str:
+        paths = ",".join(sorted(self.paths))
+        out = f"[paths={paths!r}, handler={self.handler!r}"
+        if self.dependencies:
+            out += f", dependencies={' -> '.join(self.dependencies[::-1])!r}"
+        out += f"] {msg}"
+        return out
+
 
 class KwargsModel:
     """Model required kwargs for a given RouteHandler and its dependencies.
@@ -268,7 +276,7 @@ class KwargsModel:
         return param_definitions, expected_dependencies
 
     @classmethod
-    def create_for_signature_model(
+    def create_for_signature_model(  # noqa: C901
         cls,
         signature_model: type[SignatureModel],
         parsed_signature: ParsedSignature,
@@ -352,6 +360,8 @@ class KwargsModel:
             elif media_type == RequestEncodingType.MESSAGEPACK:
                 expected_msgpack_data = data_field_definition
 
+        expected_data_field_defs = []
+
         for dependency in expected_dependencies:
             dependency_kwargs_model = cls.create_for_signature_model(
                 signature_model=dependency.provide.signature_model,
@@ -375,14 +385,22 @@ class KwargsModel:
                 expected_header_parameters, dependency_kwargs_model.expected_header_params
             )
 
-            if "data" in expected_reserved_kwargs and "data" in dependency_kwargs_model.expected_reserved_kwargs:
-                cls._validate_dependency_data(
-                    expected_form_data=expected_form_data,
-                    dependency_kwargs_model=dependency_kwargs_model,
-                )
+            if "data" in dependency_kwargs_model.expected_reserved_kwargs:
+                if "data" in expected_reserved_kwargs:
+                    cls._validate_dependency_data(
+                        expected_form_data=expected_form_data,
+                        dependency_kwargs_model=dependency_kwargs_model,
+                    )
+                expected_data_field_defs.append(dependency.provide.signature_model._fields["data"])
 
             expected_reserved_kwargs.update(dependency_kwargs_model.expected_reserved_kwargs)
             sequence_query_parameter_names.update(dependency_kwargs_model.sequence_query_parameter_names)
+
+        if handler_data_field := field_definitions.get("data"):
+            expected_data_field_defs.append(handler_data_field)
+
+        if expected_data_field_defs:
+            cls._validate_data_field_definitions(expected_data_field_defs, ctx)
 
         is_data_optional = (
             field_definitions["data"].is_optional
@@ -477,6 +495,28 @@ class KwargsModel:
                 )
 
     @classmethod
+    def _validate_data_field_definitions(
+        cls,
+        field_definitions: list[FieldDefinition],
+        ctx: HandlerContext | None,
+    ) -> None:
+        expected_raw_types = []
+        seen = set()
+        for field_def in field_definitions:
+            if field_def.is_any:
+                continue
+            if field_def.type_ not in seen:
+                expected_raw_types.append(field_def.raw)
+            seen.add(field_def.type_)
+
+        if len(seen) > 1:
+            expected_types_repr = " <> ".join([f"'{t}'" for t in sorted(expected_raw_types, key=str)])
+            msg = f"'data' fields have mismatched types: {expected_types_repr}"
+            if ctx is not None:
+                msg = ctx.format(msg)
+            raise ImproperlyConfiguredException(msg)
+
+    @classmethod
     def _validate_raw_kwargs(
         cls,
         path_parameters: set[str],
@@ -564,11 +604,6 @@ def _warn_deprecated_param_style(
             raise ValueError(f"Unknown style {style!r}")
 
     if ctx is not None:
-        paths = ",".join(sorted(ctx.paths))
-        out = f"[paths={paths!r}, handler={ctx.handler!r}"
-        if ctx.dependencies:
-            out += f", dependencies={' -> '.join(ctx.dependencies[::-1])!r}"
-        out += f"] {msg}"
-        msg = out
+        msg = ctx.format(msg)
 
     warnings.warn(msg, category=LitestarDeprecationWarning, stacklevel=stacklevel)

--- a/litestar/_openapi/path_item.py
+++ b/litestar/_openapi/path_item.py
@@ -59,10 +59,16 @@ class PathItemFactory:
         """
         operation_id = self.create_operation_id(route_handler, http_method)
         parameters = create_parameters_for_handler(self.context, route_handler, self.route.path_parameters)
-        signature_fields = route_handler.parsed_fn_signature.parameters
+        handler_signature_fields = route_handler.parsed_fn_signature.parameters
 
         request_body = None
-        if data_field := signature_fields.get("data"):
+        if (data_field := handler_signature_fields.get("data")) is None:
+            for dependency in route_handler.resolve_dependencies().values():
+                data_field = dependency.parsed_fn_signature.parameters.get("data")
+                if data_field is not None:
+                    break
+
+        if data_field is not None:
             request_body = create_request_body(
                 self.context, route_handler.handler_id, route_handler.data_dto, data_field
             )

--- a/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
+++ b/tests/unit/test_kwargs/test_reserved_kwargs_injection.py
@@ -1,6 +1,7 @@
 # pyright: reportUnnecessaryTypeIgnoreComment=false
-
+import re
 from typing import Annotated, Any, Optional, cast
+from unittest.mock import MagicMock, call
 
 import msgspec.json
 import pytest
@@ -27,7 +28,7 @@ from litestar.status_codes import (
     HTTP_204_NO_CONTENT,
     HTTP_400_BAD_REQUEST,
 )
-from litestar.testing import create_test_client
+from litestar.testing import TestClient, create_test_client
 from litestar.types import Scope
 from tests.models import DataclassPerson, DataclassPersonFactory
 
@@ -356,3 +357,63 @@ def test_data_kwarg_in_dependency(decorator: Any, http_method: Any, expected_sta
     with create_test_client(MyController) as client:
         response = client.request(http_method, test_path, json=msgspec.to_builtins(person_instance))
         assert response.status_code == expected_status_code
+
+
+def test_data_kwarg_in_dependency_only() -> None:
+    mock = MagicMock()
+
+    async def dependency_with_data(data: list[str]) -> list[str]:
+        mock(data)
+        return data
+
+    @post("/", dependencies={"some_data": dependency_with_data})
+    def handler(some_data: list[str]) -> None:
+        mock(some_data)
+        return
+
+    app = Litestar([handler])
+    assert app.openapi_schema.paths["/"].post.request_body.to_schema() == {  # type: ignore[union-attr, index]
+        "content": {"application/json": {"schema": {"items": {"type": "string"}, "type": "array"}}},
+        "required": True,
+    }
+
+    with TestClient(app) as client:
+        res = client.post("/", json=["1", "2"])
+        assert res.status_code == 201
+        mock.assert_has_calls([call(["1", "2"]), call(["1", "2"])])
+
+        res = client.post("/", json={"foo": "bar"})
+        assert res.status_code == 400
+
+
+def test_data_kwarg_type_mismatch_between_handler_and_dependency_raises() -> None:
+    async def dependency_with_data(data: list[str]) -> list[str]:
+        return data
+
+    @post("/", dependencies={"some_data": dependency_with_data})
+    def handler(data: dict[str, str], some_data: list[str]) -> None:
+        return None
+
+    with pytest.raises(
+        ImproperlyConfiguredException,
+        match=re.escape("'data' fields have mismatched types: 'dict[str, str]' <> 'list[str]'"),
+    ):
+        Litestar([handler])
+
+
+def test_data_kwarg_type_mismatch_between_dependencies_raises() -> None:
+    async def data_a(data: list[str]) -> list[str]:
+        return data
+
+    async def data_b(data: dict[str, str]) -> dict[str, str]:
+        return data
+
+    @post("/", dependencies={"a": data_a, "b": data_b})
+    def handler(a: dict[str, str], b: list[str]) -> None:
+        return None
+
+    with pytest.raises(
+        ImproperlyConfiguredException,
+        match=re.escape("'data' fields have mismatched types: 'dict[str, str]' <> 'list[str]'"),
+    ):
+        Litestar([handler])


### PR DESCRIPTION
When `data` was declared in a dependency function but not in the handler, the request body was missing from the OpenAPI schema:

```python
from litestar import post, Litestar

async def some_dependency(data: list[str]) -> list[str]:
    return data

@post("/", dependencies={"some_data": some_dependency})
async def handler(some_data: list[str]) -> None:
    return None
```

<hr>

Ensure `data` is always documented, and ensure that `data` annotations are compatible between dependencies and handler functions.