### PR TITLE
docs: fix grammatical errors

### DIFF
--- a/docs/examples/middleware/session/cookies_full_example.py
+++ b/docs/examples/middleware/session/cookies_full_example.py
@@ -3,7 +3,7 @@ from os import urandom
 from litestar import Litestar, Request, delete, get, post
 from litestar.middleware.session.client_side import CookieBackendConfig
 
-# we initialize to config with a 16 byte key, i.e. 128 a bit key.
+# we initialize to config with a 16 byte key, i.e. a 128 bit key.
 # in real world usage we should inject the secret from the environment
 session_config = CookieBackendConfig(secret=urandom(16))
 

--- a/docs/usage/applications.rst
+++ b/docs/usage/applications.rst
@@ -234,7 +234,7 @@ develop third-party application configuration systems.
 Layered architecture
 --------------------
 
-Litestar has a layered architecture compromising of 4 layers:
+Litestar has a layered architecture comprising of 4 layers:
 
 #. :class:`The application object <litestar.app.Litestar>`
 #. :class:`Routers <.router.Router>`

--- a/docs/usage/caching.rst
+++ b/docs/usage/caching.rst
@@ -19,7 +19,7 @@ enabled for the :attr:`~.config.response_cache.ResponseCacheConfig.default_expir
     ``None``, setting up the route handler with :paramref:`~litestar.handlers.HTTPRouteHandler.cache` set to ``True``
     will keep the response in cache indefinitely.
 
-Alternatively you can specify the number of seconds to cache the responses from the given handler like so:
+Alternatively you can specify the number of seconds to cache the responses for the given handler like so:
 
 .. literalinclude:: /examples/caching/cache.py
     :language: python

--- a/docs/usage/channels.rst
+++ b/docs/usage/channels.rst
@@ -327,7 +327,7 @@ allows to easily run other code concurrently.
 In the above example, the stream is used to send data to a
 :class:`WebSocket <litestar.connection.WebSocket>`.
 
-The same can be achieve by passing :meth:`Websocket.send_text() <litestar.connection.WebSocket.send_text>` as the
+The same can be achieved by passing :meth:`Websocket.send_text() <litestar.connection.WebSocket.send_text>` as the
 callback to :meth:`~Subscriber.run_in_background`. This will cause the WebSocket's method to be invoked every time
 a new :term:`event` becomes available in the :term:`stream <event stream>`, but gives control back to the application,
 providing an opportunity to perform other tasks, such as receiving incoming data from the socket.
@@ -399,7 +399,7 @@ The following backends are currently implemented:
 
 :class:`RedisChannelsPubSubBackend <.redis.RedisChannelsPubSubBackend>`
     A Redis based backend, using `Pub/Sub <https://redis.io/docs/manual/pubsub/>`_ to
-    delivery messages. This Redis backend has a low latency and overhead and is
+    deliver messages. This Redis backend has a low latency and overhead and is
     generally recommended if :term:`history` is not needed
 
 :class:`RedisChannelsStreamBackend <.redis.RedisChannelsStreamBackend>`

--- a/docs/usage/events.rst
+++ b/docs/usage/events.rst
@@ -35,7 +35,7 @@ Litestar supports a simple implementation of the event emitter / listener patter
         await user_repository.insert(data)
 
         # assuming we have now inserted a user, we want to send a welcome email.
-        # To do this in a none-blocking fashion, we will emit an event to a listener, which will send the email,
+        # To do this in a non-blocking fashion, we will emit an event to a listener, which will send the email,
         # using a different async block than the one where we are returning a response.
         request.app.emit("user_created", email=data.email)
 
@@ -124,7 +124,7 @@ The method :meth:`emit <litestar.events.BaseEventEmitterBackend.emit>` has the f
 
 
 
-This means that it expects a string for ``event_id`` following by any number of positional and keyword arguments. While
+This means that it expects a string for ``event_id`` followed by any number of positional and keyword arguments. While
 this is highly flexible, it also means you need to ensure the listeners for a given event can handle all the expected args
 and kwargs.
 

--- a/docs/usage/metrics/opentelemetry.rst
+++ b/docs/usage/metrics/opentelemetry.rst
@@ -32,5 +32,5 @@ The above example will work out of the box if you configure a global ``tracer_pr
 exporter to use these (see the
 `OpenTelemetry Exporter docs <https://opentelemetry.io/docs/instrumentation/python/exporters/>`_ for further details).
 
-You can also pass con figuration to the ``OpenTelemetryConfig`` telling it which providers to use. Consult
+You can also pass configuration to the ``OpenTelemetryConfig`` telling it which providers to use. Consult
 :class:`reference docs <litestar.plugins.opentelemetry.OpenTelemetryConfig>` regarding the configuration options you can use.

--- a/docs/usage/middleware/creating-middleware.rst
+++ b/docs/usage/middleware/creating-middleware.rst
@@ -286,7 +286,7 @@ Modifying ASGI Requests and Responses using the MiddlewareProtocol
     special life-cycle hook called :ref:`after_request <after_request>`. The instructions in this section are for how to
     modify the ASGI response message itself, which is a step further in the response process.
 
-Using the :class:`~litestar.middleware.base.MiddlewareProtocol` you can intercept and modifying both the
+Using the :class:`~litestar.middleware.base.MiddlewareProtocol` you can intercept and modify both the
 incoming and outgoing data in a request / response cycle by "wrapping" that respective ``receive`` and ``send`` ASGI
 functions.
 
@@ -356,11 +356,11 @@ create middleware:
 
            await self.app(scope, receive, send_wrapper)
 
-The three class variables defined in the above example ``scopes``, ``exclude``, and ``exclude_opt_key`` can be used to
+The three class variables defined in the above example ``scope``, ``exclude``, and ``exclude_opt_key`` can be used to
 fine-tune for which routes and request types the middleware is called:
 
 
-- The scopes variable is a set that can include either or both : ``ScopeType.HTTP`` and ``ScopeType.WEBSOCKET`` , with the default being both.
+- The scope variable is a set that can include either or both : ``ScopeType.HTTP`` and ``ScopeType.WEBSOCKET`` , with the default being both.
 - ``exclude`` accepts either a single string or list of strings that are compiled into a regex against which the request's ``path`` is checked.
 - ``exclude_opt_key`` is the key to use for in a route handler's :class:`Router.opt <litestar.router.Router>` dict for a boolean, whether to omit from the middleware.
 
@@ -405,5 +405,5 @@ these values to our middleware:
    )
 
 The ``DefineMiddleware`` is a simple container - it takes a middleware callable as a first parameter, and then any
-positional arguments, followed by key word arguments. The middleware callable will be called with these values as well
+positional arguments, followed by keyword arguments. The middleware callable will be called with these values as well
 as the kwarg ``app`` as mentioned above.

--- a/docs/usage/routing/handlers.rst
+++ b/docs/usage/routing/handlers.rst
@@ -378,7 +378,7 @@ In difference to the other route handlers, the :func:`@asgi() <.handlers.asgi>` 
 You can read more about these in the `ASGI specification <https://asgi.readthedocs.io/en/latest/specs/main.html>`_.
 
 Additionally, ASGI route handler functions **must** be :ref:`async functions <python:async def>`.
-This is enforced using inspection, and if the function is not an :ref:`async functions <python:async def>`,
+This is enforced using inspection, and if the function is not an :ref:`async function <python:async def>`,
 an informative exception will be raised.
 
 See the :class:`ASGIRouteHandler API reference documentation <.handlers.asgi_handlers.ASGIRouteHandler>` for full

--- a/docs/usage/routing/parameters.rst
+++ b/docs/usage/routing/parameters.rst
@@ -8,7 +8,7 @@ Request parameters are parts of the request that can be injected into a handler 
 or dependency. They allow type-coercion, validation, and will show up in the generated
 OpenAPI schema.
 
-There are for request parameter types supported, which can be specified in two different
+There are four request parameter types supported, which can be specified in two different
 forms:
 
 +--------+----------------------------+---------------------------------------------------------------------------+
@@ -270,7 +270,7 @@ A request to ``http://127.0.0.1:8000?camelCase=foo`` will be received as
 ``snake_case="foo"`` inside the handler.
 
 The same pattern applies to
-:class:`~.params.HeaderParameter`,:class:`~.params.CookieParameter` and
+:class:`~.params.HeaderParameter`, :class:`~.params.CookieParameter` and
 :class:`~.params.PathParameter`.
 
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
- follow [Litestar's AI Policy](https://github.com/litestar-org/.github/blob/main/AI_POLICY.md)

If the pull request is not yet ready for review (e.g. tests or other checks are still failing),
please submit it as a draft PR, to avoid noise for reviewers.
-->

## Description

Fixed grammatical errors in the documentation **docs/usage** guide.

### changes
- changed the word "compromising" to "comprising" in application.rst
- fixed a grammar mistake, changed it to "for" instead of "from" in caching.rst
- fixed a grammar mistake, changed the word "achieve" to "achieved" in channel.rst
- fixed a spelling mistake, changed "none-blocking" to "non-blocking" in event.rst
- fixed a spelling mistake, changed "con figuration" to "configuration" in opentelemetry.rst
- fixed a grammar mistake, changed it to "modify" instead of "modifying" in creating-middleware.rst
- fixed a grammar mistake, changed the word "async functions" to "async function" in handlers.rst
- fixed a spelling mistake, changed the word "for" to "four" in parameters.rst

These changes do not affect any code.


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4957">https://litestar-org.github.io/litestar-docs-preview/4957</a> 
