### PR TITLE
fix(routing): unsupported websocket upgrade attempt should be 400, not 500 -- v2 backport

### DIFF
--- a/litestar/_asgi/routing_trie/traversal.py
+++ b/litestar/_asgi/routing_trie/traversal.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Pattern
 
 from litestar._asgi.routing_trie.types import PathParameterSentinel
-from litestar.exceptions import MethodNotAllowedException, NotFoundException
+from litestar.exceptions import ClientException, MethodNotAllowedException, NotFoundException
 from litestar.utils import normalize_path
 
 __all__ = ("parse_node_handlers", "parse_path_params", "parse_path_to_route", "traverse_route_map")
@@ -83,7 +83,10 @@ def parse_node_handlers(
             return node.asgi_handlers[method]
         except KeyError as e:
             raise MethodNotAllowedException(headers={"allow": ", ".join(node.asgi_handlers.keys())}) from e
-    return node.asgi_handlers["websocket"]
+    try:
+        return node.asgi_handlers["websocket"]
+    except KeyError as e:
+        raise ClientException() from e
 
 
 @lru_cache(1024)

--- a/tests/unit/test_asgi/test_routing_trie/test_traversal.py
+++ b/tests/unit/test_asgi/test_routing_trie/test_traversal.py
@@ -1,6 +1,9 @@
 from typing import Any
 
+import pytest
+
 from litestar import Router, asgi, get
+from litestar.exceptions import WebSocketDisconnect
 from litestar.response.base import ASGIResponse
 from litestar.status_codes import HTTP_404_NOT_FOUND
 from litestar.testing import create_test_client
@@ -91,3 +94,18 @@ def test_parse_path_to_route_mounted_app_path_router() -> None:
 
         response = client.get("/base/sub/unknown/foobar/")
         assert response.status_code == HTTP_404_NOT_FOUND
+
+
+def test_websocket_upgrade_to_http_only_route_is_bad_request() -> None:
+    # a route that exists but doesn't support the websocket protocol is a client error
+    # (400), distinct from a route that doesn't exist at all (404).
+    @get("/")
+    async def index() -> str:
+        return "hello"
+
+    with create_test_client([index], logging_config=None) as client, pytest.raises(
+        WebSocketDisconnect
+    ) as exc_info, client.websocket_connect("/"):
+        pass
+
+    assert exc_info.value.detail == "Bad Request"


### PR DESCRIPTION
## Description

Fixes #4935 (previously merged to main as #4938) on v2 release branch
