### PR TITLE
fix: KeyError in LoggingMiddleware when a request fails before a response body is sent

### DIFF
--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -130,14 +130,21 @@ class LoggingMiddleware(ASGIMiddleware):
             # Log response with the correct status code from the exception
             if self.response_log_fields:
                 scope_state = ScopeState.from_scope(scope)
-                scope_state.log_context[HTTP_RESPONSE_START] = {"status": exc.status_code}
+                # The request failed before a response was sent, so synthesize the
+                # response messages the extractor expects. Without a HTTP_RESPONSE_BODY
+                # entry, extract_response_data() would raise a KeyError. See #4855.
+                scope_state.log_context[HTTP_RESPONSE_START] = {"status": exc.status_code, "headers": []}
+                scope_state.log_context[HTTP_RESPONSE_BODY] = {"body": b""}
                 self.log_response(scope=scope)
             raise
         except Exception:
             # Log response with 500 status for unhandled exceptions
             if self.response_log_fields:
                 scope_state = ScopeState.from_scope(scope)
-                scope_state.log_context[HTTP_RESPONSE_START] = {"status": HTTP_500_INTERNAL_SERVER_ERROR}
+                # See the HTTPException branch above: synthesize the response messages so
+                # extract_response_data() doesn't raise a KeyError. See #4855.
+                scope_state.log_context[HTTP_RESPONSE_START] = {"status": HTTP_500_INTERNAL_SERVER_ERROR, "headers": []}
+                scope_state.log_context[HTTP_RESPONSE_BODY] = {"body": b""}
                 self.log_response(scope=scope)
             raise
 

--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -23,6 +23,11 @@ from litestar.utils.scope.state import ScopeState
 
 __all__ = ("LoggingMiddleware",)
 
+# Key under which ``LoggingMiddleware`` records, in ``ScopeState.log_context``, the status code of an
+# exception it caught. Its presence tells ``extract_response_data()`` that the request ended early, so
+# any response message the send wrapper never got to record has to be filled in.
+CAUGHT_EXCEPTION_STATUS_CODE = "caught_exception_status_code"
+
 
 if TYPE_CHECKING:
     import logging
@@ -129,24 +134,30 @@ class LoggingMiddleware(ASGIMiddleware):
         except HTTPException as exc:
             # Log response with the correct status code from the exception
             if self.response_log_fields:
-                scope_state = ScopeState.from_scope(scope)
-                # The request failed before a response was sent, so synthesize the
-                # response messages the extractor expects. Without a HTTP_RESPONSE_BODY
-                # entry, extract_response_data() would raise a KeyError. See #4855.
-                scope_state.log_context[HTTP_RESPONSE_START] = {"status": exc.status_code, "headers": []}
-                scope_state.log_context[HTTP_RESPONSE_BODY] = {"body": b""}
-                self.log_response(scope=scope)
+                self._log_response_for_caught_exception(scope=scope, status_code=exc.status_code)
             raise
         except Exception:
             # Log response with 500 status for unhandled exceptions
             if self.response_log_fields:
-                scope_state = ScopeState.from_scope(scope)
-                # See the HTTPException branch above: synthesize the response messages so
-                # extract_response_data() doesn't raise a KeyError. See #4855.
-                scope_state.log_context[HTTP_RESPONSE_START] = {"status": HTTP_500_INTERNAL_SERVER_ERROR, "headers": []}
-                scope_state.log_context[HTTP_RESPONSE_BODY] = {"body": b""}
-                self.log_response(scope=scope)
+                self._log_response_for_caught_exception(scope=scope, status_code=HTTP_500_INTERNAL_SERVER_ERROR)
             raise
+
+    def _log_response_for_caught_exception(self, scope: Scope, status_code: int) -> None:
+        """Log the response for a request that ended in an exception.
+
+        The send wrapper only records response messages that were actually sent, so a request that
+        fails early leaves the logging context incomplete. Record the status code the exception maps
+        to and let :meth:`extract_response_data` fill in whatever is missing. See #4855.
+
+        Args:
+            scope: The ASGI connection scope.
+            status_code: The status code the caught exception maps to.
+
+        Returns:
+            None
+        """
+        ScopeState.from_scope(scope).log_context[CAUGHT_EXCEPTION_STATUS_CODE] = status_code
+        self.log_response(scope=scope)
 
     async def log_request(self, scope: Scope, receive: Receive) -> None:
         """Extract request data and log the message.
@@ -225,6 +236,16 @@ class LoggingMiddleware(ASGIMiddleware):
         data: dict[str, Any] = {"message": self.response_log_message}
         serializer = get_serializer_from_scope(scope)
         connection_state = ScopeState.from_scope(scope)
+        caught_exception_status_code = connection_state.log_context.pop(CAUGHT_EXCEPTION_STATUS_CODE, None)
+        if caught_exception_status_code is not None:
+            # The request ended in an exception, so the send wrapper never recorded the messages the
+            # extractor needs. Supply only the ones that are missing, so a response that had already
+            # started is logged as it was actually sent rather than being overwritten.
+            connection_state.log_context.setdefault(
+                HTTP_RESPONSE_START,
+                {"type": HTTP_RESPONSE_START, "status": caught_exception_status_code, "headers": []},
+            )
+            connection_state.log_context.setdefault(HTTP_RESPONSE_BODY, {"type": HTTP_RESPONSE_BODY, "body": b""})
         extracted_data = self.response_extractor(
             messages=(
                 # NOTE: we don't pop the start message from the logging context in case

--- a/tests/unit/test_middleware/test_logging_middleware.py
+++ b/tests/unit/test_middleware/test_logging_middleware.py
@@ -8,14 +8,15 @@ from structlog.testing import capture_logs
 
 from litestar import Response, get, post
 from litestar.config.compression import CompressionConfig
-from litestar.connection import Request
+from litestar.connection import ASGIConnection, Request
 from litestar.datastructures import Cookie, UploadFile
 from litestar.enums import RequestEncodingType
 from litestar.exceptions import NotAuthorizedException, PermissionDeniedException
 from litestar.handlers import HTTPRouteHandler
+from litestar.middleware.authentication import AbstractAuthenticationMiddleware, AuthenticationResult
 from litestar.middleware.logging import LoggingMiddleware
 from litestar.params import Body
-from litestar.status_codes import HTTP_200_OK, HTTP_201_CREATED
+from litestar.status_codes import HTTP_200_OK, HTTP_201_CREATED, HTTP_401_UNAUTHORIZED
 from litestar.testing import create_test_client
 from tests.helpers import cleanup_logging_impl
 
@@ -46,6 +47,37 @@ def handler() -> HTTPRouteHandler:
         )
 
     return handler_fn
+
+
+def test_logging_middleware_no_keyerror_when_inner_middleware_raises(caplog: "LogCaptureFixture") -> None:
+    """Regression test for https://github.com/litestar-org/litestar/issues/4855.
+
+    When an inner middleware raises an ``HTTPException`` before any response body is sent
+    (e.g. an auth middleware rejecting the request), ``LoggingMiddleware``'s exception
+    branch set ``HTTP_RESPONSE_START`` but not ``HTTP_RESPONSE_BODY``, so
+    ``extract_response_data()`` raised ``KeyError`` on ``.pop(HTTP_RESPONSE_BODY)`` and the
+    intended 401 surfaced as a 500.
+    """
+
+    class AlwaysRejectAuthMiddleware(AbstractAuthenticationMiddleware):
+        async def authenticate_request(self, connection: ASGIConnection) -> AuthenticationResult:
+            raise NotAuthorizedException("Token expired")
+
+    @get("/")
+    def protected_handler() -> dict[str, str]:
+        return {"secret": "data"}
+
+    with (
+        create_test_client(
+            route_handlers=[protected_handler],
+            middleware=[LoggingMiddleware("litestar.test"), AlwaysRejectAuthMiddleware],
+            raise_server_exceptions=False,
+        ) as client,
+        caplog.at_level(INFO),
+    ):
+        response = client.get("/")
+
+    assert response.status_code == HTTP_401_UNAUTHORIZED
 
 
 def test_logging_middleware_regular_logger(caplog: "LogCaptureFixture", handler: HTTPRouteHandler) -> None:

--- a/tests/unit/test_middleware/test_logging_middleware.py
+++ b/tests/unit/test_middleware/test_logging_middleware.py
@@ -1,4 +1,5 @@
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
+from contextlib import suppress
 from logging import INFO
 from typing import TYPE_CHECKING, Annotated, Any
 
@@ -16,6 +17,7 @@ from litestar.handlers import HTTPRouteHandler
 from litestar.middleware.authentication import AbstractAuthenticationMiddleware, AuthenticationResult
 from litestar.middleware.logging import LoggingMiddleware
 from litestar.params import Body
+from litestar.response import Stream
 from litestar.status_codes import HTTP_200_OK, HTTP_201_CREATED, HTTP_401_UNAUTHORIZED
 from litestar.testing import create_test_client
 from tests.helpers import cleanup_logging_impl
@@ -68,16 +70,63 @@ def test_logging_middleware_no_keyerror_when_inner_middleware_raises(caplog: "Lo
         return {"secret": "data"}
 
     with (
+        capture_logs() as cap_logs,
         create_test_client(
             route_handlers=[protected_handler],
-            middleware=[LoggingMiddleware("litestar.test"), AlwaysRejectAuthMiddleware],
+            middleware=[
+                LoggingMiddleware(
+                    structlog.getLogger("litestar.test"),
+                    log_structured=True,
+                    response_log_fields=("status_code",),
+                ),
+                AlwaysRejectAuthMiddleware,
+            ],
             raise_server_exceptions=False,
         ) as client,
-        caplog.at_level(INFO),
     ):
         response = client.get("/")
 
     assert response.status_code == HTTP_401_UNAUTHORIZED
+    # the response is logged with the status code the exception maps to, not a synthesized 500
+    assert cap_logs[-1]["status_code"] == HTTP_401_UNAUTHORIZED
+
+
+def test_logging_middleware_exception_does_not_overwrite_a_started_response(caplog: "LogCaptureFixture") -> None:
+    """A response that already started is logged as it was sent, not as the exception status.
+
+    ``extract_response_data()`` only fills in the response messages the send wrapper never got to
+    record, so a stream that fails partway through is still logged with the status it actually sent.
+    """
+
+    async def failing_stream() -> AsyncGenerator[bytes, None]:
+        yield b"first chunk"
+        raise RuntimeError("stream failed partway through")
+
+    @get("/")
+    async def streaming_handler() -> Stream:
+        return Stream(failing_stream())
+
+    with (
+        capture_logs() as cap_logs,
+        create_test_client(
+            route_handlers=[streaming_handler],
+            middleware=[
+                LoggingMiddleware(
+                    structlog.getLogger("litestar.test"),
+                    log_structured=True,
+                    response_log_fields=("status_code",),
+                )
+            ],
+            raise_server_exceptions=False,
+        ) as client,
+    ):
+        with suppress(Exception):
+            client.get("/")
+
+    response_logs = [log for log in cap_logs if "status_code" in log]
+    assert response_logs
+    # 200 was already sent to the client, so logging it as a 500 would misreport what happened
+    assert all(log["status_code"] == HTTP_200_OK for log in response_logs)
 
 
 def test_logging_middleware_regular_logger(caplog: "LogCaptureFixture", handler: HTTPRouteHandler) -> None:


### PR DESCRIPTION
## Description

Fixes #4855.

When an inner middleware (e.g. an auth middleware) raises an HTTPException before any response body is sent, `LoggingMiddleware`'s exception branches set `HTTP_RESPONSE_START` but never `HTTP_RESPONSE_BODY`. `extract_response_data()` then does `log_context.pop(HTTP_RESPONSE_BODY)`, raising `KeyError` — so the intended 401 surfaces
as a 500.

This synthesizes the missing response messages (an empty body, plus empty headers on the start message) in both exception branches so the extractor has what it expects. Added a regression test that reproduces the KeyError-as-500 and confirms the correct status after the fix.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4887">https://litestar-org.github.io/litestar-docs-preview/4887</a> 
