### PR TITLE
feat(jwt): add leeway support for JWT token decoding

### DIFF
--- a/litestar/security/jwt/auth.py
+++ b/litestar/security/jwt/auth.py
@@ -94,6 +94,11 @@ class BaseJWTAuth(Generic[UserType, TokenT], AbstractSecurityConfig[UserType, To
     not a list of values, and matches ``audience`` exactly. Requires that
     ``accepted_audiences`` is a sequence of length 1
     """
+    leeway: int | float | timedelta = 0
+    """Leeway, in seconds, to account for clock skew when verifying ``exp`` and
+    ``nbf`` claims. Passed directly to PyJWT's :func:`jwt.decode`.
+    Defaults to ``0`` (no leeway).
+    """
 
     @property
     def openapi_components(self) -> Components:
@@ -153,6 +158,7 @@ class BaseJWTAuth(Generic[UserType, TokenT], AbstractSecurityConfig[UserType, To
             verify_expiry=self.verify_expiry,
             verify_not_before=self.verify_not_before,
             strict_audience=self.strict_audience,
+            leeway=self.leeway,
         )
 
     def login(
@@ -499,6 +505,7 @@ class JWTCookieAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, TokenT]):
             verify_expiry=self.verify_expiry,
             verify_not_before=self.verify_not_before,
             strict_audience=self.strict_audience,
+            leeway=self.leeway,
         )
 
     def login(
@@ -719,6 +726,7 @@ class OAuth2PasswordBearerAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, 
             verify_expiry=self.verify_expiry,
             verify_not_before=self.verify_not_before,
             strict_audience=self.strict_audience,
+            leeway=self.leeway,
         )
 
     @property

--- a/litestar/security/jwt/middleware.py
+++ b/litestar/security/jwt/middleware.py
@@ -29,6 +29,7 @@ class JWTAuthenticationMiddleware(AbstractAuthenticationMiddleware):
     __slots__ = (
         "algorithm",
         "auth_header",
+        "leeway",
         "require_claims",
         "retrieve_user_handler",
         "revoked_token_handler",
@@ -59,6 +60,7 @@ class JWTAuthenticationMiddleware(AbstractAuthenticationMiddleware):
         verify_expiry: bool = True,
         verify_not_before: bool = True,
         strict_audience: bool = False,
+        leeway: int | float | timedelta = 0,
         revoked_token_handler: Callable[[Token, ASGIConnection[Any, Any, Any, Any]], Awaitable[Any]] | None = None,
     ) -> None:
         """Check incoming requests for an encoded token in the auth header specified, and if present retrieve the user
@@ -111,6 +113,7 @@ class JWTAuthenticationMiddleware(AbstractAuthenticationMiddleware):
         self.verify_expiry = verify_expiry
         self.verify_not_before = verify_not_before
         self.strict_audience = strict_audience
+        self.leeway = leeway
 
     async def authenticate_request(self, connection: ASGIConnection[Any, Any, Any, Any]) -> AuthenticationResult:
         """Given an HTTP Connection, parse the JWT api key stored in the header and retrieve the user correlating to the
@@ -156,6 +159,7 @@ class JWTAuthenticationMiddleware(AbstractAuthenticationMiddleware):
             verify_exp=self.verify_expiry,
             verify_nbf=self.verify_not_before,
             strict_audience=self.strict_audience,
+            leeway=self.leeway,
         )
 
         user = await self.retrieve_user_handler(token, connection)
@@ -194,6 +198,7 @@ class JWTCookieAuthenticationMiddleware(JWTAuthenticationMiddleware):
         verify_expiry: bool = True,
         verify_not_before: bool = True,
         strict_audience: bool = False,
+        leeway: int | float | timedelta = 0,
         revoked_token_handler: Callable[[Token, ASGIConnection[Any, Any, Any, Any]], Awaitable[Any]] | None = None,
     ) -> None:
         """Check incoming requests for an encoded token in the auth header or cookie name specified, and if present
@@ -219,12 +224,15 @@ class JWTCookieAuthenticationMiddleware(JWTAuthenticationMiddleware):
             token_issuer: Verify the issuer when decoding the token. If the issuer in
                 the token does not match any issuer given, raise a
                 :exc:`NotAuthorizedException`
-            require_claims: Require these claims to be present in the JWT payload
+            require_claims: Require these claims are present in the JWT payload
             verify_expiry: Verify that the value of the ``exp`` (*expiration*) claim is in the future
             verify_not_before: Verify that the value of the ``nbf`` (*not before*) claim is in the past
             strict_audience: Verify that the value of the ``aud`` (*audience*) claim is a single value, and
                 not a list of values, and matches ``audience`` exactly. Requires that
                 ``accepted_audiences`` is a sequence of length 1
+            leeway: Leeway, in seconds, to account for clock skew when verifying
+                ``exp`` and ``nbf`` claims. Passed directly to PyJWT's
+                :func:`jwt.decode`. Defaults to ``0``.
             revoked_token_handler: A function that receives a :class:`Token <.security.jwt.Token>` and returns a boolean
                 indicating whether the token has been revoked.
         """
@@ -246,6 +254,7 @@ class JWTCookieAuthenticationMiddleware(JWTAuthenticationMiddleware):
             verify_expiry=verify_expiry,
             verify_not_before=verify_not_before,
             strict_audience=strict_audience,
+            leeway=leeway,
         )
         self.auth_cookie_key = auth_cookie_key
 

--- a/litestar/security/jwt/token.py
+++ b/litestar/security/jwt/token.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 from collections.abc import Sequence  # noqa: TC003
 from dataclasses import asdict, dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import jwt
@@ -92,6 +92,7 @@ class Token:
         issuer: str | Sequence[str] | None = None,
         audience: str | Sequence[str] | None = None,
         options: JWTDecodeOptions | None = None,
+        leeway: int | float | timedelta = 0,
     ) -> Any:
         """Decode and verify the JWT and return its payload"""
         return jwt.decode(
@@ -101,6 +102,7 @@ class Token:
             issuer=issuer,
             audience=audience,
             options=options,  # type: ignore[arg-type]
+            leeway=leeway,
         )
 
     @classmethod
@@ -115,6 +117,7 @@ class Token:
         verify_exp: bool = True,
         verify_nbf: bool = True,
         strict_audience: bool = False,
+        leeway: int | float | timedelta = 0,
     ) -> Self:
         """Decode a passed in token string and return a Token instance.
 
@@ -137,6 +140,9 @@ class Token:
                 a single value, and not a list of values, and matches ``audience``
                 exactly. Requires the value passed to the ``audience`` to be a sequence
                 of length 1
+            leeway: Leeway, in seconds, to account for clock skew when verifying
+                ``exp`` and ``nbf`` claims. Passed directly to PyJWT's
+                :func:`jwt.decode`. Defaults to ``0``.
 
         Returns:
             A decoded Token instance.
@@ -172,6 +178,7 @@ class Token:
                 audience=audience,
                 issuer=issuer,
                 options=options,
+                leeway=leeway,
             )
             # msgspec can do these conversions as well, but to keep backwards
             # compatibility, we do it ourselves, since the datetime parsing works a


### PR DESCRIPTION
## Summary

Adds a `leeway` parameter to the JWT token decoding pipeline, allowing users to specify a time offset (in seconds) to account for clock skew when verifying `exp` and `nbf` claims.

This is a standard PyJWT feature that was not exposed through Litestar's JWT auth layer.

## Changes

- `Token.decode_payload()`: added `leeway` parameter, passed to `jwt.decode()`
- `Token.decode()`: added `leeway` parameter with docstring
- `JWTAuthenticationMiddleware`: added `leeway` to `__slots__`, `__init__`, and `decode()` call
- `JWTCookieAuthenticationMiddleware`: added `leeway` to `__init__` and `super().__init__()` call
- `BaseJWTAuth` / `JWTAuth` / `JWTCookieAuth` / `OAuth2PasswordBearerAuth`: added `leeway` config field and passed to middleware

## Usage

```python
from litestar.security.jwt import JWTAuth

auth = JWTAuth(
    token_secret=secret,
    retrieve_user_handler=...,
    leeway=30,  # 30 seconds of leeway for clock skew
)
```

Closes #4584