### PR TITLE
fix(routing): raise on paths that only differ in their path parameters

### DIFF
--- a/docs/usage/routing/parameters.rst
+++ b/docs/usage/routing/parameters.rst
@@ -175,6 +175,15 @@ The following types are supported in the ``{name:type}`` slot:
 * ``timedelta``: Accepts duration strings compatible with the standard (Pydantic/Msgspec) timedelta formats.
 * ``uuid``: Accepts all uuid values.
 
+.. important::
+    Routing does not take the name or the type of a path parameter into account, so
+    ``/{id:int}`` and ``/{id:str}`` are the same route as far as routing is concerned;
+    the declared type only determines how the captured value is coerced. Registering
+    handlers for both would leave one of them unreachable and therefore raises an
+    :exc:`~.exceptions.ImproperlyConfiguredException`. To serve several value types
+    under the same path, use a single handler with the widest slot type and branch on
+    the value inside it.
+
 Query parameters
 ~~~~~~~~~~~~~~~~
 

--- a/litestar/_asgi/routing_trie/mapping.py
+++ b/litestar/_asgi/routing_trie/mapping.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from litestar._asgi.routing_trie.types import (
     ASGIHandlerTuple,
@@ -9,6 +9,7 @@ from litestar._asgi.routing_trie.types import (
     create_node,
 )
 from litestar._asgi.utils import wrap_in_exception_handler
+from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types.internal_types import PathParameterDefinition
 
 __all__ = ("add_mount_route", "add_route_to_trie", "build_route_middleware_stack", "configure_node")
@@ -18,7 +19,7 @@ if TYPE_CHECKING:
     from litestar._asgi.routing_trie.types import RouteTrieNode
     from litestar.app import Litestar
     from litestar.routes import ASGIRoute, HTTPRoute, WebSocketRoute
-    from litestar.types import ASGIApp, RouteHandlerType
+    from litestar.types import ASGIApp, Method, RouteHandlerType
 
 
 def add_mount_route(
@@ -122,6 +123,49 @@ def add_route_to_trie(
     return current_node
 
 
+def _validate_node_is_not_taken(
+    node: RouteTrieNode,
+    route: HTTPRoute | WebSocketRoute | ASGIRoute,
+    key: Method | Literal["websocket", "asgi"],
+) -> None:
+    """Ensure that ``route`` does not shadow a route that is already registered on ``node``.
+
+    Routing does not take the name or the type of path parameters into account, so paths such as ``/{id:int}`` and
+    ``/{id:str}`` resolve to the very same trie node. Registering both of them would silently make the one registered
+    first unreachable.
+
+    Args:
+        node: The trie node being configured.
+        route: The route that is being added.
+        key: The key under which the route's handler is about to be stored on the node.
+
+    Raises:
+        ImproperlyConfiguredException: If a different route has already been registered on the node under ``key``.
+
+    Returns:
+        None
+    """
+    # an 'OPTIONS' handler is generated for every path that does not define one itself, so handlers stored under this
+    # key collide whenever two paths share a node, without any user defined handler being shadowed
+    if key == "OPTIONS":
+        return
+
+    if (existing := node.asgi_handlers.get(key)) is None:
+        return
+
+    # a node is uniquely identified by its path components and its path parameter definitions, so equal definitions
+    # mean that the very same route is being registered again, e.g. when the trie is reconstructed after handlers
+    # have been registered on an already created app
+    if node.path_parameters.get(key) == tuple(route.path_parameters.values()):
+        return
+
+    raise ImproperlyConfiguredException(
+        f"Path '{route.path}' conflicts with the path registered for route handler '{existing.handler}'. Routing "
+        "does not take the name or type of path parameters into account, so paths that only differ in their path "
+        "parameters are considered equal."
+    )
+
+
 def configure_node(
     app: Litestar,
     route: HTTPRoute | WebSocketRoute | ASGIRoute,
@@ -145,6 +189,7 @@ def configure_node(
 
     if isinstance(route, HTTPRoute):
         for method, handler in route.route_handler_map.items():
+            _validate_node_is_not_taken(node=node, route=route, key=method)
             node.asgi_handlers[method] = ASGIHandlerTuple(
                 asgi_app=build_route_middleware_stack(app=app, route=route, route_handler=handler),
                 handler=handler,
@@ -152,6 +197,7 @@ def configure_node(
             node.path_parameters[method] = tuple(route.path_parameters.values())
 
     elif isinstance(route, WebSocketRoute):
+        _validate_node_is_not_taken(node=node, route=route, key="websocket")
         node.asgi_handlers["websocket"] = ASGIHandlerTuple(
             asgi_app=build_route_middleware_stack(app=app, route=route, route_handler=route.route_handler),
             handler=route.route_handler,
@@ -159,6 +205,7 @@ def configure_node(
         node.path_parameters["websocket"] = tuple(route.path_parameters.values())
 
     else:
+        _validate_node_is_not_taken(node=node, route=route, key="asgi")
         node.asgi_handlers["asgi"] = ASGIHandlerTuple(
             asgi_app=build_route_middleware_stack(app=app, route=route, route_handler=route.route_handler),
             handler=route.route_handler,

--- a/tests/unit/test_asgi/test_routing_trie/test_mapping.py
+++ b/tests/unit/test_asgi/test_routing_trie/test_mapping.py
@@ -4,10 +4,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from litestar import Litestar, get
+from litestar import Litestar, get, post, websocket_listener
 from litestar._asgi.routing_trie.mapping import build_route_middleware_stack
+from litestar.exceptions import ImproperlyConfiguredException
 from litestar.middleware._internal.exceptions import ExceptionHandlerMiddleware
+from litestar.params import FromPath
 from litestar.routes import HTTPRoute
+from litestar.testing import create_test_client
 
 
 def test_build_route_middleware_stack_no_middleware(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -45,3 +48,77 @@ def test_build_route_middleware_stack_with_middleware(monkeypatch: pytest.Monkey
     assert len(call_args.args) == 1
     assert isinstance(call_args.args[0], ExceptionHandlerMiddleware)
     assert not call_args.kwargs
+
+
+def test_conflicting_path_parameter_types_raise() -> None:
+    # https://github.com/litestar-org/litestar/issues/3622
+
+    @get("/{id:int}")
+    async def int_handler(id: FromPath[int]) -> int:
+        return id
+
+    @get("/{id:str}")
+    async def str_handler(id: FromPath[str]) -> str:
+        return id
+
+    with pytest.raises(ImproperlyConfiguredException, match="Path '/{id:str}' conflicts"):
+        Litestar(route_handlers=[int_handler, str_handler])
+
+
+def test_conflicting_path_parameter_names_raise() -> None:
+    @get("/{first:int}/detail")
+    async def first_handler(first: FromPath[int]) -> int:
+        return first
+
+    @get("/{second:int}/detail")
+    async def second_handler(second: FromPath[int]) -> int:
+        return second
+
+    with pytest.raises(ImproperlyConfiguredException, match="Path '/{second:int}/detail' conflicts"):
+        Litestar(route_handlers=[first_handler, second_handler])
+
+
+def test_conflicting_websocket_path_parameter_types_raise() -> None:
+    @websocket_listener("/{id:int}")
+    async def int_handler(data: str, id: FromPath[int]) -> int:
+        return id
+
+    @websocket_listener("/{id:str}")
+    async def str_handler(data: str, id: FromPath[str]) -> str:
+        return id
+
+    with pytest.raises(ImproperlyConfiguredException, match="Path '/{id:str}' conflicts"):
+        Litestar(route_handlers=[int_handler, str_handler])
+
+
+def test_differing_path_parameters_on_distinct_paths_do_not_conflict() -> None:
+    # the path parameters share a trie node, but neither handler shadows the other
+
+    @get("/{first:int}/first")
+    async def first_handler(first: FromPath[int]) -> int:
+        return first
+
+    @get("/{second:str}/second")
+    async def second_handler(second: FromPath[str]) -> str:
+        return second
+
+    @post("/{third:str}/first")
+    async def third_handler(third: FromPath[str]) -> str:
+        return third
+
+    with create_test_client([first_handler, second_handler, third_handler]) as client:
+        assert client.get("/1/first").json() == 1
+        assert client.get("/1/second").text == "1"
+        assert client.post("/1/first").text == "1"
+
+
+def test_reconstructing_the_routing_trie_does_not_raise() -> None:
+    # the trie is constructed anew for an already configured node when handlers are
+    # registered on an app after its creation
+
+    @get("/{id:int}")
+    async def handler(id: FromPath[int]) -> int:
+        return id
+
+    app = Litestar(route_handlers=[handler])
+    app.asgi_router.construct_routing_trie()


### PR DESCRIPTION
The routing trie collapses every path parameter at a given position into one node, so `/{id:int}` and `/{id:str}` resolve to the same node. Whichever route got registered last silently overwrote the earlier handler and made it unreachable. The issue discussion settled on raising an error instead of routing by parameter type, so registering paths like that now raises `ImproperlyConfiguredException`.

The check runs per method, so two paths that share a node but register different methods still work. OPTIONS is skipped. Litestar generates an OPTIONS handler for every path that does not declare one, so those handlers collide on a shared node even though no user handler is being shadowed. Re-registering the exact same route is still fine, which matters when the trie gets rebuilt after handlers are added to an app that already exists.

Tests are in tests/unit/test_asgi/test_routing_trie/test_mapping.py. I also added a note to the path parameter docs.

Closes #3622

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4989">https://litestar-org.github.io/litestar-docs-preview/4989</a>
