### PR TITLE
fix: return 413 when multipart form part limit is exceeded

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -6,6 +6,15 @@
 .. changelog:: 3.0.0
     :date: 2364-01-27
 
+    .. change:: Return HTTP 413 when the multipart form part limit is exceeded
+        :type: feature
+        :pr: 4990
+        :issue: 4439
+        :breaking:
+
+        Exceeding the configured multipart form part limit now returns
+        ``413 Request Entity Too Large`` instead of ``400 Bad Request``.
+
     .. change:: Remove the RapiDoc OpenAPI UI plugin
         :type: feature
         :pr: 4977

--- a/litestar/_multipart.py
+++ b/litestar/_multipart.py
@@ -15,6 +15,7 @@ from multipart import (  # type: ignore[import-untyped]
 
 from litestar.datastructures.upload_file import UploadFile
 from litestar.exceptions import ClientException
+from litestar.exceptions.http_exceptions import RequestEntityTooLarge
 
 __all__ = ("parse_content_header", "parse_multipart_form")
 
@@ -134,8 +135,6 @@ async def parse_multipart_form(  # noqa: C901
             await data.close()
         await _close_upload_files(fields)
 
-        # FIXME (3.0): This should raise a '413 - Request Entity Too Large', but for
-        # backwards compatibility, we keep it as a 400 for now
-        raise ClientException("Request Entity Too Large") from None
+        raise RequestEntityTooLarge from None
 
     return {k: v if len(v) > 1 else v[0] for k, v in fields.items()}

--- a/tests/unit/test_kwargs/test_multipart_data.py
+++ b/tests/unit/test_kwargs/test_multipart_data.py
@@ -14,7 +14,11 @@ from litestar import Request, post
 from litestar.datastructures.upload_file import UploadFile
 from litestar.enums import RequestEncodingType
 from litestar.params import Body, MultipartBody
-from litestar.status_codes import HTTP_201_CREATED, HTTP_400_BAD_REQUEST
+from litestar.status_codes import (
+    HTTP_201_CREATED,
+    HTTP_400_BAD_REQUEST,
+    HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+)
 from litestar.testing import create_test_client
 
 from . import Form
@@ -472,7 +476,7 @@ def test_multipart_form_part_limit(limit: int) -> None:
         data = {str(i): "a" for i in range(limit)}
         data[str(limit + 1)] = "b"
         response = client.post("/", files=data)
-        assert response.status_code == HTTP_400_BAD_REQUEST
+        assert response.status_code == HTTP_413_REQUEST_ENTITY_TOO_LARGE
 
 
 def test_multipart_form_part_limit_body_param_precedence() -> None:
@@ -494,7 +498,7 @@ def test_multipart_form_part_limit_body_param_precedence() -> None:
 
         data = {str(i): "a" for i in range(route_limit + 1)}
         response = client.post("/", files=data)
-        assert response.status_code == HTTP_400_BAD_REQUEST
+        assert response.status_code == HTTP_413_REQUEST_ENTITY_TOO_LARGE
 
 
 @dataclass


### PR DESCRIPTION
## Summary

This PR updates multipart form parsing so that exceeding the configured multipart form part limit returns **HTTP 413 Request Entity Too Large** instead of **HTTP 400 Bad Request**.

When the multipart parser raises `ParserLimitReached`, Litestar now translates that condition to `RequestEntityTooLarge`. Existing upload-file cleanup behavior is preserved.

Closes #4439.

## Changes

- Import and use `RequestEntityTooLarge` in `litestar/_multipart.py`.
- Replace the generic `ClientException("Request Entity Too Large")` raised for multipart part-limit violations.
- Remove the obsolete v3 FIXME associated with the previous 400 response.
- Update multipart part-limit tests to expect HTTP 413.
- Preserve HTTP 400 behavior for malformed multipart requests.

## Behavior

Before this change:

```text
multipart form part limit exceeded
→ HTTP 400 Bad Request
```

After this change:

```text
multipart form part limit exceeded
→ HTTP 413 Request Entity Too Large
```

Malformed multipart requests continue to return HTTP 400.

## Testing

The following checks were run locally:

```bash
uv run pytest tests/unit/test_kwargs/test_multipart_data.py \
  -k multipart_form_part_limit -v
```

Result:

```text
4 passed, 38 deselected
```

Full multipart test module:

```bash
uv run pytest tests/unit/test_kwargs/test_multipart_data.py -v
```

Result:

```text
41 passed, 1 xfailed
```

Lint and formatting:

```bash
uv run ruff check litestar/_multipart.py tests/unit/test_kwargs/test_multipart_data.py
uv run ruff format --check litestar/_multipart.py tests/unit/test_kwargs/test_multipart_data.py
```

Results:

```text
All checks passed!
2 files already formatted
```

Type checking:

```bash
make type-check
```

Results:

```text
mypy: Success: no issues found in 1114 source files
pyright: 0 errors, 0 warnings, 0 informations
```

Diff validation:

```bash
git diff --check
```

Result: no errors.

## Breaking-change note

This intentionally changes the response status for multipart form part-limit violations from 400 to 413 for Litestar v3. Clients that explicitly depend on the previous 400 status for this condition may need to update their handling.

No change is made to malformed multipart request handling.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4990">https://litestar-org.github.io/litestar-docs-preview/4990</a> 
