### PR TITLE
fix(cors): never emit a wildcard Access-Control-Allow-Origin alongside credentials

### DIFF
--- a/litestar/config/cors.py
+++ b/litestar/config/cors.py
@@ -110,7 +110,11 @@ class CORSConfig:
             A dictionary of headers to set on the response object.
         """
         headers: dict[str, str] = {"Access-Control-Max-Age": str(self.max_age)}
-        if self.is_allow_all_origins:
+        # A literal "*" is invalid alongside credentials per the Fetch spec - browsers
+        # reject the response outright. When both are configured, the specific request
+        # origin has to be echoed back instead, which middleware does per-request since
+        # this property is cached and origin-agnostic.
+        if self.is_allow_all_origins and not self.allow_credentials:
             headers["Access-Control-Allow-Origin"] = "*"
         else:
             headers["Vary"] = "Origin"
@@ -138,7 +142,7 @@ class CORSConfig:
             A dictionary of headers to set on the response object.
         """
         simple_headers = {}
-        if self.is_allow_all_origins:
+        if self.is_allow_all_origins and not self.allow_credentials:
             simple_headers["Access-Control-Allow-Origin"] = "*"
         if self.allow_credentials:
             simple_headers["Access-Control-Allow-Credentials"] = "true"

--- a/litestar/middleware/_internal/cors.py
+++ b/litestar/middleware/_internal/cors.py
@@ -50,15 +50,14 @@ class CORSMiddleware(AbstractMiddleware):
             )
             await asgi_response(scope, receive, send)
         elif origin:
-            await self.app(scope, receive, self.send_wrapper(send=send, origin=origin, has_cookie="cookie" in headers))
+            await self.app(scope, receive, self.send_wrapper(send=send, origin=origin))
         else:
             await self.app(scope, receive, send)
 
-    def send_wrapper(self, send: Send, origin: str, has_cookie: bool) -> Send:
+    def send_wrapper(self, send: Send, origin: str) -> Send:
         """Wrap ``send`` to ensure that state is not disconnected.
 
         Args:
-            has_cookie: Boolean flag dictating if the connection has a cookie set.
             origin: The value of the ``Origin`` header.
             send: The ASGI send function.
 
@@ -72,7 +71,11 @@ class CORSMiddleware(AbstractMiddleware):
                 headers = MutableScopeHeaders.from_message(message=message)
                 headers.update(self.config.simple_headers)
 
-                if (self.config.is_allow_all_origins and has_cookie) or (
+                # A wildcard origin can't be combined with credentials (browsers reject
+                # it), so a specific, validated origin has to be echoed back instead in
+                # that case - self.config.simple_headers omits Access-Control-Allow-Origin
+                # entirely rather than emitting an invalid "*" when allow_credentials is set.
+                if (self.config.is_allow_all_origins and self.config.allow_credentials) or (
                     not self.config.is_allow_all_origins and self.config.is_origin_allowed(origin=origin)
                 ):
                     headers["Access-Control-Allow-Origin"] = origin

--- a/tests/e2e/test_cors/test_cors_credentials.py
+++ b/tests/e2e/test_cors/test_cors_credentials.py
@@ -37,3 +37,27 @@ def test_cors_with_credentials_disallowed() -> None:
         )
         assert response.status_code == HTTP_204_NO_CONTENT
         assert "access-control-allow-credentials" not in response.headers
+
+
+def test_cors_credentials_with_wildcard_origin_echoes_specific_origin() -> None:
+    """A literal "*" can't be combined with credentials - browsers reject the response
+    outright (Fetch spec) - so when both are configured, the request's own Origin must
+    be echoed back on both the preflight and the actual response, never "*".
+    """
+    cors_config = CORSConfig(allow_methods=["GET"], allow_credentials=True)  # allow_origins defaults to ["*"]
+    app = Litestar(route_handlers=[credentials_handler], cors_config=cors_config)
+
+    with TestClient(app) as client:
+        preflight = client.options(
+            "/credentials-test",
+            headers={"Origin": "https://example.com", "Access-Control-Request-Method": "GET"},
+        )
+        assert preflight.status_code == HTTP_204_NO_CONTENT
+        assert preflight.headers["access-control-allow-origin"] == "https://example.com"
+        assert preflight.headers["access-control-allow-credentials"] == "true"
+
+        # No Cookie header present - e.g. the first request of a session - must still
+        # get a valid, credentials-compatible response.
+        response = client.get("/credentials-test", headers={"Origin": "https://example.com"})
+        assert response.headers["access-control-allow-origin"] == "https://example.com"
+        assert response.headers["access-control-allow-credentials"] == "true"

--- a/tests/unit/test_middleware/test_cors_middleware.py
+++ b/tests/unit/test_middleware/test_cors_middleware.py
@@ -80,7 +80,11 @@ def test_cors_simple_response(
 
         if origin:
             if cors_config.is_allow_all_origins:
-                assert response.headers.get("Access-Control-Allow-Origin") == "*"
+                # A literal "*" can't be combined with credentials - browsers reject
+                # such a response outright - so the specific origin is echoed back
+                # instead whenever credentials are allowed.
+                expected_origin = origin if cors_config.allow_credentials else "*"
+                assert response.headers.get("Access-Control-Allow-Origin") == expected_origin
             if cors_config.allow_credentials:
                 assert response.headers.get("Access-Control-Allow-Credentials") == "true"
             if cors_config.expose_headers:


### PR DESCRIPTION
## What

`CORSConfig(allow_credentials=True)` combined with the default `allow_origins=["*"]` produces a response carrying both:

```
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true
```

Per the [Fetch spec](https://fetch.spec.whatwg.org/#http-access-control-allow-origin), a literal `*` is invalid alongside credentials — when a request's credentials mode is `include`, the server has to echo back a specific origin, not the wildcard. Browsers enforce this by rejecting the response outright (treating it as a CORS failure), so any app that sets `allow_credentials=True` without also narrowing `allow_origins` away from the default wildcard gets credentialed cross-origin requests that silently never succeed in the browser, even though the server-side response looks fine.

Repro against current `main`:

```python
from litestar import Litestar, get
from litestar.config.cors import CORSConfig
from litestar.testing import TestClient

@get("/endpoint")
async def handler() -> str: return "ok"

app = Litestar(route_handlers=[handler], cors_config=CORSConfig(allow_credentials=True))

with TestClient(app) as client:
    r = client.get("/endpoint", headers={"Origin": "https://example.com"})
    print(r.headers["access-control-allow-origin"])       # "*"
    print(r.headers["access-control-allow-credentials"])  # "true"  <- invalid combination
```

I found this doing a read through `config/cors.py` / `middleware/_internal/cors.py` — it isn't covered by any existing test; `test_cors_credentials.py` only exercises credentials with an explicit, narrow `allow_origins`, never the wildcard-plus-credentials combination.

## Fix

- `simple_headers` / `preflight_headers` (`config/cors.py`) now omit the wildcard `Access-Control-Allow-Origin` entirely when `allow_credentials` is set, since these are cached and origin-agnostic — they can't know the request's actual origin.
- The middleware (`middleware/_internal/cors.py`) always echoes the validated request origin back in that case, on both the preflight response and the actual response.
- This also fixes an existing correctness gap in `send_wrapper`: origin-echoing was previously gated on `has_cookie` (whether the current request happens to carry a `Cookie` header) rather than on `self.config.allow_credentials`. That heuristic misses the very first credentialed request of a session — the one establishing the cookie in the first place — which doesn't carry one yet. Swapped it for the config flag, which is both correct and simpler (removed the now-unused `has_cookie` parameter entirely).

## Tests

- Updated the existing `test_cors_simple_response` parametrized test — it was asserting the old (invalid) `"*"` behavior for every `allow_credentials=True` case; now asserts the origin is echoed instead when credentials are on.
- Added `test_cors_credentials_with_wildcard_origin_echoes_specific_origin`, exercising both the preflight and actual-response path with the default wildcard `allow_origins`, including the no-cookie-yet case.

Full suite (5536 tests), `pre-commit`, and `mypy` all pass locally.