### PR TITLE
fix(openapi): preserve msgspec field metadata

### DIFF
--- a/litestar/typing.py
+++ b/litestar/typing.py
@@ -110,6 +110,17 @@ def _annotated_types_extractor(meta: Any, is_sequence_container: bool) -> dict[s
     return kwargs
 
 
+def _merge_kwarg_definitions(primary: KwargDefinition, fallback: KwargDefinition) -> KwargDefinition:
+    defaults = KwargDefinition()
+    fallback_values = {
+        field.name: getattr(fallback, field.name)
+        for field in dataclasses.fields(KwargDefinition)
+        if getattr(primary, field.name) == getattr(defaults, field.name)
+        and getattr(fallback, field.name) != getattr(defaults, field.name)
+    }
+    return dataclasses.replace(primary, **fallback_values)
+
+
 @dataclass(frozen=True)
 class FieldDefinition:
     """Represents a function parameter or type annotation."""
@@ -461,12 +472,16 @@ class FieldDefinition:
             # TODO: Remove in 4.0
             raise_for_kwarg_as_default(default)
 
-        if not kwargs.get("kwarg_definition"):
-            if kwarg_definition := next((v for v in metadata if isinstance(v, KwargDefinition)), None):
-                kwargs["kwarg_definition"] = kwarg_definition
-
-                metadata = tuple(v for v in metadata if not isinstance(v, KwargDefinition))
-            elif (extra := kwargs.get("extra", {})) and "kwarg_definition" in extra:
+        if kwarg_definitions := [v for v in metadata if isinstance(v, KwargDefinition)]:
+            kwarg_definition = kwarg_definitions[-1]
+            for fallback in reversed(kwarg_definitions[:-1]):
+                kwarg_definition = _merge_kwarg_definitions(kwarg_definition, fallback)
+            if existing_kwarg_definition := kwargs.get("kwarg_definition"):
+                kwarg_definition = _merge_kwarg_definitions(kwarg_definition, existing_kwarg_definition)
+            kwargs["kwarg_definition"] = kwarg_definition
+            metadata = tuple(v for v in metadata if not isinstance(v, KwargDefinition))
+        elif not kwargs.get("kwarg_definition"):
+            if (extra := kwargs.get("extra", {})) and "kwarg_definition" in extra:
                 kwargs["kwarg_definition"] = extra.pop("kwarg_definition")
 
         # there might be additional metadata

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -40,6 +40,7 @@ from litestar.openapi.spec.parameter import Parameter as OpenAPIParameter
 from litestar.openapi.spec.schema import Schema
 from litestar.pagination import ClassicPagination, CursorPagination, OffsetPagination
 from litestar.params import (
+    Body,
     FromPath,
     FromQuery,
     HeaderParameter,
@@ -342,6 +343,16 @@ def test_create_schema_from_msgspec_annotated_type() -> None:
     assert schema.properties["list_field"].min_items == 1  # type: ignore[index, union-attr]
     assert schema.properties["list_field"].max_items == 10  # type: ignore[index, union-attr]
     assert schema.properties["set_field"].min_items == 2  # type: ignore[index, union-attr]
+
+
+def test_msgspec_field_preserves_kwarg_definition_metadata() -> None:
+    class Model(msgspec.Struct):
+        value: Annotated[Annotated[int, msgspec.Meta(gt=0), Body(description="inner")], Body(description="outer")]
+
+    schema = get_schema_for_field_definition(FieldDefinition.from_annotation(Model))
+
+    assert schema.properties["value"].description == "outer"  # type: ignore[index]
+    assert schema.properties["value"].exclusive_minimum == 0  # type: ignore[index, union-attr]
 
 
 def test_msgspec_optional_annotated_meta_propagates() -> None:


### PR DESCRIPTION
## Description

Fixes #4001.

Preserve explicit `Body` metadata on fields in `msgspec.Struct` models while retaining constraints discovered through msgspec inspection. This also makes the outermost `Annotated` metadata take precedence and adds regression coverage for both behaviors.

Tests:
- `uv run pytest -q tests/unit/test_openapi/test_schema.py`
- `uv run pytest -q tests/unit/test_typing.py tests/unit/test_dto/test_msgspec.py tests/unit/test_openapi/test_request_body.py tests/unit/test_openapi/test_datastructures.py`
- `uv run ruff check litestar/typing.py tests/unit/test_openapi/test_schema.py`
- `uv run ruff format --check litestar/typing.py tests/unit/test_openapi/test_schema.py`
- `uv run mypy litestar/typing.py`

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4981">https://litestar-org.github.io/litestar-docs-preview/4981</a> 
