### PR TITLE
fix(docs): wrong postgres volume path

### DIFF
--- a/docs/topics/deployment/docker.rst
+++ b/docs/topics/deployment/docker.rst
@@ -159,7 +159,7 @@ If you want to run the container as part of a Docker Compose setup then you can 
         ports:
           - "5432:5432"
         volumes:
-          # Note that image versions previous to 18 used /var/lib/postgresql/data 
+          # Note that image versions previous to 18 used /var/lib/postgresql/data
           - db_data:/var/lib/postgresql
 
     volumes:

--- a/docs/topics/deployment/docker.rst
+++ b/docs/topics/deployment/docker.rst
@@ -159,7 +159,8 @@ If you want to run the container as part of a Docker Compose setup then you can 
         ports:
           - "5432:5432"
         volumes:
-          - db_data:/var/lib/postgresql/data
+          # Note that image versions previous to 18 used /var/lib/postgresql/data 
+          - db_data:/var/lib/postgresql
 
     volumes:
       db_data:


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
- follow [Litestar's AI Policy](https://github.com/litestar-org/.github/blob/main/AI_POLICY.md)

If the pull request is not yet ready for review (e.g. tests or other checks are still failing),
please submit it as a draft PR, to avoid noise for reviewers.
-->

## Description
Changes the path of the postgres volume in the docker compose example from `/var/lib/postgresql/data` to `/var/lib/postgresql` since it uses latest and it [changed](https://github.com/docker-library/postgres/blob/62a714f93cc32220de46fd12235c9d509e3b1ad6/18/bookworm/Dockerfile#L188-L193) on version 18+. 

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4961">https://litestar-org.github.io/litestar-docs-preview/4961</a> 
