### PR TITLE
chore(deps): update rich-click to 1.9

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -8,6 +8,7 @@
 
     .. change:: Require ``rich-click>=1.9``
         :type: feature
+        :pr: 4951
         :breaking:
 
         The ``litestar[cli]`` extra now requires ``rich-click>=1.9``. ``rich-click`` was
@@ -18,8 +19,12 @@
         The CLI configuration has been migrated off the options 1.9 deprecates
         (``use_markdown`` / ``use_rich_markup`` in favour of ``text_markup``, and
         ``show_metavars_column`` / ``append_metavars_help`` in favour of
-        ``options_table_column_types`` / ``options_table_help_sections``). Help output is
-        unchanged.
+        ``options_table_column_types`` / ``options_table_help_sections``).
+
+        The layout of the help output is preserved: option tables keep the long form in
+        the first column, the ``*`` marker on required parameters, and the metavar
+        appended directly after the help text. Colours do change, as the ``star-box``
+        theme now takes effect for the first time.
 
         This only affects applications that additionally pin ``rich-click<1.9``
         themselves.

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -6,6 +6,27 @@
 .. changelog:: 3.0.0
     :date: 2364-01-27
 
+    .. change:: Require ``rich-click>=1.9``
+        :type: feature
+        :breaking:
+
+        The ``litestar[cli]`` extra now requires ``rich-click>=1.9``. ``rich-click`` was
+        previously capped at ``<1.9``, which silently disabled the CLI's ``star-box``
+        theme: the underlying ``theme`` option only exists from 1.9 onwards, and
+        assigning an unknown setting is ignored rather than raising.
+
+        The CLI configuration has been migrated off the options 1.9 deprecates
+        (``use_markdown`` / ``use_rich_markup`` in favour of ``text_markup``, and
+        ``show_metavars_column`` / ``append_metavars_help`` in favour of
+        ``options_table_column_types`` / ``options_table_help_sections``). Help output is
+        unchanged.
+
+        This only affects applications that additionally pin ``rich-click<1.9``
+        themselves.
+
+        .. seealso::
+            :doc:`/usage/cli`
+
     .. change:: Move ``click``, ``rich`` and ``rich-click`` to the ``cli`` extra
         :type: feature
         :pr: 4949

--- a/docs/release-notes/whats-new-3.rst
+++ b/docs/release-notes/whats-new-3.rst
@@ -348,6 +348,16 @@ naming the extra to install:
     pip install 'litestar[cli]'
 
 
+``rich-click>=1.9`` is now required by the CLI
+-----------------------------------------------
+
+The ``litestar[cli]`` extra now requires ``rich-click>=1.9``, which is needed for the
+themed :doc:`CLI </usage/cli>` output. Previously ``rich-click`` was capped at ``<1.9``,
+which silently disabled the theme, as the underlying option only exists from 1.9 onwards.
+
+This only affects applications that additionally pin ``rich-click<1.9`` themselves.
+
+
 Improved file system handling / fsspec integration
 ---------------------------------------------------
 

--- a/litestar/cli/__init__.py
+++ b/litestar/cli/__init__.py
@@ -7,17 +7,25 @@ from importlib.util import find_spec
 if find_spec("rich_click") is not None:  # pragma: no cover
     import rich_click
 
-    rich_click.rich_click.THEME = "star-box"  # pyright: ignore[reportAttributeAccessIssue]
-    rich_click.rich_click.USE_RICH_MARKUP = True
-    rich_click.rich_click.USE_MARKDOWN = False
+    rich_click.rich_click.THEME = "star-box"
+    rich_click.rich_click.TEXT_MARKUP = "rich"
     rich_click.rich_click.SHOW_ARGUMENTS = True
     rich_click.rich_click.GROUP_ARGUMENTS_OPTIONS = True
     rich_click.rich_click.STYLE_ERRORS_SUGGESTION = "magenta italic"
     rich_click.rich_click.ERRORS_SUGGESTION = ""
     rich_click.rich_click.ERRORS_EPILOGUE = ""
     rich_click.rich_click.MAX_WIDTH = 120
-    rich_click.rich_click.SHOW_METAVARS_COLUMN = True
-    rich_click.rich_click.APPEND_METAVARS_HELP = True
+    # replaces 'SHOW_METAVARS_COLUMN' / 'APPEND_METAVARS_HELP'; 'opt_long' precedes
+    # 'opt_short' to keep the long form in the first column, as it has always rendered.
+    rich_click.rich_click.OPTIONS_TABLE_COLUMN_TYPES = ["opt_long", "opt_short", "metavar", "help"]
+    rich_click.rich_click.OPTIONS_TABLE_HELP_SECTIONS = [
+        "help",
+        "deprecated",
+        "envvar",
+        "default",
+        "required",
+        "metavar",
+    ]
 
 
 from .main import litestar_group

--- a/litestar/cli/__init__.py
+++ b/litestar/cli/__init__.py
@@ -15,16 +15,14 @@ if find_spec("rich_click") is not None:  # pragma: no cover
     rich_click.rich_click.ERRORS_SUGGESTION = ""
     rich_click.rich_click.ERRORS_EPILOGUE = ""
     rich_click.rich_click.MAX_WIDTH = 120
-    # replaces 'SHOW_METAVARS_COLUMN' / 'APPEND_METAVARS_HELP'; 'opt_long' precedes
-    # 'opt_short' to keep the long form in the first column, as it has always rendered.
-    rich_click.rich_click.OPTIONS_TABLE_COLUMN_TYPES = ["opt_long", "opt_short", "metavar", "help"]
+    rich_click.rich_click.OPTIONS_TABLE_COLUMN_TYPES = ["required", "opt_long", "opt_short", "metavar", "help"]
     rich_click.rich_click.OPTIONS_TABLE_HELP_SECTIONS = [
         "help",
+        "metavar",
         "deprecated",
         "envvar",
         "default",
         "required",
-        "metavar",
     ]
 
 

--- a/litestar/cli/_utils.py
+++ b/litestar/cli/_utils.py
@@ -42,6 +42,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Iterable, Sequence
     from types import ModuleType
 
+    from click import Command as BaseCommand
+
     try:
         from rich_click import RichContext
     except ImportError:
@@ -154,7 +156,7 @@ class LitestarGroup(Group):  # pyright: ignore[reportGeneralTypeIssues]
     def __init__(
         self,
         name: str | None = None,
-        commands: dict[str, Command] | Sequence[Command] | None = None,
+        commands: dict[str, BaseCommand] | Sequence[BaseCommand] | None = None,
         **attrs: Any,
     ) -> None:
         """Init ``LitestarGroup``"""
@@ -199,7 +201,7 @@ class LitestarExtensionGroup(LitestarGroup):
     def __init__(
         self,
         name: str | None = None,
-        commands: dict[str, Command] | Sequence[Command] | None = None,
+        commands: dict[str, BaseCommand] | Sequence[BaseCommand] | None = None,
         **attrs: Any,
     ) -> None:
         """Init ``LitestarExtensionGroup``"""
@@ -232,7 +234,7 @@ class LitestarExtensionGroup(LitestarGroup):
 
         self._prepare_done = True
 
-    def make_context(  # type: ignore[override]
+    def make_context(
         self,
         info_name: str | None,
         args: list[str],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,7 @@ brotli = ["brotli"]
 zstd = [
     "backports-zstd>=1.3.0; python_version < '3.14'",
 ]
-# capped: rich-click 1.9 deprecates the options set in 'litestar/cli/__init__.py'. See https://github.com/ewels/rich-click/releases/tag/v1.9.0
-cli = ["click", "jsbeautifier", "rich>=13.0.0", "rich-click<1.9", "uvicorn[standard]"]
+cli = ["click", "jsbeautifier", "rich>=13.0.0", "rich-click>=1.9", "uvicorn[standard]"]
 cryptography = ["cryptography"]
 full = [
   """litestar[annotated-types, \
@@ -226,8 +225,6 @@ filterwarnings = [
   "ignore:.*Deprecated in litestar:DeprecationWarning",
   "ignore:.*Call to deprecated reset:DeprecationWarning", # redis
   "ignore:`general_plain_validator_function`:DeprecationWarning::",
-  # this is coming from rich_click itself, nothing we can do about that for now:
-  "ignore: 'RichMultiCommand':DeprecationWarning::",
   "ignore: Python Debugger on exception enabled:litestar.exceptions.LitestarWarning:",
   "ignore: datetime.datetime.utcnow:DeprecationWarning:time_machine",
   "ignore:Use of deprecated default '__check_model__':DeprecationWarning:polyfactory:",

--- a/uv.lock
+++ b/uv.lock
@@ -2192,7 +2192,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'yaml'" },
     { name = "redis", extras = ["hiredis"], marker = "extra == 'redis'", specifier = ">=4.4.4,!=5.3.*" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=13.0.0" },
-    { name = "rich-click", marker = "extra == 'cli'", specifier = "<1.9" },
+    { name = "rich-click", marker = "extra == 'cli'", specifier = ">=1.9" },
     { name = "sniffio", specifier = ">=1.3.1" },
     { name = "typing-extensions" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'cli'" },
@@ -3733,16 +3733,16 @@ wheels = [
 
 [[package]]
 name = "rich-click"
-version = "1.8.9"
+version = "1.9.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/a8/dcc0a8ec9e91d76ecad9413a84b6d3a3310c6111cfe012d75ed385c78d96/rich_click-1.8.9.tar.gz", hash = "sha256:fd98c0ab9ddc1cf9c0b7463f68daf28b4d0033a74214ceb02f761b3ff2af3136", size = 39378, upload-time = "2025-05-19T21:33:05.569Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ea/21e4867ea0ef881ffd4c0550fc21a061435e50d6324bcd034396633cbc18/rich_click-1.9.8.tar.gz", hash = "sha256:4008f921da88b5d91646c134ec881c1500e5a6b3f093e90e8f29400e09608371", size = 75363, upload-time = "2026-05-28T19:54:59.144Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/c2/9fce4c8a9587c4e90500114d742fe8ef0fd92d7bad29d136bb9941add271/rich_click-1.8.9-py3-none-any.whl", hash = "sha256:c3fa81ed8a671a10de65a9e20abf642cfdac6fdb882db1ef465ee33919fbcfe2", size = 36082, upload-time = "2025-05-19T21:33:04.195Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/97/a87901aef6b7e7e4a34c6dd6cc17dca8594a592ef9d9dd765fca2b7facf7/rich_click-1.9.8-py3-none-any.whl", hash = "sha256:12873865396e6927835d4eabb1cc3996edcd65b7ac9b2391a29eca4f335a2f93", size = 72189, upload-time = "2026-05-28T19:54:57.867Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
It updates rich click to be >=1.9.0 instead of pinned <=1.9.0

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4951">https://litestar-org.github.io/litestar-docs-preview/4951</a> 
