### PR TITLE
fix(logging): match structlog logger factory to renderer output type

### DIFF
--- a/litestar/logging/config.py
+++ b/litestar/logging/config.py
@@ -440,8 +440,45 @@ def default_structlog_standard_lib_processors(as_json: bool = True) -> list[Proc
         return []
 
 
-def default_logger_factory(as_json: bool = True) -> Callable[..., WrappedLogger] | None:
+def _final_renderer_emits_bytes(processors: list[Processor]) -> bool | None:  # pyright: ignore
+    """Detect whether the last processor (the renderer) emits ``bytes`` or ``str``.
+
+    The logger factory must match the renderer's output type: ``BytesLoggerFactory``
+    writes ``bytes`` while ``WriteLoggerFactory`` writes ``str``. The output type cannot
+    be inferred from the renderer's class alone -- ``JSONRenderer`` emits ``str`` with the
+    default serializer but ``bytes`` with a bytes serializer -- so the terminal processor
+    is probed on a minimal event dict. Renderers are pure formatters, so the probe has no
+    side effects.
+
+    Returns:
+        ``True`` if the renderer emits ``bytes``, ``False`` if it emits ``str``, or
+        ``None`` if the output type could not be determined.
+    """
+    if not processors:
+        return None
+    try:
+        rendered = processors[-1](None, "info", {"event": ""})
+    except Exception:  # noqa: BLE001 -- a custom renderer may reject the probe; fall back
+        return None
+    if isinstance(rendered, bytes):
+        return True
+    if isinstance(rendered, str):
+        return False
+    return None
+
+
+def default_logger_factory(
+    as_json: bool = True, processors: list[Processor] | None = None
+) -> Callable[..., WrappedLogger] | None:  # pyright: ignore
     """Set the default logger factory for structlog.
+
+    When ``processors`` is supplied, the factory is chosen to match the output type of the
+    configured renderer (the terminal processor). This keeps a user-supplied ``str``-emitting
+    renderer (e.g. ``KeyValueRenderer`` or ``ConsoleRenderer``) from being paired with the
+    bytes-only ``BytesLoggerFactory``, which raises ``TypeError: can only concatenate str
+    (not "bytes") to str`` on every log record when stderr is not a TTY (e.g. under ``nohup``
+    or a service manager). The ``as_json`` flag is used only as a fallback when the renderer's
+    output type cannot be determined.
 
     Returns:
         An optional logger factory.
@@ -449,7 +486,10 @@ def default_logger_factory(as_json: bool = True) -> Callable[..., WrappedLogger]
     try:
         import structlog
 
-        if as_json:
+        emits_bytes = _final_renderer_emits_bytes(processors) if processors is not None else None
+        if emits_bytes is None:
+            emits_bytes = as_json
+        if emits_bytes:
             return structlog.BytesLoggerFactory()
         return structlog.WriteLoggerFactory()
     except ImportError:
@@ -498,7 +538,7 @@ class StructLoggingConfig(BaseLoggingConfig):
         if self.processors is None:
             self.processors = default_structlog_processors(as_json=self.as_json())
         if self.logger_factory is None:
-            self.logger_factory = default_logger_factory(as_json=self.as_json())
+            self.logger_factory = default_logger_factory(as_json=self.as_json(), processors=self.processors)
         if self.log_exceptions != "never" and self.exception_logging_handler is None:
             self.exception_logging_handler = _default_exception_logging_handler_factory(
                 is_struct_logger=True, traceback_line_limit=self.traceback_line_limit

--- a/tests/unit/test_logging/test_structlog_config.py
+++ b/tests/unit/test_logging/test_structlog_config.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import structlog
 from pytest import CaptureFixture
-from structlog import BytesLoggerFactory, get_logger
+from structlog import BytesLoggerFactory, WriteLoggerFactory, get_logger
 from structlog.processors import JSONRenderer
 from structlog.types import BindableLogger, WrappedLogger
 
@@ -218,3 +218,53 @@ def test_structlog_disable_stack_trace(
             assert mock_handler.called, "Structlog exception handler should have been called"
         else:
             assert not mock_handler.called, "Structlog exception handler should not have been called"
+
+
+@pytest.mark.parametrize(
+    "isatty, processors, expected_factory",
+    [
+        # Default processors: factory tracks as_json (JSONRenderer -> bytes when non-TTY).
+        (False, None, BytesLoggerFactory),
+        (True, None, WriteLoggerFactory),
+        # A user-supplied str-emitting renderer must not be paired with BytesLoggerFactory,
+        # even when non-TTY (as_json is True) -- regression test for #4617.
+        (False, [structlog.processors.KeyValueRenderer()], WriteLoggerFactory),
+        (True, [structlog.processors.KeyValueRenderer()], WriteLoggerFactory),
+        # A user-supplied bytes-emitting renderer still gets BytesLoggerFactory.
+        (False, [JSONRenderer(serializer=default_json_serializer)], BytesLoggerFactory),
+    ],
+)
+def test_structlog_config_logger_factory_matches_renderer_output(
+    isatty: bool,
+    processors: "list[structlog.types.Processor] | None",
+    expected_factory: type,
+) -> None:
+    """The default logger factory must match the renderer's output type (bytes vs str).
+
+    Regression test for #4617: a ``str``-emitting renderer such as ``KeyValueRenderer``
+    or ``ConsoleRenderer`` was paired with the bytes-only ``BytesLoggerFactory`` whenever
+    stderr was not a TTY, raising ``TypeError`` on every log record.
+    """
+    with patch("litestar.logging.config.sys.stderr.isatty") as isatty_mock:
+        isatty_mock.return_value = isatty
+        logging_config = StructLoggingConfig(processors=processors)
+        assert isinstance(logging_config.logger_factory, expected_factory)
+
+
+def test_structlog_config_str_renderer_does_not_crash_when_not_a_tty(capsys: CaptureFixture) -> None:
+    """A str-emitting renderer logs cleanly when stderr is not a TTY.
+
+    Regression test for #4617: under ``nohup``/a service manager (non-TTY), a
+    ``KeyValueRenderer`` used to be paired with ``BytesLoggerFactory``, so every log
+    record raised ``TypeError: can only concatenate str (not "bytes") to str``.
+    """
+    with patch("litestar.logging.config.sys.stderr.isatty") as isatty_mock:
+        isatty_mock.return_value = False
+        logging_config = StructLoggingConfig(processors=[structlog.processors.KeyValueRenderer()])
+        assert logging_config.as_json() is True
+        assert isinstance(logging_config.logger_factory, WriteLoggerFactory)
+
+        logger = logging_config.configure()()
+        logger.info("inside a request", key="value")
+
+    assert "event='inside a request'" in capsys.readouterr().out


### PR DESCRIPTION
### Summary

Fixes #4617. A `StructLoggingConfig` configured with a `str`-emitting renderer
(e.g. `structlog.processors.KeyValueRenderer` or `structlog.dev.ConsoleRenderer`)
raises `TypeError: can only concatenate str (not "bytes") to str` on **every** log
record when stderr is not a TTY — i.e. under `nohup`, `systemd`, or any service
manager. It works in an interactive terminal, which is why it goes unnoticed in
development. This is the same class of bug as #2151 (which covered `ConsoleRenderer`).

### Root cause

`StructLoggingConfig.__post_init__` defaults `logger_factory` from `as_json()`:

```python
def as_json(self) -> bool:
    return not (sys.stderr.isatty() and self.pretty_print_tty)
```

When stderr is not a TTY, `as_json()` is `True`, so the default factory is
`BytesLoggerFactory` — which writes bytes (`message + b"\n"`). But a user-supplied
`str`-emitting renderer produces `str`, so the concatenation fails on every record.

The assumption *"`as_json` implies bytes output"* only holds for Litestar's **own**
default processors, whose terminal renderer tracks `as_json`. As soon as the user
overrides `processors` but leaves `logger_factory` unset, the two desync.

The output type also **cannot be inferred from the renderer's class**: `JSONRenderer`
emits `str` with its default serializer but `bytes` with a bytes serializer (which is
exactly how Litestar configures its default `JSONRenderer(serializer=default_json_serializer)`).

### Fix

When `processors` is supplied and `logger_factory` is not, probe the terminal
processor on a minimal event dict (`{"event": ""}`) and select the factory to match
its actual output type — `BytesLoggerFactory` for `bytes`, `WriteLoggerFactory` for
`str`. `as_json` remains the fallback when the type can't be determined (empty
processor list, or a renderer that rejects the probe). structlog renderers are pure
formatters, so the probe has no side effects.

### Before / after (`Host` not-a-TTY, `KeyValueRenderer`)

| | default `logger_factory` | result on `logger.info(...)` |
|---|---|---|
| before | `BytesLoggerFactory` (bytes) | `TypeError: can only concatenate str (not "bytes") to str` |
| after | `WriteLoggerFactory` (str) | `path='/' method='GET' event='inside a request'` |

The default-processor path (bytes `JSONRenderer` + `BytesLoggerFactory` when non-TTY)
and an explicitly bytes-emitting custom `JSONRenderer` are unchanged.

### Tests

Added to `tests/unit/test_logging/test_structlog_config.py`:

- `test_structlog_config_logger_factory_matches_renderer_output` — parametrized over
  default processors (TTY / non-TTY), a custom `KeyValueRenderer` (TTY / non-TTY), and
  a custom bytes `JSONRenderer`, asserting the selected factory matches the renderer's
  output type.
- `test_structlog_config_str_renderer_does_not_crash_when_not_a_tty` — end-to-end:
  configures a `KeyValueRenderer` with stderr mocked as non-TTY and logs a record,
  asserting no `TypeError` and that the record is emitted.

Both **fail on the unfixed source** and **pass with the fix** (verified by stashing
only `litestar/logging/config.py`):

```
# with fix
$ pytest tests/unit/test_logging/test_structlog_config.py -q
30 passed

# fix stashed (tests kept)
$ git stash push -- litestar/logging/config.py
$ pytest tests/unit/test_logging/test_structlog_config.py -q -k "logger_factory_matches or str_renderer_does_not_crash"
2 failed, 4 passed   # the 4 that pass are the paths the old code already handled correctly
```

### Local verification

- `pytest tests/unit/test_logging/test_structlog_config.py` — **30 passed** (24 existing + 6 new), no regressions.
- `ruff check litestar/logging/config.py tests/unit/test_logging/test_structlog_config.py` — All checks passed.
- `ruff format --check` — already formatted.
- `mypy --strict litestar/logging/config.py` — Success: no issues found.
