### PR TITLE
docs(openapi): document default schema endpoints

### DIFF
--- a/docs/usage/openapi/index.rst
+++ b/docs/usage/openapi/index.rst
@@ -20,6 +20,19 @@ configuration globally to setting
 :ref:`specific kwargs on route <usage/openapi/schema_generation:Configuring schema generation on a route handler>`
 handler decorators.
 
+Default schema endpoints
+------------------------
+
+By default, the OpenAPI schema is served at ``/schema`` (configurable via
+:attr:`OpenAPIConfig.path <litestar.openapi.config.OpenAPIConfig.path>`).
+The following endpoints are available under the configured path:
+
+- ``/schema/openapi.json`` — OpenAPI schema as JSON
+- ``/schema/openapi.yaml`` — OpenAPI schema as YAML
+
+These endpoints can be used to import the schema into API clients such as
+`Scalar API Client <https://scalar.com/>`_ or other OpenAPI-compatible tools.
+
 .. toctree::
 
     schema_generation


### PR DESCRIPTION
## Summary

Add documentation for the default OpenAPI schema endpoints to the main OpenAPI docs page.

## Changes

- Document that the OpenAPI schema is served at `/schema` by default (configurable via `OpenAPIConfig.path`)
- List the available endpoints: `/schema/openapi.json` and `/schema/openapi.yaml`
- Mention use cases like importing into Scalar API Client or other OpenAPI-compatible tools

Closes #3941