### PR TITLE
docs: fix implicit sync handler warnings

### DIFF
--- a/docs/examples/data_transfer_objects/factory/type_checking.py
+++ b/docs/examples/data_transfer_objects/factory/type_checking.py
@@ -22,7 +22,7 @@ class Foo(Base):
 UserDTO = SQLAlchemyDTO[User]
 
 
-@post("/users", dto=UserDTO)
+@post("/users", dto=UserDTO, sync_to_thread=False)
 def create_user(data: Foo) -> Foo:
     return data
 

--- a/docs/examples/data_transfer_objects/the_dto_parameter.py
+++ b/docs/examples/data_transfer_objects/the_dto_parameter.py
@@ -3,6 +3,6 @@ from litestar import post
 from .models import User, UserDTO
 
 
-@post(dto=UserDTO)
+@post(dto=UserDTO, sync_to_thread=False)
 def create_user(data: User) -> User:
     return data

--- a/docs/examples/data_transfer_objects/the_return_dto_parameter.py
+++ b/docs/examples/data_transfer_objects/the_return_dto_parameter.py
@@ -3,6 +3,6 @@ from litestar import post
 from .models import User, UserDTO, UserReturnDTO
 
 
-@post(dto=UserDTO, return_dto=UserReturnDTO)
+@post(dto=UserDTO, return_dto=UserReturnDTO, sync_to_thread=False)
 def create_user(data: User) -> User:
     return data

--- a/docs/examples/openapi/customize_path.py
+++ b/docs/examples/openapi/customize_path.py
@@ -2,7 +2,7 @@ from litestar import Litestar, get
 from litestar.openapi.config import OpenAPIConfig
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def hello_world() -> dict[str, str]:
     return {"message": "Hello World"}
 

--- a/docs/examples/responses/streaming_responses.py
+++ b/docs/examples/responses/streaming_responses.py
@@ -13,7 +13,7 @@ async def my_generator() -> AsyncGenerator[bytes, None]:
         yield encode_json({"current_time": datetime.now()})
 
 
-@get(path="/time")
+@get(path="/time", sync_to_thread=False)
 def stream_time() -> Stream:
     return Stream(my_generator())
 

--- a/docs/examples/security/guards.py
+++ b/docs/examples/security/guards.py
@@ -29,7 +29,7 @@ def admin_user_guard(connection: ASGIConnection, _: BaseRouteHandler) -> None:
         raise PermissionDeniedException()
 
 
-@post(path="/user", guards=[admin_user_guard])
+@post(path="/user", guards=[admin_user_guard], sync_to_thread=False)
 def create_user(data: User) -> User: ...
 
 

--- a/docs/examples/security/jwt/custom_token_cls.py
+++ b/docs/examples/security/jwt/custom_token_cls.py
@@ -30,7 +30,7 @@ jwt_auth = JWTAuth[User](
 )
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def handler(request: Request[User, CustomToken, Any]) -> dict[str, Any]:
     return {"id": request.user.id, "token_flag": request.auth.token_flag}
 

--- a/docs/examples/security/jwt/verify_issuer_audience.py
+++ b/docs/examples/security/jwt/verify_issuer_audience.py
@@ -24,7 +24,7 @@ jwt_auth = JWTAuth[User](
 )
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def handler(request: Request[User, Token, Any]) -> dict[str, Any]:
     return {"id": request.user.id}
 

--- a/docs/examples/security/using_abstract_authentication_middleware.py
+++ b/docs/examples/security/using_abstract_authentication_middleware.py
@@ -43,7 +43,7 @@ class CustomAuthenticationMiddleware(AbstractAuthenticationMiddleware):
         return AuthenticationResult(user=user, auth=token)
 
 
-@get("/")
+@get("/", sync_to_thread=False)
 def my_http_handler(request: Request[MyUser, MyToken, State]) -> None:
     user = request.user  # correctly typed as MyUser
     auth = request.auth  # correctly typed as MyToken


### PR DESCRIPTION
## Description

Update examples in the documentation to prevent LitestarWarning(Use of a synchronous callable <function ...> without setting sync_to_thread is discouraged ...) by explicitly specifying `sync_to_thread=False`

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4882">https://litestar-org.github.io/litestar-docs-preview/4882</a> 
