### PR TITLE
fix(datastructures): MutableScopeHeaders.getall() treats an empty-list default as "no default"

### DIFF
--- a/litestar/datastructures/headers.py
+++ b/litestar/datastructures/headers.py
@@ -169,7 +169,7 @@ class MutableScopeHeaders(MutableMapping):
             if header_name.decode("latin-1").lower() == name
         ]
         if not values:
-            if default:
+            if default is not None:
                 return default
             raise KeyError
         return values

--- a/tests/unit/test_datastructures/test_headers.py
+++ b/tests/unit/test_datastructures/test_headers.py
@@ -156,6 +156,11 @@ def test_mutable_scope_headers_getall_not_found_default(mutable_headers: Mutable
     assert mutable_headers.getall("bar", ["default"]) == ["default"]
 
 
+def test_mutable_scope_headers_getall_not_found_empty_list_default(mutable_headers: MutableScopeHeaders) -> None:
+    """An explicit empty-list default should be returned as-is, not treated as "no default"."""
+    assert mutable_headers.getall("bar", []) == []
+
+
 def test_mutable_scope_headers_extend_header_value(
     raw_headers: "RawHeadersList", mutable_headers: MutableScopeHeaders
 ) -> None:


### PR DESCRIPTION
## What

`getall(key, default)` used `if default:` to decide whether a default was supplied, so an explicit `default=[]` (a legitimate way to ask for "return an empty list if the header is missing" rather than raising) is falsy and gets treated the same as `default=None` — raising `KeyError` instead of returning `[]`.

## Fix

Check `if default is not None:` instead, matching the type signature (`default: list[str] | None = None`) and the pattern already used elsewhere in this file (e.g. `MutableScopeHeaders.__getitem__`).

## How I verified this

- Added `test_mutable_scope_headers_getall_not_found_empty_list_default`, confirmed it fails with `KeyError` before the fix and passes after.
- Ran the full `tests/unit/test_datastructures/` suite: 148 passed.
- mypy and pre-commit (ruff, unasyncd, typos) clean.

## Disclosure

I used AI assistance (Claude) to help investigate and draft this fix, but I personally reviewed the root cause, wrote/ran the regression test, and reviewed the final diff before submitting.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4924">https://litestar-org.github.io/litestar-docs-preview/4924</a> 
