### PR TITLE
fix: don't crash OpenAPI generation when an example value is rejected by model validation

### DIFF
--- a/litestar/_openapi/schema_generation/examples.py
+++ b/litestar/_openapi/schema_generation/examples.py
@@ -79,5 +79,10 @@ def create_examples_for_field(field: FieldDefinition) -> list[Example]:
         field_meta = _create_field_meta(replace(field, annotation=_normalize_example_value(field.annotation)))
         value = ExampleFactory.get_field_value(field_meta)
         return [Example(description=f"Example {field.name} value", value=value)]
-    except ParameterException:
+    except (ParameterException, ValueError):
+        # Example generation is best effort: the synthesized value can be
+        # rejected by the model's own validation, e.g. pydantic's
+        # ValidationError (a ValueError subclass) for a field with a
+        # ``validation_alias``, which polyfactory populates by field name.
+        # https://github.com/litestar-org/litestar/issues/4288
         return []

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -842,3 +842,38 @@ def test_decimal_schema_type() -> None:
 
     schema = create_schema_for_annotation(Decimal)
     assert schema.type == OpenAPIType.STRING
+
+
+def test_response_spec_list_container_with_validation_alias() -> None:
+    """Schema generation must not fail when an example value is rejected by
+    the model's own validation.
+
+    polyfactory builds pydantic models by field name, so a field with a
+    ``validation_alias`` raises a ``ValidationError`` during example
+    synthesis, which crashed OpenAPI generation with a 500.
+    https://github.com/litestar-org/litestar/issues/4288
+    """
+    from uuid import UUID
+
+    from pydantic import BaseModel
+    from pydantic import Field as PydanticField
+
+    from litestar import Litestar, get, status_codes
+    from litestar.openapi import OpenAPIConfig, ResponseSpec
+
+    class AliasedModel(BaseModel):
+        model_id: Optional[UUID] = PydanticField(validation_alias="model_id_model")
+        name: Optional[str] = PydanticField(default=None)
+
+    @get(
+        path="/",
+        responses={
+            status_codes.HTTP_200_OK: ResponseSpec(data_container=list[AliasedModel], description="Ok"),
+        },
+    )
+    async def handler() -> list[AliasedModel]:
+        return []
+
+    app = Litestar([handler], openapi_config=OpenAPIConfig(title="t", version="1.0.0"))
+    schema = app.openapi_schema.to_schema()
+    assert any(key.endswith("AliasedModel") for key in schema["components"]["schemas"])


### PR DESCRIPTION
### Description

Fixes the 500 on `/docs` reported for `ResponseSpec(data_container=list[Model])` where the pydantic `Model` has a field with `validation_alias`.

Root cause (from running the MCVE): OpenAPI **example generation** synthesizes a model instance via polyfactory, which populates pydantic models **by field name**. A field with `validation_alias` then fails validation:

```
pydantic_core.ValidationError: 1 validation error for Model
model_id_model
  Field required [type=missing, input_value={'model_id': None, ...}]
```

`create_examples_for_field` already treats example generation as best effort (`except ParameterException: return []`), but pydantic's `ValidationError` — a `ValueError` subclass — escaped that handler and took down the whole schema build.

This also catches `ValueError`, so a synthesized value rejected by the model's own validation degrades to "no example" instead of a 500. No pydantic import is needed in the module.

Verified with the issue's MCVE: `/schema/openapi.json` returns 500 on `main` and 200 with this change (schema contains the model component). Added `test_response_spec_list_container_with_validation_alias`, which fails on `main` and passes here; the full `tests/unit/test_openapi/` suite passes (262 passed); ruff clean.

Disclosure per the contribution guidelines: this fix was developed with AI assistance (Claude Code), with the crash and fix verified locally as described above.

### Closes

Closes #4288

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4931">https://litestar-org.github.io/litestar-docs-preview/4931</a> 
