### PR TITLE
feat(ci): Zizmor baseline policy + Dependabot/uv cooldown (follow-up to #4489) (#4947)

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,23 @@
+name: Zizmor Security Audit
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+# Zizmor security audit baseline policy configuration
+rules:
+  dependabot-cooldown:
+    config:
+      days: 7


### PR DESCRIPTION
Follow-up to #4489.

- Adds `.github/workflows/zizmor.yml`: runs zizmor on `pull_request` and `push` to `main`, with hash-pinned actions and least-privilege permissions.
- Adds `.github/zizmor.yml`: sets the `dependabot-cooldown` baseline to 7 days.

Closes #4947


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4962">https://litestar-org.github.io/litestar-docs-preview/4962</a> 
