### PR TITLE
docs: fix Litestar Organization navbar link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -360,7 +360,7 @@ html_theme_options = {
                 {
                     "title": "Litestar Organization",
                     "summary": "Details about the Litestar organization",
-                    "url": "https://litestar.dev/about/organization",
+                    "url": "https://litestar.dev/about",
                     "icon": "org",
                 },
                 {


### PR DESCRIPTION
The /about/organization page no longer exists; point the navbar entry at /about instead.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4979">https://litestar-org.github.io/litestar-docs-preview/4979</a> 
