### PR TITLE
fix(cli): import yaml lazily so the CLI works without the yaml extra

### DIFF
--- a/litestar/cli/commands/schema.py
+++ b/litestar/cli/commands/schema.py
@@ -10,13 +10,12 @@ try:
 except ImportError:
     import click  # type: ignore[no-redef]
 
-from yaml import dump as dump_yaml
-
 from litestar import Litestar
 from litestar._openapi.typescript_converter.converter import (
     convert_openapi_to_typescript,
 )
 from litestar.cli._utils import JSBEAUTIFIER_INSTALLED, LitestarCLIException, LitestarGroup
+from litestar.exceptions import MissingDependencyException
 from litestar.serialization import encode_json, get_serializer
 
 __all__ = ("generate_openapi_schema", "generate_typescript_specs", "schema_group")
@@ -31,6 +30,13 @@ def _generate_openapi_schema(app: Litestar, output: Path) -> None:
     """Generate an OpenAPI Schema."""
     serializer = get_serializer(app.type_encoders)
     if output.suffix in (".yml", ".yaml"):
+        try:
+            # Import lazily: pyyaml is an optional dependency, and importing it at
+            # module level made every CLI invocation fail when it is not installed.
+            # https://github.com/litestar-org/litestar/issues/4449
+            from yaml import dump as dump_yaml
+        except ImportError as e:
+            raise MissingDependencyException("pyyaml", extra="yaml") from e
         content = dump_yaml(
             msgspec.to_builtins(app.openapi_schema.to_schema(), enc_hook=serializer),
             default_flow_style=False,

--- a/tests/unit/test_cli/test_schema_commands.py
+++ b/tests/unit/test_cli/test_schema_commands.py
@@ -103,3 +103,22 @@ def test_openapi_typescript_command_without_jsbeautifier(
     result = runner.invoke(cli_command, command)
     assert result.exit_code == 0
     assert mock_path_write_text.called
+
+
+def test_cli_importable_without_pyyaml(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI must not require pyyaml at import time.
+
+    An eager module-level yaml import made every CLI invocation fail with
+    ``ModuleNotFoundError: No module named 'yaml'`` when litestar was installed
+    without the ``yaml`` extra. https://github.com/litestar-org/litestar/issues/4449
+    """
+    import importlib
+    import sys
+
+    # Simulate pyyaml not being installed: a None entry makes `import yaml`
+    # raise ImportError.
+    monkeypatch.setitem(sys.modules, "yaml", None)
+    monkeypatch.delitem(sys.modules, "litestar.cli.commands.schema", raising=False)
+
+    module = importlib.import_module("litestar.cli.commands.schema")
+    assert module.schema_group is not None


### PR DESCRIPTION
### Description

Fixes the CLI dying at import time when litestar is installed without pyyaml:

```
$ litestar -h
...
  File ".../litestar/cli/commands/schema.py", line 13, in <module>
    from yaml import dump as dump_yaml
ModuleNotFoundError: No module named 'yaml'
```

`litestar/cli/commands/schema.py` imported yaml at module level, and it is imported eagerly via `litestar.cli.main` — so *every* CLI invocation failed. pyyaml only arrives transitively with the `standard` extras (via uvicorn), while the docs promise the CLI and its hard dependencies are included by default.

The yaml import now happens inside the YAML-export branch of `_generate_openapi_schema`, raising `MissingDependencyException("pyyaml", extra="yaml")` when missing — the same pattern used for other optional dependencies. Exporting to `.json` (and every other CLI command) no longer needs pyyaml; exporting to `.yaml`/`.yml` gives an actionable install hint instead of a bare traceback.

Verified in a venv without pyyaml: `litestar --help` fails on `main` with the reported traceback and works with this change. Added `test_cli_importable_without_pyyaml` (simulates pyyaml's absence via `sys.modules`), which fails on `main`; the full `test_schema_commands.py` suite passes (14 passed).

Disclosure per the contribution guidelines: this fix was developed with AI assistance (Claude Code), with the behavior verified end-to-end locally as described above.

### Closes

Closes #4449

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4929">https://litestar-org.github.io/litestar-docs-preview/4929</a> 
