### PR TITLE
fix(channels): resolve race condition in the plugin to prevent silent event loss

### DIFF
--- a/litestar/channels/plugin.py
+++ b/litestar/channels/plugin.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from asyncio import CancelledError, Queue, Task, create_task
+from asyncio import CancelledError, Lock, Queue, Task, create_task
 from contextlib import AbstractAsyncContextManager, asynccontextmanager, suppress
 from functools import partial
 from typing import TYPE_CHECKING
@@ -103,6 +103,7 @@ class ChannelsPlugin(InitPlugin, AbstractAsyncContextManager):
         self._subscriber_class = subscriber_class
 
         self._channels: dict[str, set[Subscriber]] = {channel: set() for channel in channels or []}
+        self._lock = Lock()
 
     def encode_data(self, data: LitestarEncodableType) -> bytes:
         """Encode data before storing it in the backend"""
@@ -187,23 +188,23 @@ class ChannelsPlugin(InitPlugin, AbstractAsyncContextManager):
             backlog_strategy=self._backlog_strategy,
         )
         channels_to_subscribe = set()
+        async with self._lock:
+            for channel in channels:
+                if channel not in self._channels:
+                    if not self._arbitrary_channels_allowed:
+                        raise ChannelsException(
+                            f"Unknown channel: {channel!r}. Either explicitly defined the channel or set "
+                            "arbitrary_channels_allowed=True"
+                        )
+                    self._channels[channel] = set()
+                channel_subscribers = self._channels[channel]
+                if not channel_subscribers:
+                    channels_to_subscribe.add(channel)
 
-        for channel in channels:
-            if channel not in self._channels:
-                if not self._arbitrary_channels_allowed:
-                    raise ChannelsException(
-                        f"Unknown channel: {channel!r}. Either explicitly defined the channel or set "
-                        "arbitrary_channels_allowed=True"
-                    )
-                self._channels[channel] = set()
-            channel_subscribers = self._channels[channel]
-            if not channel_subscribers:
-                channels_to_subscribe.add(channel)
+                channel_subscribers.add(subscriber)
 
-            channel_subscribers.add(subscriber)
-
-        if channels_to_subscribe:
-            await self._backend.subscribe(channels_to_subscribe)
+            if channels_to_subscribe:
+                await self._backend.subscribe(channels_to_subscribe)
 
         if history:
             await self.put_subscriber_history(subscriber=subscriber, limit=history, channels=channels)
@@ -218,31 +219,32 @@ class ChannelsPlugin(InitPlugin, AbstractAsyncContextManager):
             channels: Channels to unsubscribe from. If ``None``, unsubscribe from all channels
             subscriber: :class:`Subscriber` to unsubscribe
         """
-        if channels is None:
-            channels = list(self._channels.keys())
-        elif isinstance(channels, str):
-            channels = [channels]
+        async with self._lock:
+            if channels is None:
+                channels = list(self._channels.keys())
+            elif isinstance(channels, str):
+                channels = [channels]
 
-        channels_to_unsubscribe: set[str] = set()
+            channels_to_unsubscribe: set[str] = set()
 
-        for channel in channels:
-            channel_subscribers = self._channels[channel]
+            for channel in channels:
+                channel_subscribers = self._channels[channel]
 
-            try:
-                channel_subscribers.remove(subscriber)
-            except KeyError:  # subscriber was not subscribed to this channel. This may happen if channels is None
-                continue
+                try:
+                    channel_subscribers.remove(subscriber)
+                except KeyError:  # subscriber was not subscribed to this channel. This may happen if channels is None
+                    continue
 
-            if not channel_subscribers:
-                channels_to_unsubscribe.add(channel)
+                if not channel_subscribers:
+                    channels_to_unsubscribe.add(channel)
+
+            if channels_to_unsubscribe:
+                await self._backend.unsubscribe(channels_to_unsubscribe)
 
         if all(subscriber not in queues for queues in self._channels.values()):
             await subscriber.put(None)  # this will stop any running task or generator by breaking the inner loop
             if subscriber.is_running:
                 await subscriber.stop()
-
-        if channels_to_unsubscribe:
-            await self._backend.unsubscribe(channels_to_unsubscribe)
 
     @asynccontextmanager
     async def start_subscription(

--- a/tests/unit/test_channels/test_plugin.py
+++ b/tests/unit/test_channels/test_plugin.py
@@ -466,13 +466,13 @@ class StubMemoryChannelBackend(MemoryChannelsBackend):
         return await super().unsubscribe(channels)
 
 
-async def test_race_condition_on_unsubscription():
+async def test_race_condition_on_unsubscription() -> None:
     network_lag, second_start_subscription = asyncio.Event(), asyncio.Event()
     plugin = ChannelsPlugin(
         arbitrary_channels_allowed=True, backend=StubMemoryChannelBackend(network_lag, second_start_subscription)
     )
 
-    async def concurrent_subscribe():
+    async def concurrent_subscribe() -> None:
         await network_lag.wait()
         second_start_subscription.set()
         subscriber = await plugin.subscribe("42")
@@ -487,7 +487,7 @@ async def test_race_condition_on_unsubscription():
         await asyncio.gather(concurrent_subscribe(), plugin.unsubscribe(first_subscriber, "42"))
 
 
-async def test_unsubscribe_releases_lock_before_stop_background(memory_backend: MemoryChannelsBackend):
+async def test_unsubscribe_releases_lock_before_stop_background(memory_backend: MemoryChannelsBackend) -> None:
     async with ChannelsPlugin(arbitrary_channels_allowed=True, backend=memory_backend) as plugin:
         subscriber = await plugin.subscribe("test_channel")
         locked = False

--- a/tests/unit/test_channels/test_plugin.py
+++ b/tests/unit/test_channels/test_plugin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterable
 from secrets import token_hex
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
@@ -451,3 +452,58 @@ async def test_startup_shutdown_cycle(memory_backend: MemoryChannelsBackend) -> 
     assert messages == [b"final_message"]
 
     await plugin._on_shutdown()
+
+
+class StubMemoryChannelBackend(MemoryChannelsBackend):
+    def __init__(self, network_lag: asyncio.Event, second_start_subscription: asyncio.Event, history: int = 0) -> None:
+        super().__init__(history)
+        self.network_lag = network_lag
+        self.second_start_subscription = second_start_subscription
+
+    async def unsubscribe(self, channels: Iterable[str]) -> None:
+        self.network_lag.set()
+        await self.second_start_subscription.wait()
+        return await super().unsubscribe(channels)
+
+
+async def test_race_condition_on_unsubscription():
+    network_lag, second_start_subscription = asyncio.Event(), asyncio.Event()
+    plugin = ChannelsPlugin(
+        arbitrary_channels_allowed=True, backend=StubMemoryChannelBackend(network_lag, second_start_subscription)
+    )
+
+    async def concurrent_subscribe():
+        await network_lag.wait()
+        second_start_subscription.set()
+        subscriber = await plugin.subscribe("42")
+        await plugin.wait_published("42", "42")
+        try:
+            await asyncio.wait_for(anext(subscriber.iter_events()), timeout=1.0)
+        except TimeoutError as e:
+            raise ValueError("Expected event not received") from e
+
+    async with plugin:
+        first_subscriber = await plugin.subscribe("42")
+        await asyncio.gather(concurrent_subscribe(), plugin.unsubscribe(first_subscriber, "42"))
+
+
+async def test_unsubscribe_releases_lock_before_stop_background(memory_backend: MemoryChannelsBackend):
+    async with ChannelsPlugin(arbitrary_channels_allowed=True, backend=memory_backend) as plugin:
+        subscriber = await plugin.subscribe("test_channel")
+        locked = False
+        event_received = asyncio.Event()
+
+        async def bg_task(_: bytes) -> None:
+            nonlocal locked, event_received
+            event_received.set()
+            try:
+                await asyncio.sleep(999)
+            except asyncio.CancelledError:
+                locked = plugin._lock.locked()
+                raise
+
+        async with subscriber.run_in_background(on_event=bg_task):
+            plugin.publish("test", "test_channel")
+            await event_received.wait()
+            await plugin.unsubscribe(subscriber, "test_channel")
+        assert not locked


### PR DESCRIPTION
## Description

Fixes #4894.

Add a global lock in the ChannelsPlugin to prevent race conditions between subscription/unsubscription.

- uses a single lock instead of per-channel locking to avoid complexity (the default asyncio.Lock doesn't provide such functionality) and the risk of deadlocks.
- `subscriber.stop` is called outside the lock to prevent a deadlock since background tasks may subscribe/unsubscribe during cancellation.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4895">https://litestar-org.github.io/litestar-docs-preview/4895</a> 
