### PR TITLE
fix: `getall` method in `Headers` datastructure

### DIFF
--- a/litestar/datastructures/headers.py
+++ b/litestar/datastructures/headers.py
@@ -169,9 +169,9 @@ class MutableScopeHeaders(MutableMapping):
             if header_name.decode("latin-1").lower() == name
         ]
         if not values:
-            if default:
+            if default is not None:
                 return default
-            raise KeyError
+            raise KeyError(key)
         return values
 
     def extend_header_value(self, key: str, value: str) -> None:
@@ -199,7 +199,7 @@ class MutableScopeHeaders(MutableMapping):
         for header in self.headers:
             if header[0].decode("latin-1").lower() == name:
                 return header[1].decode("latin-1")
-        raise KeyError
+        raise KeyError(key)
 
     def _find_indices(self, key: str) -> list[int]:
         name = key.lower()

--- a/tests/unit/test_datastructures/test_headers.py
+++ b/tests/unit/test_datastructures/test_headers.py
@@ -148,12 +148,19 @@ def test_mutable_scope_headers_getall_multi_value(
 
 
 def test_mutable_scope_headers_getall_not_found_no_default(mutable_headers: MutableScopeHeaders) -> None:
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match="bar"):
         mutable_headers.getall("bar")
 
+    with pytest.raises(KeyError, match="bar"):
+        mutable_headers.getall("bar", None)
 
-def test_mutable_scope_headers_getall_not_found_default(mutable_headers: MutableScopeHeaders) -> None:
-    assert mutable_headers.getall("bar", ["default"]) == ["default"]
+
+@pytest.mark.parametrize("default", [[], ["one", "two"]])
+def test_mutable_scope_headers_getall_not_found_default(
+    mutable_headers: MutableScopeHeaders,
+    default: list[str],
+) -> None:
+    assert mutable_headers.getall("bar", default) == default
 
 
 def test_mutable_scope_headers_extend_header_value(


### PR DESCRIPTION
Refs: https://github.com/litestar-org/litestar/pull/4927

Changes:
- `KeyError` now always has the key which is missing, like the default Python does: 

```python
>>> {}[1]
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    {}[1]
    ~~^^^
KeyError: 1
```

- Empty list is not treated as the valid default

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4932">https://litestar-org.github.io/litestar-docs-preview/4932</a> 
