### PR TITLE
chore: update msgspec links

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ litestar run
 - [OpenAPI 3.1 schema generation](#openapi)
 - [Life Cycle Hooks](#request-life-cycle-hooks)
 - [Route Guards based Authorization](#route-guards)
-- Support for `dataclasses`, `TypedDict`, [`msgspec`](https://jcristharif.com/msgspec/), [pydantic version 1 and version 2 (even within the same application)](https://docs.pydantic.dev/latest/) and [(c)attrs](https://catt.rs/en/stable/)
+- Support for `dataclasses`, `TypedDict`, [`msgspec`](https://msgspec.dev), [pydantic version 1 and version 2 (even within the same application)](https://docs.pydantic.dev/latest/) and [(c)attrs](https://catt.rs/en/stable/)
 - Layered parameter declaration
 - Support for [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) standardized "Problem Detail" error responses
 - [Automatic API documentation with](#redoc-swagger-ui-and-stoplight-elements-api-documentation):

--- a/docs/PYPI_README.md
+++ b/docs/PYPI_README.md
@@ -92,7 +92,7 @@ litestar run
 - [OpenAPI 3.1 schema generation](#openapi)
 - [Life Cycle Hooks](#request-life-cycle-hooks)
 - [Route Guards based Authorization](#route-guards)
-- Support for `dataclasses`, `TypedDict`, [`msgspec`](https://jcristharif.com/msgspec/), [pydantic version 1 and version 2 (even within the same application)](https://docs.pydantic.dev/latest/) and [(c)attrs](https://catt.rs/en/stable/)
+- Support for `dataclasses`, `TypedDict`, [`msgspec`](https://msgspec.dev), [pydantic version 1 and version 2 (even within the same application)](https://docs.pydantic.dev/latest/) and [(c)attrs](https://catt.rs/en/stable/)
 - Layered parameter declaration
 - Support for [RFC 9457](https://datatracker.ietf.org/doc/html/rfc9457) standardized "Problem Detail" error responses
 - [Automatic API documentation with](#redoc-swagger-ui-and-stoplight-elements-api-documentation):

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -42,7 +42,7 @@ Serializing a dictionary into JSON
 
 .. note::
     Because all frameworks are being used in their "stock" configuration, Litestar will
-    run the data through `msgspec <https://jcristharif.com/msgspec/>`_ and FastAPI
+    run the data through `msgspec <https://msgspec.dev>`_ and FastAPI
     through `Pydantic <https://docs.pydantic.dev/latest/>`_
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "msgspec": ("https://jcristharif.com/msgspec/", None),
+    "msgspec": ("https://msgspec.dev", None),
     "anyio": ("https://anyio.readthedocs.io/en/stable/", None),
     "multidict": ("https://multidict.aio-libs.org/en/stable/", None),
     "cryptography": ("https://cryptography.io/en/latest/", None),

--- a/docs/onboarding/fastapi.rst
+++ b/docs/onboarding/fastapi.rst
@@ -26,7 +26,7 @@ Pydantic support
 
 Litestar does support Pydantic, but other than FastAPI, it is mostly agnostic about
 the modelling library you use. Litestar internally uses
-`msgspec <https://jcristharif.com/msgspec/>`_, but also ships with support for Pydantic,
+`msgspec <https://msgspec.dev>`_, but also ships with support for Pydantic,
 attrs and all builtin container types such as dataclasses or ``TypedDict``\ s.
 
 These, as well as ``msgspec``, are supported through its plugin system (

--- a/docs/release-notes/2.x-changelog.rst
+++ b/docs/release-notes/2.x-changelog.rst
@@ -2700,7 +2700,7 @@
         :pr: 1712
         :issue: 1531, 1532
 
-        DTO factories for `msgspec <https://jcristharif.com/msgspec/>`_ and
+        DTO factories for `msgspec <https://msgspec.dev>`_ and
         `Pydantic <https://docs.pydantic.dev/latest/>`_ have been added:
 
         - :class:`~litestar.dto.msgspec_dto.MsgspecDTO`
@@ -3338,7 +3338,7 @@
         :pr: 1487
 
         Support OpenAPI schema generation for `attrs <https://www.attrs.org>`_ classes and
-        `msgspec <https://jcristharif.com/msgspec/>`_ ``Struct``\ s.
+        `msgspec <https://msgspec.dev>`_ ``Struct``\ s.
 
     .. change:: SQLAlchemy repository: Add ``ModelProtocol``
         :type: feature

--- a/docs/usage/requests.rst
+++ b/docs/usage/requests.rst
@@ -17,7 +17,7 @@ The type of ``data`` can be any supported type, including
 * :class:`TypedDicts <typing.TypedDict>`
 * :func:`dataclasses <dataclasses.dataclass>`
 * Types supported via :doc:`plugins </usage/plugins/index>` ie.
-    - `Msgspec Struct <https://jcristharif.com/msgspec/structs.html>`_
+    - `Msgspec Struct <https://msgspec.devstructs.html>`_
     - `Pydantic models <https://docs.pydantic.dev/usage/models/>`_
     - `Attrs classes <https://www.attrs.org/en/stable/>`_
 

--- a/docs/usage/responses.rst
+++ b/docs/usage/responses.rst
@@ -71,7 +71,7 @@ As previously mentioned, the default ``media_type`` is ``MediaType.JSON``. which
 * models from libraries that extend pydantic models
 * :class:`UUIDs <uuid.UUID>`
 * :doc:`datetime objects <python:library/datetime>`
-* `msgspec.Struct <https://jcristharif.com/msgspec/structs.html>`_
+* `msgspec.Struct <https://msgspec.devstructs.html>`_
 * container types such as :class:`dict` or :class:`list` containing supported types
 
 If you need to return other values and would like to extend serialization you can do

--- a/litestar/_openapi/schema_generation/plugins/struct.py
+++ b/litestar/_openapi/schema_generation/plugins/struct.py
@@ -43,7 +43,7 @@ class StructSchemaPlugin(OpenAPISchemaPlugin):
 
         required = [field.encode_name for field in struct_fields if self._is_field_required(field=field)]
 
-        # Support tagged unions: https://jcristharif.com/msgspec/structs.html#tagged-unions
+        # Support tagged unions: https://msgspec.devstructs.html#tagged-unions
         # These structs contain a tag_field and a tag. Since these fields are added
         # dynamically, they are not present within the regular struct fields and don't
         # have any type annotation associated with them, so we create a FieldDefinition


### PR DESCRIPTION
Replace `https://jscrist.com/msgsec` with `msgspec.dev`. 

https://github.com/msgspec/msgspec/issues/1035


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4838">https://litestar-org.github.io/litestar-docs-preview/4838</a> 
