### PR TITLE
Fix AllowedHostsMiddleware rejecting valid hosts with a port in the Host header

### DIFF
--- a/litestar/middleware/allowed_hosts.py
+++ b/litestar/middleware/allowed_hosts.py
@@ -64,7 +64,7 @@ class AllowedHostsMiddleware(AbstractMiddleware):
             return
 
         headers = MutableScopeHeaders(scope=scope)
-        if (host := headers.get("host")) is not None and host.split(":")[0]:
+        if (raw_host := headers.get("host")) is not None and (host := raw_host.split(":")[0]):
             if self.allowed_hosts_regex.fullmatch(host):
                 await self.app(scope, receive, send)
                 return


### PR DESCRIPTION
## Summary
Fixes #4869 — `AllowedHostsMiddleware` used to strip the port from the `Host` header before matching it against the allowed-hosts regex. As of 2.22.0 it matches the full, un-stripped header, so a request with `Host: localhost:8000` no longer matches an allowed host of `localhost` and is rejected with `400 - invalid host header`. This only manifests when the `Host` header carries a port, which typically doesn't happen behind a reverse proxy — likely why it went unnoticed.

**Root cause (as diagnosed in the issue):** the port-strip was lost in `c4189610` ("fix: fix typing after merge"), a follow-up to the intentional `x-forwarded-host` removal:

```python
# before (2.21.x) — port stripped, then matched
if host := headers.get("host").split(":")[0]:
    if self.allowed_hosts_regex.fullmatch(host):

# after (2.22.0+) — `host` keeps the port; the strip only gates the `if`
if (host := headers.get("host")) is not None and host.split(":")[0]:
    if self.allowed_hosts_regex.fullmatch(host):   # matches "localhost:8000"
```

The walrus now binds `host` to the un-stripped header value; `host.split(":")[0]` survives only as the truthiness guard, while `fullmatch(host)` receives the value with the port still attached.

## Fix
Bind `host` to the split result itself, per the issue's suggested fix:

```python
if (raw_host := headers.get("host")) is not None and (host := raw_host.split(":")[0]):
```

This also fixes the same `host` variable's use a few lines below in the `redirect_domains.fullmatch(host)` check, which had the identical bug (same variable, same root cause).

## Verification
Local Python here is 3.7 (predates the walrus operator), so I verified the equivalent old-vs-new logic without walrus syntax:

| Case | Old | New |
|---|---|---|
| `Host: localhost:8000`, allowed=`["localhost"]` (the reported bug) | reject | **allow** |
| `Host: localhost` (no port) | allow | allow (unaffected) |
| `Host: evil.com:8000` (disallowed) | reject | reject (unaffected) |
| No `Host` header | reject | reject (unaffected) |

## Test plan
- [x] Verified the fix flips only the reported bug case; all other cases (no port, disallowed host, missing header) are unaffected.
- [ ] Didn't run against litestar's own test suite / the MCVE from the issue in this environment (walrus-operator syntax needs Python 3.8+, unavailable locally) — the logic-equivalence check above covers the same branches. Happy to iterate if CI surfaces anything.
