### PR TITLE
docs: add information on default OpenAPI files available

### DIFF
--- a/docs/usage/openapi/index.rst
+++ b/docs/usage/openapi/index.rst
@@ -8,8 +8,28 @@ Litestar has first class OpenAPI support offering the following features:
 - Builtin support for static documentation site generation using several different libraries.
 - Full configuration using pre-defined type-safe dataclasses.
 
+Default OpenAPI Files
+---------------------
 
-Litestar includes a complete implementation of the `latest version of the OpenAPI specification <https://spec.openapis.org/oas/latest.html>`_
+Litestar automatically serves the generated OpenAPI schema as downloadable files at the
+following endpoints, relative to the configured schema path (``/schema`` by default):
+
+- ``/schema/openapi.json`` -- The full OpenAPI schema in JSON format.
+- ``/schema/openapi.yaml`` -- The full OpenAPI schema in YAML format.
+- ``/schema/openapi.yml`` -- Alias for the YAML format.
+
+These files are useful for importing the API definition into external tools such as
+`Scalar API client <https://github.com/scalar/scalar>`_, Postman, or any other
+OpenAPI-compatible tool. For example, with the default configuration::
+
+    https://your-app.example.com/schema/openapi.json
+
+If you have customized the OpenAPI path (see :ref:`OpenAPI Root Path <usage/openapi/ui_plugins:Configuring the OpenAPI Root Path>`),
+replace ``/schema`` with your configured path. For instance, if the path is set to
+``/docs``, the files would be available at ``/docs/openapi.json``,
+``/docs/openapi.yaml``, and ``/docs/openapi.yml``.
+
+Litestar includes a complete implementation
 using Python dataclasses. This implementation is used as a basis for generating OpenAPI specs,
 supporting :func:`~dataclasses.dataclass`, :class:`~typing.TypedDict`,
 as well as Pydantic and msgspec models, and any 3rd party entities


### PR DESCRIPTION
## Description

Documents the automatically served OpenAPI file endpoints (`.json`, `.yaml`, `.yml`) that Litestar makes available at the schema root path by default.

Fixes #3941

## Changes

Added a new "Default OpenAPI Files" section to `docs/usage/openapi/index.rst` that clearly lists:
- `/schema/openapi.json` -- JSON format
- `/schema/openapi.yaml` -- YAML format
- `/schema/openapi.yml` -- YAML alias

Includes guidance on how paths change when a custom schema root path is configured, with a cross-reference to the existing "Configuring the OpenAPI Root Path" section.

## Checklist

- [x] Documentation added
- [x] Cross-references included
- [x] Follows existing RST style and conventions

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4857">https://litestar-org.github.io/litestar-docs-preview/4857</a> 
