### PR TITLE
docs: fix typos in builtin-middleware and flask docs

### DIFF
--- a/docs/onboarding/flask.rst
+++ b/docs/onboarding/flask.rst
@@ -73,7 +73,7 @@ parameter matching the function parameter name, but you can also specify an alia
 
 .. note::
     The type defined in the path parameter does not have to match the function
-    parameter. The path parameter is what defines the inout type, and what's reflected
+    parameter. The path parameter is what defines the input type, and what's reflected
     in the OpenAPI schema. The function parameter is what will be validated against.
 
 .. tab-set::

--- a/docs/usage/middleware/builtin-middleware.rst
+++ b/docs/usage/middleware/builtin-middleware.rst
@@ -271,7 +271,7 @@ The only required configuration kwarg is ``rate_limit``, which expects a tuple c
 Using behind a proxy
 ^^^^^^^^^^^^^^^^^^^^
 
-The default mode for uniquely identifiying client uses the client's address. When an
+The default mode for uniquely identifying client uses the client's address. When an
 application is running behind a proxy, that address will be the proxy's, not the "real"
 address of the end-user.
 


### PR DESCRIPTION
## Description

Fixes two typos found while reading through docs:

- `docs/usage/middleware/builtin-middleware.rst`: "identifiying" -> "identifying"
- `docs/onboarding/flask.rst`: "inout" -> "input" (in "defines the inout type" - "inout" doesn't appear as a term anywhere else in the docs, so this reads as a typo for "input")

Docs only change, no code or behavior affected. 

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4886">https://litestar-org.github.io/litestar-docs-preview/4886</a> 
