### PR TITLE
feat(middleware): add W3C Trace Context correlation middleware

### DIFF
--- a/docs/examples/middleware/correlation_standalone.py
+++ b/docs/examples/middleware/correlation_standalone.py
@@ -1,0 +1,13 @@
+from litestar import Litestar, get
+from litestar.middleware.correlation import CorrelationContext, CorrelationMiddleware
+
+
+@get("/")
+async def index_handler() -> dict[str, str | None]:
+    return {"correlation_id": CorrelationContext.get()}
+
+
+app = Litestar(
+    route_handlers=[index_handler],
+    middleware=[CorrelationMiddleware],
+)

--- a/docs/examples/middleware/correlation_standalone.py
+++ b/docs/examples/middleware/correlation_standalone.py
@@ -1,13 +1,13 @@
-from litestar import Litestar, get
-from litestar.middleware.correlation import CorrelationContext, CorrelationMiddleware
+from litestar import Litestar, Request, get
+from litestar.middleware.correlation import CorrelationMiddleware, get_correlation_id
 
 
 @get("/")
-async def index_handler() -> dict[str, str | None]:
-    return {"correlation_id": CorrelationContext.get()}
+async def index_handler(request: Request) -> dict[str, str | None]:
+    return {"correlation_id": get_correlation_id(request.scope)}
 
 
 app = Litestar(
     route_handlers=[index_handler],
-    middleware=[CorrelationMiddleware],
+    middleware=[CorrelationMiddleware()],
 )

--- a/docs/examples/middleware/correlation_standalone.py
+++ b/docs/examples/middleware/correlation_standalone.py
@@ -4,7 +4,7 @@ from litestar.middleware.correlation import CorrelationMiddleware, get_correlati
 
 @get("/")
 async def index_handler(request: Request) -> dict[str, str | None]:
-    return {"correlation_id": get_correlation_id(request.scope)}
+    return {"correlation_id": get_correlation_id(request)}
 
 
 app = Litestar(

--- a/docs/reference/middleware/correlation.rst
+++ b/docs/reference/middleware/correlation.rst
@@ -1,0 +1,6 @@
+===========
+correlation
+===========
+
+.. automodule:: litestar.middleware.correlation
+    :members:

--- a/docs/reference/middleware/index.rst
+++ b/docs/reference/middleware/index.rst
@@ -10,6 +10,7 @@ middleware
     allowed_hosts
     authentication
     compression
+    correlation
     csrf
     logging
     rate_limit

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -13,6 +13,16 @@
         dynamic ``LISTEN`` and ``UNLISTEN`` operations no longer contend with the listener.
         Psycopg 3.2.4 or newer is now required for development and documentation builds.
 
+    .. change:: Add W3C Trace Context Correlation Middleware
+        :type: feature
+        :issue: 4719
+
+        Added standalone W3C Trace Context correlation middleware via
+        :class:`~litestar.middleware.correlation.CorrelationMiddleware`.
+
+        .. seealso::
+            :doc:`/usage/middleware/correlation`
+
     .. change:: Move ``httpx`` to the ``testing`` extra
         :type: feature
         :pr: 4950

--- a/docs/usage/middleware/correlation.rst
+++ b/docs/usage/middleware/correlation.rst
@@ -55,7 +55,16 @@ Header behavior
 
 The middleware validates W3C ``traceparent`` values. Values from all other configured headers are treated as opaque
 correlation values. Additional formats, including ``grpc-trace-bin`` and provider-specific headers, can be selected
-with ``header_names``; the middleware does not parse those formats.
+without repeating the defaults:
+
+.. code-block:: python
+
+    CorrelationMiddleware(
+        additional_header_names=("grpc-trace-bin", "x-cloud-trace-context"),
+    )
+
+Use ``header_names`` instead to replace the complete lookup list and control its priority. The two options are
+mutually exclusive. The middleware does not parse additional or replacement header formats.
 
 Incoming scope headers are not modified. By default, the selected correlation ID replaces ``x-request-id`` in the
 response; set ``response_header_name=None`` to disable this. This response header contains the selected correlation

--- a/docs/usage/middleware/correlation.rst
+++ b/docs/usage/middleware/correlation.rst
@@ -1,0 +1,42 @@
+======================
+Correlation Middleware
+======================
+
+The correlation middleware extracts, generates, and propagates correlation and trace IDs across asynchronous execution contexts using Python's :mod:`contextvars`.
+
+This facilitates distributed tracing and unified logging across microservices and async handlers.
+
+Features
+--------
+
+- Priority header fallback (:code:`x-request-id`, :code:`traceparent`, :code:`x-cloud-trace-context`, etc.).
+- W3C :code:`traceparent` defensive parsing.
+- UUID4 generation fallback when no header matches.
+- ContextVar isolation across concurrent requests.
+- Automatic scope state propagation (:code:`scope["state"]["correlation_id"]`).
+- Optional response-header propagation.
+
+Standalone Usage
+----------------
+
+.. literalinclude:: /examples/middleware/correlation_standalone.py
+    :language: python
+
+Correlation Context API
+-----------------------
+
+The :class:`~litestar.middleware.correlation.CorrelationContext` utility class provides static accessors:
+
+.. code-block:: python
+
+    from litestar.middleware.correlation import CorrelationContext
+
+    # Retrieve current ID
+    correlation_id = CorrelationContext.get()
+
+    # Scope context manager
+    with CorrelationContext.context("custom-id"):
+        ...
+
+The middleware validates W3C ``traceparent`` values, reads raw ASGI headers, optionally propagates the selected ID in
+the response, and restores pre-existing scope state after each request.

--- a/docs/usage/middleware/correlation.rst
+++ b/docs/usage/middleware/correlation.rst
@@ -2,7 +2,7 @@
 Correlation Middleware
 ======================
 
-The correlation middleware extracts, generates, and propagates correlation and trace IDs across asynchronous execution contexts using Python's :mod:`contextvars`.
+The correlation middleware extracts, generates, and propagates correlation and trace IDs for each connection.
 
 This facilitates distributed tracing and unified logging across microservices and async handlers.
 
@@ -12,31 +12,30 @@ Features
 - Priority header fallback (:code:`x-request-id`, :code:`traceparent`, :code:`x-cloud-trace-context`, etc.).
 - W3C :code:`traceparent` defensive parsing.
 - UUID4 generation fallback when no header matches.
-- ContextVar isolation across concurrent requests.
-- Automatic scope state propagation (:code:`scope["state"]["correlation_id"]`).
+- The active ID is stored on the connection scope, making it available to handlers and other middlewares.
 - Optional response-header propagation.
 
-Standalone Usage
-----------------
+Usage
+-----
 
 .. literalinclude:: /examples/middleware/correlation_standalone.py
     :language: python
 
-Correlation Context API
------------------------
+Accessing the correlation ID
+----------------------------
 
-The :class:`~litestar.middleware.correlation.CorrelationContext` utility class provides static accessors:
+The active correlation ID is stored on the connection scope and can be retrieved anywhere the scope is available -
+in handlers, dependencies, or other middlewares - using
+:func:`~litestar.middleware.correlation.get_correlation_id`:
 
 .. code-block:: python
 
-    from litestar.middleware.correlation import CorrelationContext
+    from litestar import Request, get
+    from litestar.middleware.correlation import get_correlation_id
 
-    # Retrieve current ID
-    correlation_id = CorrelationContext.get()
 
-    # Scope context manager
-    with CorrelationContext.context("custom-id"):
-        ...
+    @get("/")
+    async def handler(request: Request) -> str | None:
+        return get_correlation_id(request.scope)
 
-The middleware validates W3C ``traceparent`` values, reads raw ASGI headers, optionally propagates the selected ID in
-the response, and restores pre-existing scope state after each request.
+The middleware validates W3C ``traceparent`` values and optionally propagates the selected ID in the response.

--- a/docs/usage/middleware/correlation.rst
+++ b/docs/usage/middleware/correlation.rst
@@ -9,7 +9,7 @@ This facilitates distributed tracing and unified logging across microservices an
 Features
 --------
 
-- Priority header fallback (:code:`x-request-id`, :code:`traceparent`, :code:`x-cloud-trace-context`, etc.).
+- Priority header fallback (:code:`x-request-id`, :code:`x-correlation-id`, and :code:`traceparent` by default).
 - W3C :code:`traceparent` defensive parsing.
 - UUID4 generation fallback when no header matches.
 - The active ID is stored on the connection scope, making it available to handlers and other middlewares.
@@ -36,6 +36,28 @@ in handlers, dependencies, or other middlewares - using
 
     @get("/")
     async def handler(request: Request) -> str | None:
-        return get_correlation_id(request.scope)
+        return get_correlation_id(request)
 
-The middleware validates W3C ``traceparent`` values and optionally propagates the selected ID in the response.
+The helper also accepts a raw ASGI scope or a :class:`~litestar.connection.WebSocket` directly:
+
+.. code-block:: python
+
+    from litestar import WebSocket, websocket
+
+
+    @websocket("/ws")
+    async def websocket_handler(socket: WebSocket) -> None:
+        await socket.accept()
+        await socket.send_text(get_correlation_id(socket) or "missing")
+
+Header behavior
+---------------
+
+The middleware validates W3C ``traceparent`` values. Values from all other configured headers are treated as opaque
+correlation values. Additional formats, including ``grpc-trace-bin`` and provider-specific headers, can be selected
+with ``header_names``; the middleware does not parse those formats.
+
+Incoming scope headers are not modified. By default, the selected correlation ID replaces ``x-request-id`` in the
+response; set ``response_header_name=None`` to disable this. This response header contains the selected correlation
+value, not a raw copy of the incoming header. The middleware does not propagate correlation headers to outbound
+requests.

--- a/docs/usage/middleware/index.rst
+++ b/docs/usage/middleware/index.rst
@@ -19,4 +19,5 @@ See :doc:`the documentation regarding these </usage/middleware/builtin-middlewar
 
     using-middleware
     builtin-middleware
+    correlation
     creating-middleware

--- a/litestar/middleware/__init__.py
+++ b/litestar/middleware/__init__.py
@@ -8,12 +8,20 @@ from litestar.middleware.base import (
     DefineMiddleware,
     MiddlewareProtocol,
 )
+from litestar.middleware.correlation import (
+    TRACE_CONTEXT_FALLBACK_HEADERS,
+    CorrelationContext,
+    CorrelationMiddleware,
+)
 
 __all__ = (
+    "TRACE_CONTEXT_FALLBACK_HEADERS",
     "ASGIMiddleware",
     "AbstractAuthenticationMiddleware",
     "AbstractMiddleware",
     "AuthenticationResult",
+    "CorrelationContext",
+    "CorrelationMiddleware",
     "DefineMiddleware",
     "MiddlewareProtocol",
 )

--- a/litestar/middleware/__init__.py
+++ b/litestar/middleware/__init__.py
@@ -10,8 +10,8 @@ from litestar.middleware.base import (
 )
 from litestar.middleware.correlation import (
     TRACE_CONTEXT_FALLBACK_HEADERS,
-    CorrelationContext,
     CorrelationMiddleware,
+    get_correlation_id,
 )
 
 __all__ = (
@@ -20,8 +20,8 @@ __all__ = (
     "AbstractAuthenticationMiddleware",
     "AbstractMiddleware",
     "AuthenticationResult",
-    "CorrelationContext",
     "CorrelationMiddleware",
     "DefineMiddleware",
     "MiddlewareProtocol",
+    "get_correlation_id",
 )

--- a/litestar/middleware/correlation.py
+++ b/litestar/middleware/correlation.py
@@ -1,18 +1,20 @@
-from collections.abc import Generator, Sequence
-from contextlib import contextmanager
-from contextvars import ContextVar, Token
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Final
 from uuid import uuid4
 
-from litestar.datastructures.headers import MutableScopeHeaders
+from litestar.datastructures.headers import Headers, MutableScopeHeaders
+from litestar.enums import ScopeType
+from litestar.middleware.base import ASGIMiddleware
+from litestar.types import Empty
+from litestar.utils.scope.state import ScopeState
 
 if TYPE_CHECKING:
     from litestar.types import ASGIApp, Message, Receive, Scope, Send
 
 __all__ = (
     "TRACE_CONTEXT_FALLBACK_HEADERS",
-    "CorrelationContext",
     "CorrelationMiddleware",
+    "get_correlation_id",
 )
 
 TRACE_CONTEXT_FALLBACK_HEADERS: Final[tuple[str, ...]] = (
@@ -26,99 +28,33 @@ TRACE_CONTEXT_FALLBACK_HEADERS: Final[tuple[str, ...]] = (
     "x-client-trace-id",
 )
 
-_correlation_id_var: ContextVar[str | None] = ContextVar("litestar_correlation_id", default=None)
 _LOWERCASE_HEX = frozenset("0123456789abcdef")
-_MISSING = object()
 
 
-def _is_lowercase_hex(value: str, length: int) -> bool:
-    return len(value) == length and not _LOWERCASE_HEX.difference(value)
+def get_correlation_id(scope: "Scope") -> str | None:
+    """Get the correlation ID stored on the connection scope by :class:`CorrelationMiddleware`.
+
+    Args:
+        scope: The ASGI scope.
+
+    Returns:
+        The correlation ID, or ``None`` if none was set.
+    """
+    correlation_id = ScopeState.from_scope(scope).correlation_id
+    return None if correlation_id is Empty else correlation_id
 
 
-def _strip_safe_value(value: str) -> str | None:
-    value = value.strip()
-    if not value or any(ord(character) < 32 or ord(character) == 127 for character in value):
-        return None
-    return value
+class CorrelationMiddleware(ASGIMiddleware):
+    """ASGI middleware for extracting, generating, and propagating correlation IDs.
 
+    The active correlation ID is stored on the connection scope and can be retrieved
+    with :func:`get_correlation_id`.
+    """
 
-class CorrelationContext:
-    """Context manager and accessor for correlation ID tracking."""
-
-    __slots__ = ()
-
-    @classmethod
-    def get(cls) -> str | None:
-        """Get the current correlation ID.
-
-        Returns:
-            The current correlation ID or None if not set.
-        """
-        return _correlation_id_var.get()
-
-    @classmethod
-    def set(cls, value: str | None) -> Token[str | None]:
-        """Set the current correlation ID.
-
-        Args:
-            value: Correlation ID value to set.
-
-        Returns:
-            A ContextVar Token for resetting context.
-        """
-        return _correlation_id_var.set(value)
-
-    @classmethod
-    def reset(cls, token: Token[str | None]) -> None:
-        """Reset the correlation ID using a token.
-
-        Args:
-            token: ContextVar token returned from set().
-        """
-        _correlation_id_var.reset(token)
-
-    @classmethod
-    def clear(cls) -> None:
-        """Clear the current correlation ID."""
-        _correlation_id_var.set(None)
-
-    @classmethod
-    def generate(cls) -> str:
-        """Generate a new correlation ID UUID.
-
-        Returns:
-            A stringified UUID4.
-        """
-        return str(uuid4())
-
-    @classmethod
-    @contextmanager
-    def context(cls, value: str | None = None) -> Generator[str, None, None]:
-        """Context manager for correlation ID tracking.
-
-        Args:
-            value: Optional correlation ID to use. If None, generates a new one.
-
-        Yields:
-            The active correlation ID.
-        """
-        if value is None:
-            value = cls.generate()
-        token = cls.set(value)
-        try:
-            yield value
-        finally:
-            cls.reset(token)
-
-
-class CorrelationMiddleware:
-    """ASGI middleware for extracting, generating, and propagating correlation IDs."""
-
-    __slots__ = ("app", "header_names", "max_length", "response_header_name")
+    scopes = (ScopeType.HTTP, ScopeType.WEBSOCKET)
 
     def __init__(
         self,
-        app: "ASGIApp",
         header_names: Sequence[str] = TRACE_CONTEXT_FALLBACK_HEADERS,
         response_header_name: str | None = "x-request-id",
         max_length: int = 128,
@@ -126,7 +62,6 @@ class CorrelationMiddleware:
         """Initialize CorrelationMiddleware.
 
         Args:
-            app: The ASGI application.
             header_names: Header name or sequence of header names to inspect in priority order.
             response_header_name: Optional header name to echo correlation ID in response. Set to None to disable.
             max_length: Maximum length for correlation IDs to prevent log injection.
@@ -140,22 +75,51 @@ class CorrelationMiddleware:
             normalized_name = name.strip().casefold()
             if normalized_name and normalized_name not in normalized_header_names:
                 normalized_header_names.append(normalized_name)
-        self.app = app
         self.header_names = tuple(normalized_header_names)
         self.response_header_name = response_header_name.strip().casefold() if response_header_name else None
         self.max_length = max_length
 
-    def _sanitize(self, value: str) -> str | None:
-        """Sanitize a correlation ID by stripping whitespace and rejecting control characters.
+    async def handle(self, scope: "Scope", receive: "Receive", send: "Send", next_app: "ASGIApp") -> None:
+        """ASGI call handler.
 
         Args:
-            value: Raw correlation ID.
+            scope: The ASGI scope.
+            receive: The ASGI receive callable.
+            send: The ASGI send callable.
+            next_app: The next ASGI application in the middleware stack.
+        """
+        correlation_id = self._extract_correlation_id(scope)
+        ScopeState.from_scope(scope).correlation_id = correlation_id
+
+        if (response_header_name := self.response_header_name) is None:
+            await next_app(scope, receive, send)
+            return
+
+        async def send_wrapper(message: "Message") -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableScopeHeaders.from_message(message)
+                headers[response_header_name] = correlation_id
+            await send(message)
+
+        await next_app(scope, receive, send_wrapper)
+
+    def _extract_correlation_id(self, scope: "Scope") -> str:
+        """Extract correlation ID from incoming request headers or generate fallback.
+
+        Args:
+            scope: The ASGI scope.
 
         Returns:
-            Sanitized correlation ID, or ``None`` when the value is unsafe.
+            Extracted or generated correlation ID.
         """
-        sanitized = _strip_safe_value(value)
-        return sanitized[: self.max_length] if sanitized is not None else None
+        headers = Headers.from_scope(scope)
+        for name in self.header_names:
+            if (value := headers.get(name)) is None:
+                continue
+            correlation_id = self._parse_traceparent(value) if name == "traceparent" else self._sanitize(value)
+            if correlation_id is not None:
+                return correlation_id
+        return str(uuid4())
 
     def _parse_traceparent(self, value: str) -> str | None:
         """Defensively parse W3C traceparent header.
@@ -185,55 +149,25 @@ class CorrelationMiddleware:
             return trace_id[: self.max_length]
         return sanitized[: self.max_length]
 
-    def _extract_correlation_id(self, scope: "Scope") -> str:
-        """Extract correlation ID from incoming request headers or generate fallback.
+    def _sanitize(self, value: str) -> str | None:
+        """Sanitize a correlation ID by stripping whitespace and rejecting control characters.
 
         Args:
-            scope: The ASGI scope.
+            value: Raw correlation ID.
 
         Returns:
-            Extracted or generated correlation ID.
+            Sanitized correlation ID, or ``None`` when the value is unsafe.
         """
-        for name in self.header_names:
-            name_bytes = name.encode("latin-1")
-            for raw_name, raw_value in scope.get("headers", ()):
-                if raw_name.lower() != name_bytes:
-                    continue
-                value = raw_value.decode("latin-1")
-                correlation_id = self._parse_traceparent(value) if name == "traceparent" else self._sanitize(value)
-                if correlation_id is not None:
-                    return correlation_id
-        return CorrelationContext.generate()
+        sanitized = _strip_safe_value(value)
+        return sanitized[: self.max_length] if sanitized is not None else None
 
-    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
-        """ASGI call handler.
 
-        Args:
-            scope: The ASGI scope.
-            receive: The ASGI receive callable.
-            send: The ASGI send callable.
-        """
-        if scope["type"] not in ("http", "websocket"):
-            await self.app(scope, receive, send)
-            return
+def _is_lowercase_hex(value: str, length: int) -> bool:
+    return len(value) == length and _LOWERCASE_HEX.issuperset(value)
 
-        correlation_id = self._extract_correlation_id(scope)
-        token = CorrelationContext.set(correlation_id)
-        state = scope.setdefault("state", {})
-        previous_correlation_id = state.get("correlation_id", _MISSING)
-        state["correlation_id"] = correlation_id
 
-        async def send_wrapper(message: "Message") -> None:
-            if message["type"] == "http.response.start" and self.response_header_name:
-                headers = MutableScopeHeaders.from_message(message)
-                headers[self.response_header_name] = correlation_id
-            await send(message)
-
-        try:
-            await self.app(scope, receive, send_wrapper)
-        finally:
-            CorrelationContext.reset(token)
-            if previous_correlation_id is _MISSING:
-                state.pop("correlation_id", None)
-            else:
-                state["correlation_id"] = previous_correlation_id
+def _strip_safe_value(value: str) -> str | None:
+    value = value.strip()
+    if not value or any(ord(character) < 32 or ord(character) == 127 for character in value):
+        return None
+    return value

--- a/litestar/middleware/correlation.py
+++ b/litestar/middleware/correlation.py
@@ -32,7 +32,7 @@ _MISSING = object()
 
 
 def _is_lowercase_hex(value: str, length: int) -> bool:
-    return len(value) == length and all(character in _LOWERCASE_HEX for character in value)
+    return len(value) == length and not _LOWERCASE_HEX.difference(value)
 
 
 def _strip_safe_value(value: str) -> str | None:

--- a/litestar/middleware/correlation.py
+++ b/litestar/middleware/correlation.py
@@ -1,0 +1,239 @@
+from collections.abc import Generator, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from typing import TYPE_CHECKING, Final
+from uuid import uuid4
+
+from litestar.datastructures.headers import MutableScopeHeaders
+
+if TYPE_CHECKING:
+    from litestar.types import ASGIApp, Message, Receive, Scope, Send
+
+__all__ = (
+    "TRACE_CONTEXT_FALLBACK_HEADERS",
+    "CorrelationContext",
+    "CorrelationMiddleware",
+)
+
+TRACE_CONTEXT_FALLBACK_HEADERS: Final[tuple[str, ...]] = (
+    "x-request-id",
+    "x-correlation-id",
+    "traceparent",
+    "x-cloud-trace-context",
+    "grpc-trace-bin",
+    "x-amzn-trace-id",
+    "x-b3-traceid",
+    "x-client-trace-id",
+)
+
+_correlation_id_var: ContextVar[str | None] = ContextVar("litestar_correlation_id", default=None)
+_LOWERCASE_HEX = frozenset("0123456789abcdef")
+_MISSING = object()
+
+
+def _is_lowercase_hex(value: str, length: int) -> bool:
+    return len(value) == length and all(character in _LOWERCASE_HEX for character in value)
+
+
+def _strip_safe_value(value: str) -> str | None:
+    value = value.strip()
+    if not value or any(ord(character) < 32 or ord(character) == 127 for character in value):
+        return None
+    return value
+
+
+class CorrelationContext:
+    """Context manager and accessor for correlation ID tracking."""
+
+    __slots__ = ()
+
+    @classmethod
+    def get(cls) -> str | None:
+        """Get the current correlation ID.
+
+        Returns:
+            The current correlation ID or None if not set.
+        """
+        return _correlation_id_var.get()
+
+    @classmethod
+    def set(cls, value: str | None) -> Token[str | None]:
+        """Set the current correlation ID.
+
+        Args:
+            value: Correlation ID value to set.
+
+        Returns:
+            A ContextVar Token for resetting context.
+        """
+        return _correlation_id_var.set(value)
+
+    @classmethod
+    def reset(cls, token: Token[str | None]) -> None:
+        """Reset the correlation ID using a token.
+
+        Args:
+            token: ContextVar token returned from set().
+        """
+        _correlation_id_var.reset(token)
+
+    @classmethod
+    def clear(cls) -> None:
+        """Clear the current correlation ID."""
+        _correlation_id_var.set(None)
+
+    @classmethod
+    def generate(cls) -> str:
+        """Generate a new correlation ID UUID.
+
+        Returns:
+            A stringified UUID4.
+        """
+        return str(uuid4())
+
+    @classmethod
+    @contextmanager
+    def context(cls, value: str | None = None) -> Generator[str, None, None]:
+        """Context manager for correlation ID tracking.
+
+        Args:
+            value: Optional correlation ID to use. If None, generates a new one.
+
+        Yields:
+            The active correlation ID.
+        """
+        if value is None:
+            value = cls.generate()
+        token = cls.set(value)
+        try:
+            yield value
+        finally:
+            cls.reset(token)
+
+
+class CorrelationMiddleware:
+    """ASGI middleware for extracting, generating, and propagating correlation IDs."""
+
+    __slots__ = ("app", "header_names", "max_length", "response_header_name")
+
+    def __init__(
+        self,
+        app: "ASGIApp",
+        header_names: Sequence[str] = TRACE_CONTEXT_FALLBACK_HEADERS,
+        response_header_name: str | None = "x-request-id",
+        max_length: int = 128,
+    ) -> None:
+        """Initialize CorrelationMiddleware.
+
+        Args:
+            app: The ASGI application.
+            header_names: Header name or sequence of header names to inspect in priority order.
+            response_header_name: Optional header name to echo correlation ID in response. Set to None to disable.
+            max_length: Maximum length for correlation IDs to prevent log injection.
+        """
+        if max_length <= 0:
+            raise ValueError("max_length must be greater than 0")
+        if isinstance(header_names, str):
+            header_names = (header_names,)
+        normalized_header_names: list[str] = []
+        for name in header_names:
+            normalized_name = name.strip().casefold()
+            if normalized_name and normalized_name not in normalized_header_names:
+                normalized_header_names.append(normalized_name)
+        self.app = app
+        self.header_names = tuple(normalized_header_names)
+        self.response_header_name = response_header_name.strip().casefold() if response_header_name else None
+        self.max_length = max_length
+
+    def _sanitize(self, value: str) -> str | None:
+        """Sanitize a correlation ID by stripping whitespace and rejecting control characters.
+
+        Args:
+            value: Raw correlation ID.
+
+        Returns:
+            Sanitized correlation ID, or ``None`` when the value is unsafe.
+        """
+        sanitized = _strip_safe_value(value)
+        return sanitized[: self.max_length] if sanitized is not None else None
+
+    def _parse_traceparent(self, value: str) -> str | None:
+        """Defensively parse W3C traceparent header.
+
+        Args:
+            value: Incoming traceparent header value.
+
+        Returns:
+            The extracted trace ID if valid, else the sanitized raw header string.
+        """
+        sanitized = _strip_safe_value(value)
+        if sanitized is None:
+            return None
+        parts = sanitized.split("-")
+        if len(parts) != 4:
+            return sanitized[: self.max_length]
+        version, trace_id, parent_id, flags = parts
+        if (
+            _is_lowercase_hex(version, 2)
+            and version != "ff"
+            and _is_lowercase_hex(trace_id, 32)
+            and trace_id != "0" * 32
+            and _is_lowercase_hex(parent_id, 16)
+            and parent_id != "0" * 16
+            and _is_lowercase_hex(flags, 2)
+        ):
+            return trace_id[: self.max_length]
+        return sanitized[: self.max_length]
+
+    def _extract_correlation_id(self, scope: "Scope") -> str:
+        """Extract correlation ID from incoming request headers or generate fallback.
+
+        Args:
+            scope: The ASGI scope.
+
+        Returns:
+            Extracted or generated correlation ID.
+        """
+        for name in self.header_names:
+            name_bytes = name.encode("latin-1")
+            for raw_name, raw_value in scope.get("headers", ()):
+                if raw_name.lower() != name_bytes:
+                    continue
+                value = raw_value.decode("latin-1")
+                correlation_id = self._parse_traceparent(value) if name == "traceparent" else self._sanitize(value)
+                if correlation_id is not None:
+                    return correlation_id
+        return CorrelationContext.generate()
+
+    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+        """ASGI call handler.
+
+        Args:
+            scope: The ASGI scope.
+            receive: The ASGI receive callable.
+            send: The ASGI send callable.
+        """
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        correlation_id = self._extract_correlation_id(scope)
+        token = CorrelationContext.set(correlation_id)
+        state = scope.setdefault("state", {})
+        previous_correlation_id = state.get("correlation_id", _MISSING)
+        state["correlation_id"] = correlation_id
+
+        async def send_wrapper(message: "Message") -> None:
+            if message["type"] == "http.response.start" and self.response_header_name:
+                headers = MutableScopeHeaders.from_message(message)
+                headers[self.response_header_name] = correlation_id
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            CorrelationContext.reset(token)
+            if previous_correlation_id is _MISSING:
+                state.pop("correlation_id", None)
+            else:
+                state["correlation_id"] = previous_correlation_id

--- a/litestar/middleware/correlation.py
+++ b/litestar/middleware/correlation.py
@@ -1,7 +1,9 @@
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Final
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final
 from uuid import uuid4
 
+from litestar.connection import ASGIConnection
 from litestar.datastructures.headers import Headers, MutableScopeHeaders
 from litestar.enums import ScopeType
 from litestar.middleware.base import ASGIMiddleware
@@ -9,6 +11,8 @@ from litestar.types import Empty
 from litestar.utils.scope.state import ScopeState
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from litestar.types import ASGIApp, Message, Receive, Scope, Send
 
 __all__ = (
@@ -21,25 +25,21 @@ TRACE_CONTEXT_FALLBACK_HEADERS: Final[tuple[str, ...]] = (
     "x-request-id",
     "x-correlation-id",
     "traceparent",
-    "x-cloud-trace-context",
-    "grpc-trace-bin",
-    "x-amzn-trace-id",
-    "x-b3-traceid",
-    "x-client-trace-id",
 )
 
 _LOWERCASE_HEX = frozenset("0123456789abcdef")
 
 
-def get_correlation_id(scope: "Scope") -> str | None:
+def get_correlation_id(connection: ASGIConnection[Any, Any, Any, Any] | Scope) -> str | None:
     """Get the correlation ID stored on the connection scope by :class:`CorrelationMiddleware`.
 
     Args:
-        scope: The ASGI scope.
+        connection: An ASGI connection or scope.
 
     Returns:
         The correlation ID, or ``None`` if none was set.
     """
+    scope = connection.scope if isinstance(connection, ASGIConnection) else connection
     correlation_id = ScopeState.from_scope(scope).correlation_id
     return None if correlation_id is Empty else correlation_id
 
@@ -79,7 +79,7 @@ class CorrelationMiddleware(ASGIMiddleware):
         self.response_header_name = response_header_name.strip().casefold() if response_header_name else None
         self.max_length = max_length
 
-    async def handle(self, scope: "Scope", receive: "Receive", send: "Send", next_app: "ASGIApp") -> None:
+    async def handle(self, scope: Scope, receive: Receive, send: Send, next_app: ASGIApp) -> None:
         """ASGI call handler.
 
         Args:
@@ -95,7 +95,7 @@ class CorrelationMiddleware(ASGIMiddleware):
             await next_app(scope, receive, send)
             return
 
-        async def send_wrapper(message: "Message") -> None:
+        async def send_wrapper(message: Message) -> None:
             if message["type"] == "http.response.start":
                 headers = MutableScopeHeaders.from_message(message)
                 headers[response_header_name] = correlation_id
@@ -103,7 +103,7 @@ class CorrelationMiddleware(ASGIMiddleware):
 
         await next_app(scope, receive, send_wrapper)
 
-    def _extract_correlation_id(self, scope: "Scope") -> str:
+    def _extract_correlation_id(self, scope: Scope) -> str:
         """Extract correlation ID from incoming request headers or generate fallback.
 
         Args:

--- a/litestar/middleware/correlation.py
+++ b/litestar/middleware/correlation.py
@@ -55,19 +55,30 @@ class CorrelationMiddleware(ASGIMiddleware):
 
     def __init__(
         self,
-        header_names: Sequence[str] = TRACE_CONTEXT_FALLBACK_HEADERS,
+        header_names: Sequence[str] | None = None,
+        additional_header_names: Sequence[str] | None = None,
         response_header_name: str | None = "x-request-id",
         max_length: int = 128,
     ) -> None:
         """Initialize CorrelationMiddleware.
 
         Args:
-            header_names: Header name or sequence of header names to inspect in priority order.
+            header_names: Header name or sequence of header names to inspect in priority order, replacing the defaults.
+            additional_header_names: Header name or sequence of header names to inspect after the defaults.
             response_header_name: Optional header name to echo correlation ID in response. Set to None to disable.
             max_length: Maximum length for correlation IDs to prevent log injection.
+
+        Raises:
+            ValueError: If ``max_length`` is not positive or both header name options are provided.
         """
         if max_length <= 0:
             raise ValueError("max_length must be greater than 0")
+        if header_names is not None and additional_header_names is not None:
+            raise ValueError("header_names and additional_header_names are mutually exclusive")
+        if header_names is None:
+            if isinstance(additional_header_names, str):
+                additional_header_names = (additional_header_names,)
+            header_names = (*TRACE_CONTEXT_FALLBACK_HEADERS, *(additional_header_names or ()))
         if isinstance(header_names, str):
             header_names = (header_names,)
         normalized_header_names: list[str] = []

--- a/litestar/utils/scope/state.py
+++ b/litestar/utils/scope/state.py
@@ -31,6 +31,7 @@ class ScopeState:
         "body",
         "content_type",
         "cookies",
+        "correlation_id",
         "csrf_token",
         "dependency_cache",
         "do_cache",
@@ -55,6 +56,7 @@ class ScopeState:
         self.body = Empty
         self.content_type = Empty
         self.cookies = Empty
+        self.correlation_id = Empty
         self.csrf_token = Empty
         self.dependency_cache = Empty
         self.do_cache = Empty
@@ -77,6 +79,7 @@ class ScopeState:
     body: bytes | EmptyType
     content_type: tuple[str, dict[str, str]] | EmptyType
     cookies: dict[str, str] | EmptyType
+    correlation_id: str | EmptyType
     csrf_token: str | EmptyType
     dependency_cache: dict[str, Any] | EmptyType
     do_cache: bool | EmptyType

--- a/tests/unit/test_middleware/test_correlation.py
+++ b/tests/unit/test_middleware/test_correlation.py
@@ -16,15 +16,8 @@ from litestar.params import FromPath
 from litestar.testing import AsyncTestClient
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
-
     from litestar.connection import WebSocket
     from litestar.types import Message, Receive, Scope, Send
-
-
-@pytest.fixture
-def anyio_backend() -> str:
-    return "asyncio"
 
 
 async def _receive() -> Any:
@@ -33,10 +26,6 @@ async def _receive() -> Any:
 
 async def _send(_: Message) -> None:
     return None
-
-
-async def _await_middleware(awaitable: Awaitable[None]) -> None:
-    await awaitable
 
 
 def _scope(scope_type: str = "http", headers: list[tuple[bytes, bytes]] | None = None) -> Any:
@@ -50,15 +39,31 @@ def test_header_names_are_normalized_and_deduplicated() -> None:
 
 def test_default_header_names_are_conservative() -> None:
     assert TRACE_CONTEXT_FALLBACK_HEADERS == ("x-request-id", "x-correlation-id", "traceparent")
+    assert CorrelationMiddleware().header_names == TRACE_CONTEXT_FALLBACK_HEADERS
 
 
-def test_single_header_name_is_not_treated_as_a_sequence_of_characters() -> None:
+def test_additional_header_names_extend_defaults() -> None:
+    middleware = CorrelationMiddleware(additional_header_names=("grpc-trace-bin", " X-Request-ID "))
+    assert middleware.header_names == (*TRACE_CONTEXT_FALLBACK_HEADERS, "grpc-trace-bin")
+
+
+def test_single_additional_header_name_is_not_treated_as_a_sequence_of_characters() -> None:
+    middleware = CorrelationMiddleware(additional_header_names="grpc-trace-bin")
+    assert middleware.header_names == (*TRACE_CONTEXT_FALLBACK_HEADERS, "grpc-trace-bin")
+
+
+def test_header_names_and_additional_header_names_are_mutually_exclusive() -> None:
+    with pytest.raises(ValueError, match="header_names and additional_header_names are mutually exclusive"):
+        CorrelationMiddleware(header_names=("x-custom-id",), additional_header_names=("grpc-trace-bin",))
+
+
+async def test_single_header_name_is_not_treated_as_a_sequence_of_characters() -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         assert get_correlation_id(scope) == "selected"
 
     middleware = CorrelationMiddleware(header_names="X-Correlation-ID")
     scope = _scope(headers=[(b"x-correlation-id", b"selected")])
-    asyncio.run(_await_middleware(middleware(app)(scope, _receive, _send)))
+    await middleware(app)(scope, _receive, _send)
 
 
 @pytest.mark.parametrize("max_length", [0, -1])
@@ -68,13 +73,13 @@ def test_max_length_must_be_positive(max_length: int) -> None:
 
 
 @pytest.mark.parametrize("unsafe_value", [b"", b"   ", b"bad\x00id", b"bad\x1fid", b"bad\x7fid", b"bad\tid"])
-def test_blank_or_control_character_values_fall_through_to_lower_priority_header(unsafe_value: bytes) -> None:
+async def test_blank_or_control_character_values_fall_through_to_lower_priority_header(unsafe_value: bytes) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         assert get_correlation_id(scope) == "safe-id"
 
     middleware = CorrelationMiddleware(header_names=["x-first", "x-second"])
     scope = _scope(headers=[(b"x-first", unsafe_value), (b"x-second", b"safe-id")])
-    asyncio.run(_await_middleware(middleware(app)(scope, _receive, _send)))
+    await middleware(app)(scope, _receive, _send)
 
 
 @pytest.mark.parametrize(
@@ -91,59 +96,57 @@ def test_blank_or_control_character_values_fall_through_to_lower_priority_header
         "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa012302b7-01-extra",
     ],
 )
-def test_malformed_traceparent_uses_sanitized_raw_value(value: str) -> None:
+async def test_malformed_traceparent_uses_sanitized_raw_value(value: str) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         assert get_correlation_id(scope) == value[:128]
 
     scope = _scope(headers=[(b"traceparent", f"  {value}  ".encode())])
-    asyncio.run(_await_middleware(CorrelationMiddleware(header_names="traceparent")(app)(scope, _receive, _send)))
+    await CorrelationMiddleware(header_names="traceparent")(app)(scope, _receive, _send)
 
 
-def test_valid_traceparent_extracts_trace_id() -> None:
+async def test_valid_traceparent_extracts_trace_id() -> None:
     trace_id = "4bf92f3577b34da6a3ce929d0e0e4736"
 
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         assert get_correlation_id(scope) == trace_id
 
     scope = _scope(headers=[(b"traceparent", f"00-{trace_id}-00f067aa012302b7-01".encode())])
-    asyncio.run(_await_middleware(CorrelationMiddleware(header_names="traceparent")(app)(scope, _receive, _send)))
+    await CorrelationMiddleware(header_names="traceparent")(app)(scope, _receive, _send)
 
 
-def test_traceparent_is_validated_before_max_length_is_applied() -> None:
+async def test_traceparent_is_validated_before_max_length_is_applied() -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         assert get_correlation_id(scope) == "4bf92f35"
 
     value = b"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa012302b7-01"
     scope = _scope(headers=[(b"traceparent", value)])
-    asyncio.run(
-        _await_middleware(CorrelationMiddleware(header_names="traceparent", max_length=8)(app)(scope, _receive, _send))
-    )
+    await CorrelationMiddleware(header_names="traceparent", max_length=8)(app)(scope, _receive, _send)
 
 
-def test_unsafe_traceparent_falls_through_to_lower_priority_header() -> None:
+async def test_unsafe_traceparent_falls_through_to_lower_priority_header() -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         assert get_correlation_id(scope) == "safe-id"
 
     scope = _scope(headers=[(b"traceparent", b"bad\tvalue"), (b"x-request-id", b"safe-id")])
     middleware = CorrelationMiddleware(header_names=["traceparent", "x-request-id"])
-    asyncio.run(_await_middleware(middleware(app)(scope, _receive, _send)))
+    await middleware(app)(scope, _receive, _send)
 
 
-def test_uuid_is_generated_when_no_safe_header_matches() -> None:
+async def test_uuid_is_generated_when_no_safe_header_matches() -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         correlation_id = get_correlation_id(scope)
         assert correlation_id is not None
         assert UUID(correlation_id)
 
     scope = _scope(headers=[(b"x-request-id", b"bad\nvalue")])
-    asyncio.run(_await_middleware(CorrelationMiddleware()(app)(scope, _receive, _send)))
+    await CorrelationMiddleware()(app)(scope, _receive, _send)
 
 
 def test_get_correlation_id_returns_none_when_middleware_did_not_run() -> None:
     assert get_correlation_id(_scope()) is None
 
 
-def test_explicit_grpc_trace_header_is_opaque_and_unchanged() -> None:
+async def test_explicit_grpc_trace_header_is_opaque_and_unchanged() -> None:
     value = b"opaque-grpc-trace-value"
 
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
@@ -151,10 +154,10 @@ def test_explicit_grpc_trace_header_is_opaque_and_unchanged() -> None:
         assert scope["headers"] == [(b"grpc-trace-bin", value)]
 
     scope = _scope(headers=[(b"grpc-trace-bin", value)])
-    asyncio.run(_await_middleware(CorrelationMiddleware(header_names="grpc-trace-bin")(app)(scope, _receive, _send)))
+    await CorrelationMiddleware(header_names="grpc-trace-bin")(app)(scope, _receive, _send)
 
 
-def test_response_header_replaces_existing_values() -> None:
+async def test_response_header_replaces_existing_values() -> None:
     sent: list[Any] = []
 
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
@@ -170,11 +173,11 @@ def test_response_header_replaces_existing_values() -> None:
         sent.append(message)
 
     scope = _scope(headers=[(b"x-request-id", b"authoritative")])
-    asyncio.run(_await_middleware(CorrelationMiddleware()(app)(scope, _receive, send)))
+    await CorrelationMiddleware()(app)(scope, _receive, send)
     assert sent[0]["headers"] == [(b"x-request-id", b"authoritative")]
 
 
-def test_response_header_can_be_disabled() -> None:
+async def test_response_header_can_be_disabled() -> None:
     sent: list[Any] = []
 
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
@@ -184,11 +187,10 @@ def test_response_header_can_be_disabled() -> None:
         sent.append(message)
 
     scope = _scope()
-    asyncio.run(_await_middleware(CorrelationMiddleware(response_header_name=None)(app)(scope, _receive, send)))
+    await CorrelationMiddleware(response_header_name=None)(app)(scope, _receive, send)
     assert sent[0]["headers"] == []
 
 
-@pytest.mark.anyio
 async def test_correlation_id_is_available_to_downstream_middleware_and_handlers() -> None:
     async def downstream(scope: Scope, receive: Receive, send: Send, next_app: Any) -> None:
         assert get_correlation_id(scope) == "shared-id"
@@ -211,7 +213,6 @@ async def test_correlation_id_is_available_to_downstream_middleware_and_handlers
     assert response.headers["x-request-id"] == "shared-id"
 
 
-@pytest.mark.anyio
 async def test_http_requests_are_isolated_concurrently() -> None:
     @get("/{request_id:str}")
     async def handler(request: Request[Any, Any, Any], request_id: FromPath[str]) -> dict[str, str | None]:
@@ -226,7 +227,6 @@ async def test_http_requests_are_isolated_concurrently() -> None:
     assert [response.json()["correlation_id"] for response in responses] == [f"id-{index}" for index in range(10)]
 
 
-@pytest.mark.anyio
 async def test_websocket_scope_exposes_correlation_id() -> None:
     @websocket("/")
     async def handler(socket: WebSocket[Any, Any, Any]) -> None:

--- a/tests/unit/test_middleware/test_correlation.py
+++ b/tests/unit/test_middleware/test_correlation.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+import pytest
+
+from litestar import Litestar, get, websocket
+from litestar.middleware.correlation import CorrelationContext, CorrelationMiddleware
+from litestar.params import FromPath
+from litestar.testing import AsyncTestClient
+
+if TYPE_CHECKING:
+    from litestar.connection import WebSocket
+    from litestar.types import Message, Receive, Scope, Send
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def _receive() -> Any:
+    return {"type": "http.request"}
+
+
+async def _send(_: Message) -> None:
+    return None
+
+
+def _scope(
+    scope_type: str = "http", headers: list[tuple[bytes, bytes]] | None = None, state: dict[str, Any] | None = None
+) -> Any:
+    scope: dict[str, Any] = {"type": scope_type, "headers": headers or []}
+    if state is not None:
+        scope["state"] = state
+    return scope
+
+
+def test_correlation_context_operations() -> None:
+    token = CorrelationContext.set("outer")
+    try:
+        with CorrelationContext.context("inner") as correlation_id:
+            assert correlation_id == "inner"
+            assert CorrelationContext.get() == "inner"
+        assert CorrelationContext.get() == "outer"
+
+        with CorrelationContext.context() as generated:
+            assert UUID(generated)
+
+        CorrelationContext.clear()
+        assert CorrelationContext.get() is None
+    finally:
+        CorrelationContext.reset(token)
+
+
+def test_header_names_are_normalized_and_deduplicated() -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        return None
+
+    middleware = CorrelationMiddleware(app, header_names=[" X-Request-ID ", "x-request-id", "X-Trace-ID"])
+    assert middleware.header_names == ("x-request-id", "x-trace-id")
+
+
+def test_single_header_name_is_not_treated_as_a_sequence_of_characters() -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        assert CorrelationContext.get() == "selected"
+
+    middleware = CorrelationMiddleware(app, header_names="X-Correlation-ID")
+    scope = _scope(headers=[(b"x-correlation-id", b"selected")])
+    asyncio.run(middleware(scope, _receive, _send))
+
+
+@pytest.mark.parametrize("max_length", [0, -1])
+def test_max_length_must_be_positive(max_length: int) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        return None
+
+    with pytest.raises(ValueError, match="max_length must be greater than 0"):
+        CorrelationMiddleware(app, max_length=max_length)
+
+
+@pytest.mark.parametrize("unsafe_value", [b"", b"   ", b"bad\x00id", b"bad\x1fid", b"bad\x7fid", b"bad\tid"])
+def test_blank_or_control_character_values_fall_through_to_lower_priority_header(unsafe_value: bytes) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        assert CorrelationContext.get() == "safe-id"
+
+    middleware = CorrelationMiddleware(app, header_names=["x-first", "x-second"])
+    scope = _scope(headers=[(b"x-first", unsafe_value), (b"x-second", b"safe-id")])
+    asyncio.run(middleware(scope, _receive, _send))
+
+
+def test_reads_raw_scope_headers_after_downstream_header_cache_was_created() -> None:
+    from litestar.datastructures.headers import Headers
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        assert CorrelationContext.get() == "mutated"
+
+    scope = _scope(headers=[(b"x-request-id", b"original")])
+    assert Headers.from_scope(scope)["x-request-id"] == "original"
+    scope["headers"] = [(b"x-request-id", b"mutated")]
+    asyncio.run(CorrelationMiddleware(app)(scope, _receive, _send))
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa012302b7-01",
+        "0-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa012302b7-01",
+        "0G-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa012302b7-01",
+        "00-4BF92F3577B34DA6A3CE929D0E0E4736-00f067aa012302b7-01",
+        "00-00000000000000000000000000000000-00f067aa012302b7-01",
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01",
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00F067AA012302B7-01",
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa012302b7-0G",
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa012302b7-01-extra",
+    ],
+)
+def test_malformed_traceparent_uses_sanitized_raw_value(value: str) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        assert CorrelationContext.get() == value[:128]
+
+    scope = _scope(headers=[(b"traceparent", f"  {value}  ".encode())])
+    asyncio.run(CorrelationMiddleware(app, header_names="traceparent")(scope, _receive, _send))
+
+
+def test_valid_traceparent_extracts_trace_id() -> None:
+    trace_id = "4bf92f3577b34da6a3ce929d0e0e4736"
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        assert CorrelationContext.get() == trace_id
+
+    scope = _scope(headers=[(b"traceparent", f"00-{trace_id}-00f067aa012302b7-01".encode())])
+    asyncio.run(CorrelationMiddleware(app, header_names="traceparent")(scope, _receive, _send))
+
+
+def test_traceparent_is_validated_before_max_length_is_applied() -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        assert CorrelationContext.get() == "4bf92f35"
+
+    value = b"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa012302b7-01"
+    scope = _scope(headers=[(b"traceparent", value)])
+    asyncio.run(CorrelationMiddleware(app, header_names="traceparent", max_length=8)(scope, _receive, _send))
+
+
+def test_unsafe_traceparent_falls_through_to_lower_priority_header() -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        assert CorrelationContext.get() == "safe-id"
+
+    scope = _scope(headers=[(b"traceparent", b"bad\tvalue"), (b"x-request-id", b"safe-id")])
+    middleware = CorrelationMiddleware(app, header_names=["traceparent", "x-request-id"])
+    asyncio.run(middleware(scope, _receive, _send))
+
+
+def test_uuid_is_generated_when_no_safe_header_matches() -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        correlation_id = CorrelationContext.get()
+        assert correlation_id is not None
+        assert UUID(correlation_id)
+
+    scope = _scope(headers=[(b"x-request-id", b"bad\nvalue")])
+    asyncio.run(CorrelationMiddleware(app)(scope, _receive, _send))
+
+
+def test_response_header_replaces_existing_values() -> None:
+    sent: list[Any] = []
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"x-request-id", b"old-one"), (b"X-Request-ID", b"old-two")],
+            }
+        )
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    scope = _scope(headers=[(b"x-request-id", b"authoritative")])
+    asyncio.run(CorrelationMiddleware(app)(scope, _receive, send))
+    assert sent[0]["headers"] == [(b"x-request-id", b"authoritative")]
+
+
+def test_response_header_can_be_disabled() -> None:
+    sent: list[Any] = []
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    scope = _scope()
+    asyncio.run(CorrelationMiddleware(app, response_header_name=None)(scope, _receive, send))
+    assert sent[0]["headers"] == []
+
+
+@pytest.mark.parametrize("raises", [False, True])
+def test_context_and_prior_scope_state_are_restored(raises: bool) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        assert CorrelationContext.get() == "request-id"
+        assert scope["state"]["correlation_id"] == "request-id"
+        if raises:
+            raise RuntimeError("boom")
+
+    token = CorrelationContext.set("outer-id")
+    scope = _scope(headers=[(b"x-request-id", b"request-id")], state={"correlation_id": "prior-state"})
+    try:
+        if raises:
+            with pytest.raises(RuntimeError, match="boom"):
+                asyncio.run(CorrelationMiddleware(app)(scope, _receive, _send))
+        else:
+            asyncio.run(CorrelationMiddleware(app)(scope, _receive, _send))
+        assert CorrelationContext.get() == "outer-id"
+        assert scope["state"]["correlation_id"] == "prior-state"
+    finally:
+        CorrelationContext.reset(token)
+
+
+def test_new_scope_state_value_is_removed_on_unwind() -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        assert "correlation_id" in scope["state"]
+
+    scope = _scope(scope_type="websocket", state={})
+    asyncio.run(CorrelationMiddleware(app)(scope, _receive, _send))
+    assert "correlation_id" not in scope["state"]
+
+
+def test_non_request_scope_is_bypassed() -> None:
+    called = False
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        nonlocal called
+        called = True
+        assert CorrelationContext.get() is None
+        assert "state" not in scope
+
+    scope = _scope(scope_type="lifespan")
+    scope.pop("headers")
+    asyncio.run(CorrelationMiddleware(app)(scope, _receive, _send))
+    assert called
+
+
+@pytest.mark.anyio
+async def test_http_requests_are_isolated_concurrently() -> None:
+    @get("/{request_id:str}")
+    async def handler(request_id: FromPath[str]) -> dict[str, str | None]:
+        await asyncio.sleep(0)
+        return {"correlation_id": CorrelationContext.get(), "request_id": request_id}
+
+    app = Litestar(route_handlers=[handler], middleware=[CorrelationMiddleware])
+    async with AsyncTestClient(app=app) as client:
+        responses = await asyncio.gather(
+            *(client.get(f"/{index}", headers={"x-request-id": f"id-{index}"}) for index in range(10))
+        )
+    assert [response.json()["correlation_id"] for response in responses] == [f"id-{index}" for index in range(10)]
+
+
+@pytest.mark.anyio
+async def test_websocket_scope_exposes_correlation_context() -> None:
+    @websocket("/")
+    async def handler(socket: WebSocket[Any, Any, Any]) -> None:
+        await socket.accept()
+        await socket.send_text(CorrelationContext.get() or "missing")
+        await socket.close()
+
+    app = Litestar(route_handlers=[handler], middleware=[CorrelationMiddleware])
+    async with AsyncTestClient(app=app) as client:
+        async with await client.websocket_connect("/", headers={"x-request-id": "websocket-id"}) as socket:
+            assert await socket.receive_text() == "websocket-id"

--- a/tests/unit/test_middleware/test_correlation.py
+++ b/tests/unit/test_middleware/test_correlation.py
@@ -7,7 +7,7 @@ from uuid import UUID
 import pytest
 
 from litestar import Litestar, get, websocket
-from litestar.middleware.correlation import CorrelationContext, CorrelationMiddleware
+from litestar.middleware.correlation import CorrelationMiddleware, get_correlation_id
 from litestar.params import FromPath
 from litestar.testing import AsyncTestClient
 
@@ -29,78 +29,38 @@ async def _send(_: Message) -> None:
     return None
 
 
-def _scope(
-    scope_type: str = "http", headers: list[tuple[bytes, bytes]] | None = None, state: dict[str, Any] | None = None
-) -> Any:
-    scope: dict[str, Any] = {"type": scope_type, "headers": headers or []}
-    if state is not None:
-        scope["state"] = state
-    return scope
-
-
-def test_correlation_context_operations() -> None:
-    token = CorrelationContext.set("outer")
-    try:
-        with CorrelationContext.context("inner") as correlation_id:
-            assert correlation_id == "inner"
-            assert CorrelationContext.get() == "inner"
-        assert CorrelationContext.get() == "outer"
-
-        with CorrelationContext.context() as generated:
-            assert UUID(generated)
-
-        CorrelationContext.clear()
-        assert CorrelationContext.get() is None
-    finally:
-        CorrelationContext.reset(token)
+def _scope(scope_type: str = "http", headers: list[tuple[bytes, bytes]] | None = None) -> Any:
+    return {"type": scope_type, "headers": headers or []}
 
 
 def test_header_names_are_normalized_and_deduplicated() -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        return None
-
-    middleware = CorrelationMiddleware(app, header_names=[" X-Request-ID ", "x-request-id", "X-Trace-ID"])
+    middleware = CorrelationMiddleware(header_names=[" X-Request-ID ", "x-request-id", "X-Trace-ID"])
     assert middleware.header_names == ("x-request-id", "x-trace-id")
 
 
 def test_single_header_name_is_not_treated_as_a_sequence_of_characters() -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        assert CorrelationContext.get() == "selected"
+        assert get_correlation_id(scope) == "selected"
 
-    middleware = CorrelationMiddleware(app, header_names="X-Correlation-ID")
+    middleware = CorrelationMiddleware(header_names="X-Correlation-ID")
     scope = _scope(headers=[(b"x-correlation-id", b"selected")])
-    asyncio.run(middleware(scope, _receive, _send))
+    asyncio.run(middleware(app)(scope, _receive, _send))
 
 
 @pytest.mark.parametrize("max_length", [0, -1])
 def test_max_length_must_be_positive(max_length: int) -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        return None
-
     with pytest.raises(ValueError, match="max_length must be greater than 0"):
-        CorrelationMiddleware(app, max_length=max_length)
+        CorrelationMiddleware(max_length=max_length)
 
 
 @pytest.mark.parametrize("unsafe_value", [b"", b"   ", b"bad\x00id", b"bad\x1fid", b"bad\x7fid", b"bad\tid"])
 def test_blank_or_control_character_values_fall_through_to_lower_priority_header(unsafe_value: bytes) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        assert CorrelationContext.get() == "safe-id"
+        assert get_correlation_id(scope) == "safe-id"
 
-    middleware = CorrelationMiddleware(app, header_names=["x-first", "x-second"])
+    middleware = CorrelationMiddleware(header_names=["x-first", "x-second"])
     scope = _scope(headers=[(b"x-first", unsafe_value), (b"x-second", b"safe-id")])
-    asyncio.run(middleware(scope, _receive, _send))
-
-
-def test_reads_raw_scope_headers_after_downstream_header_cache_was_created() -> None:
-    from litestar.datastructures.headers import Headers
-
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        assert CorrelationContext.get() == "mutated"
-
-    scope = _scope(headers=[(b"x-request-id", b"original")])
-    assert Headers.from_scope(scope)["x-request-id"] == "original"
-    scope["headers"] = [(b"x-request-id", b"mutated")]
-    asyncio.run(CorrelationMiddleware(app)(scope, _receive, _send))
+    asyncio.run(middleware(app)(scope, _receive, _send))
 
 
 @pytest.mark.parametrize(
@@ -119,48 +79,52 @@ def test_reads_raw_scope_headers_after_downstream_header_cache_was_created() -> 
 )
 def test_malformed_traceparent_uses_sanitized_raw_value(value: str) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        assert CorrelationContext.get() == value[:128]
+        assert get_correlation_id(scope) == value[:128]
 
     scope = _scope(headers=[(b"traceparent", f"  {value}  ".encode())])
-    asyncio.run(CorrelationMiddleware(app, header_names="traceparent")(scope, _receive, _send))
+    asyncio.run(CorrelationMiddleware(header_names="traceparent")(app)(scope, _receive, _send))
 
 
 def test_valid_traceparent_extracts_trace_id() -> None:
     trace_id = "4bf92f3577b34da6a3ce929d0e0e4736"
 
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        assert CorrelationContext.get() == trace_id
+        assert get_correlation_id(scope) == trace_id
 
     scope = _scope(headers=[(b"traceparent", f"00-{trace_id}-00f067aa012302b7-01".encode())])
-    asyncio.run(CorrelationMiddleware(app, header_names="traceparent")(scope, _receive, _send))
+    asyncio.run(CorrelationMiddleware(header_names="traceparent")(app)(scope, _receive, _send))
 
 
 def test_traceparent_is_validated_before_max_length_is_applied() -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        assert CorrelationContext.get() == "4bf92f35"
+        assert get_correlation_id(scope) == "4bf92f35"
 
     value = b"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa012302b7-01"
     scope = _scope(headers=[(b"traceparent", value)])
-    asyncio.run(CorrelationMiddleware(app, header_names="traceparent", max_length=8)(scope, _receive, _send))
+    asyncio.run(CorrelationMiddleware(header_names="traceparent", max_length=8)(app)(scope, _receive, _send))
 
 
 def test_unsafe_traceparent_falls_through_to_lower_priority_header() -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        assert CorrelationContext.get() == "safe-id"
+        assert get_correlation_id(scope) == "safe-id"
 
     scope = _scope(headers=[(b"traceparent", b"bad\tvalue"), (b"x-request-id", b"safe-id")])
-    middleware = CorrelationMiddleware(app, header_names=["traceparent", "x-request-id"])
-    asyncio.run(middleware(scope, _receive, _send))
+    middleware = CorrelationMiddleware(header_names=["traceparent", "x-request-id"])
+    asyncio.run(middleware(app)(scope, _receive, _send))
 
 
 def test_uuid_is_generated_when_no_safe_header_matches() -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        correlation_id = CorrelationContext.get()
+        correlation_id = get_correlation_id(scope)
         assert correlation_id is not None
         assert UUID(correlation_id)
 
     scope = _scope(headers=[(b"x-request-id", b"bad\nvalue")])
-    asyncio.run(CorrelationMiddleware(app)(scope, _receive, _send))
+    asyncio.run(CorrelationMiddleware()(app)(scope, _receive, _send))
+
+
+def test_get_correlation_id_returns_none_when_middleware_did_not_run() -> None:
+    assert get_correlation_id(_scope()) is None
 
 
 def test_response_header_replaces_existing_values() -> None:
@@ -179,7 +143,7 @@ def test_response_header_replaces_existing_values() -> None:
         sent.append(message)
 
     scope = _scope(headers=[(b"x-request-id", b"authoritative")])
-    asyncio.run(CorrelationMiddleware(app)(scope, _receive, send))
+    asyncio.run(CorrelationMiddleware()(app)(scope, _receive, send))
     assert sent[0]["headers"] == [(b"x-request-id", b"authoritative")]
 
 
@@ -193,64 +157,41 @@ def test_response_header_can_be_disabled() -> None:
         sent.append(message)
 
     scope = _scope()
-    asyncio.run(CorrelationMiddleware(app, response_header_name=None)(scope, _receive, send))
+    asyncio.run(CorrelationMiddleware(response_header_name=None)(app)(scope, _receive, send))
     assert sent[0]["headers"] == []
 
 
-@pytest.mark.parametrize("raises", [False, True])
-def test_context_and_prior_scope_state_are_restored(raises: bool) -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        assert CorrelationContext.get() == "request-id"
-        assert scope["state"]["correlation_id"] == "request-id"
-        if raises:
-            raise RuntimeError("boom")
+@pytest.mark.anyio
+async def test_correlation_id_is_available_to_downstream_middleware_and_handlers() -> None:
+    async def downstream(scope: Scope, receive: Receive, send: Send, next_app: Any) -> None:
+        assert get_correlation_id(scope) == "shared-id"
+        await next_app(scope, receive, send)
 
-    token = CorrelationContext.set("outer-id")
-    scope = _scope(headers=[(b"x-request-id", b"request-id")], state={"correlation_id": "prior-state"})
-    try:
-        if raises:
-            with pytest.raises(RuntimeError, match="boom"):
-                asyncio.run(CorrelationMiddleware(app)(scope, _receive, _send))
-        else:
-            asyncio.run(CorrelationMiddleware(app)(scope, _receive, _send))
-        assert CorrelationContext.get() == "outer-id"
-        assert scope["state"]["correlation_id"] == "prior-state"
-    finally:
-        CorrelationContext.reset(token)
+    from litestar.middleware.base import ASGIMiddleware
 
+    class DownstreamMiddleware(ASGIMiddleware):
+        async def handle(self, scope: Scope, receive: Receive, send: Send, next_app: Any) -> None:
+            await downstream(scope, receive, send, next_app)
 
-def test_new_scope_state_value_is_removed_on_unwind() -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        assert "correlation_id" in scope["state"]
+    @get("/")
+    async def handler(request: Any) -> dict[str, str | None]:
+        return {"correlation_id": get_correlation_id(request.scope)}
 
-    scope = _scope(scope_type="websocket", state={})
-    asyncio.run(CorrelationMiddleware(app)(scope, _receive, _send))
-    assert "correlation_id" not in scope["state"]
-
-
-def test_non_request_scope_is_bypassed() -> None:
-    called = False
-
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        nonlocal called
-        called = True
-        assert CorrelationContext.get() is None
-        assert "state" not in scope
-
-    scope = _scope(scope_type="lifespan")
-    scope.pop("headers")
-    asyncio.run(CorrelationMiddleware(app)(scope, _receive, _send))
-    assert called
+    app = Litestar(route_handlers=[handler], middleware=[CorrelationMiddleware(), DownstreamMiddleware()])
+    async with AsyncTestClient(app=app) as client:
+        response = await client.get("/", headers={"x-request-id": "shared-id"})
+    assert response.json() == {"correlation_id": "shared-id"}
+    assert response.headers["x-request-id"] == "shared-id"
 
 
 @pytest.mark.anyio
 async def test_http_requests_are_isolated_concurrently() -> None:
     @get("/{request_id:str}")
-    async def handler(request_id: FromPath[str]) -> dict[str, str | None]:
+    async def handler(request: Any, request_id: FromPath[str]) -> dict[str, str | None]:
         await asyncio.sleep(0)
-        return {"correlation_id": CorrelationContext.get(), "request_id": request_id}
+        return {"correlation_id": get_correlation_id(request.scope), "request_id": request_id}
 
-    app = Litestar(route_handlers=[handler], middleware=[CorrelationMiddleware])
+    app = Litestar(route_handlers=[handler], middleware=[CorrelationMiddleware()])
     async with AsyncTestClient(app=app) as client:
         responses = await asyncio.gather(
             *(client.get(f"/{index}", headers={"x-request-id": f"id-{index}"}) for index in range(10))
@@ -259,14 +200,14 @@ async def test_http_requests_are_isolated_concurrently() -> None:
 
 
 @pytest.mark.anyio
-async def test_websocket_scope_exposes_correlation_context() -> None:
+async def test_websocket_scope_exposes_correlation_id() -> None:
     @websocket("/")
     async def handler(socket: WebSocket[Any, Any, Any]) -> None:
         await socket.accept()
-        await socket.send_text(CorrelationContext.get() or "missing")
+        await socket.send_text(get_correlation_id(socket.scope) or "missing")
         await socket.close()
 
-    app = Litestar(route_handlers=[handler], middleware=[CorrelationMiddleware])
+    app = Litestar(route_handlers=[handler], middleware=[CorrelationMiddleware()])
     async with AsyncTestClient(app=app) as client:
         async with await client.websocket_connect("/", headers={"x-request-id": "websocket-id"}) as socket:
             assert await socket.receive_text() == "websocket-id"

--- a/tests/unit/test_middleware/test_correlation.py
+++ b/tests/unit/test_middleware/test_correlation.py
@@ -6,12 +6,18 @@ from uuid import UUID
 
 import pytest
 
-from litestar import Litestar, get, websocket
-from litestar.middleware.correlation import CorrelationMiddleware, get_correlation_id
+from litestar import Litestar, Request, get, websocket
+from litestar.middleware.correlation import (
+    TRACE_CONTEXT_FALLBACK_HEADERS,
+    CorrelationMiddleware,
+    get_correlation_id,
+)
 from litestar.params import FromPath
 from litestar.testing import AsyncTestClient
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
     from litestar.connection import WebSocket
     from litestar.types import Message, Receive, Scope, Send
 
@@ -29,6 +35,10 @@ async def _send(_: Message) -> None:
     return None
 
 
+async def _await_middleware(awaitable: Awaitable[None]) -> None:
+    await awaitable
+
+
 def _scope(scope_type: str = "http", headers: list[tuple[bytes, bytes]] | None = None) -> Any:
     return {"type": scope_type, "headers": headers or []}
 
@@ -38,13 +48,17 @@ def test_header_names_are_normalized_and_deduplicated() -> None:
     assert middleware.header_names == ("x-request-id", "x-trace-id")
 
 
+def test_default_header_names_are_conservative() -> None:
+    assert TRACE_CONTEXT_FALLBACK_HEADERS == ("x-request-id", "x-correlation-id", "traceparent")
+
+
 def test_single_header_name_is_not_treated_as_a_sequence_of_characters() -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         assert get_correlation_id(scope) == "selected"
 
     middleware = CorrelationMiddleware(header_names="X-Correlation-ID")
     scope = _scope(headers=[(b"x-correlation-id", b"selected")])
-    asyncio.run(middleware(app)(scope, _receive, _send))
+    asyncio.run(_await_middleware(middleware(app)(scope, _receive, _send)))
 
 
 @pytest.mark.parametrize("max_length", [0, -1])
@@ -60,7 +74,7 @@ def test_blank_or_control_character_values_fall_through_to_lower_priority_header
 
     middleware = CorrelationMiddleware(header_names=["x-first", "x-second"])
     scope = _scope(headers=[(b"x-first", unsafe_value), (b"x-second", b"safe-id")])
-    asyncio.run(middleware(app)(scope, _receive, _send))
+    asyncio.run(_await_middleware(middleware(app)(scope, _receive, _send)))
 
 
 @pytest.mark.parametrize(
@@ -82,7 +96,7 @@ def test_malformed_traceparent_uses_sanitized_raw_value(value: str) -> None:
         assert get_correlation_id(scope) == value[:128]
 
     scope = _scope(headers=[(b"traceparent", f"  {value}  ".encode())])
-    asyncio.run(CorrelationMiddleware(header_names="traceparent")(app)(scope, _receive, _send))
+    asyncio.run(_await_middleware(CorrelationMiddleware(header_names="traceparent")(app)(scope, _receive, _send)))
 
 
 def test_valid_traceparent_extracts_trace_id() -> None:
@@ -92,7 +106,7 @@ def test_valid_traceparent_extracts_trace_id() -> None:
         assert get_correlation_id(scope) == trace_id
 
     scope = _scope(headers=[(b"traceparent", f"00-{trace_id}-00f067aa012302b7-01".encode())])
-    asyncio.run(CorrelationMiddleware(header_names="traceparent")(app)(scope, _receive, _send))
+    asyncio.run(_await_middleware(CorrelationMiddleware(header_names="traceparent")(app)(scope, _receive, _send)))
 
 
 def test_traceparent_is_validated_before_max_length_is_applied() -> None:
@@ -101,7 +115,9 @@ def test_traceparent_is_validated_before_max_length_is_applied() -> None:
 
     value = b"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa012302b7-01"
     scope = _scope(headers=[(b"traceparent", value)])
-    asyncio.run(CorrelationMiddleware(header_names="traceparent", max_length=8)(app)(scope, _receive, _send))
+    asyncio.run(
+        _await_middleware(CorrelationMiddleware(header_names="traceparent", max_length=8)(app)(scope, _receive, _send))
+    )
 
 
 def test_unsafe_traceparent_falls_through_to_lower_priority_header() -> None:
@@ -110,7 +126,7 @@ def test_unsafe_traceparent_falls_through_to_lower_priority_header() -> None:
 
     scope = _scope(headers=[(b"traceparent", b"bad\tvalue"), (b"x-request-id", b"safe-id")])
     middleware = CorrelationMiddleware(header_names=["traceparent", "x-request-id"])
-    asyncio.run(middleware(app)(scope, _receive, _send))
+    asyncio.run(_await_middleware(middleware(app)(scope, _receive, _send)))
 
 
 def test_uuid_is_generated_when_no_safe_header_matches() -> None:
@@ -120,11 +136,22 @@ def test_uuid_is_generated_when_no_safe_header_matches() -> None:
         assert UUID(correlation_id)
 
     scope = _scope(headers=[(b"x-request-id", b"bad\nvalue")])
-    asyncio.run(CorrelationMiddleware()(app)(scope, _receive, _send))
+    asyncio.run(_await_middleware(CorrelationMiddleware()(app)(scope, _receive, _send)))
 
 
 def test_get_correlation_id_returns_none_when_middleware_did_not_run() -> None:
     assert get_correlation_id(_scope()) is None
+
+
+def test_explicit_grpc_trace_header_is_opaque_and_unchanged() -> None:
+    value = b"opaque-grpc-trace-value"
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        assert get_correlation_id(scope) == value.decode()
+        assert scope["headers"] == [(b"grpc-trace-bin", value)]
+
+    scope = _scope(headers=[(b"grpc-trace-bin", value)])
+    asyncio.run(_await_middleware(CorrelationMiddleware(header_names="grpc-trace-bin")(app)(scope, _receive, _send)))
 
 
 def test_response_header_replaces_existing_values() -> None:
@@ -143,7 +170,7 @@ def test_response_header_replaces_existing_values() -> None:
         sent.append(message)
 
     scope = _scope(headers=[(b"x-request-id", b"authoritative")])
-    asyncio.run(CorrelationMiddleware()(app)(scope, _receive, send))
+    asyncio.run(_await_middleware(CorrelationMiddleware()(app)(scope, _receive, send)))
     assert sent[0]["headers"] == [(b"x-request-id", b"authoritative")]
 
 
@@ -157,7 +184,7 @@ def test_response_header_can_be_disabled() -> None:
         sent.append(message)
 
     scope = _scope()
-    asyncio.run(CorrelationMiddleware(response_header_name=None)(app)(scope, _receive, send))
+    asyncio.run(_await_middleware(CorrelationMiddleware(response_header_name=None)(app)(scope, _receive, send)))
     assert sent[0]["headers"] == []
 
 
@@ -174,8 +201,8 @@ async def test_correlation_id_is_available_to_downstream_middleware_and_handlers
             await downstream(scope, receive, send, next_app)
 
     @get("/")
-    async def handler(request: Any) -> dict[str, str | None]:
-        return {"correlation_id": get_correlation_id(request.scope)}
+    async def handler(request: Request[Any, Any, Any]) -> dict[str, str | None]:
+        return {"correlation_id": get_correlation_id(request)}
 
     app = Litestar(route_handlers=[handler], middleware=[CorrelationMiddleware(), DownstreamMiddleware()])
     async with AsyncTestClient(app=app) as client:
@@ -187,9 +214,9 @@ async def test_correlation_id_is_available_to_downstream_middleware_and_handlers
 @pytest.mark.anyio
 async def test_http_requests_are_isolated_concurrently() -> None:
     @get("/{request_id:str}")
-    async def handler(request: Any, request_id: FromPath[str]) -> dict[str, str | None]:
+    async def handler(request: Request[Any, Any, Any], request_id: FromPath[str]) -> dict[str, str | None]:
         await asyncio.sleep(0)
-        return {"correlation_id": get_correlation_id(request.scope), "request_id": request_id}
+        return {"correlation_id": get_correlation_id(request), "request_id": request_id}
 
     app = Litestar(route_handlers=[handler], middleware=[CorrelationMiddleware()])
     async with AsyncTestClient(app=app) as client:
@@ -204,7 +231,7 @@ async def test_websocket_scope_exposes_correlation_id() -> None:
     @websocket("/")
     async def handler(socket: WebSocket[Any, Any, Any]) -> None:
         await socket.accept()
-        await socket.send_text(get_correlation_id(socket.scope) or "missing")
+        await socket.send_text(get_correlation_id(socket) or "missing")
         await socket.close()
 
     app = Litestar(route_handlers=[handler], middleware=[CorrelationMiddleware()])


### PR DESCRIPTION
## Description

Applications need a consistent correlation identifier across handlers, logging, and other request-scoped work without requiring an observability integration. This adds standalone correlation middleware for HTTP and WebSocket connections.

`CorrelationMiddleware` selects the first safe value from a configurable list of request headers and generates a UUID when no suitable value is present. W3C `traceparent` values are validated before extracting the trace ID. The selected identifier is available through `CorrelationContext` and `scope["state"]["correlation_id"]`, and can be written to a configurable response header.

Header names are normalized and deduplicated in priority order. Empty values and values containing control characters are skipped. Existing response correlation headers are replaced, and request context and scope state are restored when the middleware unwinds.

The middleware reads directly from the ASGI scope without additional dependencies or blocking work. It uses `__slots__`, performs bounded header processing, and does not add application-level state.

Refs #4719


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4970">https://litestar-org.github.io/litestar-docs-preview/4970</a> 
