### PR TITLE
fix(prometheus)!: default group_path to True to bound metric cardinality

### DIFF
--- a/docs/examples/plugins/prometheus/using_prometheus_exporter.py
+++ b/docs/examples/plugins/prometheus/using_prometheus_exporter.py
@@ -2,7 +2,7 @@ from litestar import Litestar
 from litestar.plugins.prometheus import PrometheusConfig, PrometheusController
 
 
-def create_app(group_path: bool = False) -> Litestar:
+def create_app(group_path: bool = True) -> Litestar:
     # Default app name and prefix is litestar.
     prometheus_config = PrometheusConfig(group_path=group_path)
 

--- a/litestar/plugins/prometheus/config.py
+++ b/litestar/plugins/prometheus/config.py
@@ -52,7 +52,7 @@ class PrometheusConfig:
     middleware_class: type[PrometheusMiddleware] = field(default=PrometheusMiddleware)
     """The middleware class to use.
     """
-    group_path: bool = field(default=False)
+    group_path: bool = field(default=True)
     """Whether to group paths in the metrics to avoid cardinality explosion.
     """
 

--- a/tests/unit/test_plugins/test_prometheus.py
+++ b/tests/unit/test_plugins/test_prometheus.py
@@ -10,6 +10,7 @@ from pytest_mock import MockerFixture
 
 from litestar import get, post, websocket_listener
 from litestar.exceptions import HTTPException, NotAuthorizedException, PermissionDeniedException
+from litestar.params import FromPath
 from litestar.plugins.prometheus import PrometheusConfig, PrometheusController, PrometheusMiddleware
 from litestar.status_codes import HTTP_200_OK
 from litestar.testing import create_test_client
@@ -97,6 +98,31 @@ def test_prometheus_exporter_metrics_with_http() -> None:
             """litestar_requests_in_progress{app_name="litestar",method="GET",path="/metrics",status_code="200"} 1.0"""
             in metrics
         )
+
+
+def test_prometheus_group_path_defaults_to_true() -> None:
+    assert PrometheusConfig().group_path is True
+
+
+def test_prometheus_group_path_default_uses_route_template_for_parameterized_routes() -> None:
+    config = create_config()
+
+    @get("/users/{user_id:int}")
+    def get_user(user_id: FromPath[int]) -> dict:
+        return {"user_id": user_id}
+
+    with create_test_client([get_user, PrometheusController], middleware=[config.middleware]) as client:
+        for user_id in range(1, 4):
+            client.get(f"/users/{user_id}")
+        metrics = client.get("/metrics").content.decode()
+
+        assert (
+            """litestar_requests_total{app_name="litestar",method="GET",path="/users/{user_id}",status_code="200"} 3.0"""
+            in metrics
+        )
+        assert 'path="/users/1"' not in metrics
+        assert 'path="/users/2"' not in metrics
+        assert 'path="/users/3"' not in metrics
 
 
 def test_prometheus_middleware_configurations() -> None:


### PR DESCRIPTION
## Description

Fixes #4891.

`PrometheusMiddleware` records the `path` metric label from the raw request
path by default. On a route with path parameters, every distinct value seen
in traffic becomes a new time series, so the metric set grows without bound
as traffic hits distinct parameter values, for example `/users/1`,
`/users/2`, `/users/3`, ... each get their own series.

`group_path=True` already avoids this by using the route template
(`/users/{user_id}`) instead of the raw path. The mechanics of that option
were made robust in #3533, #3687 and #3784. The remaining gap was that the
safe behavior was opt-in, so users hit the cardinality trap silently by
using the default.

### Fix

Flip the default to `True`. Raw-path behavior stays fully available via
`group_path=False` for anyone who wants it. Also updated the docs example's
local default to match, so the snippet shown in the Prometheus docs page
reflects the new default rather than silently diverging from it.

## How was this tested

Added two tests in `tests/unit/test_plugins/test_prometheus.py`:
- `PrometheusConfig().group_path is True`
- a route with a path parameter hit with three different values produces a
  single `path="/users/{user_id}"` series, not three separate raw-path
  series

Both fail on `main` (raw paths leak through) and pass with this change.

Also ran the reproduction script from the issue directly:

```
group_path=False: 5 distinct app path series -> ['/users/1', '/users/2', '/users/3', '/users/4', '/users/5']
group_path=True:  1 distinct app path series -> ['/users/{user_id}']
```

With this change, calling `PrometheusConfig()` with no arguments now
produces the `group_path=True` result above instead of the `False` one.

Full suite: `tests/unit/test_plugins/` and `tests/examples/test_contrib/prometheus/` pass (491 tests), no existing test asserted raw-path grouping since none of them use parameterized routes.


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4925">https://litestar-org.github.io/litestar-docs-preview/4925</a> 
