### PR TITLE
fix: include msgspec ClassVar tag field annotations in OpenAPI schema

### DIFF
--- a/litestar/_openapi/schema_generation/plugins/struct.py
+++ b/litestar/_openapi/schema_generation/plugins/struct.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+import typing
+from typing import TYPE_CHECKING, Literal, get_args, get_origin
 
 import msgspec
 from msgspec import Struct
 
 from litestar.plugins import OpenAPISchemaPlugin
 from litestar.plugins.core._msgspec import kwarg_definition_from_field
+from litestar.params import ParameterKwarg
 from litestar.types.empty import Empty
 from litestar.typing import FieldDefinition
 
@@ -22,6 +24,73 @@ class StructSchemaPlugin(OpenAPISchemaPlugin):
     @staticmethod
     def _is_field_required(field: msgspec.inspect.Field) -> bool:
         return field.required or field.default_factory is Empty
+
+    @staticmethod
+    def _extract_tag_field_kwarg_definition(
+        struct_type: type[Struct], tag_field: str
+    ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+        """Extract kwarg definition and extra metadata from a ClassVar tag field annotation.
+
+        When a msgspec Struct uses ``ClassVar[Annotated[Literal[...], msgspec.Meta(...)]]``
+        for the tag field, the metadata (description, title, examples, etc.) is not
+        available via ``msgspec.inspect`` because ``ClassVar`` fields are excluded
+        from the struct's field list. This method extracts that metadata so it can
+        be included in the OpenAPI schema.
+
+        Returns:
+            A tuple of ``(kwarg_definition_kwargs, extra)`` where ``kwarg_definition_kwargs``
+            is a dict suitable for constructing a ``ParameterKwarg`` (or ``None`` if no
+            metadata was found), and ``extra`` is a dict of additional metadata.
+        """
+        type_hints = typing.get_type_hints(struct_type, include_extras=True)
+        annotation = type_hints.get(tag_field)
+        if annotation is None:
+            return None, {}
+
+        # Unwrap ClassVar to get the inner type
+        if get_origin(annotation) is not typing.ClassVar:
+            return None, {}
+
+        inner = get_args(annotation)[0]
+        origin = get_origin(inner)
+
+        # Look for msgspec.Meta in Annotated metadata
+        if origin is typing.Annotated:
+            annotated_args = get_args(inner)
+            # First arg is the actual type (e.g. Literal['1']), rest are metadata
+            for meta in annotated_args[1:]:
+                if isinstance(meta, msgspec.Meta):
+                    kwargs: dict[str, Any] = {}
+                    extra: dict[str, Any] = {}
+                    if meta.description:
+                        kwargs["description"] = meta.description
+                    if meta.title:
+                        kwargs["title"] = meta.title
+                    if meta.examples:
+                        from litestar.openapi.spec import Example
+
+                        kwargs["examples"] = [Example(value=e) for e in meta.examples]
+                    if meta.extra_json_schema:
+                        if meta.extra_json_schema.get("description"):
+                            kwargs.setdefault("description", meta.extra_json_schema["description"])
+                        if meta.extra_json_schema.get("title"):
+                            kwargs.setdefault("title", meta.extra_json_schema["title"])
+                        if meta.extra_json_schema.get("examples"):
+                            from litestar.openapi.spec import Example
+
+                            kwargs.setdefault(
+                                "examples",
+                                [Example(value=e) for e in meta.extra_json_schema["examples"]],
+                            )
+                        if meta.extra_json_schema.get("extra"):
+                            kwargs["schema_extra"] = meta.extra_json_schema["extra"]
+                    if meta.extra:
+                        extra = meta.extra
+                    if kwargs:
+                        return kwargs, extra
+                    return None, extra
+
+        return None, {}
 
     def to_openapi_schema(self, field_definition: FieldDefinition, schema_creator: SchemaCreator) -> Schema:
         type_hints = field_definition.get_type_hints(include_extras=True, resolve_generics=True)
@@ -50,7 +119,26 @@ class StructSchemaPlugin(OpenAPISchemaPlugin):
         # manually
         if struct_info.tag_field:
             # using a Literal here will set these as a const in the schema
-            property_fields[struct_info.tag_field] = FieldDefinition.from_annotation(Literal[struct_info.tag])
+            tag_kwarg_definition_kwargs: dict[str, Any] | None = None
+            tag_extra: dict[str, Any] = {}
+
+            # Check if the tag field has a ClassVar annotation with msgspec.Meta metadata
+            tag_kwarg_definition_kwargs, tag_extra = self._extract_tag_field_kwarg_definition(
+                struct_type=field_definition.type_,  # type: ignore[arg-type]
+                tag_field=struct_info.tag_field,
+            )
+
+            tag_field_definition_kwargs: dict[str, Any] = {}
+            if tag_kwarg_definition_kwargs:
+                tag_field_definition_kwargs["kwarg_definition"] = ParameterKwarg(**tag_kwarg_definition_kwargs)
+            if tag_extra:
+                tag_field_definition_kwargs["extra"] = tag_extra
+
+            property_fields[struct_info.tag_field] = FieldDefinition.from_annotation(
+                Literal[struct_info.tag],
+                name=struct_info.tag_field,
+                **tag_field_definition_kwargs,
+            )
             required.append(struct_info.tag_field)
 
         return schema_creator.create_component_schema(

--- a/tests/unit/test_dto/test_msgspec.py
+++ b/tests/unit/test_dto/test_msgspec.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import itertools
 from dataclasses import replace
-from typing import TYPE_CHECKING, Annotated, ClassVar
+from typing import TYPE_CHECKING, Annotated, ClassVar, Literal
 from unittest.mock import ANY
 
 import pytest
@@ -215,6 +215,92 @@ def test_tag_field_included_in_schema() -> None:
         "type": "object",
         "required": ["foo", "regular_field"],
         "title": "Model3",
+    }
+
+
+def test_tag_field_classvar_annotations_in_schema() -> None:
+    """Test that ClassVar tag field annotations (e.g. msgspec.Meta) are included in OpenAPI schema."""
+
+    class ModelWithAnnotatedTag(
+        Struct, tag="v1", tag_field="version"
+    ):
+        version: ClassVar[
+            Annotated[Literal["v1"], Meta(description="API version identifier")]
+        ] = "v1"
+        name: str = "default"
+
+    class ModelWithTitle(
+        Struct, tag="stable", tag_field="status"
+    ):
+        status: ClassVar[
+            Annotated[
+                Literal["stable"],
+                Meta(title="Release Status", description="Current release status"),
+            ]
+        ] = "stable"
+        value: int = 0
+
+    class ModelPlainTag(Struct, tag="plain", tag_field="kind"):
+        kind: ClassVar[Literal["plain"]] = "plain"
+        data: str = ""
+
+    @post("/annotated")
+    def handler_annotated(data: ModelWithAnnotatedTag) -> None:
+        return None
+
+    @post("/titled")
+    def handler_titled(data: ModelWithTitle) -> None:
+        return None
+
+    @post("/plain")
+    def handler_plain(data: ModelPlainTag) -> None:
+        return None
+
+    components = Litestar(
+        [handler_annotated, handler_titled, handler_plain],
+        signature_types=[ModelWithAnnotatedTag, ModelWithTitle, ModelPlainTag],
+    ).openapi_schema.components.to_schema()["schemas"]
+
+    # ClassVar with Annotated[Literal[...], Meta(description=...)] should include description
+    assert components["test_tag_field_classvar_annotations_in_schema.ModelWithAnnotatedTag"] == {
+        "properties": {
+            "name": {"type": "string", "default": "default"},
+            "version": {
+                "type": "string",
+                "const": "v1",
+                "description": "API version identifier",
+            },
+        },
+        "type": "object",
+        "required": ["version"],
+        "title": "ModelWithAnnotatedTag",
+    }
+
+    # ClassVar with both title and description in Meta
+    assert components["test_tag_field_classvar_annotations_in_schema.ModelWithTitle"] == {
+        "properties": {
+            "value": {"type": "integer", "default": 0},
+            "status": {
+                "type": "string",
+                "const": "stable",
+                "title": "Release Status",
+                "description": "Current release status",
+            },
+        },
+        "type": "object",
+        "required": ["status"],
+        "title": "ModelWithTitle",
+    }
+
+    # ClassVar without Annotated/Meta should still work as before (no description)
+    assert components["test_tag_field_classvar_annotations_in_schema.ModelPlainTag"] == {
+        "properties": {
+            "data": {"type": "string", "default": ""},
+            "kind": {"type": "string", "const": "plain"},
+        },
+        "type": "object",
+        "required": ["kind"],
+        "title": "ModelPlainTag",
     }
 
 


### PR DESCRIPTION
## Summary

When a `msgspec.Struct` uses `ClassVar[Annotated[Literal[...], msgspec.Meta(...)]]` for the tag/discriminator field, the metadata (description, title, examples, etc.) was not included in the generated OpenAPI schema.

This was because `ClassVar` fields are excluded from msgspec's field inspection API, so the annotation metadata was lost during schema generation.

## Changes

- Added `_extract_tag_field_kwarg_definition()` static method to `StructSchemaPlugin` that:
  1. Checks the struct's type hints for a `ClassVar` annotation on the tag field
  2. Extracts `msgspec.Meta` metadata from `Annotated` types
  3. Converts the metadata into a `ParameterKwarg` for proper OpenAPI schema generation
- Updated tag field handling in `to_openapi_schema()\) to use extracted metadata
- Added comprehensive test `test_tag_field_classvar_annotations_in_schema` covering:
  - ClassVar with `Meta(description=...)`
  - ClassVar with `Meta(title=..., description=...)`
  - Plain ClassVar without metadata (backward compatibility)

## Example

```python
class Resp(msgspec.Struct, tag="v1", tag_field="version"):
    version: ClassVar[
        Annotated[Literal["v1"], Meta(description="API version identifier")]
    ] = "v1"
    name: str = "default"
```

**Before:** The `version` field in the OpenAPI schema was `{"type": "string", "const": "v1"\}` (no description).

**After:** The `version` field includes the description: `{"type": "string", "const": "v1", "description": "API version identifier"\}`.

## Testing

- All 6 existing tests in `tests/unit/test_dto/test_msgspec.py` pass
- All 250 tests in `tests/unit/test_openapi/` pass
- New test covers all three scenarios (description, title+description, plain)

Fixes #4564