### PR TITLE
chore(docs): fix Msgspec links

### DIFF
--- a/docs/usage/requests.rst
+++ b/docs/usage/requests.rst
@@ -17,7 +17,7 @@ The type of ``data`` can be any supported type, including
 * :class:`TypedDicts <typing.TypedDict>`
 * :func:`dataclasses <dataclasses.dataclass>`
 * Types supported via :doc:`plugins </usage/plugins/index>` ie.
-    - `Msgspec Struct <https://msgspec.devstructs.html>`_
+    - `Msgspec Struct <https://msgspec.dev/structs>`_
     - `Pydantic models <https://docs.pydantic.dev/usage/models/>`_
     - `Attrs classes <https://www.attrs.org/en/stable/>`_
 

--- a/docs/usage/responses.rst
+++ b/docs/usage/responses.rst
@@ -71,7 +71,7 @@ As previously mentioned, the default ``media_type`` is ``MediaType.JSON``. which
 * models from libraries that extend pydantic models
 * :class:`UUIDs <uuid.UUID>`
 * :doc:`datetime objects <python:library/datetime>`
-* `msgspec.Struct <https://msgspec.devstructs.html>`_
+* `msgspec.Struct <https://msgspec.dev/structs>`_
 * container types such as :class:`dict` or :class:`list` containing supported types
 
 If you need to return other values and would like to extend serialization you can do

--- a/litestar/_openapi/schema_generation/plugins/struct.py
+++ b/litestar/_openapi/schema_generation/plugins/struct.py
@@ -43,7 +43,7 @@ class StructSchemaPlugin(OpenAPISchemaPlugin):
 
         required = [field.encode_name for field in struct_fields if self._is_field_required(field=field)]
 
-        # Support tagged unions: https://msgspec.devstructs.html#tagged-unions
+        # Support tagged unions: https://msgspec.dev/structs#tagged-unions
         # These structs contain a tag_field and a tag. Since these fields are added
         # dynamically, they are not present within the regular struct fields and don't
         # have any type annotation associated with them, so we create a FieldDefinition


### PR DESCRIPTION
## Description

Fixup a bad search and replace from #4838


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4842">https://litestar-org.github.io/litestar-docs-preview/4842</a> 
