### PR TITLE
fix(channels): serialize AsyncPg listener mutations

### DIFF
--- a/litestar/channels/backends/asyncpg.py
+++ b/litestar/channels/backends/asyncpg.py
@@ -40,14 +40,18 @@ class AsyncPgChannelsBackend(ChannelsBackend):
         self._exit_stack = AsyncExitStack()
         self._connect = make_connection or partial(asyncpg.connect, dsn=dsn)
         self._queue: asyncio.Queue[tuple[str, bytes]] | None = None
+        self._listener_lock = asyncio.Lock()
 
     async def on_startup(self) -> None:
-        self._queue = asyncio.Queue()
-        self._listener_conn = await self._connect()
+        async with self._listener_lock:
+            self._queue = asyncio.Queue()
+            self._listener_conn = await self._connect()
 
     async def on_shutdown(self) -> None:
-        await self._listener_conn.close()
-        self._queue = None
+        async with self._listener_lock:
+            await self._listener_conn.close()
+            self._subscribed_channels.clear()
+            self._queue = None
 
     async def publish(self, data: bytes, channels: Iterable[str]) -> None:
         if self._queue is None:
@@ -63,14 +67,18 @@ class AsyncPgChannelsBackend(ChannelsBackend):
             await conn.close()
 
     async def subscribe(self, channels: Iterable[str]) -> None:
-        for channel in set(channels) - self._subscribed_channels:
-            await self._listener_conn.add_listener(channel, self._listener)  # type: ignore[arg-type]
-            self._subscribed_channels.add(channel)
+        requested_channels = set(channels)
+        async with self._listener_lock:
+            for channel in requested_channels - self._subscribed_channels:
+                await self._listener_conn.add_listener(channel, self._listener)  # type: ignore[arg-type]
+                self._subscribed_channels.add(channel)
 
     async def unsubscribe(self, channels: Iterable[str]) -> None:
-        for channel in channels:
-            await self._listener_conn.remove_listener(channel, self._listener)  # type: ignore[arg-type]
-        self._subscribed_channels = self._subscribed_channels - set(channels)
+        requested_channels = set(channels)
+        async with self._listener_lock:
+            for channel in requested_channels & self._subscribed_channels:
+                await self._listener_conn.remove_listener(channel, self._listener)  # type: ignore[arg-type]
+                self._subscribed_channels.remove(channel)
 
     async def stream_events(self) -> AsyncGenerator[tuple[str, bytes], None]:
         if self._queue is None:

--- a/tests/unit/test_channels/test_asyncpg_backend.py
+++ b/tests/unit/test_channels/test_asyncpg_backend.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from litestar.channels.backends.asyncpg import AsyncPgChannelsBackend
+
+
+class _ConcurrentConnection:
+    def __init__(self) -> None:
+        self.active_operations = 0
+        self.max_active_operations = 0
+        self.added_channels: list[str] = []
+        self.removed_channels: list[str] = []
+        self.closed = False
+
+    async def add_listener(self, channel: str, *args: Any, **kwargs: Any) -> None:
+        await self._operation()
+        self.added_channels.append(channel)
+
+    async def remove_listener(self, channel: str, *args: Any, **kwargs: Any) -> None:
+        await self._operation()
+        self.removed_channels.append(channel)
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def _operation(self) -> None:
+        self.active_operations += 1
+        self.max_active_operations = max(self.max_active_operations, self.active_operations)
+        await asyncio.sleep(0)
+        self.active_operations -= 1
+
+
+async def test_listener_mutations_are_serialized() -> None:
+    backend = AsyncPgChannelsBackend(make_connection=asyncio.Future)
+    connection = _ConcurrentConnection()
+    backend._listener_conn = connection  # type: ignore[assignment]
+
+    await asyncio.gather(backend.subscribe(["one"]), backend.subscribe(["two"]))
+
+    assert connection.max_active_operations == 1
+
+
+async def test_duplicate_listener_mutations_are_idempotent() -> None:
+    backend = AsyncPgChannelsBackend(make_connection=asyncio.Future)
+    connection = _ConcurrentConnection()
+    backend._listener_conn = connection  # type: ignore[assignment]
+
+    await backend.subscribe(channel for channel in ["one", "one"])
+    await backend.subscribe(["one"])
+    await backend.unsubscribe(channel for channel in ["one", "one"])
+    await backend.unsubscribe(["one"])
+
+    assert connection.added_channels == ["one"]
+    assert connection.removed_channels == ["one"]
+
+
+async def test_backend_is_reusable_across_lifecycles() -> None:
+    connections = [_ConcurrentConnection(), _ConcurrentConnection()]
+
+    async def make_connection() -> Any:
+        return connections.pop(0)
+
+    backend = AsyncPgChannelsBackend(make_connection=make_connection)
+
+    await backend.on_startup()
+    first_connection = backend._listener_conn
+    await backend.subscribe(["one"])
+    await backend.on_shutdown()
+    await backend.on_startup()
+    second_connection = backend._listener_conn
+    await backend.subscribe(["one"])
+
+    assert first_connection.added_channels == ["one"]  # type: ignore[attr-defined]
+    assert second_connection.added_channels == ["one"]  # type: ignore[attr-defined]


### PR DESCRIPTION
## Description

`AsyncPgChannelsBackend` uses one listener connection for `add_listener()` and `remove_listener()`. Concurrent subscription changes can overlap operations on that connection and raise `InterfaceError: another operation is in progress`.

This change:

- serializes listener and lifecycle operations with a backend-owned lock
- materializes channel inputs once
- makes duplicate subscribe and unsubscribe operations idempotent
- updates subscription state after each successful listener mutation
- clears subscription state during shutdown
- allows one backend instance to be reused across lifecycles

Notification delivery and publishing are unchanged. The lock only affects listener and lifecycle operations.

This resolves the AsyncPg concurrency failure reported in [#4110](https://github.com/litestar-org/litestar/issues/4110). The backend-independent WebSocket readiness behavior remains unchanged.


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4968">https://litestar-org.github.io/litestar-docs-preview/4968</a> 
