### PR TITLE
docs: point RapiDoc links to GitHub repo (#4975)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Litestar serves the documentation from the generated OpenAPI schema with:
 - [ReDoc](https://redoc.ly/)
 - [Swagger-UI](https://swagger.io/tools/swagger-ui/)
 - [Stoplight Elements](https://github.com/stoplightio/elements)
-- [RapiDoc](https://rapidocweb.com/)
+- [RapiDoc](https://github.com/rapi-doc/RapiDoc)
 
 All these are available and enabled by default.
 

--- a/docs/PYPI_README.md
+++ b/docs/PYPI_README.md
@@ -225,7 +225,7 @@ Litestar serves the documentation from the generated OpenAPI schema with:
 - [ReDoc](https://redoc.ly/)
 - [Swagger-UI](https://swagger.io/tools/swagger-ui/)
 - [Stoplight Elements](https://github.com/stoplightio/elements)
-- [RapiDoc](https://rapidocweb.com/)
+- [RapiDoc](https://github.com/rapi-doc/RapiDoc)
 
 All these are available and enabled by default.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -128,7 +128,7 @@ and
     * ``http://localhost:8000/schema`` (for `ReDoc <https://redocly.com/redoc>`_),
     * ``http://localhost:8000/schema/swagger`` (for `Swagger UI <https://swagger.io/>`_),
     * ``http://localhost:8000/schema/elements`` (for `Stoplight Elements <https://stoplight.io/open-source/elements/>`_)
-    * ``http://localhost:8000/schema/rapidoc`` (for `RapiDoc <https://rapidocweb.com/>`_)
+    * ``http://localhost:8000/schema/rapidoc`` (for `RapiDoc <https://github.com/rapi-doc/RapiDoc>`_)
 
 You can check out a more in-depth tutorial in the :doc:`/tutorials/todo-app/index` section!
 

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -6,6 +6,15 @@ Litestar 2 Changelog
 .. changelog:: 2.24.0
     :date: 2026-06-11
 
+    .. change:: Deprecate ``RapidocRenderPlugin``
+        :type: feature
+        :pr: 4976
+        :issue: 4975
+
+        Deprecate :class:`~litestar.openapi.plugins.RapidocRenderPlugin`. RapiDoc is unmaintained and its
+        former domain has been hijacked. The plugin will be removed in 3.0.0; use another render plugin,
+        such as :class:`~litestar.openapi.plugins.ScalarRenderPlugin`, instead.
+
     .. change:: Fix OpenAPI schema incorrectly marking nullable required fields as not required
         :type: bugfix
         :pr: 4687

--- a/docs/usage/openapi/ui_plugins.rst
+++ b/docs/usage/openapi/ui_plugins.rst
@@ -10,7 +10,7 @@ to understand and interact with your API.
 Litestar maintains and ships with UI plugins for a range of popular popular OpenAPI documentation tools:
 
 - `Scalar <https://github.com/scalar/scalar/>`_
-- `RapiDoc <https://rapidocweb.com/>`_
+- `RapiDoc <https://github.com/rapi-doc/RapiDoc>`_
 - `ReDoc <https://redocly.com/>`_
 - `Stoplight Elements <https://stoplight.io/open-source/elements>`_
 - `Swagger UI <https://swagger.io/tools/swagger-ui/>`_

--- a/docs/usage/openapi/ui_plugins.rst
+++ b/docs/usage/openapi/ui_plugins.rst
@@ -19,6 +19,11 @@ Litestar maintains and ships with UI plugins for a range of popular popular Open
 Each plugin is easily configurable, allowing developers to customize aspects like version, paths, CSS and JavaScript
 resources.
 
+.. deprecated:: 2.24.0
+    RapiDoc is unmaintained and its former domain has been hijacked. The
+    :class:`~litestar.openapi.plugins.RapidocRenderPlugin` will be removed in 3.0; use another UI plugin,
+    such as Scalar, Swagger UI or ReDoc, instead.
+
 
 Using OpenAPI UI Plugins
 ------------------------

--- a/litestar/openapi/plugins.py
+++ b/litestar/openapi/plugins.py
@@ -10,6 +10,7 @@ from litestar.constants import OPENAPI_JSON_HANDLER_NAME
 from litestar.enums import MediaType, OpenAPIMediaType
 from litestar.handlers import get
 from litestar.serialization import encode_json, get_serializer
+from litestar.utils.deprecation import warn_deprecation
 
 if TYPE_CHECKING:
     from litestar.config.csrf import CSRFConfig
@@ -193,7 +194,12 @@ class YamlRenderPlugin(OpenAPIRenderPlugin):
 
 
 class RapidocRenderPlugin(OpenAPIRenderPlugin):
-    """Render an OpenAPI schema using Rapidoc."""
+    """Render an OpenAPI schema using Rapidoc.
+
+    .. deprecated:: 2.24.0
+        RapiDoc is unmaintained and its former domain has been hijacked. This plugin will be removed in
+        3.0; use another render plugin, such as :class:`ScalarRenderPlugin`, instead.
+    """
 
     def __init__(
         self,
@@ -212,6 +218,14 @@ class RapidocRenderPlugin(OpenAPIRenderPlugin):
             path: Path to serve the OpenAPI UI at.
             **kwargs: Additional arguments to pass to the base class.
         """
+        warn_deprecation(
+            version="2.24.0",
+            deprecated_name="RapidocRenderPlugin",
+            kind="class",
+            removal_in="3.0",
+            alternative="ScalarRenderPlugin",
+            info="RapiDoc is unmaintained and its former domain has been hijacked.",
+        )
         self.js_url = js_url or f"https://unpkg.com/rapidoc@{version}/dist/rapidoc-min.js"
         super().__init__(path=path, **kwargs)
 

--- a/tests/unit/test_openapi/test_plugins.py
+++ b/tests/unit/test_openapi/test_plugins.py
@@ -2,12 +2,18 @@ import pytest
 
 from litestar import Litestar
 from litestar.config.csrf import CSRFConfig
+from litestar.exceptions import LitestarDeprecationWarning
 from litestar.openapi.config import OpenAPIConfig
 from litestar.openapi.plugins import RapidocRenderPlugin, ScalarRenderPlugin, SwaggerRenderPlugin
 from litestar.testing import TestClient
 
 rapidoc_fragment = ".addEventListener('before-try',"
 swagger_fragment = "requestInterceptor:"
+
+
+def test_rapidoc_deprecation_warning() -> None:
+    with pytest.warns(LitestarDeprecationWarning, match="RapidocRenderPlugin"):
+        RapidocRenderPlugin()
 
 
 def test_rapidoc_csrf() -> None:


### PR DESCRIPTION

## Description

Adjust RapiDoc URL from a hijacked site to their GitHub - https://github.com/rapi-doc/RapiDoc

This PR is targeting `v2` branch for immediate release (lmk if this is incorrect). A follow-on PR against `main` will remove RapiDoc plugin for the eventual V3 release. 

In Part Fix #4975 
