### PR TITLE
fix(tests): restore optional gender and lucky_number openapi params (`v2` CI)

### DIFF
--- a/litestar/channels/backends/psycopg.py
+++ b/litestar/channels/backends/psycopg.py
@@ -35,8 +35,6 @@ class PsycoPgChannelsBackend(ChannelsBackend):
     async def on_startup(self) -> None:
         self._exit_stack = AsyncExitStack()
         self._event_queue = asyncio.Queue()
-        # Created here rather than in __init__ because on Python <= 3.9 it binds to the event loop
-        # active at creation time
         self._listener_lock = asyncio.Lock()
         self._shutting_down = False
         self._listener_conn = await AsyncConnection[Any].connect(self._pg_dsn, autocommit=True)

--- a/litestar/channels/backends/psycopg.py
+++ b/litestar/channels/backends/psycopg.py
@@ -21,12 +21,12 @@ _STOP_LISTENER_TIMEOUT = 5.0
 
 class PsycoPgChannelsBackend(ChannelsBackend):
     _listener_conn: AsyncConnection[Any]
+    _listener_lock: asyncio.Lock
 
     def __init__(self, pg_dsn: str) -> None:
         self._pg_dsn = pg_dsn
         self._subscribed_channels: set[str] = set()
         self._exit_stack = AsyncExitStack()
-        self._listener_lock = asyncio.Lock()
         self._listener_task: asyncio.Task[None] | None = None
         self._event_queue: asyncio.Queue[tuple[str, bytes] | Exception] = asyncio.Queue()
         self._shutting_down = False
@@ -35,7 +35,8 @@ class PsycoPgChannelsBackend(ChannelsBackend):
     async def on_startup(self) -> None:
         self._exit_stack = AsyncExitStack()
         self._event_queue = asyncio.Queue()
-        # Recreate the lock because on Python <= 3.9 it binds to the event loop active at creation time
+        # Created here rather than in __init__ because on Python <= 3.9 it binds to the event loop
+        # active at creation time
         self._listener_lock = asyncio.Lock()
         self._shutting_down = False
         self._listener_conn = await AsyncConnection[Any].connect(self._pg_dsn, autocommit=True)

--- a/litestar/channels/backends/psycopg.py
+++ b/litestar/channels/backends/psycopg.py
@@ -35,6 +35,8 @@ class PsycoPgChannelsBackend(ChannelsBackend):
     async def on_startup(self) -> None:
         self._exit_stack = AsyncExitStack()
         self._event_queue = asyncio.Queue()
+        # Recreate the lock because on Python <= 3.9 it binds to the event loop active at creation time
+        self._listener_lock = asyncio.Lock()
         self._shutting_down = False
         self._listener_conn = await AsyncConnection[Any].connect(self._pg_dsn, autocommit=True)
         await self._exit_stack.enter_async_context(self._listener_conn)

--- a/tests/unit/test_channels/test_psycopg_backend.py
+++ b/tests/unit/test_channels/test_psycopg_backend.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, AsyncGenerator
 
 import pytest
+from psycopg import AsyncConnection
 
 from litestar.channels.backends.psycopg import PsycoPgChannelsBackend
 
@@ -14,6 +15,12 @@ class _ConcurrentConnection:
         self.active_operations = 0
         self.max_active_operations = 0
 
+    async def __aenter__(self) -> _ConcurrentConnection:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
     async def execute(self, *args: Any, **kwargs: Any) -> None:
         self.active_operations += 1
         self.max_active_operations = max(self.max_active_operations, self.active_operations)
@@ -22,6 +29,16 @@ class _ConcurrentConnection:
 
     async def commit(self) -> None:
         return None
+
+    def notifies(self, *, timeout: float | None = None, stop_after: int | None = None) -> Any:
+        return self._no_notifications()
+
+    @staticmethod
+    async def _no_notifications() -> AsyncGenerator[Any, None]:
+        await asyncio.sleep(0.01)
+        nothing: Any
+        for nothing in ():
+            yield nothing
 
 
 class _FailingConnection(_ConcurrentConnection):
@@ -43,15 +60,32 @@ class _Notification:
     payload: str
 
 
-async def test_subscription_mutations_are_serialized() -> None:
+@pytest.fixture()
+def stub_connection() -> _ConcurrentConnection:
+    return _ConcurrentConnection()
+
+
+@pytest.fixture()
+async def started_backend(
+    monkeypatch: pytest.MonkeyPatch, stub_connection: _ConcurrentConnection
+) -> AsyncGenerator[PsycoPgChannelsBackend, None]:
+    async def fake_connect(*args: Any, **kwargs: Any) -> _ConcurrentConnection:
+        return stub_connection
+
+    monkeypatch.setattr(AsyncConnection, "connect", fake_connect)
+
     backend = PsycoPgChannelsBackend("postgresql://unused")
-    connection = _ConcurrentConnection()
-    backend._listener_conn = connection  # type: ignore[assignment]
-    backend._listener_lock = asyncio.Lock()  # normally created by on_startup, which needs a real connection
+    await backend.on_startup()
+    yield backend
+    await backend.on_shutdown()
 
-    await asyncio.gather(backend.subscribe(["one"]), backend.subscribe(["two"]))
 
-    assert connection.max_active_operations == 1
+async def test_subscription_mutations_are_serialized(
+    started_backend: PsycoPgChannelsBackend, stub_connection: _ConcurrentConnection
+) -> None:
+    await asyncio.gather(started_backend.subscribe(["one"]), started_backend.subscribe(["two"]))
+
+    assert stub_connection.max_active_operations == 1
 
 
 async def test_stream_events_propagates_listener_failures() -> None:

--- a/tests/unit/test_channels/test_psycopg_backend.py
+++ b/tests/unit/test_channels/test_psycopg_backend.py
@@ -47,6 +47,7 @@ async def test_subscription_mutations_are_serialized() -> None:
     backend = PsycoPgChannelsBackend("postgresql://unused")
     connection = _ConcurrentConnection()
     backend._listener_conn = connection  # type: ignore[assignment]
+    backend._listener_lock = asyncio.Lock()  # normally created by on_startup, which needs a real connection
 
     await asyncio.gather(backend.subscribe(["one"]), backend.subscribe(["two"]))
 

--- a/tests/unit/test_openapi/conftest.py
+++ b/tests/unit/test_openapi/conftest.py
@@ -38,15 +38,17 @@ def create_person_controller() -> Type[Controller]:
             page: FromQuery[int],
             name: FromQuery[Optional[Union[str, List[str]]]],  # intentionally without default
             lucky_number: Annotated[
-                Optional[LuckyNumber], QueryParameter(examples=[Example(value=LuckyNumber.SEVEN)])
-            ] = 1,  # type: ignore[assignment]
+                Optional[LuckyNumber], QueryParameter(required=False, examples=[Example(value=LuckyNumber.SEVEN)])
+            ],
             # header parameter
             secret_header: Annotated[str, HeaderParameter(name="secret")],
             # cookie parameter
             cookie_value: Annotated[int, CookieParameter(name="value")],
             gender: Annotated[
                 Optional[Union[Gender, List[Gender]]],
-                QueryParameter(examples=[Example(value=Gender.MALE), Example(value=[Gender.MALE, Gender.OTHER])]),
+                QueryParameter(
+                    required=False, examples=[Example(value=Gender.MALE), Example(value=[Gender.MALE, Gender.OTHER])]
+                ),
             ],
             page_size: Annotated[
                 int,

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -128,7 +128,7 @@ def test_create_parameters(person_controller: Type[Controller]) -> None:
         ],
         examples=[Gender.MALE, [Gender.MALE, Gender.OTHER]],
     )
-    assert gender.required
+    assert not gender.required
 
     assert secret_header.param_in == ParamType.HEADER
     assert is_schema_value(secret_header.schema)
@@ -151,7 +151,6 @@ def test_create_parameters(person_controller: Type[Controller]) -> None:
             Schema(type=OpenAPIType.NULL),
         ],
         examples=[LuckyNumber.SEVEN],
-        default=1,
     )
     assert not lucky_number.required
 


### PR DESCRIPTION
Stacked on #4987. Fixes the two failures keeping `v2` CI red.

The typescript converter test: the #4750 cherry-pick dropped `required=False` from the `gender` and `lucky_number` query params in the openapi test conftest, and adjusted the assertions to match instead of restoring them.

The psycopg channels tests on 3.8/3.9: the backend creates its `asyncio.Lock` in `__init__`, and on ≤3.9 a lock binds to the loop active at creation (lazy binding only came in 3.10). The tests create the backend on one loop and run the app on the `TestClient` portal loop, so a contended acquire during shutdown blows up with "got Future attached to a different loop". Now recreated in `on_startup` on the running loop, like the event queue already is.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5002">https://litestar-org.github.io/litestar-docs-preview/5002</a> 
