### PR TITLE
fix(openapi): don't dispatch unions of enums to the enum schema handler

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -8,6 +8,7 @@
 
     .. change:: Fix ``TypeError`` when generating a schema for a union of enums
         :type: bugfix
+        :pr: 4997
 
         Annotating a handler with a union whose members are all enums (e.g.
         ``Color | Size``) crashed schema generation with ``TypeError: issubclass()

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -6,6 +6,15 @@
 .. changelog:: 3.0.0
     :date: 2364-01-27
 
+    .. change:: Fix ``TypeError`` when generating a schema for a union of enums
+        :type: bugfix
+
+        Annotating a handler with a union whose members are all enums (e.g.
+        ``Color | Size``) crashed schema generation with ``TypeError: issubclass()
+        arg 1 must be a class``, as the union was dispatched to the enum schema
+        handler. Such unions are now documented as a ``oneOf`` with a component
+        schema per enum.
+
     .. change:: Return HTTP 413 when the multipart form part limit is exceeded
         :type: feature
         :pr: 4990

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -345,7 +345,8 @@ class SchemaCreator:
             )
         elif field_definition.is_optional:
             result = self.for_optional_field(field_definition)
-        elif field_definition.is_enum:
+        elif field_definition.is_enum and not field_definition.is_union:
+            # `is_enum` is also true for unions whose members are all enums
             result = self.for_enum_field(field_definition)
         elif field_definition.is_union:
             result = self.for_union_field(field_definition)

--- a/litestar/_openapi/schema_generation/schema.py
+++ b/litestar/_openapi/schema_generation/schema.py
@@ -346,7 +346,6 @@ class SchemaCreator:
         elif field_definition.is_optional:
             result = self.for_optional_field(field_definition)
         elif field_definition.is_enum and not field_definition.is_union:
-            # `is_enum` is also true for unions whose members are all enums
             result = self.for_enum_field(field_definition)
         elif field_definition.is_union:
             result = self.for_union_field(field_definition)

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -1122,3 +1122,21 @@ def test_reference_result_keeps_kwarg_metadata_on_subsequent_use() -> None:
     assert second.description == "second use"
     assert second.all_of is not None
     assert isinstance(second.all_of[0], Reference)
+
+
+def test_union_of_enums() -> None:
+    class Color(Enum):
+        RED = "red"
+
+    class Size(Enum):
+        SMALL = "small"
+
+    creator = SchemaCreator(plugins=openapi_schema_plugins)
+    schema = creator.for_field_definition(FieldDefinition.from_annotation(Union[Color, Size]))
+
+    assert isinstance(schema, Schema)
+    assert schema.one_of is not None
+    assert len(schema.one_of) == 2
+    components = creator.schema_registry.generate_components_schemas()
+    enums = sorted(v.enum for v in components.values())  # type: ignore[arg-type]
+    assert enums == [["red"], ["small"]]

--- a/tests/unit/test_openapi/test_schema.py
+++ b/tests/unit/test_openapi/test_schema.py
@@ -1138,5 +1138,4 @@ def test_union_of_enums() -> None:
     assert schema.one_of is not None
     assert len(schema.one_of) == 2
     components = creator.schema_registry.generate_components_schemas()
-    enums = sorted(v.enum for v in components.values())  # type: ignore[arg-type]
-    assert enums == [["red"], ["small"]]
+    assert {tuple(v.enum or ()) for v in components.values()} == {("red",), ("small",)}


### PR DESCRIPTION
Annotating a handler with a union whose members are all enums (e.g. `Color | Size`) crashed schema generation with `TypeError: issubclass() arg 1 must be a class`. `FieldDefinition.is_enum` is built on `is_subclass_of(Enum)`, which by its documented union semantics returns `True` when every union member is an enum,  so `for_field_definition` dispatched the whole union to `for_enum_field`, which assumes a single enum class.
  
Script to reproduce the error

```python
# /// script
# requires-python = ">=3.11"
# dependencies = ["litestar", "pydantic"]
# ///
from enum import Enum

from litestar import Litestar, get


class Color(Enum):
    RED = "red"
    BLUE = "blue"


class Size(Enum):
    SMALL = "small"
    LARGE = "large"


@get("/pick")
async def pick() -> Color | Size:
    return Color.RED


app = Litestar([pick])
schema = app.openapi_schema.to_schema()  # TypeError: issubclass() arg 1 must be a class
```

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/4997">https://litestar-org.github.io/litestar-docs-preview/4997</a> 
