### PR TITLE
docs: updating uvicorn url from ~Sept 2025 domain change

### DIFF
--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -13,7 +13,7 @@ Methodology
 - Tests for the frameworks are written to make them as comparable as possible while
   completing the same tasks (you can see them
   `here <https://github.com/litestar-org/api-performance-tests/tree/main/frameworks>`__)
-- Each application is run using `uvicorn <https://www.uvicorn.org/>`__ with
+- Each application is run using `uvicorn <https://uvicorn.dev/>`__ with
   **one worker** and `uvloop <https://uvloop.readthedocs.io/>`__
 - Test data has been randomly generated and is being imported from a shared module
 - All frameworks are used with their "stock" configuration, i.e. without applying any

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -211,7 +211,7 @@ entry-point and pass it to Litestar:
 
    app = Litestar(route_handlers=[UserController])
 
-To **run your application**, use an ASGI server such as `uvicorn <https://uvicorn.env/>`_ :
+To **run your application**, use an ASGI server such as `uvicorn <https://uvicorn.dev/>`_ :
 
 .. code-block:: shell
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -211,7 +211,7 @@ entry-point and pass it to Litestar:
 
    app = Litestar(route_handlers=[UserController])
 
-To **run your application**, use an ASGI server such as `uvicorn <https://www.uvicorn.org/>`_ :
+To **run your application**, use an ASGI server such as `uvicorn <https://uvicorn.env/>`_ :
 
 .. code-block:: shell
 

--- a/docs/release-notes/2.x-changelog.rst
+++ b/docs/release-notes/2.x-changelog.rst
@@ -1330,7 +1330,7 @@
         additional validation was added to generate a more user friendly CLI errors.
 
         The other SSL-related flags (like password or CA) were not added (yet). See
-        `uvicorn CLI docs <https://www.uvicorn.org/#command-line-options>`_
+        `uvicorn CLI docs <https://uvicorn.env/#command-line-options>`_
 
         **Generating of a self-signed certificate**
 

--- a/docs/release-notes/2.x-changelog.rst
+++ b/docs/release-notes/2.x-changelog.rst
@@ -1330,7 +1330,7 @@
         additional validation was added to generate a more user friendly CLI errors.
 
         The other SSL-related flags (like password or CA) were not added (yet). See
-        `uvicorn CLI docs <https://uvicorn.env/#command-line-options>`_
+        `uvicorn CLI docs <https://uvicorn.dev/#command-line-options>`_
 
         **Generating of a self-signed certificate**
 

--- a/docs/topics/deployment/manually-with-asgi-server.rst
+++ b/docs/topics/deployment/manually-with-asgi-server.rst
@@ -37,7 +37,7 @@ Choosing an ASGI Server
     .. tab-item:: Uvicorn
         :sync: uvicorn
 
-        `Uvicorn <https://uvicorn.env/>`_ is an ASGI server that supports ``HTTP/1.1`` and WebSocket.
+        `Uvicorn <https://uvicorn.dev/>`_ is an ASGI server that supports ``HTTP/1.1`` and WebSocket.
 
     .. tab-item:: Hypercorn
         :sync: hypercorn

--- a/docs/topics/deployment/manually-with-asgi-server.rst
+++ b/docs/topics/deployment/manually-with-asgi-server.rst
@@ -37,7 +37,7 @@ Choosing an ASGI Server
     .. tab-item:: Uvicorn
         :sync: uvicorn
 
-        `Uvicorn <https://www.uvicorn.org/>`_ is an ASGI server that supports ``HTTP/1.1`` and WebSocket.
+        `Uvicorn <https://uvicorn.env/>`_ is an ASGI server that supports ``HTTP/1.1`` and WebSocket.
 
     .. tab-item:: Hypercorn
         :sync: hypercorn

--- a/docs/tutorials/todo-app/0-application-basics.rst
+++ b/docs/tutorials/todo-app/0-application-basics.rst
@@ -11,7 +11,7 @@ Install Litestar
 ++++++++++++++++
 
 To install Litestar, run ``pip install 'litestar[standard]'``. This will install Litestar
-as well as `uvicorn <https://www.uvicorn.org/>`_ -  a web server to serve your application.
+as well as `uvicorn <https://uvicorn.env/>`_ -  a web server to serve your application.
 
 .. note::
     You can use any ASGI-capable web server, but this tutorial will use - and Litestar
@@ -147,7 +147,7 @@ The last step is to actually run the application. Litestar does not include its 
 server, but instead makes use of the
 `ASGI protocol <https://asgi.readthedocs.io>`_, which is a protocol Python objects can
 use in order to interact with application servers like
-`uvicorn <https://www.uvicorn.org/>`_ that actually implement the HTTP protocol and
+`uvicorn <https://uvicorn.env/>`_ that actually implement the HTTP protocol and
 handle it for you.
 
 If you installed Litestar with ``pip install 'litestar[standard]'``, this will have

--- a/docs/tutorials/todo-app/0-application-basics.rst
+++ b/docs/tutorials/todo-app/0-application-basics.rst
@@ -11,7 +11,7 @@ Install Litestar
 ++++++++++++++++
 
 To install Litestar, run ``pip install 'litestar[standard]'``. This will install Litestar
-as well as `uvicorn <https://uvicorn.env/>`_ -  a web server to serve your application.
+as well as `uvicorn <https://uvicorn.dev/>`_ -  a web server to serve your application.
 
 .. note::
     You can use any ASGI-capable web server, but this tutorial will use - and Litestar
@@ -147,7 +147,7 @@ The last step is to actually run the application. Litestar does not include its 
 server, but instead makes use of the
 `ASGI protocol <https://asgi.readthedocs.io>`_, which is a protocol Python objects can
 use in order to interact with application servers like
-`uvicorn <https://uvicorn.env/>`_ that actually implement the HTTP protocol and
+`uvicorn <https://uvicorn.dev/>`_ that actually implement the HTTP protocol and
 handle it for you.
 
 If you installed Litestar with ``pip install 'litestar[standard]'``, this will have

--- a/docs/tutorials/todo-app/3-assembling-the-app.rst
+++ b/docs/tutorials/todo-app/3-assembling-the-app.rst
@@ -74,7 +74,7 @@ receives data of a ``TodoItem`` the same way as the ``POST`` handler.
 
 An instance of ``Litestar`` is created, including the previously defined route handlers.
 This app can now be served using an ASGI server like
-`uvicorn <https://uvicorn.env/>`_, which can be conveniently done using Litestar's
+`uvicorn <https://uvicorn.dev/>`_, which can be conveniently done using Litestar's
 CLI by executing the ``litestar run`` command.
 
 

--- a/docs/tutorials/todo-app/3-assembling-the-app.rst
+++ b/docs/tutorials/todo-app/3-assembling-the-app.rst
@@ -74,7 +74,7 @@ receives data of a ``TodoItem`` the same way as the ``POST`` handler.
 
 An instance of ``Litestar`` is created, including the previously defined route handlers.
 This app can now be served using an ASGI server like
-`uvicorn <https://www.uvicorn.org/>`_, which can be conveniently done using Litestar's
+`uvicorn <https://uvicorn.env/>`_, which can be conveniently done using Litestar's
 CLI by executing the ``litestar run`` command.
 
 

--- a/docs/usage/applications.rst
+++ b/docs/usage/applications.rst
@@ -32,7 +32,7 @@ Startup and Shutdown
 You can pass a list of :term:`callables <python:callable>` - either sync or async functions, methods, or class instances
 - to the :paramref:`~litestar.app.Litestar.on_startup` / :paramref:`~litestar.app.Litestar.on_shutdown`
 :term:`kwargs <argument>` of the :class:`app <litestar.app.Litestar>` instance. Those will be called in
-order, once the ASGI server such as `uvicorn <https://www.uvicorn.org/>`_,
+order, once the ASGI server such as `uvicorn <https://uvicorn.env/>`_,
 `Hypercorn <https://hypercorn.readthedocs.io/en/latest/#/>`_, `Granian <https://github.com/emmett-framework/granian/>`_,
 `Daphne <https://github.com/django/daphne/>`_, etc. emits the respective event.
 

--- a/docs/usage/applications.rst
+++ b/docs/usage/applications.rst
@@ -32,7 +32,7 @@ Startup and Shutdown
 You can pass a list of :term:`callables <python:callable>` - either sync or async functions, methods, or class instances
 - to the :paramref:`~litestar.app.Litestar.on_startup` / :paramref:`~litestar.app.Litestar.on_shutdown`
 :term:`kwargs <argument>` of the :class:`app <litestar.app.Litestar>` instance. Those will be called in
-order, once the ASGI server such as `uvicorn <https://uvicorn.env/>`_,
+order, once the ASGI server such as `uvicorn <https://uvicorn.dev/>`_,
 `Hypercorn <https://hypercorn.readthedocs.io/en/latest/#/>`_, `Granian <https://github.com/emmett-framework/granian/>`_,
 `Daphne <https://github.com/django/daphne/>`_, etc. emits the respective event.
 

--- a/docs/usage/cli.rst
+++ b/docs/usage/cli.rst
@@ -2,7 +2,7 @@ CLI
 ===
 
 .. |uvicorn| replace:: uvicorn
-.. _uvicorn: https://www.uvicorn.org/
+.. _uvicorn: https://uvicorn.env/
 
 Litestar provides a convenient command line interface (CLI) for running and managing Litestar applications. The CLI is
 powered by `click <https://click.palletsprojects.com/>`_, `rich <https://rich.readthedocs.io>`_,

--- a/docs/usage/cli.rst
+++ b/docs/usage/cli.rst
@@ -2,7 +2,7 @@ CLI
 ===
 
 .. |uvicorn| replace:: uvicorn
-.. _uvicorn: https://uvicorn.env/
+.. _uvicorn: https://uvicorn.dev/
 
 Litestar provides a convenient command line interface (CLI) for running and managing Litestar applications. The CLI is
 powered by `click <https://click.palletsprojects.com/>`_, `rich <https://rich.readthedocs.io>`_,

--- a/docs/usage/debugging.rst
+++ b/docs/usage/debugging.rst
@@ -26,7 +26,7 @@ Debugging with an IDE
 ---------------------
 
 You can easily attach your IDEs debugger to your application, whether you're running it
-via the CLI or a webserver like `uvicorn <https://uvicorn.env/>`_.
+via the CLI or a webserver like `uvicorn <https://uvicorn.dev/>`_.
 
 Intellij / PyCharm
 ++++++++++++++++++

--- a/docs/usage/debugging.rst
+++ b/docs/usage/debugging.rst
@@ -26,7 +26,7 @@ Debugging with an IDE
 ---------------------
 
 You can easily attach your IDEs debugger to your application, whether you're running it
-via the CLI or a webserver like `uvicorn <https://www.uvicorn.org/>`_.
+via the CLI or a webserver like `uvicorn <https://uvicorn.env/>`_.
 
 Intellij / PyCharm
 ++++++++++++++++++


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
- follow [Litestar's AI Policy](https://github.com/litestar-org/.github/blob/main/AI_POLICY.md)

If the pull request is not yet ready for review (e.g. tests or other checks are still failing),
please submit it as a draft PR, to avoid noise for reviewers.
-->

## Description

The maintainers of Uvicorn changed their domain from [www.uvicorn.org](url) to uvicorn.dev and updated their documentation in September of 2025. This change is to update the 10 places the litestar docs provide a url to uvicorn, primarily in the tutorials. 

Docs only change, no code or behavior affected.
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4901">https://litestar-org.github.io/litestar-docs-preview/4901</a> 
