### PR TITLE
fix: create the routing cache per router instance so apps can be garbage collected

### DIFF
--- a/litestar/_asgi/asgi_router.py
+++ b/litestar/_asgi/asgi_router.py
@@ -55,6 +55,7 @@ class ASGIRouter:
         "_static_routes",
         "_trie_initialized",
         "app",
+        "handle_routing",
         "root_route_map_node",
         "route_handler_index",
         "route_mapping",
@@ -73,6 +74,10 @@ class ASGIRouter:
         self._registered_routes: set[HTTPRoute | WebSocketRoute | ASGIRoute] = set()
         self._trie_initialized = False
         self.app = app
+        # The routing cache is created per instance: a class-level lru_cache would
+        # act as a GC root keeping every router (and through it, every app) alive
+        # forever. See https://github.com/litestar-org/litestar/issues/4876
+        self.handle_routing = lru_cache(1024)(self._handle_routing)
         self.root_route_map_node: RouteTrieNode = create_node()
         self.route_handler_index: dict[str, RouteHandlerType] = {}
         self.route_mapping: dict[str, list[BaseRoute]] = defaultdict(list)
@@ -109,11 +114,13 @@ class ASGIRouter:
             scope["path_template"] = path_template
         await asgi_app(scope, receive, send)
 
-    @lru_cache(1024)  # noqa: B019
-    def handle_routing(
+    def _handle_routing(
         self, path: str, method: Method | None
     ) -> tuple[ASGIApp, RouteHandlerType, str, dict[str, Any], str]:
         """Handle routing for a given path / method combo. This method is meant to allow easy caching.
+
+        The cached version of this method is available as ``self.handle_routing``,
+        set up in ``__init__``.
 
         Args:
             path: The path of the request.

--- a/tests/unit/test_asgi/test_asgi_router.py
+++ b/tests/unit/test_asgi/test_asgi_router.py
@@ -271,3 +271,29 @@ async def test_asgi_router_set_exception_handlers_in_scope_successful_routing(
     assert state.exception_handlers is not Empty
     assert state.exception_handlers[RuntimeError] is app_exception_handlers_mock
     assert state.exception_handlers[TypeError] is handler_exception_handlers_mock
+
+
+def test_routing_cache_does_not_prevent_garbage_collection() -> None:
+    """The routing cache must not keep the app alive after all references are dropped.
+
+    A class-level ``lru_cache`` on ``handle_routing`` acted as a GC root anchoring
+    every router (and, through it, every app) forever.
+    https://github.com/litestar-org/litestar/issues/4876
+    """
+    import gc
+
+    def make_app_and_request() -> int:
+        # The client (which references the app) must go out of scope before
+        # collecting, hence the helper function.
+        @get("/ping", sync_to_thread=False)
+        def ping() -> str:
+            return "pong"
+
+        app = Litestar(route_handlers=[ping])
+        with TestClient(app) as client:
+            assert client.get("/ping").status_code == 200
+        return id(app)
+
+    app_id = make_app_and_request()
+    gc.collect()
+    assert not any(id(obj) == app_id for obj in gc.get_objects() if type(obj) is Litestar)


### PR DESCRIPTION
### Description

`ASGIRouter.handle_routing` was decorated with a **class-level** `@lru_cache(1024)`. A class-level cache is a garbage-collection root: every router instance — and, through `router.app`, every `Litestar` app with all of its state — stayed strongly referenced by the cache forever. Long-running processes that create many app instances (most notably test suites) accumulated every app ever created, as reported with a gc-based MCVE in the issue.

This PR binds the cache **per instance** in `__init__`:

```python
self.handle_routing = lru_cache(1024)(self._handle_routing)
```

The cache then only participates in a self-referential cycle (`router → cache → bound method → router`) that the garbage collector reclaims once the app is no longer externally referenced. Details:

- The call surface is unchanged: `self.handle_routing(path=..., method=...)` works as before, and `cache_clear()` / `cache_info()` remain available on the per-instance bound cache (the workaround from the issue keeps working).
- `handle_routing` is added to `__slots__`; the uncached implementation lives on as `_handle_routing`.
- Per-call overhead is the same one `lru_cache` wrapper as before.

Verified with the issue's MCVE: on `main`, one `Litestar` instance survives `del app; gc.collect()`; with this change, zero survive. Added `test_routing_cache_does_not_prevent_garbage_collection`, which fails on `main` and passes here; the full `tests/unit/test_asgi/test_asgi_router.py` suite passes (14 passed).

Disclosure per the contribution guidelines: this fix was developed with AI assistance (Claude Code), with the leak and fix verified locally as described above.

### Closes

Closes #4876

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4930">https://litestar-org.github.io/litestar-docs-preview/4930</a> 
