### PR TITLE
fix(stores): use GETEX for Redis renewal

### DIFF
--- a/litestar/stores/redis.py
+++ b/litestar/stores/redis.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Literal, cast, overload
 
 from redis.asyncio import Redis
 from redis.asyncio.connection import ConnectionPool
@@ -185,7 +185,7 @@ class RedisStore(NamespacedStore):
         """
         key = self._make_key(key)
         if renew_for:
-            return await self._redis.getex(key, ex=renew_for)
+            return cast("bytes | None", await self._redis.getex(key, ex=renew_for))
         return await self._redis.get(key)
 
     async def delete(self, key: str) -> None:

--- a/litestar/stores/redis.py
+++ b/litestar/stores/redis.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from datetime import timedelta
-from typing import TYPE_CHECKING, Literal, cast, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 from redis.asyncio import Redis
 from redis.asyncio.connection import ConnectionPool
@@ -13,6 +12,7 @@ from litestar.utils.empty import value_or_default
 from .base import NamespacedStore
 
 if TYPE_CHECKING:
+    from datetime import timedelta
     from types import TracebackType
 
     from redis.asyncio.connection import Connection
@@ -25,7 +25,6 @@ class RedisStore(NamespacedStore):
 
     __slots__ = (
         "_delete_all_script",
-        "_get_and_renew_script",
         "_redis",
         "handle_client_shutdown",
     )
@@ -45,23 +44,6 @@ class RedisStore(NamespacedStore):
         self._redis = redis
         self.namespace: str | None = value_or_default(namespace, "LITESTAR")
         self.handle_client_shutdown = handle_client_shutdown
-
-        # script to get and renew a key in one atomic step
-        self._get_and_renew_script = self._redis.register_script(
-            b"""
-        local key = KEYS[1]
-        local renew = tonumber(ARGV[1])
-
-        local data = redis.call('GET', key)
-        local ttl = redis.call('TTL', key)
-
-        if ttl > 0 then
-            redis.call('EXPIRE', key, renew)
-        end
-
-        return data
-        """
-        )
 
         # script to delete all keys in the namespace
         self._delete_all_script = self._redis.register_script(
@@ -194,8 +176,8 @@ class RedisStore(NamespacedStore):
             renew_for: If given and the value had an initial expiry time set, renew the
                 expiry time for ``renew_for`` seconds. If the value has not been set
                 with an expiry time this is a no-op. Atomicity of this step is guaranteed
-                by using a lua script to execute fetch and renewal. If ``renew_for`` is
-                not given, the script will be bypassed so no overhead will occur
+                by using Redis ``GETEX`` to execute fetch and renewal. If ``renew_for``
+                is not given, ``GETEX`` will be bypassed so no overhead will occur
 
         Returns:
             The value associated with ``key`` if it exists and is not expired, else
@@ -203,10 +185,7 @@ class RedisStore(NamespacedStore):
         """
         key = self._make_key(key)
         if renew_for:
-            if isinstance(renew_for, timedelta):
-                renew_for = renew_for.seconds
-            data = await self._get_and_renew_script(keys=[key], args=[renew_for])
-            return cast("bytes | None", data)
+            return await self._redis.getex(key, ex=renew_for)
         return await self._redis.get(key)
 
     async def delete(self, key: str) -> None:

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -111,7 +111,7 @@ async def test_get_and_renew_redis(redis_store: RedisStore, renew_for: int | tim
     getex = mocker.spy(redis_store._redis, "getex")
     await redis_store.get("foo", renew_for=renew_for)
 
-    getex.assert_awaited_once_with("LITESTAR:foo", ex=renew_for)
+    getex.assert_called_once_with("LITESTAR:foo", ex=renew_for)
 
     await asyncio.sleep(1.1)
 

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -7,7 +7,7 @@ import string
 from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from _pytest.fixtures import FixtureRequest
@@ -104,17 +104,30 @@ async def test_get_and_renew(store: Store, renew_for: int | timedelta, frozen_da
 @pytest.mark.flaky(reruns=5)
 @pytest.mark.parametrize("renew_for", [10, timedelta(seconds=10)])
 @pytest.mark.xdist_group("redis")
-async def test_get_and_renew_redis(redis_store: RedisStore, renew_for: int | timedelta) -> None:
+async def test_get_and_renew_redis(redis_store: RedisStore, renew_for: int | timedelta, mocker: MockerFixture) -> None:
     # we can't sleep() in frozen datetime, and frozen datetime doesn't affect the redis
     # instance, so we test this separately
     await redis_store.set("foo", b"bar", expires_in=1)
+    getex = mocker.spy(redis_store._redis, "getex")
     await redis_store.get("foo", renew_for=renew_for)
+
+    getex.assert_awaited_once_with("LITESTAR:foo", ex=renew_for)
 
     await asyncio.sleep(1.1)
 
     stored_value = await redis_store.get("foo")
 
     assert stored_value is not None
+
+
+async def test_get_and_renew_redis_uses_getex() -> None:
+    redis = MagicMock()
+    redis.getex = AsyncMock(return_value=b"bar")
+    store = RedisStore(redis=redis)
+
+    assert await store.get("foo", renew_for=10) == b"bar"
+
+    redis.getex.assert_awaited_once_with("LITESTAR:foo", ex=10)
 
 
 @pytest.mark.flaky(reruns=5)


### PR DESCRIPTION
## Summary
- replace the Redis Lua get-and-renew script with native Redis 6.2+ GETEX
- preserve the fast GET path when renewal is not requested
- assert the namespaced key and renewal value are passed through to GETEX

Closes #4993

## Validation
- uv run --frozen pytest tests/unit/test_stores.py::test_get_and_renew_redis_uses_getex -q
- uv run --frozen ruff check litestar/stores/redis.py tests/unit/test_stores.py
- uv run --frozen ruff format --check litestar/stores/redis.py tests/unit/test_stores.py
- git diff --check

The Docker-backed Redis integration test was not run locally because Docker Desktop's Linux engine is unavailable on this host.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4994">https://litestar-org.github.io/litestar-docs-preview/4994</a> 
