### PR TITLE
fix(channels): stop the psycopg listener without cancelling it

### DIFF
--- a/litestar/channels/backends/psycopg.py
+++ b/litestar/channels/backends/psycopg.py
@@ -12,6 +12,12 @@ from litestar.channels.backends.base import ChannelsBackend
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Iterable
 
+_LISTEN_POLL_INTERVAL = 0.1
+"""Duration of a single ``notifies()`` pass, after which the listener re-checks whether to stop."""
+
+_STOP_LISTENER_TIMEOUT = 5.0
+"""How long to wait for the listener to stop on its own before falling back to cancellation."""
+
 
 class PsycoPgChannelsBackend(ChannelsBackend):
     _listener_conn: AsyncConnection[Any]
@@ -24,6 +30,7 @@ class PsycoPgChannelsBackend(ChannelsBackend):
         self._listener_task: asyncio.Task[None] | None = None
         self._event_queue: asyncio.Queue[tuple[str, bytes] | Exception] = asyncio.Queue()
         self._shutting_down = False
+        self._stop_listening = False
 
     async def on_startup(self) -> None:
         self._exit_stack = AsyncExitStack()
@@ -88,20 +95,28 @@ class PsycoPgChannelsBackend(ChannelsBackend):
         raise NotImplementedError()
 
     def _start_listener(self) -> None:
+        self._stop_listening = False
         self._listener_task = asyncio.create_task(self._listen())
 
     async def _stop_listener(self) -> None:
         if self._listener_task is None:
             return
-        self._listener_task.cancel()
-        with suppress(asyncio.CancelledError):
-            await self._listener_task
+        self._stop_listening = True
+        try:
+            async with asyncio.timeout(_STOP_LISTENER_TIMEOUT):
+                await self._listener_task
+        except TimeoutError:
+            self._listener_task.cancel()
+            with suppress(asyncio.CancelledError, TimeoutError):
+                async with asyncio.timeout(_STOP_LISTENER_TIMEOUT):
+                    await self._listener_task
         self._listener_task = None
 
     async def _listen(self) -> None:
         try:
-            async for notify in self._listener_conn.notifies():
-                self._event_queue.put_nowait((notify.channel, notify.payload.encode("utf-8")))
+            while not self._stop_listening:
+                async for notify in self._listener_conn.notifies(timeout=_LISTEN_POLL_INTERVAL):
+                    self._event_queue.put_nowait((notify.channel, notify.payload.encode("utf-8")))
         except asyncio.CancelledError:
             raise
         except Exception as exc:  # noqa: BLE001 - listener failures are forwarded to stream consumers

--- a/tests/unit/test_channels/test_psycopg_backend.py
+++ b/tests/unit/test_channels/test_psycopg_backend.py
@@ -25,7 +25,7 @@ class _ConcurrentConnection:
 
 
 class _FailingConnection(_ConcurrentConnection):
-    def notifies(self) -> _FailingNotifications:
+    def notifies(self, *, timeout: float | None = None, stop_after: int | None = None) -> _FailingNotifications:
         return _FailingNotifications()
 
 


### PR DESCRIPTION
Cancelling a task parked in psycopg's `wait()` is caught by its interrupt handling, which issues a server-side cancel and then waits again while the task is already cancelling. When that does not resolve, the task stays in the cancelling state and awaiting it never returns, so `unsubscribe()` and `on_shutdown()` hang.

This should fix the issue with the 3.11 tests suite getting time out after 10 minutes. 

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4978">https://litestar-org.github.io/litestar-docs-preview/4978</a> 
