### PR TITLE
feat(openapi): document structured query kwargs as query parameters

### DIFF
--- a/litestar/_openapi/parameters.py
+++ b/litestar/_openapi/parameters.py
@@ -170,12 +170,56 @@ class ParameterFactory:
         )
         return self.create_parameter(field_definition=field_definition, parameter_name=parameter_name)
 
+    def create_parameters_for_query_kwarg(self, field_definition: FieldDefinition) -> None:
+        """Add a Parameter model for each member of a structured ``query`` kwarg.
+
+        The reserved ``query`` kwarg receives the full mapping of query parameters, so when it is
+        annotated with a structured type every field of that type is itself a query parameter and
+        is validated as one at runtime. Documenting the annotation as a single parameter would be
+        wrong, so it is decomposed into one parameter per field instead.
+
+        Args:
+            field_definition: The field definition of the ``query`` kwarg.
+        """
+        if field_definition.is_any or field_definition.is_mapping:
+            # ``query`` is unannotated or annotated as a plain mapping, so there are no known
+            # parameter names to document. Returning before touching the schema creator keeps
+            # this the no-op it has always been for those annotations.
+            return
+
+        result = self.schema_creator.for_field_definition(field_definition)
+        schema = result if isinstance(result, Schema) else self.context.schema_registry.from_reference(result).schema
+
+        if not schema.properties:
+            return
+
+        required_fields = set(schema.required or ())
+
+        for parameter_name, property_schema in schema.properties.items():
+            resolved_schema = (
+                property_schema
+                if isinstance(property_schema, Schema)
+                else self.context.schema_registry.from_reference(property_schema).schema
+            )
+            self.parameters.add(
+                Parameter(
+                    description=resolved_schema.description,
+                    name=parameter_name,
+                    param_in=ParamType.QUERY,
+                    required=parameter_name in required_fields,
+                    schema=property_schema,
+                )
+            )
+
     def create_parameters_for_field_definitions(self, fields: dict[str, FieldDefinition]) -> None:
         """Add Parameter models to the handler's collection for the given field definitions.
 
         Args:
             fields: The field definitions.
         """
+        if (query_field_definition := fields.get("query")) is not None:
+            self.create_parameters_for_query_kwarg(query_field_definition)
+
         unique_handler_fields = (
             (k, v) for k, v in fields.items() if k not in RESERVED_KWARGS and k not in self.layered_parameters
         )

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -9,6 +9,7 @@ from litestar._openapi.datastructures import OpenAPIContext
 from litestar._openapi.parameters import ParameterFactory
 from litestar._openapi.schema_generation.examples import ExampleFactory
 from litestar._openapi.typescript_converter.schema_parsing import is_schema_value
+from litestar.datastructures import MultiDict
 from litestar.di import NamedDependency, Provide
 from litestar.enums import ParamType
 from litestar.exceptions import ImproperlyConfiguredException
@@ -28,6 +29,7 @@ from litestar.params import (
     QueryParameter,
 )
 from litestar.routes import BaseRoute
+from litestar.status_codes import HTTP_200_OK, HTTP_400_BAD_REQUEST
 from litestar.testing import create_test_client
 from litestar.utils import find_index
 from tests.unit.test_openapi.utils import Gender, LuckyNumber
@@ -612,3 +614,95 @@ def test_explicit_path_param_with_alias_excluded_when_alias_not_in_path() -> Non
         # routing also works for the aliased path parameter
         assert client.get("/foo").text == "foo"
         assert client.get("/").text == ""
+
+
+@dataclasses.dataclass
+class QueryKwargFilters:
+    required_field: str
+    optional_field: int = 10
+
+
+def test_structured_query_kwarg_documents_each_field() -> None:
+    # https://github.com/litestar-org/litestar/issues/2015
+    @get("/")
+    def handler(query: QueryKwargFilters) -> None:
+        pass
+
+    app = Litestar([handler])
+    params = {p.name: p for p in app.openapi_schema.paths["/"].get.parameters}  # type: ignore[union-attr, index]
+
+    assert set(params) == {"required_field", "optional_field"}
+    assert params["required_field"].to_schema() == {
+        "name": "required_field",
+        "in": "query",
+        "schema": {"type": "string"},
+        "required": True,
+        "deprecated": False,
+        "allowEmptyValue": False,
+        "allowReserved": False,
+    }
+    assert params["optional_field"].to_schema() == {
+        "name": "optional_field",
+        "in": "query",
+        "schema": {"type": "integer", "default": 10},
+        "required": False,
+        "deprecated": False,
+        "allowEmptyValue": False,
+        "allowReserved": False,
+    }
+
+
+def test_structured_query_kwarg_matches_runtime_validation() -> None:
+    """The documented parameters must be the ones the handler actually validates."""
+
+    @get("/")
+    def handler(query: QueryKwargFilters) -> None:
+        pass
+
+    with create_test_client(handler) as client:
+        assert client.get("/", params={"required_field": "value"}).status_code == HTTP_200_OK
+        assert client.get("/", params={"optional_field": 1}).status_code == HTTP_400_BAD_REQUEST
+        assert client.get("/", params={"required_field": "v", "optional_field": "nope"}).status_code == (
+            HTTP_400_BAD_REQUEST
+        )
+
+
+@dataclasses.dataclass
+class NestedQueryKwargFilters:
+    nested: QueryKwargFilters
+    top_level: str
+
+
+def test_structured_query_kwarg_keeps_nested_references() -> None:
+    @get("/")
+    def handler(query: NestedQueryKwargFilters) -> None:
+        pass
+
+    app = Litestar([handler])
+    params = {p.name: p for p in app.openapi_schema.paths["/"].get.parameters}  # type: ignore[union-attr, index]
+
+    assert isinstance(params["nested"].schema, Reference)
+    assert params["nested"].schema.ref == "#/components/schemas/QueryKwargFilters"
+    assert params["top_level"].schema == Schema(type=OpenAPIType.STRING)  # type: ignore[union-attr]
+
+
+@pytest.mark.parametrize("annotation", [Any, dict, dict[str, str], MultiDict])
+def test_unstructured_query_kwarg_documents_no_parameters(annotation: Any) -> None:
+    """An unannotated or mapping-annotated ``query`` kwarg has no known parameter names."""
+
+    @get("/")
+    def handler(query: annotation) -> None:  # type: ignore[valid-type]
+        pass
+
+    app = Litestar([handler])
+    assert not app.openapi_schema.paths["/"].get.parameters  # type: ignore[union-attr, index]
+
+
+def test_structured_query_kwarg_conflicting_with_explicit_parameter() -> None:
+    @get("/")
+    def handler(query: QueryKwargFilters, required_field: FromQuery[int]) -> None:
+        pass
+
+    app = Litestar([handler])
+    with pytest.raises(ImproperlyConfiguredException):
+        app.openapi_schema

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -681,8 +681,8 @@ def test_structured_query_kwarg_keeps_nested_references() -> None:
     app = Litestar([handler])
     params = {p.name: p for p in app.openapi_schema.paths["/"].get.parameters}  # type: ignore[union-attr, index]
 
-    assert isinstance(params["nested"].schema, Reference)
-    assert params["nested"].schema.ref == "#/components/schemas/QueryKwargFilters"
+    assert isinstance(params["nested"].schema, Reference)  # type: ignore[union-attr]
+    assert params["nested"].schema.ref == "#/components/schemas/QueryKwargFilters"  # type: ignore[union-attr]
     assert params["top_level"].schema == Schema(type=OpenAPIType.STRING)  # type: ignore[union-attr]
 
 
@@ -691,7 +691,7 @@ def test_unstructured_query_kwarg_documents_no_parameters(annotation: Any) -> No
     """An unannotated or mapping-annotated ``query`` kwarg has no known parameter names."""
 
     @get("/")
-    def handler(query: annotation) -> None:  # type: ignore[valid-type]
+    def handler(query: annotation) -> None:  # pyright: ignore[reportInvalidTypeForm]
         pass
 
     app = Litestar([handler])


### PR DESCRIPTION
## What

Closes #2015.

The reserved `query` kwarg receives the whole query mapping, so annotating it with a model makes every field of that model a query parameter, validated as one at runtime. Schema generation skipped all reserved kwargs unconditionally, so those routes came out with no `parameters` entry at all and consumers of the spec couldn't see the parameters the handler actually enforces.

## How

`ParameterFactory.create_parameters_for_query_kwarg` decomposes a structured `query` annotation into one `Parameter` per field.

It goes through the existing `SchemaCreator` rather than introspecting each model library directly, so pydantic, msgspec, attrs, dataclasses and TypedDicts are all handled by the code that already knows how, and nested models keep resolving to component references.

An unannotated `query`, or one annotated as a mapping, returns early — that stays a no-op, and returning before touching the schema creator keeps it side-effect free for those annotations.

## One thing to flag

Because the shared schema registry is used, the annotated model itself is also registered as a component. For `query: Filters` you get parameters for each field **and** a `Filters` entry under `components/schemas` that nothing references.

I went this way deliberately: a throwaway registry would avoid the unreferenced component but would break `$ref`s for nested models, which seemed like the worse trade. If you'd rather not emit it, I'm happy to look at pruning it after generation — just say which you prefer.

## Tests

Seven tests in `tests/unit/test_openapi/test_parameters.py`: per-field parameters with correct required-ness and defaults, nested models keeping their references, no-ops for `Any` / `dict` / `dict[str, str]` / `MultiDict`, the existing collision error still raised when a decomposed field clashes with an explicit parameter of a different type, and a runtime test asserting the documented parameters are the ones actually validated.
