### PR TITLE
refactor(types): widen PrometheusConfig.buckets from list to Sequence

### DIFF
--- a/litestar/plugins/prometheus/config.py
+++ b/litestar/plugins/prometheus/config.py
@@ -37,7 +37,7 @@ class PrometheusConfig:
     """A mapping of labels to add to the metrics. The values can be either a string or a callable that returns a string."""
     exemplars: Callable[[Request], dict] | None = field(default=None)
     """A callable that returns a list of exemplars to add to the metrics. Only supported in opementrics-text exposition format."""
-    buckets: list[str | float] | None = field(default=None)
+    buckets: Sequence[str | float] | None = field(default=None)
     """A list of buckets to use for the histogram."""
     excluded_http_methods: Method | Sequence[Method] | None = field(default=None)
     """A list of http methods to exclude from the metrics."""


### PR DESCRIPTION
## Description
Part of #4883 
This PR widens the type of `PrometheusConfig.buckets` from list to Sequence to match the type of `prometheus_client.metrics.Histogram` constructor's buckets argument, which requires common `Sequence[float | str]`. 

Since list[T] is a Sequence[T], this change is backward compatible.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4884">https://litestar-org.github.io/litestar-docs-preview/4884</a> 
