### PR TITLE
docs: fix and enable type checkers for examples

### DIFF
--- a/docs/examples/data_transfer_objects/factory/enveloping_return_data.py
+++ b/docs/examples/data_transfer_objects/factory/enveloping_return_data.py
@@ -2,11 +2,10 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Generic, TypeVar
 
-from advanced_alchemy.extensions.litestar import SQLAlchemyDTO
+from advanced_alchemy.extensions.litestar import SQLAlchemyDTO, SQLAlchemyDTOConfig
 from sqlalchemy.orm import Mapped
 
 from litestar import Litestar, get
-from litestar.dto import DTOConfig
 
 from .my_lib import Base
 
@@ -26,7 +25,7 @@ class User(Base):
 
 
 class UserDTO(SQLAlchemyDTO[User]):
-    config = DTOConfig(exclude={"password", "created_at"})
+    config = SQLAlchemyDTOConfig(exclude={"password", "created_at"})
 
 
 @get("/users", dto=UserDTO, sync_to_thread=False)

--- a/docs/examples/data_transfer_objects/factory/my_lib.py
+++ b/docs/examples/data_transfer_objects/factory/my_lib.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from advanced_alchemy.extensions.litestar import base, mixins
 from sqlalchemy.orm import DeclarativeBase
 
+if TYPE_CHECKING:
 
-class _Base(base.CommonTableAttributes, mixins.UUIDPrimaryKey, DeclarativeBase):
-    """Fake base SQLAlchemy model for typing purposes."""
-
-
-Base: _Base
+    class Base(base.CommonTableAttributes, mixins.UUIDPrimaryKey, DeclarativeBase):
+        """Fake base SQLAlchemy model for typing purposes."""
 
 
 def __getattr__(name: str) -> Any:

--- a/docs/examples/data_transfer_objects/factory/paginated_return_data.py
+++ b/docs/examples/data_transfer_objects/factory/paginated_return_data.py
@@ -1,10 +1,9 @@
 from datetime import datetime
 
-from advanced_alchemy.extensions.litestar import SQLAlchemyDTO
+from advanced_alchemy.extensions.litestar import SQLAlchemyDTO, SQLAlchemyDTOConfig
 from sqlalchemy.orm import Mapped
 
 from litestar import Litestar, get
-from litestar.dto import DTOConfig
 from litestar.pagination import ClassicPagination
 
 from .my_lib import Base
@@ -17,7 +16,7 @@ class User(Base):
 
 
 class UserDTO(SQLAlchemyDTO[User]):
-    config = DTOConfig(exclude={"password", "created_at"})
+    config = SQLAlchemyDTOConfig(exclude={"password", "created_at"})
 
 
 @get("/users", dto=UserDTO, sync_to_thread=False)

--- a/docs/examples/data_transfer_objects/factory/response_return_data.py
+++ b/docs/examples/data_transfer_objects/factory/response_return_data.py
@@ -1,10 +1,9 @@
 from datetime import datetime
 
-from advanced_alchemy.extensions.litestar import SQLAlchemyDTO
+from advanced_alchemy.extensions.litestar import SQLAlchemyDTO, SQLAlchemyDTOConfig
 from sqlalchemy.orm import Mapped
 
 from litestar import Litestar, Response, get
-from litestar.dto import DTOConfig
 
 from .my_lib import Base
 
@@ -16,7 +15,7 @@ class User(Base):
 
 
 class UserDTO(SQLAlchemyDTO[User]):
-    config = DTOConfig(exclude={"password", "created_at"})
+    config = SQLAlchemyDTOConfig(exclude={"password", "created_at"})
 
 
 @get("/users", dto=UserDTO, sync_to_thread=False)

--- a/docs/examples/file_systems/register_linkable.py
+++ b/docs/examples/file_systems/register_linkable.py
@@ -3,9 +3,10 @@ import os
 from fsspec.implementations.local import LocalFileSystem
 
 from litestar.file_system import AnyFileSystem, LinkableFileSystem
+from litestar.types import PathType
 
 
-async def local_resolver(fs: AnyFileSystem, path: str) -> str:
+async def local_resolver(fs: AnyFileSystem, path: PathType) -> str:
     return os.path.realpath(path)
 
 

--- a/docs/examples/file_systems/registry.py
+++ b/docs/examples/file_systems/registry.py
@@ -10,7 +10,7 @@ async def file_handler(file_name: str) -> File:
     return File(file_name, file_system="assets")
 
 
-def create_app(assets_fs: fsspec.AbstractFileSystem):
+def create_app(assets_fs: fsspec.AbstractFileSystem) -> Litestar:
     return Litestar(
         [file_handler],
         plugins=[FileSystemRegistry({"assets": assets_fs})],

--- a/docs/examples/file_systems/registry_access.py
+++ b/docs/examples/file_systems/registry_access.py
@@ -5,7 +5,7 @@ from litestar.file_system import FileSystemRegistry
 @get("/")
 async def handler(request: Request) -> bytes:
     registry = request.app.plugins.get(FileSystemRegistry)
-    return registry.default.read_bytes("some/file.txt")
+    return await registry.default.read_bytes("some/file.txt")
 
 
 app = Litestar([handler])

--- a/docs/examples/middleware/call_order.py
+++ b/docs/examples/middleware/call_order.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from litestar import Controller, Litestar, Router, get
 from litestar.datastructures import State
@@ -31,7 +31,7 @@ class MyController(Controller):
         middleware=[create_test_middleware(6), create_test_middleware(7)],
     )
     async def my_handler(self, state: State) -> list[int]:
-        return state["middleware_calls"]
+        return cast(list[int], state["middleware_calls"])
 
 
 router = Router(

--- a/docs/examples/middleware/session/cookie_backend.py
+++ b/docs/examples/middleware/session/cookie_backend.py
@@ -3,6 +3,6 @@ from os import urandom
 from litestar import Litestar
 from litestar.middleware.session.client_side import CookieBackendConfig
 
-session_config = CookieBackendConfig(secret=urandom(16))  # type: ignore
+session_config = CookieBackendConfig(secret=urandom(16))
 
 app = Litestar(middleware=[session_config.middleware])

--- a/docs/examples/middleware/session/cookies_full_example.py
+++ b/docs/examples/middleware/session/cookies_full_example.py
@@ -5,7 +5,7 @@ from litestar.middleware.session.client_side import CookieBackendConfig
 
 # we initialize to config with a 16 byte key, i.e. 128 a bit key.
 # in real world usage we should inject the secret from the environment
-session_config = CookieBackendConfig(secret=urandom(16))  # type: ignore[arg-type]
+session_config = CookieBackendConfig(secret=urandom(16))
 
 
 @get("/session", sync_to_thread=False)

--- a/docs/examples/onboarding/fastapi/state.py
+++ b/docs/examples/onboarding/fastapi/state.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from litestar import Litestar, get
 from litestar.datastructures import State
 from litestar.di import Provide
@@ -8,7 +10,7 @@ class ArqRedis:
 
 
 async def get_arq_redis(state: State) -> ArqRedis:
-    return state.arq_redis
+    return cast(ArqRedis, state.arq_redis)
 
 
 @get("/", dependencies={"arq_redis": Provide(get_arq_redis)})

--- a/docs/examples/parameters/path_parameters_3.py
+++ b/docs/examples/parameters/path_parameters_3.py
@@ -25,7 +25,7 @@ def get_product_version(
             description="Get a specific version spec from the available specs",
             examples=[Example(value=1)],
             external_docs=ExternalDocumentation(
-                url="https://mywebsite.com/documentation/product#versions",  # type: ignore[arg-type]
+                url="https://mywebsite.com/documentation/product#versions",
             ),
         ),
     ],

--- a/docs/examples/plugins/di_plugin.py
+++ b/docs/examples/plugins/di_plugin.py
@@ -8,7 +8,7 @@ from litestar.plugins import DIPlugin
 
 
 class MyBaseType:
-    def __init__(self, param):
+    def __init__(self, param: str) -> None:
         self.param = param
 
 

--- a/docs/examples/plugins/prometheus/using_prometheus_exporter.py
+++ b/docs/examples/plugins/prometheus/using_prometheus_exporter.py
@@ -2,7 +2,7 @@ from litestar import Litestar
 from litestar.plugins.prometheus import PrometheusConfig, PrometheusController
 
 
-def create_app(group_path: bool = False):
+def create_app(group_path: bool = False) -> Litestar:
     # Default app name and prefix is litestar.
     prometheus_config = PrometheusConfig(group_path=group_path)
 

--- a/docs/examples/plugins/prometheus/using_prometheus_exporter_with_extra_configs.py
+++ b/docs/examples/plugins/prometheus/using_prometheus_exporter_with_extra_configs.py
@@ -17,7 +17,7 @@ def custom_label_callable(request: Request[Any, Any, Any]) -> str:
     return "v2.0"
 
 
-extra_labels: dict[str, str | Callable] = {
+extra_labels: dict[str, str | Callable[[Request[Any, Any, Any]], str]] = {
     "version_no": custom_label_callable,
     "location": "earth",
 }

--- a/docs/examples/plugins/prometheus/using_prometheus_exporter_with_extra_configs.py
+++ b/docs/examples/plugins/prometheus/using_prometheus_exporter_with_extra_configs.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import Any
 
 from litestar import Litestar, Request
@@ -16,13 +17,13 @@ def custom_label_callable(request: Request[Any, Any, Any]) -> str:
     return "v2.0"
 
 
-extra_labels = {
+extra_labels: dict[str, str | Callable] = {
     "version_no": custom_label_callable,
     "location": "earth",
 }
 
 # Customizing the buckets for the histogram.
-buckets = [0.1, 0.2, 0.3, 0.4, 0.5]
+buckets: list[str | float] = [0.1, 0.2, 0.3, 0.4, 0.5]
 
 
 # Adding exemplars to the metrics.
@@ -38,7 +39,7 @@ prometheus_config = PrometheusConfig(
     app_name="litestar-example",
     prefix="litestar",
     labels=extra_labels,
-    buckets=buckets,  # pyright: ignore[reportArgumentType]
+    buckets=buckets,
     exemplars=custom_exemplar,
     excluded_http_methods=["POST"],
 )

--- a/docs/examples/plugins/prometheus/using_prometheus_exporter_with_extra_configs.py
+++ b/docs/examples/plugins/prometheus/using_prometheus_exporter_with_extra_configs.py
@@ -23,7 +23,7 @@ extra_labels: dict[str, str | Callable] = {
 }
 
 # Customizing the buckets for the histogram.
-buckets: list[str | float] = [0.1, 0.2, 0.3, 0.4, 0.5]
+buckets = [0.1, 0.2, 0.3, 0.4, 0.5]
 
 
 # Adding exemplars to the metrics.

--- a/docs/examples/plugins/serialization_plugin_protocol.py
+++ b/docs/examples/plugins/serialization_plugin_protocol.py
@@ -34,7 +34,7 @@ class CompanySerializationPlugin(SerializationPlugin):
         assert isinstance(annotation, type)
         if (cached := self._type_dto_map.get(annotation)) is not None:
             return cached
-        dto_type: type[AbstractDTO] = DataclassDTO[annotation]
+        dto_type: type[AbstractDTO] = DataclassDTO[annotation]  # type: ignore[valid-type]
         self._type_dto_map[annotation] = dto_type
         return dto_type
 

--- a/docs/examples/plugins/sqlalchemy_init_plugin/full_app_with_session_di.py
+++ b/docs/examples/plugins/sqlalchemy_init_plugin/full_app_with_session_di.py
@@ -61,7 +61,7 @@ def serialize_todo(todo: TodoItem) -> TodoType:
     return {"title": todo.title, "done": todo.done}
 
 
-async def get_todo_by_title(todo_name, session: AsyncSession) -> TodoItem:
+async def get_todo_by_title(todo_name: str, session: AsyncSession) -> TodoItem:
     query = select(TodoItem).where(TodoItem.title == todo_name)
     result = await session.execute(query)
     try:

--- a/docs/examples/request_data/custom_request.py
+++ b/docs/examples/request_data/custom_request.py
@@ -1,6 +1,6 @@
 from litestar import Litestar, Request, get
 from litestar.connection.base import empty_receive, empty_send
-from litestar.enums import HttpMethod
+from litestar.enums import HttpMethod, ScopeType
 from litestar.types import Receive, Scope, Send
 
 KITTEN_NAMES_MAP = {
@@ -16,7 +16,9 @@ class CustomRequest(Request):
     def __init__(self, scope: Scope, receive: Receive = empty_receive, send: Send = empty_send) -> None:
         """Initialize CustomRequest class."""
         super().__init__(scope=scope, receive=receive, send=send)
-        self.kitten_name = KITTEN_NAMES_MAP.get(scope["method"], "Mittens")
+        self.kitten_name = "Mittens"
+        if scope["type"] == ScopeType.HTTP and (kitten_name := KITTEN_NAMES_MAP.get(HttpMethod(scope["method"]))):
+            self.kitten_name = kitten_name
 
 
 @get(path="/kitten-name")

--- a/docs/examples/request_data/request_data_10.py
+++ b/docs/examples/request_data/request_data_10.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from litestar import Litestar, post
 from litestar.datastructures import UploadFile
 from litestar.params import MultipartBody
@@ -8,7 +6,7 @@ from litestar.params import MultipartBody
 @post(path="/")
 async def handle_file_upload(
     data: MultipartBody[list[UploadFile]],
-) -> dict[str, tuple[str, str, Any]]:
+) -> dict[str, tuple[int, str, dict[str, str]]]:
     result = {}
     for file in data:
         content = await file.read()

--- a/docs/examples/request_data/request_data_5.py
+++ b/docs/examples/request_data/request_data_5.py
@@ -13,7 +13,7 @@ class User:
 
 
 @post(path="/")
-async def create_user(data: MultipartBody[User]) -> dict[str, str]:
+async def create_user(data: MultipartBody[User]) -> dict[str, str | int]:
     content = await data.form_input_name.read()
     filename = data.form_input_name.filename
     return {"id": data.id, "name": data.name, "filename": filename, "size": len(content)}

--- a/docs/examples/request_data/request_data_9.py
+++ b/docs/examples/request_data/request_data_9.py
@@ -6,7 +6,7 @@ from litestar.params import MultipartBody
 @post(path="/")
 async def handle_file_upload(
     data: MultipartBody[dict[str, UploadFile]],
-) -> dict[str, str]:
+) -> dict[str, int]:
     file_contents = {}
     for name, file in data.items():
         content = await file.read()

--- a/docs/examples/responses/background_tasks_3.py
+++ b/docs/examples/responses/background_tasks_3.py
@@ -5,7 +5,7 @@ from litestar.background_tasks import BackgroundTask, BackgroundTasks
 from litestar.params import FromQuery
 
 logger = logging.getLogger(__name__)
-greeted = set()
+greeted: set[str] = set()
 
 
 async def logging_task(name: str) -> None:

--- a/docs/examples/responses/response_content.py
+++ b/docs/examples/responses/response_content.py
@@ -2,7 +2,7 @@ from litestar import Litestar, MediaType, Request, Response, get
 
 
 @get("/resource", sync_to_thread=False)
-def retrieve_resource(request: Request) -> Response[bytes]:
+def retrieve_resource(request: Request) -> Response[bytes | None]:
     provided_types = [MediaType.TEXT, MediaType.HTML, "application/xml"]
     preferred_type = request.accept.best_match(provided_types, default=MediaType.TEXT)
 

--- a/docs/examples/responses/response_content.py
+++ b/docs/examples/responses/response_content.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from litestar import Litestar, MediaType, Request, Response, get
 
 

--- a/docs/examples/responses/response_content.py
+++ b/docs/examples/responses/response_content.py
@@ -2,7 +2,7 @@ from litestar import Litestar, MediaType, Request, Response, get
 
 
 @get("/resource", sync_to_thread=False)
-def retrieve_resource(request: Request) -> Response[bytes | None]:
+def retrieve_resource(request: Request[Any, Any, Any]) -> Response[bytes | None]:
     provided_types = [MediaType.TEXT, MediaType.HTML, "application/xml"]
     preferred_type = request.accept.best_match(provided_types, default=MediaType.TEXT)
 

--- a/docs/examples/security/guards.py
+++ b/docs/examples/security/guards.py
@@ -30,7 +30,8 @@ def admin_user_guard(connection: ASGIConnection, _: BaseRouteHandler) -> None:
 
 
 @post(path="/user", guards=[admin_user_guard], sync_to_thread=False)
-def create_user(data: User) -> User: ...
+def create_user(data: User) -> User:
+    raise NotImplementedError
 
 
 def my_guard(connection: ASGIConnection, handler: BaseRouteHandler) -> None: ...

--- a/docs/examples/security/jwt/custom_decode_payload.py
+++ b/docs/examples/security/jwt/custom_decode_payload.py
@@ -1,6 +1,6 @@
 import dataclasses
 from collections.abc import Sequence
-from typing import Any, Union
+from typing import Any
 
 from litestar.security.jwt.token import JWTDecodeOptions, Token
 
@@ -11,10 +11,10 @@ class CustomToken(Token):
     def decode_payload(
         cls,
         encoded_token: str,
-        secret: str,
+        secret: str | bytes,
         algorithms: list[str],
-        issuer: list[str] | None = None,
-        audience: Union[str, Sequence[str], None] = None,
+        issuer: str | Sequence[str] | None = None,
+        audience: str | Sequence[str] | None = None,
         options: JWTDecodeOptions | None = None,
     ) -> Any:
         payload = super().decode_payload(

--- a/docs/examples/security/using_abstract_authentication_middleware.py
+++ b/docs/examples/security/using_abstract_authentication_middleware.py
@@ -37,9 +37,9 @@ class CustomAuthenticationMiddleware(AbstractAuthenticationMiddleware):
 
         # this would be a database call
         token = MyToken(api_key=auth_header)
-        user = MyUser(name=TOKEN_USER_DATABASE.get(token.api_key))
-        if not user.name:
+        if not (name := TOKEN_USER_DATABASE.get(token.api_key)):
             raise NotAuthorizedException()
+        user = MyUser(name=name)
         return AuthenticationResult(user=user, auth=token)
 
 

--- a/docs/examples/security/using_session_auth.py
+++ b/docs/examples/security/using_session_auth.py
@@ -64,11 +64,11 @@ async def login(data: UserLoginPayload, request: "Request[Any, Any, Any]") -> Us
     # are correct. If we are using passwords, we should check that
     # the password hashes match etc. We will simply assume that we
     # have done all of that we now have a user value:
-    user_id = await memory_store.get(data.email)
+    encoded_user_id = await memory_store.get(data.email)
 
-    if not user_id:
+    if not encoded_user_id:
         raise NotAuthorizedException
-    user_id = user_id.decode("utf-8")
+    user_id = encoded_user_id.decode("utf-8")
 
     # once verified we can create a session.
     # to do this we simply need to call the Litestar

--- a/docs/examples/sqla/plugins/sqlalchemy_async_dependencies.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_async_dependencies.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyInitPlugin
-from sqlalchemy import select
+from sqlalchemy import literal, select
 
 from litestar import Litestar, post
 from litestar.di import NamedDependency
@@ -16,10 +16,10 @@ if TYPE_CHECKING:
 async def handler(
     db_session: NamedDependency[AsyncSession], db_engine: NamedDependency[AsyncEngine]
 ) -> tuple[int, int]:
-    one = (await db_session.execute(select(1))).scalar()
+    one = (await db_session.scalars(select(literal(1)))).one()
 
     async with db_engine.begin() as conn:
-        two = (await conn.execute(select(2))).scalar()
+        two = (await conn.scalars(select(literal(2)))).one()
 
     return one, two
 

--- a/docs/examples/sqla/plugins/sqlalchemy_sync_dependencies.py
+++ b/docs/examples/sqla/plugins/sqlalchemy_sync_dependencies.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from advanced_alchemy.extensions.litestar import SQLAlchemyInitPlugin, SQLAlchemySyncConfig
-from sqlalchemy import select
+from sqlalchemy import literal, select
 
 from litestar import Litestar, post
 from litestar.di import NamedDependency
@@ -15,10 +15,10 @@ if TYPE_CHECKING:
 
 @post("/", sync_to_thread=True)
 def handler(db_session: NamedDependency[Session], db_engine: NamedDependency[Engine]) -> tuple[int, int]:
-    one = db_session.execute(select(1)).scalar()
+    one = db_session.scalars(select(literal(1))).one()
 
     with db_engine.begin() as conn:
-        two = conn.execute(select(2)).scalar()
+        two = conn.scalars(select(literal(2))).one()
 
     return one, two
 

--- a/docs/examples/sqla/plugins/tutorial/full_app_with_session_di.py
+++ b/docs/examples/sqla/plugins/tutorial/full_app_with_session_di.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Sequence
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -72,7 +72,7 @@ async def get_todo_by_title(todo_name: FromPath[str], session: AsyncSession) -> 
         raise NotFoundException(detail=f"TODO {todo_name!r} not found") from e
 
 
-async def get_todo_list(done: FromQuery[bool | None], session: AsyncSession) -> list[TodoItem]:
+async def get_todo_list(done: FromQuery[bool | None], session: AsyncSession) -> Sequence[TodoItem]:
     query = select(TodoItem)
     if done is not None:
         query = query.where(TodoItem.done.is_(done))

--- a/docs/examples/sqla/sqlalchemy_async_repository.py
+++ b/docs/examples/sqla/sqlalchemy_async_repository.py
@@ -38,7 +38,7 @@ class BaseModel(_BaseModel):
 # The `UUIDBase` class includes a `UUID` based primary key (`id`)
 class AuthorModel(base.UUIDBase):
     # we can optionally provide the table name instead of auto-generating it
-    __tablename__ = "author"  #  type: ignore[assignment]
+    __tablename__ = "author"
     name: Mapped[str]
     dob: Mapped[date | None]
     books: Mapped[list[BookModel]] = relationship(back_populates="author", lazy="noload")
@@ -48,7 +48,7 @@ class AuthorModel(base.UUIDBase):
 # additional columns: `created_at` and `updated_at`. `created_at` is a timestamp of when the
 # record created, and `updated_at` is the last time the record was modified.
 class BookModel(base.UUIDAuditBase):
-    __tablename__ = "book"  #  type: ignore[assignment]
+    __tablename__ = "book"
     title: Mapped[str]
     author_id: Mapped[UUID] = mapped_column(ForeignKey("author.id"))
     author: Mapped[AuthorModel] = relationship(lazy="joined", innerjoin=True, viewonly=True)

--- a/docs/examples/sqla/sqlalchemy_repository_bulk_operations.py
+++ b/docs/examples/sqla/sqlalchemy_repository_bulk_operations.py
@@ -14,7 +14,7 @@ console = get_console()
 
 class USState(base.UUIDBase):
     # you can optionally override the generated table name by manually setting it.
-    __tablename__ = "us_state_lookup"  # type: ignore[assignment]
+    __tablename__ = "us_state_lookup"
     abbreviation: Mapped[str]
     name: Mapped[str]
 
@@ -63,7 +63,7 @@ def run_script() -> None:
     with session_factory() as db_session:
         # 1) Load the JSON data into the US States table.
         repo = USStateRepository(session=db_session)
-        fixture = open_fixture(here, USStateRepository.model_type.__tablename__)  # type: ignore
+        fixture = open_fixture(here, USStateRepository.model_type.__tablename__)
         objs = repo.add_many([USStateRepository.model_type(**raw_obj) for raw_obj in fixture])
         db_session.commit()
         console.print(f"Created {len(objs)} new objects.")

--- a/docs/examples/sqla/sqlalchemy_sync_repository.py
+++ b/docs/examples/sqla/sqlalchemy_sync_repository.py
@@ -37,7 +37,7 @@ class BaseModel(_BaseModel):
 # The `UUIDBase` class includes a `UUID` based primary key (`id`)
 class AuthorModel(base.UUIDBase):
     # we can optionally provide the table name instead of auto-generating it
-    __tablename__ = "author"  #  type: ignore[assignment]
+    __tablename__ = "author"
     name: Mapped[str]
     dob: Mapped[date | None]
     books: Mapped[list[BookModel]] = relationship(back_populates="author", lazy="noload")
@@ -47,7 +47,7 @@ class AuthorModel(base.UUIDBase):
 # additional columns: `created_at` and `updated_at`. `created_at` is a timestamp of when the
 # record created, and `updated_at` is the last time the record was modified.
 class BookModel(base.UUIDAuditBase):
-    __tablename__ = "book"  #  type: ignore[assignment]
+    __tablename__ = "book"
     title: Mapped[str]
     author_id: Mapped[UUID] = mapped_column(ForeignKey("author.id"))
     author: Mapped[AuthorModel] = relationship(lazy="joined", innerjoin=True, viewonly=True)

--- a/docs/examples/static_files/full_example.py
+++ b/docs/examples/static_files/full_example.py
@@ -6,7 +6,7 @@ from litestar.static_files import create_static_files_router
 ASSETS_DIR = Path("assets")
 
 
-def on_startup():
+def on_startup() -> None:
     ASSETS_DIR.mkdir(exist_ok=True)
     ASSETS_DIR.joinpath("hello.txt").write_text("Hello, world!")
 

--- a/docs/examples/stores/namespacing.py
+++ b/docs/examples/stores/namespacing.py
@@ -6,8 +6,8 @@ cache_store = root_store.with_namespace("cache")
 session_store = root_store.with_namespace("sessions")
 
 
-async def before_shutdown() -> None:
+async def on_shutdown() -> None:
     await cache_store.delete_all()
 
 
-app = Litestar(before_shutdown=[before_shutdown])
+app = Litestar(on_shutdown=[on_shutdown])

--- a/docs/examples/templating/template_functions_jinja.py
+++ b/docs/examples/templating/template_functions_jinja.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -7,7 +8,7 @@ from litestar.response import Template
 from litestar.template.config import TemplateConfig
 
 
-def my_template_function(ctx: dict[str, Any]) -> str:
+def my_template_function(ctx: Mapping[str, Any]) -> Any:
     return ctx.get("my_context_key", "nope")
 
 

--- a/docs/examples/templating/template_functions_mako.py
+++ b/docs/examples/templating/template_functions_mako.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -7,7 +8,7 @@ from litestar.response import Template
 from litestar.template.config import TemplateConfig
 
 
-def my_template_function(ctx: dict[str, Any]) -> str:
+def my_template_function(ctx: Mapping[str, Any]) -> Any:
     return ctx.get("my_context_key", "nope")
 
 

--- a/docs/examples/testing/async_resource_test_issue.py
+++ b/docs/examples/testing/async_resource_test_issue.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncIterable
+from collections.abc import AsyncIterator
 
 import httpx
 import pytest
@@ -22,7 +22,7 @@ def create_app(http_client: httpx.AsyncClient) -> Litestar:
 
 
 @pytest_asyncio.fixture()
-async def http_test_client() -> AsyncIterable[httpx.AsyncClient]:
+async def http_test_client() -> AsyncIterator[httpx.AsyncClient]:
     client = httpx.AsyncClient(headers={"Authorization": "something"})
     yield client
     await client.aclose()

--- a/docs/examples/testing/async_resource_test_issue_fix.py
+++ b/docs/examples/testing/async_resource_test_issue_fix.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncIterable
+from collections.abc import AsyncIterator
 
 import httpx
 import pytest
@@ -22,7 +22,7 @@ def create_app(http_client: httpx.AsyncClient) -> Litestar:
 
 
 @pytest_asyncio.fixture()
-async def http_test_client() -> AsyncIterable[httpx.AsyncClient]:
+async def http_test_client() -> AsyncIterator[httpx.AsyncClient]:
     client = httpx.AsyncClient(headers={"Authorization": "something"})
     yield client
     await client.aclose()

--- a/docs/examples/websockets/custom_websocket.py
+++ b/docs/examples/websockets/custom_websocket.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+from typing import Literal, overload
+
 from litestar import Litestar, WebSocket, websocket_listener
 from litestar.types.asgi_types import WebSocketMode
 
 
 class CustomWebSocket(WebSocket):
+    @overload
+    async def receive_data(self, mode: Literal["text"]) -> str: ...
+
+    @overload
+    async def receive_data(self, mode: Literal["binary"]) -> bytes: ...
+
     async def receive_data(self, mode: WebSocketMode) -> str | bytes:
         """Return fixed response for every websocket message."""
         await super().receive_data(mode=mode)

--- a/docs/examples/websockets/dependency_injection_yield.py
+++ b/docs/examples/websockets/dependency_injection_yield.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from typing import TypedDict
 
 from litestar import Litestar, websocket_listener
@@ -10,7 +11,7 @@ class Message(TypedDict):
     client_count: int
 
 
-def socket_client_count(state: State) -> int:
+def socket_client_count(state: State) -> Iterator[int]:
     if not hasattr(state, "count"):
         state.count = 0
 

--- a/docs/examples/websockets/stream_di_hog.py
+++ b/docs/examples/websockets/stream_di_hog.py
@@ -1,11 +1,13 @@
 import asyncio
 from collections.abc import AsyncGenerator
 
-from app.lib import ping_external_resource
-
 from litestar import Litestar, websocket_stream
 
 RESOURCE_LOCK = asyncio.Lock()
+
+
+async def ping_external_resource() -> float:
+    return 1.0
 
 
 async def acquire_lock() -> AsyncGenerator[None, None]:

--- a/docs/examples/websockets/stream_di_hog_fix.py
+++ b/docs/examples/websockets/stream_di_hog_fix.py
@@ -1,11 +1,13 @@
 import asyncio
 from collections.abc import AsyncGenerator
 
-from app.lib import ping_external_resource
-
 from litestar import Litestar, websocket_stream
 
 RESOURCE_LOCK = asyncio.Lock()
+
+
+async def ping_external_resource() -> float:
+    return 1.0
 
 
 @websocket_stream("/")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,7 +253,7 @@ enable_error_code = [
   "possibly-undefined",
   "redundant-self",
 ]
-packages = ["litestar", "tests"]
+packages = ["litestar", "tests", "docs.examples"]
 plugins = ["pydantic.mypy"]
 python_version = "3.11"
 
@@ -343,7 +343,7 @@ exclude = [
   "**/.venv/**",
   "**/.*"
 ]
-include = ["litestar", "tests"]
+include = ["litestar", "tests", "docs/examples"]
 pythonVersion = "3.11"
 reportUnnecessaryTypeIgnoreComment = true
 


### PR DESCRIPTION
## Description

Closes #3816 

1 - All errors are fixed, and corresponding settings are included in the config file to add checks into the CI.
2, 3 - seem unnecessary at the moment since all errors were fixed without any additional configurations
4 - The latest version of documentation already describes `type: ignore`. Anyway this PR reduces quantity of these comments.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4883">https://litestar-org.github.io/litestar-docs-preview/4883</a> 
