### PR TITLE
fix(routing): return Not Found for websocket upgrade to non-websocket route

### DIFF
--- a/litestar/_asgi/routing_trie/traversal.py
+++ b/litestar/_asgi/routing_trie/traversal.py
@@ -85,7 +85,10 @@ def parse_node_handlers(
             return node.asgi_handlers[method]
         except KeyError as e:
             raise MethodNotAllowedException(headers={"allow": ", ".join(node.asgi_handlers.keys())}) from e
-    return node.asgi_handlers["websocket"]
+    try:
+        return node.asgi_handlers["websocket"]
+    except KeyError as e:
+        raise NotFoundException() from e
 
 
 @lru_cache(1024)

--- a/tests/unit/test_asgi/test_routing_trie/test_traversal.py
+++ b/tests/unit/test_asgi/test_routing_trie/test_traversal.py
@@ -113,4 +113,6 @@ def test_websocket_upgrade_without_matching_handler_is_not_found(path: str) -> N
     ):
         pass
 
-    assert exc.value.exceptions[0].detail == "Not Found"
+    disconnect = exc.value.exceptions[0]
+    assert isinstance(disconnect, WebSocketDisconnect)
+    assert disconnect.detail == "Not Found"

--- a/tests/unit/test_asgi/test_routing_trie/test_traversal.py
+++ b/tests/unit/test_asgi/test_routing_trie/test_traversal.py
@@ -1,6 +1,9 @@
 from typing import Any
 
+import pytest
+
 from litestar import Router, asgi, get
+from litestar.exceptions import WebSocketDisconnect
 from litestar.response.base import ASGIResponse
 from litestar.status_codes import HTTP_404_NOT_FOUND
 from litestar.testing import create_test_client
@@ -91,3 +94,23 @@ def test_parse_path_to_route_mounted_app_path_router() -> None:
 
         response = client.get("/base/sub/unknown/foobar/")
         assert response.status_code == HTTP_404_NOT_FOUND
+
+
+@pytest.mark.parametrize("path", ["/", "/unknown"])
+def test_websocket_upgrade_without_matching_handler_is_not_found(path: str) -> None:
+    # a websocket upgrade for a path that has no websocket handler - whether the path is
+    # unknown or only has HTTP handlers - should be rejected as "Not Found" rather than
+    # raising an unhandled ``KeyError`` (see https://github.com/litestar-org/litestar/issues/4935)
+
+    @get("/")
+    async def handler() -> str:
+        return "hello"
+
+    with (
+        create_test_client([handler]) as client,
+        pytest.RaisesGroup(pytest.RaisesExc(WebSocketDisconnect)) as exc,
+        client.websocket_connect(path),
+    ):
+        pass
+
+    assert exc.value.exceptions[0].detail == "Not Found"


### PR DESCRIPTION
## Description

Fixes #4935.

If you send a websocket upgrade to a path that only has HTTP handlers (e.g. a route defined with `@get("/")`), the server blows up with a raw `KeyError: 'websocket'` instead of just rejecting the connection.

The cause is in `parse_node_handlers`: for a websocket (no method) it does `node.asgi_handlers["websocket"]` directly, with no guard. If the node exists but has no websocket handler, that lookup raises `KeyError`, which bubbles up as an unhandled 500. The method branch right above it already guards its lookup and raises `MethodNotAllowedException`, and a completely unknown path already returns Not Found — so the HTTP-only-route case was the only one left unguarded.

The fix wraps that lookup and raises `NotFoundException`, so a websocket upgrade to a non-websocket route closes cleanly with 4500 "Not Found", same as an unknown path.

I added a regression test that connects a websocket to both an unknown path and an HTTP-only route and checks both are rejected as Not Found. The HTTP-only case fails with the old code (raises `KeyError`) and passes with the fix.

## Closes

Closes #4935
