### PR TITLE
fix(dto): apply msgspec constraints to the constrained union member

### DIFF
--- a/litestar/dto/_backend.py
+++ b/litestar/dto/_backend.py
@@ -15,7 +15,6 @@ from typing import (
     Protocol,
     Union,
     cast,
-    get_args,
 )
 
 import msgspec
@@ -38,9 +37,8 @@ from litestar.enums import RequestEncodingType
 from litestar.params import KwargDefinition
 from litestar.serialization import decode_json, decode_msgpack
 from litestar.types import Empty
-from litestar.types.builtin_types import NoneType
 from litestar.typing import FieldDefinition
-from litestar.utils import is_union, unique_name_for_scope
+from litestar.utils import unique_name_for_scope
 
 if TYPE_CHECKING:
     from litestar.connection import ASGIConnection
@@ -820,22 +818,6 @@ def _create_struct_field_meta_for_field_definition(field_definition: TransferDTO
     )
 
 
-def _annotate_with_meta(annotation: Any, meta: msgspec.Meta) -> Any:
-    """Annotate ``annotation`` with ``meta``.
-
-    msgspec only accepts type specific constraints such as ``min_length`` on the type they apply to, so if
-    ``annotation`` is a union of a single concrete type and ``None`` / ``UnsetType`` - as created for optional or
-    partial fields - the metadata has to be applied to that member instead of the union itself.
-    """
-    if is_union(annotation):
-        inner_types = get_args(annotation)
-        constrainable = [inner for inner in inner_types if inner is not NoneType and inner is not UnsetType]
-        if len(constrainable) == 1:
-            return Union[tuple(Annotated[inner, meta] if inner is constrainable[0] else inner for inner in inner_types)]
-
-    return Annotated[annotation, meta]
-
-
 def _create_struct_for_field_definitions(
     *,
     model_name: str,
@@ -850,12 +832,18 @@ def _create_struct_for_field_definitions(
             continue
 
         field_type = _create_transfer_model_type_annotation(field_definition.transfer_type)
-        if field_definition.is_partial:
-            field_type = Union[field_type, UnsetType]
 
         if field_definition.passthrough_constraints:
             if (field_meta := _create_struct_field_meta_for_field_definition(field_definition)) is not None:
-                field_type = _annotate_with_meta(field_type, field_meta)
+                if field_definition.is_partial:
+                    # msgspec only accepts constraints on concrete types, not unions.
+                    # Apply meta to the inner type before wrapping in Union.
+                    field_type = Annotated[field_type, field_meta]
+                    field_type = Union[field_type, UnsetType]
+                else:
+                    field_type = Annotated[field_type, field_meta]
+        elif field_definition.is_partial:
+            field_type = Union[field_type, UnsetType]
         elif field_definition.kwarg_definition:
             field_type = Annotated[field_type, field_definition.kwarg_definition]
 

--- a/litestar/dto/_backend.py
+++ b/litestar/dto/_backend.py
@@ -15,6 +15,7 @@ from typing import (
     Protocol,
     Union,
     cast,
+    get_args,
 )
 
 import msgspec
@@ -37,8 +38,9 @@ from litestar.enums import RequestEncodingType
 from litestar.params import KwargDefinition
 from litestar.serialization import decode_json, decode_msgpack
 from litestar.types import Empty
+from litestar.types.builtin_types import NoneType
 from litestar.typing import FieldDefinition
-from litestar.utils import unique_name_for_scope
+from litestar.utils import is_union, unique_name_for_scope
 
 if TYPE_CHECKING:
     from litestar.connection import ASGIConnection
@@ -810,12 +812,28 @@ def _create_struct_field_meta_for_field_definition(field_definition: TransferDTO
         gt=kwarg_definition.gt,
         le=kwarg_definition.le,
         lt=kwarg_definition.lt,
-        max_length=kwarg_definition.max_length if not field_definition.is_partial else None,
-        min_length=kwarg_definition.min_length if not field_definition.is_partial else None,
+        max_length=kwarg_definition.max_length,
+        min_length=kwarg_definition.min_length,
         multiple_of=kwarg_definition.multiple_of,
         pattern=kwarg_definition.pattern,
         title=kwarg_definition.title,
     )
+
+
+def _annotate_with_meta(annotation: Any, meta: msgspec.Meta) -> Any:
+    """Annotate ``annotation`` with ``meta``.
+
+    msgspec only accepts type specific constraints such as ``min_length`` on the type they apply to, so if
+    ``annotation`` is a union of a single concrete type and ``None`` / ``UnsetType`` - as created for optional or
+    partial fields - the metadata has to be applied to that member instead of the union itself.
+    """
+    if is_union(annotation):
+        inner_types = get_args(annotation)
+        constrainable = [inner for inner in inner_types if inner is not NoneType and inner is not UnsetType]
+        if len(constrainable) == 1:
+            return Union[tuple(Annotated[inner, meta] if inner is constrainable[0] else inner for inner in inner_types)]
+
+    return Annotated[annotation, meta]
 
 
 def _create_struct_for_field_definitions(
@@ -837,7 +855,7 @@ def _create_struct_for_field_definitions(
 
         if field_definition.passthrough_constraints:
             if (field_meta := _create_struct_field_meta_for_field_definition(field_definition)) is not None:
-                field_type = Annotated[field_type, field_meta]
+                field_type = _annotate_with_meta(field_type, field_meta)
         elif field_definition.kwarg_definition:
             field_type = Annotated[field_type, field_definition.kwarg_definition]
 

--- a/tests/unit/test_dto/test_factory/test_integration.py
+++ b/tests/unit/test_dto/test_factory/test_integration.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from types import ModuleType
-from typing import TYPE_CHECKING, Annotated, Generic, Optional, TypeVar, cast
+from typing import TYPE_CHECKING, Annotated, Generic, Optional, TypeVar, Union, cast
 from unittest.mock import MagicMock
 from uuid import UUID
 
@@ -904,20 +904,58 @@ def test_msgspec_dto_copies_constraints(
         assert client.post("/", json={"bar": request_data}).status_code == 400
 
 
-def test_msgspec_dto_dont_copy_length_constraint_for_partial_dto() -> None:
+@pytest.mark.parametrize(
+    "field_type, constraint_name, constraint_value, request_data",
+    [
+        (int, "gt", 2, 2),
+        (int, "ge", 2, 1),
+        (int, "lt", 2, 2),
+        (int, "le", 2, 3),
+        (int, "multiple_of", 2, 3),
+        (str, "min_length", 2, "1"),
+        (str, "max_length", 1, "12"),
+        (str, "pattern", r"\d", "a"),
+    ],
+)
+def test_msgspec_dto_copies_constraints_for_partial_dto(
+    field_type: Any, constraint_name: str, constraint_value: Any, request_data: Any, use_experimental_dto_backend: bool
+) -> None:
+    # https://github.com/litestar-org/litestar/issues/4181
+    struct = msgspec.defstruct(
+        "Foo",
+        fields=[("bar", Annotated[field_type, msgspec.Meta(**{constraint_name: constraint_value})])],  # type: ignore[list-item]
+    )
+
+    class FooDTO(MsgspecDTO[struct]):  # type: ignore[valid-type]
+        config = DTOConfig(partial=True, experimental_codegen_backend=use_experimental_dto_backend)
+
+    @post("/", dto=FooDTO, signature_namespace={"struct": struct})
+    def handler(data: DTOData[struct]) -> None:  # type: ignore[valid-type]
+        pass
+
+    with create_test_client([handler]) as client:
+        assert client.post("/", json={}).status_code == 201
+        assert client.post("/", json={"bar": request_data}).status_code == 400
+
+
+def test_msgspec_dto_copies_constraints_of_union_member(use_experimental_dto_backend: bool) -> None:
+    # https://github.com/litestar-org/litestar/issues/4181
     class Foo(msgspec.Struct):
-        bar: Annotated[str, msgspec.Meta(min_length=2)]
-        baz: Annotated[str, msgspec.Meta(max_length=2)]
+        bar: Union[Annotated[str, msgspec.Meta(min_length=2)], msgspec.UnsetType] = msgspec.UNSET
+        baz: Optional[Annotated[str, msgspec.Meta(max_length=2)]] = None
 
     class FooDTO(MsgspecDTO[Foo]):
-        config = DTOConfig(partial=True)
+        config = DTOConfig(experimental_codegen_backend=use_experimental_dto_backend)
 
     @post("/", dto=FooDTO, signature_types={Foo})
     def handler(data: Foo) -> None:
         pass
 
     with create_test_client([handler]) as client:
-        assert client.post("/", json={"bar": "1", "baz": "123"}).status_code == 201
+        assert client.post("/", json={"bar": "12", "baz": "12"}).status_code == 201
+        assert client.post("/", json={}).status_code == 201
+        assert client.post("/", json={"bar": "1"}).status_code == 400
+        assert client.post("/", json={"baz": "123"}).status_code == 400
 
 
 def test_openapi_schema_for_type_with_generic_pagination_type(

--- a/tests/unit/test_dto/test_factory/test_integration.py
+++ b/tests/unit/test_dto/test_factory/test_integration.py
@@ -958,6 +958,24 @@ def test_msgspec_dto_copies_constraints_of_union_member(use_experimental_dto_bac
         assert client.post("/", json={"baz": "123"}).status_code == 400
 
 
+def test_msgspec_dto_keeps_meta_on_union_of_several_types(use_experimental_dto_backend: bool) -> None:
+    # a union with more than one constrainable member has no single member to move the metadata
+    # to, so it stays on the union itself
+    class Foo(msgspec.Struct):
+        bar: Annotated[Union[int, str], msgspec.Meta(description="a bar")]
+
+    class FooDTO(MsgspecDTO[Foo]):
+        config = DTOConfig(experimental_codegen_backend=use_experimental_dto_backend)
+
+    @post("/", dto=FooDTO, signature_types={Foo})
+    def handler(data: Foo) -> Foo:
+        return data
+
+    with create_test_client([handler]) as client:
+        assert client.post("/", json={"bar": 1}).json() == {"bar": 1}
+        assert client.post("/", json={"bar": "baz"}).json() == {"bar": "baz"}
+
+
 def test_openapi_schema_for_type_with_generic_pagination_type(
     create_module: Callable[[str], ModuleType], use_experimental_dto_backend: bool
 ) -> None:


### PR DESCRIPTION
Transfer models wrap optional and partial fields in a union with `None` or `UnsetType`, but constraints copied from the source model were attached to the union itself, giving annotations like `Annotated[Union[str, UnsetType], Meta(min_length=8)]`. msgspec only accepts type specific constraints on the type they apply to and raises a TypeError for that, so any DTO with a constrained optional field or `partial=True` failed to build.

The meta now goes on the single constrainable member of the union. If a union has more than one member that could take constraints there is nowhere obvious to put it, so it stays on the union as before. Partial DTOs no longer need to drop `min_length` and `max_length`, which was a workaround for the same problem.

The old workaround test is replaced by a parametrized one covering each constraint on both backends, and I added tests for `Union[Annotated[str, Meta], UnsetType]` and `Optional[Annotated[str, Meta]]`. They are in tests/unit/test_dto/test_factory/test_integration.py and fail without the change.

Closes #4181

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4988">https://litestar-org.github.io/litestar-docs-preview/4988</a> 
