### PR TITLE
fix: remove duplicated word in changelog

### DIFF
--- a/docs/release-notes/2.x-changelog.rst
+++ b/docs/release-notes/2.x-changelog.rst
@@ -910,7 +910,7 @@
         :issue: 2812
         :pr: 2818
 
-        Fix a bug where an incorrect OpenAPI schema was generated generated when any
+        Fix a bug where an incorrect OpenAPI schema was generated when any
         ``Literal | None``-union was present in an annotation.
 
         For example


### PR DESCRIPTION
Removes duplicated word: "generated generated" → "generated"

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4954">https://litestar-org.github.io/litestar-docs-preview/4954</a> 
