### PR TITLE
fix(openapi): reflect root_path in OpenAPI servers (#2077)

### DIFF
--- a/litestar/_openapi/plugin.py
+++ b/litestar/_openapi/plugin.py
@@ -100,6 +100,24 @@ class OpenAPIPlugin(InitPlugin, ReceiveRoutePlugin):
             self._openapi_schema = self.provide_openapi().to_schema()
         return self._openapi_schema
 
+    def schema_for_request(self, request: Request) -> dict[str, Any]:
+        """Return the OpenAPI schema, reflecting the ASGI ``root_path`` in ``servers``.
+
+        When the application is mounted under a sub-path (e.g. ``root_path="/api"``)
+        the schema's default ``servers`` value of ``[{"url": "/"}]`` no longer points
+        at the real base URL. If the user has not customised ``servers``, substitute
+        the request's ``root_path`` so generated URLs are correct (issue #2077). A
+        customised ``servers`` value is left untouched, and the cached schema is not
+        mutated.
+        """
+        schema = self.provide_openapi_schema()
+        # Mirror Request.base_url precedence: app_root_path (set by e.g. uvicorn
+        # --root-path) wins over the ASGI root_path.
+        root_path = (request.scope.get("app_root_path") or request.scope.get("root_path", "")).rstrip("/")
+        if root_path and schema.get("servers") == [{"url": "/"}]:
+            schema = {**schema, "servers": [{"url": root_path}]}
+        return schema
+
     def create_openapi_router(self) -> Router:
         """Create a router for serving OpenAPI documentation and schema files.
 
@@ -159,7 +177,7 @@ class OpenAPIPlugin(InitPlugin, ReceiveRoutePlugin):
 
             @get(paths, media_type=plugin_.media_type, sync_to_thread=False, name=handler_name)
             def _handler(request: Request) -> bytes:
-                return plugin_.render(request, self.provide_openapi_schema())
+                return plugin_.render(request, self.schema_for_request(request))
 
             return _handler
 

--- a/litestar/_openapi/plugin.py
+++ b/litestar/_openapi/plugin.py
@@ -113,7 +113,7 @@ class OpenAPIPlugin(InitPlugin, ReceiveRoutePlugin):
         schema = self.provide_openapi_schema()
         # Mirror Request.base_url precedence: app_root_path (set by e.g. uvicorn
         # --root-path) wins over the ASGI root_path.
-        root_path = (request.scope.get("app_root_path") or request.scope.get("root_path", "")).rstrip("/")
+        root_path = str(request.scope.get("app_root_path") or request.scope.get("root_path", "")).rstrip("/")
         if root_path and schema.get("servers") == [{"url": "/"}]:
             schema = {**schema, "servers": [{"url": root_path}]}
         return schema

--- a/tests/unit/test_openapi/test_integration.py
+++ b/tests/unit/test_openapi/test_integration.py
@@ -19,7 +19,7 @@ from litestar.enums import MediaType, OpenAPIMediaType, ParamType
 from litestar.openapi import OpenAPIConfig
 from litestar.openapi.plugins import YamlRenderPlugin
 from litestar.openapi.spec import Parameter as OpenAPIParameter
-from litestar.openapi.spec import Schema
+from litestar.openapi.spec import Schema, Server
 from litestar.params import FromCookie, FromPath, FromQuery, HeaderParameter
 from litestar.serialization.msgspec_hooks import decode_json, encode_json, get_serializer
 from litestar.status_codes import HTTP_200_OK, HTTP_404_NOT_FOUND
@@ -491,3 +491,55 @@ def test_components_schemas_in_alphabetical_order() -> None:
         "test_components_schemas_in_alphabetical_order.C",
     ]
     assert list(openapi.components.schemas.keys()) == expected_keys
+
+
+def test_openapi_servers_reflect_root_path() -> None:
+    """When mounted under a root_path, servers should point at it (issue #2077)."""
+
+    @get("/", sync_to_thread=False)
+    def handler() -> None:
+        return None
+
+    with create_test_client(
+        route_handlers=[handler],
+        openapi_config=OpenAPIConfig(title="Example API", version="1.0.0"),
+        root_path="/api",
+    ) as client:
+        response = client.get("/schema/openapi.json")
+        assert response.status_code == HTTP_200_OK
+        assert response.json()["servers"] == [{"url": "/api"}]
+
+
+def test_openapi_servers_root_path_does_not_override_custom_servers() -> None:
+    """A user-configured ``servers`` value is left untouched by the root_path."""
+
+    @get("/", sync_to_thread=False)
+    def handler() -> None:
+        return None
+
+    with create_test_client(
+        route_handlers=[handler],
+        openapi_config=OpenAPIConfig(
+            title="Example API",
+            version="1.0.0",
+            servers=[Server(url="https://example.com")],
+        ),
+        root_path="/api",
+    ) as client:
+        response = client.get("/schema/openapi.json")
+        assert response.json()["servers"] == [{"url": "https://example.com"}]
+
+
+def test_openapi_servers_default_without_root_path() -> None:
+    """Without a root_path the default ``/`` server is unchanged."""
+
+    @get("/", sync_to_thread=False)
+    def handler() -> None:
+        return None
+
+    with create_test_client(
+        route_handlers=[handler],
+        openapi_config=OpenAPIConfig(title="Example API", version="1.0.0"),
+    ) as client:
+        response = client.get("/schema/openapi.json")
+        assert response.json()["servers"] == [{"url": "/"}]


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
- follow [Litestar's AI Policy](https://github.com/litestar-org/.github/blob/main/AI_POLICY.md)

If the pull request is not yet ready for review (e.g. tests or other checks are still failing),
please submit it as a draft PR, to avoid noise for reviewers.
-->

## Description
Fixes #2077

When an app is served under a `root_path` (e.g. `uvicorn app --root-path /api`,
or behind a proxy), the generated OpenAPI schema still listed its servers as
`[{"url": "/"}]`, so the base URL shown in the docs/spec was wrong.

This makes the OpenAPI plugin substitute the request's `root_path` into `servers`
when the user has not configured a custom `servers` value. A custom `servers`
value is left untouched, and the cached schema is not mutated (a per-request copy
is returned). It follows the same `app_root_path` / `root_path` precedence that
`Request.base_url` already uses.

Tests cover three cases: the root_path is reflected in `servers`, a custom
`servers` value is not overridden, and the default `/` is preserved when no
root_path is set.

> This PR was created with AI assistance (Claude by Anthropic). The implementation follows the approach outlined by maintainers in the issue discussion.
<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4955">https://litestar-org.github.io/litestar-docs-preview/4955</a> 
