### PR TITLE
fix(routing): do not let {path:path} shadow param+static routes

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -8,6 +8,7 @@
 
     .. change:: Prefer specific routes over a ``{path:path}`` catch-all
         :type: bugfix
+        :pr: 5004
         :issue: 4991
 
         A ``{path:path}`` catch-all no longer shadows a more specific route that

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -6,6 +6,15 @@
 .. changelog:: 3.0.0
     :date: 2364-01-27
 
+    .. change:: Prefer specific routes over a ``{path:path}`` catch-all
+        :type: bugfix
+        :issue: 4991
+
+        A ``{path:path}`` catch-all no longer shadows a more specific route that
+        starts with a path parameter and continues with a static suffix, such as
+        ``/{slug:str}/hello``. ``GET /foo/hello`` matches the specific route;
+        unmatched paths still fall through to the catch-all.
+
     .. change:: Fix ``TypeError`` when generating a schema for a union of enums
         :type: bugfix
         :pr: 4997

--- a/litestar/_asgi/routing_trie/traversal.py
+++ b/litestar/_asgi/routing_trie/traversal.py
@@ -34,31 +34,53 @@ def traverse_route_map(
     Returns:
         A tuple containing the target RouteMapNode and a list containing all path parameter values.
     """
-    current_node = root_node
-    path_params: list[str] = []
     path_components = [p for p in path.split("/") if p]
-
-    for i, component in enumerate(path_components):
-        if component in current_node.child_keys:
-            current_node = current_node.children[component]
-            continue
-
-        if current_node.is_path_param_node:
-            current_node = current_node.children[PathParameterSentinel]
-
-            if current_node.is_path_type:
-                path_params.append(normalize_path("/".join(path_components[i:])))
-                break
-
-            path_params.append(component)
-            continue
-
+    matched = _traverse_node(root_node, path_components, [])
+    if matched is None:
         raise NotFoundException()
 
+    current_node, path_params = matched
     if not current_node.asgi_handlers:
         raise NotFoundException()
 
     return current_node, path_params, path
+
+
+def _traverse_node(
+    node: RouteTrieNode,
+    components: list[str],
+    path_params: list[str],
+) -> tuple[RouteTrieNode, list[str]] | None:
+    """Walk one trie node, backtracking when a greedy ``{path:path}`` would hide a more specific route."""
+    if not components:
+        return (node, path_params) if node.asgi_handlers else None
+
+    component = components[0]
+    remaining = components[1:]
+
+    if component in node.child_keys:
+        matched = _traverse_node(node.children[component], remaining, path_params)
+        if matched is not None:
+            return matched
+
+    if not node.is_path_param_node:
+        return None
+
+    param_node = node.children[PathParameterSentinel]
+    if param_node.is_path_type:
+        # Try children of the catch-all node (e.g. ``{slug}/hello``) before
+        # consuming the rest of the path. Skip when nothing remains: an empty
+        # continuation would bind the catch-all handler to a raw segment
+        # instead of a normalised path.
+        if remaining:
+            matched = _traverse_node(param_node, remaining, [*path_params, component])
+            if matched is not None:
+                return matched
+        if param_node.asgi_handlers:
+            return param_node, [*path_params, normalize_path("/".join(components))]
+        return None
+
+    return _traverse_node(param_node, remaining, [*path_params, component])
 
 
 def parse_node_handlers(

--- a/tests/e2e/test_routing/test_path_resolution.py
+++ b/tests/e2e/test_routing/test_path_resolution.py
@@ -255,6 +255,59 @@ def test_support_for_path_type_parameters() -> None:
         assert response.status_code == HTTP_200_OK
 
 
+@pytest.mark.parametrize("catchall_first", [False, True])
+def test_path_type_catchall_does_not_shadow_param_static_suffix(catchall_first: bool) -> None:
+    # https://github.com/litestar-org/litestar/issues/4991
+    @get("/{slug:str}/hello", media_type=MediaType.TEXT)
+    def specific(slug: FromPath[str]) -> str:
+        return f"specific:{slug}"
+
+    @get("/{path:path}", media_type=MediaType.TEXT)
+    def catch_all(path: FromPath[Path]) -> str:
+        return f"catch_all:{path}"
+
+    handlers = [catch_all, specific] if catchall_first else [specific, catch_all]
+    with create_test_client(handlers) as client:
+        response = client.get("/foo/hello")
+        assert response.status_code == HTTP_200_OK
+        assert response.text == "specific:foo"
+
+        response = client.get("/foo/bar")
+        assert response.status_code == HTTP_200_OK
+        assert response.text == "catch_all:/foo/bar"
+
+        response = client.get("/foo/hello/extra")
+        assert response.status_code == HTTP_200_OK
+        assert response.text == "catch_all:/foo/hello/extra"
+
+        response = client.get("/foo")
+        assert response.status_code == HTTP_200_OK
+        assert response.text == "catch_all:/foo"
+
+
+def test_path_type_catchall_with_static_prefix() -> None:
+    @get("/hello/{slug:str}", media_type=MediaType.TEXT)
+    def specific(slug: FromPath[str]) -> str:
+        return f"specific:{slug}"
+
+    @get("/{path:path}", media_type=MediaType.TEXT)
+    def catch_all(path: FromPath[Path]) -> str:
+        return f"catch_all:{path}"
+
+    with create_test_client([specific, catch_all]) as client:
+        response = client.get("/hello/world")
+        assert response.status_code == HTTP_200_OK
+        assert response.text == "specific:world"
+
+        response = client.get("/foo/bar")
+        assert response.status_code == HTTP_200_OK
+        assert response.text == "catch_all:/foo/bar"
+
+        response = client.get("/hello")
+        assert response.status_code == HTTP_200_OK
+        assert response.text == "catch_all:/hello"
+
+
 def test_base_path_param_resolution() -> None:
     # https://github.com/litestar-org/litestar/issues/1830
     @get("/{name:str}")


### PR DESCRIPTION
## Summary

Fixes #4991.

`{path:path}` and `/{slug:str}/hello` share the same `PathParameterSentinel` node. Traversal treated `is_path_type` as "consume the rest of the URL now", so `/foo/hello` never walked the `hello` child and always hit the catch-all.

Static-prefix routes (`/hello/{slug}` next to `/{path:path}`) were already fine because the static child is tried first. The failure is specifically param-first + static suffix, which is the CMS permalink + dedicated subpath case.

## Approach

When the sentinel is a path-type node and there is still a remainder, try matching that remainder against its children (the `{slug}/hello` continuation) before joining the rest of the path into the catch-all parameter. If that continuation 404s — `/foo/bar`, `/foo/hello/extra` — fall back to the catch-all.

Single-segment catch-alls (`GET /foo`) still go through `normalize_path`, so the bound value stays `/foo` rather than the raw segment.

## Tests

- `/{slug}/hello` + `/{path:path}` in both registration orders: `/foo/hello` → specific, `/foo/bar` and `/foo/hello/extra` and `/foo` → catch-all
- `/hello/{slug}` + `/{path:path}` still prefers the static prefix; `/hello` with no slug falls through to the catch-all

```bash
uv run pytest tests/e2e/test_routing/ tests/unit/test_asgi/test_routing_trie/test_traversal.py tests/e2e/test_router_registration.py -k "not server_integration"
```

82 passed locally.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5004">https://litestar-org.github.io/litestar-docs-preview/5004</a> 
