### PR TITLE
fix(signature): resolve litestar.di names in TYPE_CHECKING handler annotations

### DIFF
--- a/litestar/di.py
+++ b/litestar/di.py
@@ -11,7 +11,6 @@ from litestar.types import Empty, TypeDecodersSequence
 from litestar.utils import ensure_async_callable
 from litestar.utils.helpers import unwrap_partial
 from litestar.utils.predicates import is_async_callable
-from litestar.utils.signature import ParsedSignature
 from litestar.utils.warnings import (
     warn_implicit_sync_to_thread,
     warn_sync_to_thread_with_async_callable,
@@ -22,6 +21,7 @@ if TYPE_CHECKING:
     from litestar._signature import SignatureModel
     from litestar.dto import AbstractDTO
     from litestar.types import AnyCallable
+    from litestar.utils.signature import ParsedSignature
 
 
 __all__ = (
@@ -142,6 +142,8 @@ class Provide:
         type_decoders: TypeDecodersSequence,
     ) -> None:
         if self._parsed_fn_signature is None:
+            from litestar.utils.signature import ParsedSignature
+
             dependency = unwrap_partial(self.dependency)
             plugin = next(
                 (p for p in plugins.di if isinstance(p, DIPlugin) and p.has_typed_init(dependency)),

--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import sys
 import typing
 from dataclasses import dataclass, replace
-from functools import lru_cache
 from inspect import Signature, getmembers, isclass, ismethod
 from itertools import chain
 from typing import TYPE_CHECKING, Annotated, Any, Self, Union, get_args, get_origin, get_type_hints
@@ -42,28 +41,10 @@ _GLOBAL_NAMES = {
 
 This allows users to include these names within an `if TYPE_CHECKING:` block in their handler module.
 
-Note:
-    ``litestar.di`` is added separately via :func:`_di_global_names` because it imports from this
-    module, so it cannot be imported at module load without a circular import.
+Names from ``litestar.di`` (e.g. ``NamedDependency``) are added lazily on first use by
+:func:`get_fn_type_hints`, as ``litestar.di`` imports from this module and so cannot be imported
+here at module load without a circular import.
 """
-
-
-@lru_cache(maxsize=1)
-def _di_global_names() -> dict[str, Any]:
-    """Names exported from ``litestar.di`` usable for handler signature forward-ref resolution.
-
-    ``litestar.di`` is imported lazily here because it imports from this module, so importing it at
-    module load would create a circular import. This allows users to reference names such as
-    ``NamedDependency`` from within an ``if TYPE_CHECKING:`` block in their handler module.
-
-    Returns:
-        Mapping of names to exports from ``litestar.di``.
-    """
-    from litestar import di
-
-    return {
-        namespace: export for namespace, export in getmembers(di) if namespace[0].isupper() and namespace in di.__all__
-    }
 
 
 def _unwrap_implicit_optional_hints(defaults: dict[str, Any], hints: dict[str, Any]) -> dict[str, Any]:
@@ -174,11 +155,21 @@ def get_fn_type_hints(fn: Any, namespace: dict[str, Any] | None = None) -> dict[
     # inspect the underlying function for methods
     if hasattr(fn_to_inspect, "__func__"):
         fn_to_inspect = fn_to_inspect.__func__  # pyright: ignore[reportFunctionMemberAccess]
+
+    if "NamedDependency" not in _GLOBAL_NAMES:
+        # `litestar.di` imports from this module, so it cannot be imported at module load without a
+        # circular import. It is imported here (once) so names such as `NamedDependency` resolve when
+        # only imported under `if TYPE_CHECKING:` in a handler module. See #4870.
+        from litestar import di
+
+        _GLOBAL_NAMES.update(
+            (name, export) for name, export in getmembers(di) if name[0].isupper() and name in di.__all__
+        )
+
     # Order important. If a litestar name has been overridden in the function module, we want
     # to use that instead of the litestar one.
     namespace = {
         **_GLOBAL_NAMES,
-        **_di_global_names(),
         **vars(typing),
         **vars(sys.modules[module_name]),
         **(namespace or {}),

--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import typing
 from dataclasses import dataclass, replace
+from functools import lru_cache
 from inspect import Signature, getmembers, isclass, ismethod
 from itertools import chain
 from typing import TYPE_CHECKING, Annotated, Any, Self, Union, get_args, get_origin, get_type_hints
@@ -40,7 +41,29 @@ _GLOBAL_NAMES = {
 """A mapping of names used for handler signature forward-ref resolution.
 
 This allows users to include these names within an `if TYPE_CHECKING:` block in their handler module.
+
+Note:
+    ``litestar.di`` is added separately via :func:`_di_global_names` because it imports from this
+    module, so it cannot be imported at module load without a circular import.
 """
+
+
+@lru_cache(maxsize=1)
+def _di_global_names() -> dict[str, Any]:
+    """Names exported from ``litestar.di`` usable for handler signature forward-ref resolution.
+
+    ``litestar.di`` is imported lazily here because it imports from this module, so importing it at
+    module load would create a circular import. This allows users to reference names such as
+    ``NamedDependency`` from within an ``if TYPE_CHECKING:`` block in their handler module.
+
+    Returns:
+        Mapping of names to exports from ``litestar.di``.
+    """
+    from litestar import di
+
+    return {
+        namespace: export for namespace, export in getmembers(di) if namespace[0].isupper() and namespace in di.__all__
+    }
 
 
 def _unwrap_implicit_optional_hints(defaults: dict[str, Any], hints: dict[str, Any]) -> dict[str, Any]:
@@ -155,6 +178,7 @@ def get_fn_type_hints(fn: Any, namespace: dict[str, Any] | None = None) -> dict[
     # to use that instead of the litestar one.
     namespace = {
         **_GLOBAL_NAMES,
+        **_di_global_names(),
         **vars(typing),
         **vars(sys.modules[module_name]),
         **(namespace or {}),

--- a/litestar/utils/signature.py
+++ b/litestar/utils/signature.py
@@ -7,7 +7,7 @@ from inspect import Signature, getmembers, isclass, ismethod
 from itertools import chain
 from typing import TYPE_CHECKING, Annotated, Any, Self, Union, get_args, get_origin, get_type_hints
 
-from litestar import connection, datastructures, params, types
+from litestar import connection, datastructures, di, params, types
 from litestar.types import Empty
 from litestar.typing import FieldDefinition
 from litestar.utils.typing import expand_type_var_in_type_hint, unwrap_annotation
@@ -33,17 +33,14 @@ _GLOBAL_NAMES = {
         tuple(getmembers(connection)),
         tuple(getmembers(datastructures)),
         tuple(getmembers(params)),
+        tuple(getmembers(di)),
     )
     if namespace[0].isupper()
-    and namespace in chain(types.__all__, connection.__all__, datastructures.__all__, params.__all__)
+    and namespace in chain(types.__all__, connection.__all__, datastructures.__all__, params.__all__, di.__all__)
 }
 """A mapping of names used for handler signature forward-ref resolution.
 
 This allows users to include these names within an `if TYPE_CHECKING:` block in their handler module.
-
-Names from ``litestar.di`` (e.g. ``NamedDependency``) are added lazily on first use by
-:func:`get_fn_type_hints`, as ``litestar.di`` imports from this module and so cannot be imported
-here at module load without a circular import.
 """
 
 
@@ -155,16 +152,6 @@ def get_fn_type_hints(fn: Any, namespace: dict[str, Any] | None = None) -> dict[
     # inspect the underlying function for methods
     if hasattr(fn_to_inspect, "__func__"):
         fn_to_inspect = fn_to_inspect.__func__  # pyright: ignore[reportFunctionMemberAccess]
-
-    if "NamedDependency" not in _GLOBAL_NAMES:
-        # `litestar.di` imports from this module, so it cannot be imported at module load without a
-        # circular import. It is imported here (once) so names such as `NamedDependency` resolve when
-        # only imported under `if TYPE_CHECKING:` in a handler module. See #4870.
-        from litestar import di
-
-        _GLOBAL_NAMES.update(
-            (name, export) for name, export in getmembers(di) if name[0].isupper() and name in di.__all__
-        )
 
     # Order important. If a litestar name has been overridden in the function module, we want
     # to use that instead of the litestar one.

--- a/tests/unit/test_handlers/test_http_handlers/test_signature_namespace.py
+++ b/tests/unit/test_handlers/test_http_handlers/test_signature_namespace.py
@@ -1,13 +1,48 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from litestar import Controller, Router, delete, get, patch, post, put
+from litestar.di import Provide
 from litestar.params import FromQuery
 from litestar.testing import create_test_client
 from litestar.types import HTTPHandlerDecorator
+
+if TYPE_CHECKING:
+    # Imported under TYPE_CHECKING only, so the name is absent from this module's runtime
+    # globals. Resolving it in a handler annotation therefore exercises the forward-ref
+    # global namespace (regression for #4870).
+    from litestar.di import NamedDependency
+
+
+class _DIService:
+    value = "provided"
+
+
+async def _provide_di_service() -> _DIService:
+    return _DIService()
+
+
+@get("/di-name")
+async def _named_dependency_handler(service: NamedDependency[_DIService]) -> dict[str, str]:
+    return {"value": service.value}
+
+
+def test_named_dependency_resolvable_in_type_checking_block() -> None:
+    """Regression for #4870: ``NamedDependency`` must resolve when only imported under
+    ``TYPE_CHECKING``, without the user having to pass it via ``signature_types``.
+
+    ``NamedDependency`` is the alias ``Annotated[T, Dependency(kind="named")]``, whose
+    ``__name__`` is ``"Annotated"`` -- so keying ``signature_types`` by ``__name__`` never
+    made it resolvable under its own name.
+    """
+    with create_test_client(
+        route_handlers=[_named_dependency_handler],
+        dependencies={"service": Provide(_provide_di_service)},
+    ) as client:
+        assert client.get("/di-name").json() == {"value": "provided"}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_handlers/test_http_handlers/test_signature_namespace.py
+++ b/tests/unit/test_handlers/test_http_handlers/test_signature_namespace.py
@@ -45,18 +45,6 @@ def test_named_dependency_resolvable_in_type_checking_block() -> None:
         assert client.get("/di-name").json() == {"value": "provided"}
 
 
-def test_di_global_names_exposes_public_di_exports() -> None:
-    """The lazily-imported ``litestar.di`` namespace exposes ``di``'s public exports."""
-    from litestar import di
-    from litestar.utils.signature import _di_global_names
-
-    _di_global_names.cache_clear()
-    names = _di_global_names()
-
-    assert "NamedDependency" in names
-    assert set(di.__all__) <= set(names)
-
-
 @pytest.mark.parametrize(
     ("method", "decorator"),
     [

--- a/tests/unit/test_handlers/test_http_handlers/test_signature_namespace.py
+++ b/tests/unit/test_handlers/test_http_handlers/test_signature_namespace.py
@@ -45,6 +45,18 @@ def test_named_dependency_resolvable_in_type_checking_block() -> None:
         assert client.get("/di-name").json() == {"value": "provided"}
 
 
+def test_di_global_names_exposes_public_di_exports() -> None:
+    """The lazily-imported ``litestar.di`` namespace exposes ``di``'s public exports."""
+    from litestar import di
+    from litestar.utils.signature import _di_global_names
+
+    _di_global_names.cache_clear()
+    names = _di_global_names()
+
+    assert "NamedDependency" in names
+    assert set(di.__all__) <= set(names)
+
+
 @pytest.mark.parametrize(
     ("method", "decorator"),
     [


### PR DESCRIPTION
## Description

Fixes #4870

`NamedDependency` used in a handler annotation behind `if TYPE_CHECKING:` raises `NameError`. Litestar's forward-ref namespace (in `litestar/utils/signature.py`) is built from `params`, `datastructures`, `connection` and `types`, but not `di`, so the name never resolves. `signature_types` doesn't help either, since it keys by `__name__` and `NamedDependency` is `Annotated[T, Dependency(...)]` whose `__name__` is `"Annotated"`.

`di` was left out because it imports from `signature.py` (circular import). I added a small lazily-imported, cached helper that merges `di`'s public names into the namespace, so `NamedDependency` resolves like `params`/`datastructures` already do.

Added a regression test that fails on `main` with the reported `NameError` and passes with the fix. Tested on Python 3.12 and 3.14.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4896">https://litestar-org.github.io/litestar-docs-preview/4896</a> 
