### PR TITLE
test: remove pragma no cover markers for _exceptions and predicates

### DIFF
--- a/litestar/repository/_exceptions.py
+++ b/litestar/repository/_exceptions.py
@@ -1,15 +1,15 @@
-from __future__ import annotations  # pragma: no cover
+from __future__ import annotations
 
-__all__ = ("ConflictError", "NotFoundError", "RepositoryError")  # pragma: no cover
+__all__ = ("ConflictError", "NotFoundError", "RepositoryError")
 
 
-class RepositoryError(Exception):  # pragma: no cover
+class RepositoryError(Exception):
     """Base repository exception type."""
 
 
-class ConflictError(RepositoryError):  # pragma: no cover
+class ConflictError(RepositoryError):
     """Data integrity error."""
 
 
-class NotFoundError(RepositoryError):  # pragma: no cover
+class NotFoundError(RepositoryError):
     """An identity does not exist."""

--- a/litestar/utils/predicates.py
+++ b/litestar/utils/predicates.py
@@ -112,7 +112,7 @@ def is_dataclass_class(annotation: Any) -> TypeGuard[type[DataclassProtocol]]:
         annotation = origin or annotation
 
         return isclass(annotation) and is_dataclass(annotation)
-    except TypeError:  # pragma: no cover
+    except TypeError:
         return False
 
 
@@ -133,7 +133,7 @@ def is_class_and_subclass(annotation: Any, type_or_type_tuple: type[T] | tuple[t
         return False
     try:
         return issubclass(origin or annotation, type_or_type_tuple)
-    except TypeError:  # pragma: no cover
+    except TypeError:
         return False
 
 
@@ -179,7 +179,7 @@ def is_non_string_iterable(annotation: Any) -> TypeGuard[Iterable[Any]]:
             issubclass(origin or annotation, (Iterable, CollectionsIterable, Dict, dict, Mapping))
             or is_non_string_sequence(annotation)
         )
-    except TypeError:  # pragma: no cover
+    except TypeError:
         return False
 
 
@@ -212,7 +212,7 @@ def is_non_string_sequence(annotation: Any) -> TypeGuard[Sequence[Any]]:
                 frozenset,
             ),
         )
-    except TypeError:  # pragma: no cover
+    except TypeError:
         return False
 
 

--- a/tests/unit/test_repository/test_exceptions.py
+++ b/tests/unit/test_repository/test_exceptions.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+
+from litestar.repository._exceptions import ConflictError, NotFoundError, RepositoryError
+
+
+def test_repository_error_is_exception() -> None:
+    assert isinstance(RepositoryError(), Exception)
+
+
+def test_conflict_error_is_repository_error() -> None:
+    assert isinstance(ConflictError(), RepositoryError)
+
+
+def test_not_found_error_is_repository_error() -> None:
+    assert isinstance(NotFoundError(), RepositoryError)
+
+
+def test_repository_error_carries_message() -> None:
+    error = RepositoryError("something broke")
+    assert str(error) == "something broke"
+
+
+def test_conflict_error_carries_message() -> None:
+    error = ConflictError("duplicate entry")
+    assert str(error) == "duplicate entry"
+
+
+def test_not_found_error_carries_message() -> None:
+    error = NotFoundError("item missing")
+    assert str(error) == "item missing"
+
+
+def test_catch_conflict_error_with_repository_error() -> None:
+    with pytest.raises(RepositoryError):
+        raise ConflictError("duplicate")
+
+
+def test_catch_not_found_error_with_repository_error() -> None:
+    with pytest.raises(RepositoryError):
+        raise NotFoundError("missing")
+
+
+def test_conflict_error_not_caught_by_not_found() -> None:
+    with pytest.raises(ConflictError):
+        try:
+            raise ConflictError("duplicate")
+        except NotFoundError:
+            pytest.fail("ConflictError should not be caught by NotFoundError")

--- a/tests/unit/test_utils/test_predicates.py
+++ b/tests/unit/test_utils/test_predicates.py
@@ -3,17 +3,7 @@ from collections.abc import AsyncGenerator, Callable, Iterable, Mapping, Mutable
 from dataclasses import MISSING, dataclass
 from functools import partial
 from inspect import Signature
-from typing import (
-    Annotated,
-    Any,
-    ClassVar,
-    Generic,
-    Optional,
-    TypeVar,
-    Union,
-    cast,
-    Literal
-)
+from typing import Annotated, Any, ClassVar, Generic, Literal, Optional, TypeVar, Union, cast
 
 import pytest
 
@@ -289,6 +279,5 @@ class NonDataclass: ...
         (Literal["a"], False),
     ),
 )
-
 def test_is_dataclass_class(cls: Any, expected: bool) -> None:
     assert is_dataclass_class(cls) is expected

--- a/tests/unit/test_utils/test_predicates.py
+++ b/tests/unit/test_utils/test_predicates.py
@@ -12,6 +12,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    Literal
 )
 
 import pytest
@@ -56,6 +57,7 @@ class Sub(C): ...
         ((Signature.from_callable(cast("Any", response_handler.fn)).return_annotation, Response), True),
         ((dict[str, Any], C), False),
         ((C(), C), False),
+        ((Literal["a"], int), False),
     ),
 )
 def test_is_class_and_subclass(args: tuple[Any, Any], expected: bool) -> None:
@@ -85,6 +87,7 @@ def test_is_class_and_subclass(args: tuple[Any, Any], expected: bool) -> None:
             (dict[str, Any], True),
             (Union[str, int], False),
             (1, False),
+            (Literal["a"], False),
         )
     ),
 )
@@ -115,6 +118,7 @@ def test_is_non_string_iterable(value: Any, expected: bool) -> None:
             (dict[str, Any], False),
             (Union[str, int], False),
             (1, False),
+            (Literal["a"], False),
         )
     ),
 )
@@ -277,7 +281,14 @@ class NonDataclass: ...
 
 @pytest.mark.parametrize(
     ("cls", "expected"),
-    ((NonGenericDataclass, True), (GenericDataclass, True), (GenericDataclass[int], True), (NonDataclass, False)),
+    (
+        (NonGenericDataclass, True),
+        (GenericDataclass, True),
+        (GenericDataclass[int], True),
+        (NonDataclass, False),
+        (Literal["a"], False),
+    ),
 )
+
 def test_is_dataclass_class(cls: Any, expected: bool) -> None:
     assert is_dataclass_class(cls) is expected


### PR DESCRIPTION
## Description

Added tests to cover code paths previously marked with `pragma: no cover`, and removed the markers now that the code is exercised by tests.

### Changes

**`litestar/repository/_exceptions.py`**
- Removed 5 `pragma: no cover` markers
- Added `tests/unit/test_repository/test_exceptions.py` with tests for exception class hierarchy, message propagation, and catch behavior

**`litestar/utils/predicates.py`**
- Removed 4 `pragma: no cover` markers from `except TypeError` branches in `is_dataclass_class`, `is_class_and_subclass`, `is_non_string_iterable`, and `is_non_string_sequence`
- Added `Literal["a"]` test cases to existing parametrized tests in `tests/unit/test_utils/test_predicates.py` to trigger the `TypeError` branches

### Note
No linked issue — this is a small coverage improvement contribution. 

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4892">https://litestar-org.github.io/litestar-docs-preview/4892</a> 
