### PR TITLE
fix(openapi): `components` field cannot be a list

### DIFF
--- a/litestar/openapi/config.py
+++ b/litestar/openapi/config.py
@@ -68,7 +68,7 @@ class OpenAPIConfig:
     Should be an instance of
         :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>`.
     """
-    components: Components | list[Components] = field(default_factory=Components)
+    components: Components = field(default_factory=Components)
     """API Components information.
 
     Should be an instance of :class:`Components <litestar.openapi.spec.components.Components>` or a list thereof.


### PR DESCRIPTION
Check the spec definition: https://spec.openapis.org/oas/v3.2.0.html#components-object It is true for both 3.0 and 3.1 as well. Oldest version: https://spec.openapis.org/oas/v3.0.0.html#fixed-fields
