### PR TITLE
fix(openapi): preserve acronyms in generated exception descriptions

### DIFF
--- a/litestar/_openapi/responses.py
+++ b/litestar/_openapi/responses.py
@@ -42,12 +42,12 @@ if TYPE_CHECKING:
 
 __all__ = ("create_responses_for_handler",)
 
-CAPITAL_LETTERS_PATTERN = re.compile(r"(?=[A-Z])")
+WORD_BOUNDARY_PATTERN = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
 
 
 def pascal_case_to_text(string: str) -> str:
     """Given a 'PascalCased' string, return its split form- 'Pascal Cased'."""
-    return " ".join(re.split(CAPITAL_LETTERS_PATTERN, string)).strip()
+    return " ".join(re.split(WORD_BOUNDARY_PATTERN, string)).strip()
 
 
 def create_cookie_schema(cookie: Cookie) -> Schema:

--- a/litestar/_openapi/responses.py
+++ b/litestar/_openapi/responses.py
@@ -42,7 +42,14 @@ if TYPE_CHECKING:
 
 __all__ = ("create_responses_for_handler",)
 
-WORD_BOUNDARY_PATTERN = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
+WORD_BOUNDARY_PATTERN = re.compile(
+    r"""
+    (?<=[a-z0-9])(?=[A-Z])      # a lowercase letter or digit, followed by an uppercase letter
+    |
+    (?<=[A-Z])(?=[A-Z][a-z])    # an uppercase run, followed by a new capitalized word
+    """,
+    re.VERBOSE,
+)
 
 
 def pascal_case_to_text(string: str) -> str:

--- a/tests/unit/test_openapi/test_responses.py
+++ b/tests/unit/test_openapi/test_responses.py
@@ -15,6 +15,7 @@ from litestar._openapi.datastructures import OpenAPIContext
 from litestar._openapi.responses import (
     ResponseFactory,
     create_error_responses,
+    pascal_case_to_text,
 )
 from litestar._openapi.schema_generation.plugins import openapi_schema_plugins
 from litestar.datastructures import Cookie, ResponseHeader
@@ -149,6 +150,37 @@ def test_create_error_responses() -> None:
         assert schema.properties
         assert schema.required
         assert schema.type
+
+
+@pytest.mark.parametrize(
+    ("string", "expected"),
+    [
+        ("PetException", "Pet Exception"),
+        ("InvalidAPIKeyError", "Invalid API Key Error"),
+        ("HTTPException", "HTTP Exception"),
+        ("ValidationException", "Validation Exception"),
+        ("API", "API"),
+        ("Error", "Error"),
+        ("error", "error"),
+        ("HTTP404Error", "HTTP404 Error"),
+        ("Base64Decoder", "Base64 Decoder"),
+        ("", ""),
+    ],
+)
+def test_pascal_case_to_text(string: str, expected: str) -> None:
+    assert pascal_case_to_text(string) == expected
+
+
+def test_create_error_responses_preserves_acronyms_in_description() -> None:
+    class InvalidAPIKeyError(HTTPException):
+        status_code = 401
+
+    _, response = next(create_error_responses(exceptions=[InvalidAPIKeyError]))
+
+    assert response.content
+    schema = response.content[MediaType.JSON].schema
+    assert isinstance(schema, Schema)
+    assert schema.description == "Invalid API Key Error"
 
 
 def test_create_error_responses_with_non_http_status_code() -> None:


### PR DESCRIPTION
## Description

Fixes #4004.

Autogenerated OpenAPI response descriptions are built from exception class
names via `pascal_case_to_text`. The helper split before every capital
letter, so any name containing an acronym came out unreadable:
`InvalidAPIKeyError` was rendered as "Invalid A P I Key Error" in the spec.

### Root cause

`litestar/_openapi/responses.py` used `re.split(r"(?=[A-Z])", ...)`, which
inserts a break in front of each capital, including every letter inside an
uppercase run.

### Fix

Split only at actual word boundaries: where a lowercase letter or digit
meets an uppercase letter, and where an uppercase run is followed by a new
capitalized word. Consecutive capitals now stay together:

- `InvalidAPIKeyError` -> `Invalid API Key Error`
- `HTTPTimeoutError` -> `HTTP Timeout Error`
- `MissingJWTError` -> `Missing JWT Error`
- `Base64DecodeError` -> `Base64 Decode Error`

Names without acronyms produce the same output as before
(`PetException` -> `Pet Exception`). The only outputs that change are ones
that previously contained spaced-out single letters.

## How was this tested

Added a parametrized test for `pascal_case_to_text` covering acronyms at
the start, middle and end of a name, digit boundaries, single words and the
empty string, plus a regression test asserting the schema description
produced by `create_error_responses` for an acronym-named exception. Both
fail on `main` with the "A P I" output and pass with this change.

Also checked against a running app: a handler with
`raises=[InvalidAPIKeyError, MissingJWTError, HTTPTimeoutError]` served via
uvicorn, reading `/schema/openapi.json`:

- Before: `"description": "Invalid A P I Key Error"`
- After: `"description": "Invalid API Key Error"`

Grouping of same-status exceptions into `oneOf` is unaffected, and no other
test in the repo asserts the old format.


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4921">https://litestar-org.github.io/litestar-docs-preview/4921</a> 
