### PR TITLE
fix: Prevent passing an empty boundary to the parser by returning a 400

### DIFF
--- a/litestar/connection/request.py
+++ b/litestar/connection/request.py
@@ -24,6 +24,7 @@ from litestar.exceptions import (
     InternalServerException,
     LitestarException,
     LitestarWarning,
+    ValidationException,
 )
 from litestar.exceptions.http_exceptions import RequestEntityTooLarge
 from litestar.serialization import decode_json, decode_msgpack
@@ -257,9 +258,13 @@ class Request(Generic[UserT, AuthT, StateT], ASGIConnection["HTTPRouteHandler", 
             if (form_data := self._connection_state.form) is Empty:
                 content_type, options = self.content_type
                 if content_type == RequestEncodingType.MULTI_PART:
+                    raw = options.get("boundary")
+                    if raw is None:
+                        raise ValidationException("multipart boundary missing in Content-Type")
+                    boundary_bytes = raw.encode()
                     form_data = await parse_multipart_form(
                         stream=self.stream(),
-                        boundary=options.get("boundary", "").encode(),
+                        boundary=boundary_bytes,
                         multipart_form_part_limit=self.app.multipart_form_part_limit,
                     )
                 elif content_type == RequestEncodingType.URL_ENCODED:

--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -692,18 +692,10 @@ def test_optional_upload_file_without_file_submitted() -> None:
         assert response.text == "file"
 
 # https://github.com/litestar-org/litestar/issues/4638
-def test_missing_or_empty_boundary_parameter_returns_400():
+def test_missing_or_empty_boundary_parameter_returns_400() -> None:
     with create_test_client(form_handler) as client:
-        response_1 = client.post(
-            "/form",
-            content=b"",
-            headers={"Content-Type": "multipart/form-data"}
-            )
+        response_1 = client.post("/form", content=b"", headers={"Content-Type": "multipart/form-data"})
         assert response_1.status_code == HTTP_400_BAD_REQUEST
 
-        response_2 = client.post(
-            "/form",
-            content=b"",
-            headers={"Content-Type": "multipart/form-data; boundary="}
-            )
+        response_2 = client.post("/form", content=b"", headers={"Content-Type": "multipart/form-data; boundary="})
         assert response_2.status_code == HTTP_400_BAD_REQUEST

--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -690,3 +690,20 @@ def test_optional_upload_file_without_file_submitted() -> None:
         response = client.post("/", files={"file": ("test.txt", b"hello", "text/plain")})
         assert response.status_code == HTTP_201_CREATED
         assert response.text == "file"
+
+# https://github.com/litestar-org/litestar/issues/4638
+def test_missing_or_empty_boundary_parameter_returns_400():
+    with create_test_client(form_handler) as client:
+        response_1 = client.post(
+            "/form",
+            content=b"",
+            headers={"Content-Type": "multipart/form-data"}
+            )
+        assert response_1.status_code == HTTP_400_BAD_REQUEST
+
+        response_2 = client.post(
+            "/form",
+            content=b"",
+            headers={"Content-Type": "multipart/form-data; boundary="}
+            )
+        assert response_2.status_code == HTTP_400_BAD_REQUEST

--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -691,6 +691,7 @@ def test_optional_upload_file_without_file_submitted() -> None:
         assert response.status_code == HTTP_201_CREATED
         assert response.text == "file"
 
+
 # https://github.com/litestar-org/litestar/issues/4638
 def test_missing_or_empty_boundary_parameter_returns_400() -> None:
     with create_test_client(form_handler) as client:


### PR DESCRIPTION
### Description

Fix https://github.com/litestar-org/litestar/issues/4638

Also got some inspiration from https://github.com/Kludex/starlette/issues/1588
Django and Flask do the same. 

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4839">https://litestar-org.github.io/litestar-docs-preview/4839</a> 
