### PR TITLE
fix(cli): don't crash autodiscovery on unresolvable type hints

### DIFF
--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -349,6 +349,23 @@ def _autodiscovery_paths(base_dir: Path, arbitrary: bool = True) -> Generator[Pa
             yield from _arbitrary_autodiscovery_paths(path)
 
 
+def _get_return_type_hint(value: Any) -> Any:
+    """Return the resolved ``"return"`` type hint for ``value``, or ``None`` if it has none or can't be resolved.
+
+    ``value`` may be an unrelated callable/class pulled in via a module-level import (e.g.
+    ``from litestar import Request``) rather than something the user actually intends as an app
+    factory. Its annotations can reference names that only exist under ``TYPE_CHECKING`` in their
+    defining module, so resolving them can raise a ``NameError`` even though it has nothing to do
+    with the app factory we're looking for.
+    """
+    if not hasattr(value, "__annotations__"):
+        return None
+    try:
+        return get_type_hints(value, include_extras=True).get("return")
+    except NameError:
+        return None
+
+
 def _autodiscover_app(cwd: Path) -> LoadedApp:
     app_name = getenv("LITESTAR_APP_NAME") or "Litestar"
     quiet_console = envflag("LITESTAR_QUIET_CONSOLE")
@@ -377,9 +394,7 @@ def _autodiscover_app(cwd: Path) -> LoadedApp:
         for attr, value in module.__dict__.items():
             if not callable(value):
                 continue
-            return_annotation = (
-                get_type_hints(value, include_extras=True).get("return") if hasattr(value, "__annotations__") else None
-            )
+            return_annotation = _get_return_type_hint(value)
             if not return_annotation:
                 continue
             if return_annotation in ("Litestar", Litestar):

--- a/tests/unit/test_cli/test_env_resolution.py
+++ b/tests/unit/test_cli/test_env_resolution.py
@@ -96,6 +96,36 @@ def test_env_from_env_autodiscover_from_files_ignore_paths(
         LitestarEnv.from_env(None)
 
 
+def test_env_from_env_autodiscover_skips_unresolvable_type_hints(
+    create_app_file: CreateAppFileFixture,
+) -> None:
+    """Modules picked up during autodiscovery may define callables whose annotations
+    reference names that only exist under ``TYPE_CHECKING`` in their *defining* module
+    (e.g. ``litestar.connection.Request``, whose ``scope`` attribute is annotated with
+    ``Scope``, only imported for type checking in ``litestar/connection/base.py``).
+
+    Resolving these while probing the module for an app factory used to raise a
+    ``NameError`` and abort autodiscovery entirely, even though the offending callable
+    has nothing to do with the actual factory. See https://github.com/litestar-org/litestar/issues/3895
+    """
+    tmp_file_path = create_app_file(
+        file="app.py",
+        content="""
+from litestar import Litestar, Request
+
+
+def any_name() -> Litestar:
+    return Litestar([])
+""",
+    )
+    env = LitestarEnv.from_env(None)
+
+    dotted_path = _path_to_dotted_path(tmp_file_path.relative_to(Path.cwd()))
+
+    assert isinstance(env.app, Litestar)
+    assert env.app_path == f"{dotted_path}:any_name"
+
+
 @pytest.mark.parametrize("use_file_in_app_path", [True, False])
 def test_env_using_app_dir(
     app_file_content: str, app_file_app_name: str, create_app_file: CreateAppFileFixture, use_file_in_app_path: bool


### PR DESCRIPTION
ran into this poking at the third loop in `_autodiscover_app` (`litestar/cli/_utils.py`) — it walks every callable in a scanned module's `__dict__` looking for a factory, and calls `get_type_hints()` on each one. thing is, if that module doesn't define `app`/`application`/`create_app` and just has something like `from litestar import Request` sitting there for annotations, `Request` itself gets probed too since classes count as callable.

`Request` pulls in `ASGIConnection`, and its `scope: Scope` attribute only has `Scope` importable under `TYPE_CHECKING` (`litestar/connection/base.py`). So `get_type_hints(Request)` throws a bare `NameError`, uncaught, and the whole CLI dies instead of just skipping that attr and moving on to the actual factory.

confirmed on main:

```python
from litestar.cli._utils import _autodiscover_app
_autodiscover_app(Path("."))
# NameError: name 'Scope' is not defined
```
for a directory containing just:
```python
from litestar import Request

def helper() -> None: ...
```

fix: pulled the `get_type_hints` call into a small helper (`_get_return_type_hint`) that catches `NameError` and returns `None`, treated the same as "no return annotation" — so autodiscovery just moves on to the next attr instead of blowing up. also happened to keep `_autodiscover_app` under ruff's C901 complexity limit, which the inline try/except pushed it over.

added a regression test in `test_env_resolution.py` that reproduces the original scenario (factory function alongside an unrelated `Request` import) — fails with `NameError` on unpatched code, passes with the fix. ran the full `tests/unit/test_cli/` suite (876 passed), plus mypy/pyright/ruff clean on the touched files.

Fixes #3895

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4943">https://litestar-org.github.io/litestar-docs-preview/4943</a> 
