### PR TITLE
fix(middleware): restore host-port stripping in AllowedHostsMiddleware

### DIFF
--- a/litestar/middleware/allowed_hosts.py
+++ b/litestar/middleware/allowed_hosts.py
@@ -64,7 +64,7 @@ class AllowedHostsMiddleware(AbstractMiddleware):
             return
 
         headers = MutableScopeHeaders(scope=scope)
-        if (host := headers.get("host")) is not None and host.split(":")[0]:
+        if (host := headers.get("host")) is not None and (host := host.split(":")[0]):
             if self.allowed_hosts_regex.fullmatch(host):
                 await self.app(scope, receive, send)
                 return

--- a/tests/unit/test_middleware/test_allowed_hosts_middleware.py
+++ b/tests/unit/test_middleware/test_allowed_hosts_middleware.py
@@ -74,6 +74,7 @@ def test_allowed_hosts_middleware_redirect_regex() -> None:
         ("http://moisheAzuchmir.com", None, HTTP_400_BAD_REQUEST),
         ("http://x.moishe.zuchmir.com", None, HTTP_400_BAD_REQUEST),
         (None, "x.example.com", HTTP_400_BAD_REQUEST),
+        ("http://x.example.com:8080", None, HTTP_200_OK),
     ],
 )
 def test_middleware_allowed_hosts(


### PR DESCRIPTION
## What

A request whose `Host` header includes a port (e.g. `example.com:8080`) is incorrectly rejected with 400 by `AllowedHostsMiddleware`, even when the bare hostname (`example.com`) is present in `allowed_hosts`.

## Root cause

Commit c4189610b ("fix: fix typing after merge") changed:
```python
if host := headers.get("host").split(":")[0]:
```
into:
```python
if (host := headers.get("host")) is not None and host.split(":")[0]:
```
The walrus assignment now binds `host` to the **full** header value (including any port), and `host.split(":")[0]` is only used for a truthiness check — its result is discarded. So `self.allowed_hosts_regex.fullmatch(host)` downstream still receives the port-suffixed value, which never matches a bare-hostname regex pattern.

## Fix

Rebind `host` via a second walrus assignment so the stripped (port-free) value is what's actually used for matching:
```python
if (host := headers.get("host")) is not None and (host := host.split(":")[0]):
```

## How I verified this

- Traced the regression to c4189610b via `git log -p --follow -- litestar/middleware/allowed_hosts.py`.
- Reproduced standalone with a minimal ASGI script directly invoking `AllowedHostsMiddleware`.
- Added a parametrize case to the existing `test_middleware_allowed_hosts` test (`("http://x.example.com:8080", None, HTTP_200_OK)`); confirmed it fails on the current code (`assert 400 == 200`) before the fix.
- Applied the one-line fix, confirmed all 14 tests in `test_allowed_hosts_middleware.py` pass.
- Ran the full `tests/unit/test_middleware/` suite: 776 passed, no regressions.
- `mypy litestar/middleware/allowed_hosts.py` — clean.
- `pre-commit run` on changed files — clean (ruff check/format, unasyncd, typos).

## Disclosure

I used AI assistance (Claude) to help investigate and draft this fix, but I personally reviewed the root-cause trace, ran the repro and full test suite myself, and reviewed the final diff before submitting. Happy to answer any questions about the change.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4922">https://litestar-org.github.io/litestar-docs-preview/4922</a> 
