### PR TITLE
perf(stores): use redis GETEX for renewal with fallback (#4993)

### DIFF
--- a/litestar/stores/redis.py
+++ b/litestar/stores/redis.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Literal, cast, overload
 
 from redis.asyncio import Redis
 from redis.asyncio.connection import ConnectionPool
+from redis.exceptions import ResponseError
 
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types import Empty, EmptyType
@@ -27,6 +28,7 @@ class RedisStore(NamespacedStore):
         "_delete_all_script",
         "_get_and_renew_script",
         "_redis",
+        "_supports_getex",
         "handle_client_shutdown",
     )
 
@@ -45,6 +47,7 @@ class RedisStore(NamespacedStore):
         self._redis = redis
         self.namespace: str | None = value_or_default(namespace, "LITESTAR")
         self.handle_client_shutdown = handle_client_shutdown
+        self._supports_getex: bool = True
 
         # script to get and renew a key in one atomic step
         self._get_and_renew_script = self._redis.register_script(
@@ -130,11 +133,13 @@ class RedisStore(NamespacedStore):
         The current instances namespace will serve as a prefix for the namespace, so it
         can be considered the parent namespace.
         """
-        return type(self)(
+        store = type(self)(
             redis=self._redis,
             namespace=f"{self.namespace}_{namespace}" if self.namespace else namespace,
             handle_client_shutdown=self.handle_client_shutdown,
         )
+        store._supports_getex = self._supports_getex
+        return store
 
     def _make_key(self, key: str) -> str:
         prefix = f"{self.namespace}:" if self.namespace else ""
@@ -205,6 +210,11 @@ class RedisStore(NamespacedStore):
         if renew_for:
             if isinstance(renew_for, timedelta):
                 renew_for = renew_for.seconds
+            if self._supports_getex:
+                try:
+                    return cast("bytes | None", await self._redis.getex(key, ex=renew_for))
+                except ResponseError:
+                    self._supports_getex = False
             data = await self._get_and_renew_script(keys=[key], args=[renew_for])
             return cast("bytes | None", data)
         return await self._redis.get(key)

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -7,11 +7,12 @@ import string
 from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from _pytest.fixtures import FixtureRequest
 from pytest_mock import MockerFixture
+from redis.exceptions import ResponseError
 from time_machine import Traveller
 
 from litestar.exceptions import ImproperlyConfiguredException
@@ -246,6 +247,73 @@ async def test_redis_set_with_expires_in_and_keep_ttl_raises(
 
     with pytest.raises(ValueError, match="Cannot set both 'expires_in' and 'keep_ttl'"):
         await store.set("key", b"value", expires_in=60, keep_ttl=True)  # type: ignore[call-overload]
+
+
+@pytest.mark.parametrize("renew_for,expected_ex", [(10, 10), (timedelta(seconds=15), 15)])
+async def test_redis_get_with_renew_for_uses_getex(renew_for: int | timedelta, expected_ex: int) -> None:
+    mock_redis = AsyncMock()
+    mock_redis.getex.return_value = b"getex_value"
+    mock_script = AsyncMock()
+    mock_redis.register_script.return_value = mock_script
+
+    store = RedisStore(redis=mock_redis)
+    res = await store.get("test_key", renew_for=renew_for)
+
+    assert res == b"getex_value"
+    mock_redis.getex.assert_awaited_once_with("LITESTAR:test_key", ex=expected_ex)
+    mock_script.assert_not_called()
+
+
+async def test_redis_get_with_renew_for_fallback_on_unsupported_getex() -> None:
+    mock_redis = AsyncMock()
+    mock_redis.getex.side_effect = ResponseError("unknown command `GETEX`")
+    mock_script = AsyncMock(return_value=b"script_value")
+    mock_redis.register_script = MagicMock(return_value=mock_script)
+
+    store = RedisStore(redis=mock_redis)
+
+    # First call encounters ResponseError and falls back to Lua script
+    res1 = await store.get("key1", renew_for=10)
+    assert res1 == b"script_value"
+    assert store._supports_getex is False
+    mock_redis.getex.assert_awaited_once_with("LITESTAR:key1", ex=10)
+    mock_script.assert_awaited_once_with(keys=["LITESTAR:key1"], args=[10])
+
+    # Second call should skip GETEX directly and use Lua script
+    mock_redis.getex.reset_mock()
+    mock_script.reset_mock()
+
+    res2 = await store.get("key2", renew_for=20)
+    assert res2 == b"script_value"
+    mock_redis.getex.assert_not_called()
+    mock_script.assert_awaited_once_with(keys=["LITESTAR:key2"], args=[20])
+
+
+async def test_redis_get_without_renew_for_uses_get() -> None:
+    mock_redis = AsyncMock()
+    mock_redis.get.return_value = b"plain_value"
+    mock_script = AsyncMock()
+    mock_redis.register_script.return_value = mock_script
+
+    store = RedisStore(redis=mock_redis)
+    res = await store.get("test_key")
+
+    assert res == b"plain_value"
+    mock_redis.get.assert_awaited_once_with("LITESTAR:test_key")
+    mock_redis.getex.assert_not_called()
+    mock_script.assert_not_called()
+
+
+async def test_redis_with_namespace_preserves_supports_getex() -> None:
+    mock_redis = AsyncMock()
+    mock_redis.getex.return_value = b"nested_value"
+
+    parent_store = RedisStore(redis=mock_redis, namespace="PARENT")
+    parent_store._supports_getex = False
+
+    child_store = parent_store.with_namespace("CHILD")
+    assert child_store._supports_getex is False
+    assert child_store.namespace == "PARENT_CHILD"
 
 
 @pytest.mark.xdist_group("redis")


### PR DESCRIPTION
## Description

Closes #4993

### Summary
This PR optimizes `RedisStore.get(..., renew_for=...)` to utilize native Redis `GETEX` on Redis 6.2+ while preserving backward compatibility for environments where `GETEX` is unavailable.

### Context & Alternative Approach
Note: #4994 by @09Catho also implements the direct `GETEX` optimization for #4993. This PR is offered as a collaborative alternative / complement exploring compatibility fallback:

1. **`GETEX` on Redis 6.2+**: Executes `await self._redis.getex(key, ex=renew_for)` directly without Lua script overhead.
2. **Backward-Compatibility Fallback**: If a Redis server (<6.2) or restrictive proxy raises `ResponseError` on `GETEX`, it seamlessly falls back to the existing `_get_and_renew_script`.
3. **Capability Downgrade Caching**: Sets `self._supports_getex = False` upon catching `ResponseError` so subsequent calls bypass `GETEX` immediately without paying exception handling overhead.
4. **Namespace Propagation**: Propagates `_supports_getex` to sub-namespaces created via `.with_namespace()`.
5. **Fast Path**: Unchanged direct `_redis.get(key)` when `renew_for` is not provided.
6. **Unit Tests**: Deterministic unit/mock tests for `GETEX`, `ResponseError` fallback, capability caching, and namespace inheritance.

Maintainers are welcome to choose either approach or combine useful pieces from both.

### Validation
- `uv run pytest tests/unit/test_stores.py -m "not flaky and not xdist_group"` (162 passed, 2 xfailed)
- `uv run ruff check litestar/stores/redis.py tests/unit/test_stores.py`
- `uv run ruff format --check litestar/stores/redis.py tests/unit/test_stores.py`
- `uv run pyright litestar/stores/redis.py tests/unit/test_stores.py`
- `uv run mypy litestar/stores/redis.py tests/unit/test_stores.py`

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4995">https://litestar-org.github.io/litestar-docs-preview/4995</a> 
