### PR TITLE
docs: Sync example for file upload did not use sync function

### DIFF
--- a/docs/examples/request_data/request_data_7.py
+++ b/docs/examples/request_data/request_data_7.py
@@ -3,8 +3,8 @@ from litestar.datastructures import UploadFile
 from litestar.params import MultipartBody
 
 
-@post(path="/", media_type=MediaType.TEXT)
-async def handle_file_upload(data: MultipartBody[UploadFile]) -> str:
+@post(path="/", media_type=MediaType.TEXT, sync_to_thread=True)
+def handle_file_upload(data: MultipartBody[UploadFile]) -> str:
     content = data.file.read()
     filename = data.filename
     return f"{filename},length: {len(content)}"


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
- follow [Litestar's AI Policy](https://github.com/litestar-org/.github/blob/main/AI_POLICY.md)

If the pull request is not yet ready for review (e.g. tests or other checks are still failing),
please submit it as a draft PR, to avoid noise for reviewers.
-->

## Description

In the docs https://docs.litestar.dev/latest/usage/requests.html#file-uploads, when choosing the "sync" version, the example still use `async def`.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4898">https://litestar-org.github.io/litestar-docs-preview/4898</a> 
