### PR TITLE
fix(routing): unsupported websocket upgrade attempt should be 400, not 500

### DIFF
--- a/litestar/_asgi/routing_trie/traversal.py
+++ b/litestar/_asgi/routing_trie/traversal.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
 from litestar._asgi.routing_trie.types import PathParameterSentinel
-from litestar.exceptions import MethodNotAllowedException, NotFoundException
+from litestar.exceptions import ClientException, MethodNotAllowedException, NotFoundException
 from litestar.utils import normalize_path
 
 __all__ = ("parse_node_handlers", "parse_path_params", "parse_path_to_route", "traverse_route_map")
@@ -85,7 +85,10 @@ def parse_node_handlers(
             return node.asgi_handlers[method]
         except KeyError as e:
             raise MethodNotAllowedException(headers={"allow": ", ".join(node.asgi_handlers.keys())}) from e
-    return node.asgi_handlers["websocket"]
+    try:
+        return node.asgi_handlers["websocket"]
+    except KeyError as e:
+        raise ClientException() from e
 
 
 @lru_cache(1024)

--- a/tests/unit/test_asgi/test_routing_trie/test_traversal.py
+++ b/tests/unit/test_asgi/test_routing_trie/test_traversal.py
@@ -1,6 +1,9 @@
 from typing import Any
 
+import pytest
+
 from litestar import Router, asgi, get
+from litestar.exceptions import WebSocketDisconnect
 from litestar.response.base import ASGIResponse
 from litestar.status_codes import HTTP_404_NOT_FOUND
 from litestar.testing import create_test_client
@@ -91,3 +94,21 @@ def test_parse_path_to_route_mounted_app_path_router() -> None:
 
         response = client.get("/base/sub/unknown/foobar/")
         assert response.status_code == HTTP_404_NOT_FOUND
+
+
+def test_websocket_upgrade_to_http_only_route_is_bad_request() -> None:
+    # a route that exists but doesn't support the websocket protocol is a client error
+    # (400), distinct from a route that doesn't exist at all (404).
+    @get("/")
+    async def index() -> str:
+        return "hello"
+
+    with (
+        create_test_client([index]) as client,
+        pytest.RaisesGroup(pytest.RaisesExc(WebSocketDisconnect)) as exc_info,
+        client.websocket_connect("/"),
+    ):
+        pass
+
+    assert isinstance(exc_info.value.exceptions[0], WebSocketDisconnect)
+    assert exc_info.value.exceptions[0].detail == "Bad Request"


### PR DESCRIPTION
## Description

Presently, a websocket upgrade attempt on a URL that doesn't support it throws a `KeyError`, which becomes a HTTP 500. A result code that reflects client rather than server misbehavior is more appropriate.

Closes #4935

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4938">https://litestar-org.github.io/litestar-docs-preview/4938</a> 
