### PR TITLE
refactor(middleware): migrate `PrometheusMiddleware` to `ASGIMiddleware`

### DIFF
--- a/docs/examples/plugins/prometheus/using_prometheus_exporter.py
+++ b/docs/examples/plugins/prometheus/using_prometheus_exporter.py
@@ -1,13 +1,13 @@
 from litestar import Litestar
-from litestar.plugins.prometheus import PrometheusConfig, PrometheusController
+from litestar.plugins.prometheus import PrometheusController, PrometheusMiddleware
 
 
 def create_app(group_path: bool = True) -> Litestar:
     # Default app name and prefix is litestar.
-    prometheus_config = PrometheusConfig(group_path=group_path)
+    prometheus_middleware = PrometheusMiddleware(group_path=group_path)
 
     # By default the metrics are available in prometheus format and the path is set to '/metrics'.
     # If you want to change the path and format you can do it by subclassing the PrometheusController class.
 
-    # Creating the litestar app instance with our custom PrometheusConfig and PrometheusController.
-    return Litestar(route_handlers=[PrometheusController], middleware=[prometheus_config.middleware])
+    # Creating the litestar app instance with our custom PrometheusMiddleware and PrometheusController.
+    return Litestar(route_handlers=[PrometheusController], middleware=[prometheus_middleware])

--- a/docs/examples/plugins/prometheus/using_prometheus_exporter_with_extra_configs.py
+++ b/docs/examples/plugins/prometheus/using_prometheus_exporter_with_extra_configs.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from typing import Any
 
 from litestar import Litestar, Request
-from litestar.plugins.prometheus import PrometheusConfig, PrometheusController
+from litestar.plugins.prometheus import PrometheusController, PrometheusMiddleware
 
 
 # We can modify the path of our custom handler and override the metrics format by subclassing the PrometheusController.
@@ -32,10 +32,10 @@ def custom_exemplar(request: Request[Any, Any, Any]) -> dict[str, str]:
     return {"trace_id": "1234"}
 
 
-# Creating the instance of PrometheusConfig with our own custom options.
+# Creating the instance of PrometheusMiddleware with our own custom options.
 # The given options are not necessary, you can use the default ones
-# as well by just creating a raw instance PrometheusConfig()
-prometheus_config = PrometheusConfig(
+# as well by just creating a raw instance PrometheusMiddleware()
+prometheus_middleware = PrometheusMiddleware(
     app_name="litestar-example",
     prefix="litestar",
     labels=extra_labels,
@@ -45,5 +45,5 @@ prometheus_config = PrometheusConfig(
 )
 
 
-# Creating the litestar app instance with our custom PrometheusConfig and PrometheusController.
-app = Litestar(route_handlers=[CustomPrometheusController], middleware=[prometheus_config.middleware])
+# Creating the litestar app instance with our custom PrometheusMiddleware and PrometheusController.
+app = Litestar(route_handlers=[CustomPrometheusController], middleware=[prometheus_middleware])

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -6,6 +6,56 @@
 .. changelog:: 3.0.0
     :date: 2364-01-27
 
+    .. change:: Migrate ``PrometheusMiddleware`` to ``ASGIMiddleware``
+        :type: feature
+        :pr: 5006
+        :issue: 4009
+        :breaking:
+
+        ``PrometheusMiddleware`` has been moved from the legacy ``AbstractMiddleware``
+        base to :class:`~litestar.middleware.ASGIMiddleware`, as part of migrating all
+        built-in middleware off the legacy bases.
+
+        Since the middleware is now directly constructible, the
+        :class:`~litestar.plugins.prometheus.PrometheusConfig` configuration object is
+        obsolete and its ``middleware`` property is deprecated; it will be removed in
+        ``4.0``. Pass a configured ``PrometheusMiddleware`` instance to the middleware
+        list instead:
+
+        .. code-block:: python
+
+            # before
+            config = PrometheusConfig(app_name="my-app", group_path=True)
+            app = Litestar(..., middleware=[config.middleware])
+
+            # after
+            app = Litestar(
+                ...,
+                middleware=[PrometheusMiddleware(app_name="my-app", group_path=True)],
+            )
+
+        Subclasses of ``PrometheusMiddleware`` must rename ``__call__`` to ``handle``,
+        which receives the next ASGI app as an additional ``next_app`` argument in place
+        of ``self.app``, and read settings from the corresponding instance attributes
+        instead of the removed private ``self._config``.
+
+        Two behavioural changes for excluded routes:
+
+        - :attr:`~litestar.plugins.prometheus.PrometheusConfig.exclude` patterns are
+          now matched against the **handler's path template** (e.g.
+          ``/user/{user_id:int}``) at startup, instead of the request path (e.g.
+          ``/user/1``) at runtime. Patterns targeting literal handler paths keep
+          working; patterns written to match expanded path parameters must be rewritten
+          against the template. For mounted ASGI apps, patterns match the mount path
+          only, not sub-paths, and a handler registered on multiple paths is excluded as
+          a whole when any of its paths matches.
+        - Handlers excluded via ``exclude`` or ``exclude_opt_key`` now bypass the
+          middleware entirely at startup rather than per request.
+
+        Mounted ASGI apps stay wrapped regardless of the configured ``scopes``, with
+        their connections filtered by scope type at runtime, so restricting the
+        middleware to e.g. ``{"websocket"}`` also holds for connections through mounts.
+
     .. change:: Migrate ``RateLimitMiddleware`` to ``ASGIMiddleware``
         :type: feature
         :pr: 5005

--- a/docs/release-notes/whats-new-3.rst
+++ b/docs/release-notes/whats-new-3.rst
@@ -302,11 +302,11 @@ Built-in middleware migrated to ``ASGIMiddleware``
 Litestar's built-in middleware are being moved from the legacy ``AbstractMiddleware`` and
 ``MiddlewareProtocol`` bases onto :class:`~litestar.middleware.ASGIMiddleware`.
 ``CORSMiddleware``, ``ResponseCacheMiddleware``, ``CSRFMiddleware``,
-``CompressionMiddleware``, ``AllowedHostsMiddleware`` and ``RateLimitMiddleware`` have
-made this move. ``ResponseCacheMiddleware`` and ``CSRFMiddleware`` have also been moved
-into ``litestar.middleware._internal``, removing them from the public API; for CSRF this
-includes the ``litestar.middleware.csrf`` module and its ``generate_csrf_token`` /
-``generate_csrf_hash`` helpers.
+``CompressionMiddleware``, ``AllowedHostsMiddleware``, ``RateLimitMiddleware`` and
+``PrometheusMiddleware`` have made this move. ``ResponseCacheMiddleware`` and
+``CSRFMiddleware`` have also been moved into ``litestar.middleware._internal``, removing
+them from the public API; for CSRF this includes the ``litestar.middleware.csrf`` module
+and its ``generate_csrf_token`` / ``generate_csrf_hash`` helpers.
 
 These classes are constructed by Litestar itself from their configuration objects (for
 CSRF, via a ``from_config`` classmethod on the middleware), so applications that only
@@ -364,13 +364,15 @@ attribute of each layer.
 Subclasses must also rename ``__call__`` to ``handle``, which receives the next ASGI app
 as an additional ``next_app`` argument in place of ``self.app``.
 
-For rate limiting, :class:`~litestar.middleware.rate_limit.RateLimitMiddleware` is now
-directly constructible, making the
-:class:`~litestar.middleware.rate_limit.RateLimitConfig` object obsolete: its
-``middleware`` property is deprecated and will be removed in ``4.0``. Pass a configured
-middleware instance to the middleware list instead, e.g.
+For rate limiting and Prometheus metrics,
+:class:`~litestar.middleware.rate_limit.RateLimitMiddleware` and
+:class:`~litestar.plugins.prometheus.PrometheusMiddleware` are now directly
+constructible, making the :class:`~litestar.middleware.rate_limit.RateLimitConfig` and
+:class:`~litestar.plugins.prometheus.PrometheusConfig` objects obsolete: their
+``middleware`` properties are deprecated and will be removed in ``4.0``. Pass a
+configured middleware instance to the middleware list instead, e.g.
 ``middleware=[RateLimitMiddleware(rate_limit=("minute", 10))]``. The ``exclude``
-patterns are now matched against the **handler's path template** (e.g.
+patterns of both middleware are now matched against the **handler's path template** (e.g.
 ``/user/{user_id:int}``) at startup, instead of the request path (e.g. ``/user/1``) at
 runtime, and handlers excluded via ``exclude`` or ``exclude_opt_key`` bypass the
 middleware entirely at startup rather than per request.

--- a/litestar/plugins/prometheus/config.py
+++ b/litestar/plugins/prometheus/config.py
@@ -4,10 +4,10 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from litestar.exceptions import MissingDependencyException
-from litestar.middleware.base import DefineMiddleware
 from litestar.plugins.prometheus.middleware import (
     PrometheusMiddleware,
 )
+from litestar.utils.deprecation import warn_deprecation
 
 __all__ = ("PrometheusConfig",)
 
@@ -57,13 +57,30 @@ class PrometheusConfig:
     """
 
     @property
-    def middleware(self) -> DefineMiddleware:
-        """Create an instance of :class:`DefineMiddleware <litestar.middleware.base.DefineMiddleware>` that wraps with.
-
-        [PrometheusMiddleware][litestar.plugins.prometheus.PrometheusMiddleware]. or a subclass
-        of this middleware.
+    def middleware(self) -> PrometheusMiddleware:
+        """Create an instance of :class:`PrometheusMiddleware <litestar.plugins.prometheus.PrometheusMiddleware>`,
+        or a subclass of this middleware, configured from this config instance.
 
         Returns:
-            An instance of ``DefineMiddleware``.
+            An instance of :attr:`middleware_class`.
         """
-        return DefineMiddleware(self.middleware_class, config=self)
+        warn_deprecation(
+            version="3.0",
+            deprecated_name="PrometheusConfig.middleware",
+            kind="property",
+            removal_in="4.0",
+            alternative="PrometheusMiddleware",
+            info="Construct a PrometheusMiddleware instance directly and pass it to the middleware list",
+        )
+        return self.middleware_class(
+            app_name=self.app_name,
+            prefix=self.prefix,
+            labels=self.labels,
+            exemplars=self.exemplars,
+            buckets=self.buckets,
+            excluded_http_methods=self.excluded_http_methods,
+            exclude=self.exclude,
+            exclude_opt_key=self.exclude_opt_key,
+            scopes=self.scopes,
+            group_path=self.group_path,
+        )

--- a/litestar/plugins/prometheus/middleware.py
+++ b/litestar/plugins/prometheus/middleware.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 from litestar.connection.request import Request
 from litestar.enums import ScopeType
 from litestar.exceptions import HTTPException, MissingDependencyException
-from litestar.middleware.base import AbstractMiddleware
+from litestar.middleware.base import ASGIMiddleware
 
 __all__ = ("PrometheusMiddleware",)
 
@@ -21,35 +21,70 @@ except ImportError as e:
 from prometheus_client import Counter, Gauge, Histogram
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping, Sequence
 
     from prometheus_client.metrics import MetricWrapperBase
 
-    from litestar.plugins.prometheus import PrometheusConfig
-    from litestar.types import ASGIApp, Message, Receive, Scope, Send
+    from litestar.types import ASGIApp, Message, Method, Receive, Scope, Scopes, Send
 
 
-class PrometheusMiddleware(AbstractMiddleware):
+class PrometheusMiddleware(ASGIMiddleware):
     """Prometheus Middleware."""
 
     _metrics: ClassVar[dict[str, MetricWrapperBase]] = {}
 
-    def __init__(self, app: ASGIApp, config: PrometheusConfig) -> None:
+    def __init__(
+        self,
+        *,
+        app_name: str = "litestar",
+        prefix: str = "litestar",
+        labels: Mapping[str, str | Callable] | None = None,
+        exemplars: Callable[[Request], dict] | None = None,
+        buckets: Sequence[str | float] | None = None,
+        excluded_http_methods: Method | Sequence[Method] | None = None,
+        exclude: str | list[str] | None = None,
+        exclude_opt_key: str | None = None,
+        scopes: Scopes | None = None,
+        group_path: bool = True,
+    ) -> None:
         """Middleware that adds Prometheus instrumentation to the application.
 
         Args:
-            app: The ``next`` ASGI app to call.
-            config: An instance of :class:`PrometheusConfig <.plugins.prometheus.PrometheusConfig>`
+            app_name: The name of the application to use in the metrics.
+            prefix: The prefix to use for the metrics.
+            labels: A mapping of labels to add to the metrics. The values can be either a string or a callable that
+                returns a string.
+            exemplars: A callable that returns a list of exemplars to add to the metrics. Only supported in
+                openmetrics-text exposition format.
+            buckets: A list of buckets to use for the histogram.
+            excluded_http_methods: A list of http methods to exclude from the metrics.
+            exclude: A pattern or list of patterns for routes to exclude from the metrics, matched against the
+                handler path.
+            exclude_opt_key: A key in ``opt`` with which a route handler can "opt-out" of the middleware.
+            scopes: ASGI scopes processed by the middleware; if ``None`` or empty, ``http``, ``websocket`` and ASGI
+                route handlers are all processed. Mounted ASGI apps stay wrapped regardless, with their connections
+                filtered by scope type.
+            group_path: Whether to group paths in the metrics to avoid cardinality explosion.
         """
-        super().__init__(app=app, scopes=config.scopes, exclude=config.exclude, exclude_opt_key=config.exclude_opt_key)
-        self._config = config
-        self._kwargs: dict[str, Any] = {}
+        self.app_name = app_name
+        self.prefix = prefix
+        self.labels = labels
+        self.exemplars = exemplars
+        self.excluded_http_methods = excluded_http_methods
+        self.exclude_path_pattern = tuple(exclude) if isinstance(exclude, list) else exclude
+        self.exclude_opt_key = exclude_opt_key
+        self.group_path = group_path
+        if scopes:
+            scope_types = frozenset(scopes)
+            self.scopes = (*(s for s in (ScopeType.HTTP, ScopeType.WEBSOCKET) if s in scope_types), ScopeType.ASGI)
+            self.should_bypass_for_scope = lambda scope: scope["type"] not in scope_types
 
-        if self._config.buckets is not None:
-            self._kwargs["buckets"] = self._config.buckets
+        self._kwargs: dict[str, Any] = {}
+        if buckets is not None:
+            self._kwargs["buckets"] = buckets
 
     def request_count(self, labels: dict[str, str | int | float]) -> Counter:
-        metric_name = f"{self._config.prefix}_requests_total"
+        metric_name = f"{self.prefix}_requests_total"
 
         if metric_name not in PrometheusMiddleware._metrics:
             PrometheusMiddleware._metrics[metric_name] = Counter(
@@ -61,7 +96,7 @@ class PrometheusMiddleware(AbstractMiddleware):
         return cast("Counter", PrometheusMiddleware._metrics[metric_name])
 
     def request_time(self, labels: dict[str, str | int | float]) -> Histogram:
-        metric_name = f"{self._config.prefix}_request_duration_seconds"
+        metric_name = f"{self.prefix}_request_duration_seconds"
 
         if metric_name not in PrometheusMiddleware._metrics:
             PrometheusMiddleware._metrics[metric_name] = Histogram(
@@ -73,7 +108,7 @@ class PrometheusMiddleware(AbstractMiddleware):
         return cast("Histogram", PrometheusMiddleware._metrics[metric_name])
 
     def requests_in_progress(self, labels: dict[str, str | int | float]) -> Gauge:
-        metric_name = f"{self._config.prefix}_requests_in_progress"
+        metric_name = f"{self.prefix}_requests_in_progress"
 
         if metric_name not in PrometheusMiddleware._metrics:
             PrometheusMiddleware._metrics[metric_name] = Gauge(
@@ -85,7 +120,7 @@ class PrometheusMiddleware(AbstractMiddleware):
         return cast("Gauge", PrometheusMiddleware._metrics[metric_name])
 
     def requests_error_count(self, labels: dict[str, str | int | float]) -> Counter:
-        metric_name = f"{self._config.prefix}_requests_error_total"
+        metric_name = f"{self.prefix}_requests_error_total"
 
         if metric_name not in PrometheusMiddleware._metrics:
             PrometheusMiddleware._metrics[metric_name] = Counter(
@@ -105,7 +140,7 @@ class PrometheusMiddleware(AbstractMiddleware):
         A dictionary of extra labels.
         """
 
-        return {k: str(v(request) if callable(v) else v) for k, v in (self._config.labels or {}).items()}
+        return {k: str(v(request) if callable(v) else v) for k, v in (self.labels or {}).items()}
 
     def _get_default_labels(self, request: Request[Any, Any, Any]) -> dict[str, str | int | float]:
         """Get default label values from the request.
@@ -118,22 +153,23 @@ class PrometheusMiddleware(AbstractMiddleware):
         """
 
         path = request.url.path
-        if self._config.group_path:
+        if self.group_path:
             path = request.scope["path_template"]
         return {
             "method": request.method if request.scope["type"] == ScopeType.HTTP else request.scope["type"],
             "path": path,
             "status_code": 200,
-            "app_name": self._config.app_name,
+            "app_name": self.app_name,
         }
 
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        """ASGI callable.
+    async def handle(self, scope: Scope, receive: Receive, send: Send, next_app: ASGIApp) -> None:
+        """Handle ASGI call.
 
         Args:
             scope: The ASGI connection scope.
             receive: The ASGI receive function.
             send: The ASGI send function.
+            next_app: The next ASGI application in the middleware stack to call.
 
         Returns:
             None
@@ -141,8 +177,8 @@ class PrometheusMiddleware(AbstractMiddleware):
 
         request = Request[Any, Any, Any](scope, receive)
 
-        if self._config.excluded_http_methods and request.method in self._config.excluded_http_methods:
-            await self.app(scope, receive, send)
+        if self.excluded_http_methods and request.method in self.excluded_http_methods:
+            await next_app(scope, receive, send)
             return
 
         labels = {**self._get_default_labels(request), **self._get_extra_labels(request)}
@@ -155,7 +191,7 @@ class PrometheusMiddleware(AbstractMiddleware):
 
         try:
             try:
-                await self.app(scope, receive, wrapped_send)
+                await next_app(scope, receive, wrapped_send)
             except HTTPException as exc:
                 request_span["status_code"] = exc.status_code
                 raise
@@ -164,8 +200,8 @@ class PrometheusMiddleware(AbstractMiddleware):
                 raise
         finally:
             extra: dict[str, Any] = {}
-            if self._config.exemplars:
-                extra["exemplar"] = self._config.exemplars(request)
+            if self.exemplars:
+                extra["exemplar"] = self.exemplars(request)
 
             self.requests_in_progress(labels).labels(*labels.values()).dec()
 

--- a/tests/unit/test_plugins/test_prometheus.py
+++ b/tests/unit/test_plugins/test_prometheus.py
@@ -16,18 +16,22 @@ from litestar.status_codes import HTTP_200_OK
 from litestar.testing import create_test_client
 
 
-def create_config(**kwargs: Any) -> PrometheusConfig:
+def create_middleware(**kwargs: Any) -> PrometheusMiddleware:
+    _reset_registry()
+    return PrometheusMiddleware(**kwargs)
+
+
+def _reset_registry() -> None:
     collectors = list(REGISTRY._collector_to_names.keys())
     for collector in collectors:
         REGISTRY.unregister(collector)
 
     PrometheusMiddleware._metrics = {}
-    return PrometheusConfig(**kwargs)
 
 
 @pytest.mark.flaky(reruns=5)
 def test_prometheus_exporter_metrics_with_http() -> None:
-    config = create_config()
+    prometheus_middleware = create_middleware()
 
     @get("/duration")
     def duration_handler() -> dict:
@@ -39,7 +43,7 @@ def test_prometheus_exporter_metrics_with_http() -> None:
         raise HTTPException("Error Occurred", status_code=500)
 
     with create_test_client(
-        [duration_handler, handler_error, PrometheusController], middleware=[config.middleware]
+        [duration_handler, handler_error, PrometheusController], middleware=[prometheus_middleware]
     ) as client:
         client.get("/error")
         client.get("/duration")
@@ -105,13 +109,13 @@ def test_prometheus_group_path_defaults_to_true() -> None:
 
 
 def test_prometheus_group_path_default_uses_route_template_for_parameterized_routes() -> None:
-    config = create_config()
+    prometheus_middleware = create_middleware()
 
     @get("/users/{user_id:int}")
     def get_user(user_id: FromPath[int]) -> dict:
         return {"user_id": user_id}
 
-    with create_test_client([get_user, PrometheusController], middleware=[config.middleware]) as client:
+    with create_test_client([get_user, PrometheusController], middleware=[prometheus_middleware]) as client:
         for user_id in range(1, 4):
             client.get(f"/users/{user_id}")
         metrics = client.get("/metrics").content.decode()
@@ -128,7 +132,7 @@ def test_prometheus_group_path_default_uses_route_template_for_parameterized_rou
 def test_prometheus_middleware_configurations() -> None:
     labels = {"foo": "bar", "baz": lambda a: "qux"}
 
-    config = create_config(
+    prometheus_middleware = create_middleware(
         app_name="litestar_test",
         prefix="litestar_rocks",
         labels=labels,
@@ -144,7 +148,7 @@ def test_prometheus_middleware_configurations() -> None:
     def ignore() -> dict:
         return {"hello": "world"}
 
-    with create_test_client([test, ignore, PrometheusController], middleware=[config.middleware]) as client:
+    with create_test_client([test, ignore, PrometheusController], middleware=[prometheus_middleware]) as client:
         client.get("/test")
         client.post("/ignore")
         metrics_exporter_response = client.get("/metrics")
@@ -177,9 +181,12 @@ def test_prometheus_middleware_configurations() -> None:
             in metrics
         )
 
+        # default-bucket boundaries must be absent, proving the custom buckets replaced them
+        assert """le="0.005",method="GET",path="/test""" not in metrics
+
 
 def test_prometheus_controller_configurations() -> None:
-    config = create_config(
+    prometheus_middleware = create_middleware(
         exemplars=lambda a: {"trace_id": "1234"},
     )
 
@@ -191,7 +198,7 @@ def test_prometheus_controller_configurations() -> None:
     def test() -> dict:
         return {"hello": "world"}
 
-    with create_test_client([test, CustomPrometheusController], middleware=[config.middleware]) as client:
+    with create_test_client([test, CustomPrometheusController], middleware=[prometheus_middleware]) as client:
         client.get("/test")
 
         metrics_exporter_response = client.get("/metrics/custom")
@@ -206,13 +213,13 @@ def test_prometheus_controller_configurations() -> None:
 
 
 def test_prometheus_with_websocket() -> None:
-    config = create_config()
+    prometheus_middleware = create_middleware()
 
     @websocket_listener("/test")
     def test(data: str) -> dict:
         return {"hello": data}
 
-    with create_test_client([test, PrometheusController], middleware=[config.middleware]) as client:
+    with create_test_client([test, PrometheusController], middleware=[prometheus_middleware]) as client:
         with client.websocket_connect("/test") as websocket:
             websocket.send_text("litestar")
             websocket.receive_json()
@@ -233,11 +240,11 @@ def test_procdir(monkeypatch: MonkeyPatch, tmp_path: Path, mocker: MockerFixture
     proc_dir = tmp_path / "something"
     proc_dir.mkdir()
     monkeypatch.setenv(env_var, str(proc_dir))
-    config = create_config()
+    prometheus_middleware = create_middleware()
     mock_registry = mocker.patch("litestar.plugins.prometheus.controller.CollectorRegistry")
     mock_collector = mocker.patch("litestar.plugins.prometheus.controller.multiprocess.MultiProcessCollector")
 
-    with create_test_client([PrometheusController], middleware=[config.middleware]) as client:
+    with create_test_client([PrometheusController], middleware=[prometheus_middleware]) as client:
         client.get("/metrics")
 
     mock_collector.assert_called_once_with(mock_registry.return_value)
@@ -250,7 +257,7 @@ def test_prometheus_middleware_records_correct_status_for_auth_exceptions() -> N
     HTTP exceptions were being recorded with status_code=200 instead of their actual
     status codes (e.g., 401, 403).
     """
-    config = create_config()
+    prometheus_middleware = create_middleware()
 
     @get("/protected")
     def protected_handler() -> dict:
@@ -266,7 +273,7 @@ def test_prometheus_middleware_records_correct_status_for_auth_exceptions() -> N
 
     with create_test_client(
         [protected_handler, forbidden_handler, server_error_handler, PrometheusController],
-        middleware=[config.middleware],
+        middleware=[prometheus_middleware],
     ) as client:
         # Test 401 Unauthorized
         response = client.get("/protected")
@@ -316,7 +323,7 @@ def test_prometheus_middleware_records_generic_exception_as_500() -> None:
     This test verifies that non-HTTPException errors are recorded with status_code=500
     in Prometheus metrics.
     """
-    config = create_config()
+    prometheus_middleware = create_middleware()
 
     @get("/generic_error")
     def generic_error_handler() -> dict:
@@ -324,7 +331,7 @@ def test_prometheus_middleware_records_generic_exception_as_500() -> None:
 
     with create_test_client(
         [generic_error_handler, PrometheusController],
-        middleware=[config.middleware],
+        middleware=[prometheus_middleware],
     ) as client:
         # Test generic exception
         response = client.get("/generic_error")
@@ -347,3 +354,81 @@ def test_prometheus_middleware_records_generic_exception_as_500() -> None:
             """litestar_requests_error_total{app_name="litestar",method="GET",path="/generic_error",status_code="500"} 1.0"""
             in metrics
         )
+
+
+def test_prometheus_mounted_asgi_apps_are_instrumented() -> None:
+    from litestar.handlers import ASGIRouteHandler
+    from litestar.response.base import ASGIResponse
+
+    prometheus_middleware = create_middleware(group_path=False)
+
+    asgi_handler = ASGIRouteHandler("/mounted", is_mount=True, fn=ASGIResponse(body="something"))
+
+    with create_test_client([asgi_handler, PrometheusController], middleware=[prometheus_middleware]) as client:
+        client.get("/mounted")
+        metrics = client.get("/metrics").content.decode()
+
+        assert 'path="/"' in metrics
+
+
+def test_prometheus_group_path_disabled_uses_request_path() -> None:
+    prometheus_middleware = create_middleware(group_path=False)
+
+    @get("/users/{user_id:int}")
+    def get_user(user_id: FromPath[int]) -> dict:
+        return {"user_id": user_id}
+
+    with create_test_client([get_user, PrometheusController], middleware=[prometheus_middleware]) as client:
+        client.get("/users/1")
+        metrics = client.get("/metrics").content.decode()
+
+        assert 'path="/users/1"' in metrics
+        assert 'path="/users/{user_id}"' not in metrics
+
+
+def test_prometheus_scopes_enforced_for_connections_through_mounts() -> None:
+    from litestar.handlers import ASGIRouteHandler
+    from litestar.response.base import ASGIResponse
+
+    # mounted ASGI apps stay wrapped regardless of scopes, so restricting to websocket must
+    # still exclude http connections through the mount at runtime
+    prometheus_middleware = create_middleware(scopes={"websocket"}, group_path=False)
+
+    asgi_handler = ASGIRouteHandler("/mounted", is_mount=True, fn=ASGIResponse(body="something"))
+
+    with create_test_client([asgi_handler, PrometheusController], middleware=[prometheus_middleware]) as client:
+        client.get("/mounted")
+        metrics = client.get("/metrics").content.decode()
+
+        assert 'path="/"' not in metrics
+
+
+def test_prometheus_custom_middleware_subclass() -> None:
+    class CustomPrometheusMiddleware(PrometheusMiddleware):
+        async def handle(self, scope: Any, receive: Any, send: Any, next_app: Any) -> None:
+            self.app_name = "overridden"
+            await super().handle(scope, receive, send, next_app)
+
+    _reset_registry()
+    prometheus_middleware = CustomPrometheusMiddleware()
+
+    @get("/test")
+    def handler() -> dict:
+        return {"hello": "world"}
+
+    with create_test_client([handler, PrometheusController], middleware=[prometheus_middleware]) as client:
+        client.get("/test")
+        metrics = client.get("/metrics").content.decode()
+
+        assert 'app_name="overridden"' in metrics
+
+
+def test_config_middleware_property_deprecated() -> None:
+    _reset_registry()
+    config = PrometheusConfig(app_name="deprecated-path")
+
+    with pytest.warns(DeprecationWarning, match="PrometheusConfig.middleware"):
+        middleware = config.middleware
+
+    assert isinstance(middleware, PrometheusMiddleware)
+    assert middleware.app_name == "deprecated-path"


### PR DESCRIPTION
Part of #4009. Stacked PR to avoid conflicts in the changelog and whats-new docs.

Moving `PrometheusMiddleware` from `AbstractMiddleware` to `ASGIMiddleware`.

The constructor takes keyword arguments now instead of an `app` and a `PrometheusConfig` object, with each argument defaulting to the matching config field. `PrometheusConfig` itself is unchanged and stays the way to configure this: its `middleware` property now returns a configured `PrometheusMiddleware` instance instead of a `DefineMiddleware`, so `middleware=[config.middleware]` keeps working as before. The `excluded_http_methods` check stays inside `handle()`.

Same breaking change as the other PRs in the series: `exclude` patterns now match the handler's path template at startup instead of the request path (documented in the changelog and whats-new-3).

Same subtlety as allowed-hosts: `PrometheusConfig.scopes` is user-configurable and mounted ASGI apps receive both `http` and `websocket` connections at runtime, so configured scopes are also enforced per connection via `should_bypass_for_scope`. Without this, restricting to `scopes={"websocket"}` would have silently kept instrumenting http connections through ASGI mounts.

Added some tests, covering the prometheus-specific behavior of this migration:
- One that checks mounted ASGI apps are still instrumented. Dropping `ASGI` from the scopes tuple was undetected before.
- One that checks configured scopes hold for connections through mounts (http through a mount is NOT recorded with `scopes={"websocket"}`). It was failing.
- One that checks `group_path=False` uses the request path instead of the template. The `False` branch was not covered before.
- One that checks a subclass set via `middleware_class` works with the new `handle` contract, since this PR changes that hook (no more `self._config`).
- Extended the buckets assertion so default bucket boundaries must be absent - without this, dropping `buckets` from the property was undetected.

Two pre-existing quirks found while porting, unchanged here (possible follow-ups): `request.method` raises `KeyError` for websocket connections when `excluded_http_methods` is set, and `PrometheusConfig.exclude_unhandled_paths` is a dead field nothing reads.


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5006">https://litestar-org.github.io/litestar-docs-preview/5006</a> 
