### PR TITLE
fix(channels): resolve deadlock with put_subscriber_history

### DIFF
--- a/litestar/channels/plugin.py
+++ b/litestar/channels/plugin.py
@@ -178,8 +178,16 @@ class ChannelsPlugin(InitPlugin, AbstractAsyncContextManager):
             ChannelsException: If a channel in ``channels`` has not been declared on this backend and
                 ``arbitrary_channels_allowed`` has not been set to ``True``
         """
-        if isinstance(channels, str):
-            channels = [channels]
+        channels = [channels] if isinstance(channels, str) else list(channels)
+        if (
+            history is not None
+            and self._max_backlog is not None
+            and self._backlog_strategy == "backoff"
+            and self._max_backlog < history * len(channels)
+        ):
+            raise ImproperlyConfiguredException(
+                "History amount cannot be greater than max backlog to prevent deadlocks with backoff strategy"
+            )
 
         subscriber = self._subscriber_class(
             plugin=self,
@@ -288,14 +296,12 @@ class ChannelsPlugin(InitPlugin, AbstractAsyncContextManager):
         # the ternary operator triggers a mypy bug: https://github.com/python/mypy/issues/10740
         on_event: EventCallback = socket.send_text if self._socket_send_mode == "text" else socket.send_bytes  # type: ignore[assignment]
 
-        async with self.start_subscription(channel_name) as subscriber:
+        async with self.start_subscription(channel_name) as subscriber, subscriber.run_in_background(on_event):
+            # use the background task, so we can block on receive(), breaking the loop when a connection closes
             if self._handler_should_send_history:
                 await self.put_subscriber_history(subscriber, channels=channel_name, limit=self._history_limit)
-
-            # use the background task, so we can block on receive(), breaking the loop when a connection closes
-            async with subscriber.run_in_background(on_event):
-                while (await socket.receive())["type"] != "websocket.disconnect":
-                    continue
+            while (await socket.receive())["type"] != "websocket.disconnect":
+                continue
 
     def _create_ws_handler_func(self, channel_name: str) -> Callable[[WebSocket], Awaitable[None]]:
         async def ws_handler_func(socket: WebSocket) -> None:

--- a/tests/unit/test_channels/test_plugin.py
+++ b/tests/unit/test_channels/test_plugin.py
@@ -7,6 +7,7 @@ from secrets import token_hex
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
+import anyio
 import pytest
 from _pytest.fixtures import FixtureRequest
 from pytest_mock import MockerFixture
@@ -50,6 +51,14 @@ def channels_backend_with_history(request: FixtureRequest) -> ChannelsBackend:
 def test_channels_no_channels_arbitrary_not_allowed_raises(memory_backend: MemoryChannelsBackend) -> None:
     with pytest.raises(ImproperlyConfiguredException):
         ChannelsPlugin(backend=memory_backend)
+
+
+async def test_subscribe_incorrect_history_raises(memory_backend: MemoryChannelsBackend) -> None:
+    plugin = ChannelsPlugin(
+        backend=memory_backend, channels=["foo"], subscriber_max_backlog=1, subscriber_backlog_strategy="backoff"
+    )
+    with pytest.raises(ImproperlyConfiguredException):
+        await plugin.subscribe("foo", 2)
 
 
 def test_broadcast_not_initialized_raises(memory_backend: MemoryChannelsBackend) -> None:
@@ -154,6 +163,27 @@ async def test_ws_route_handlers_receive_arbitrary_message(channels_backend: Cha
         ws.send("bar")
         # the subscription should still be alive
         assert ws.receive_json(timeout=2) == ["foo"]
+
+
+async def test_ws_route_publish_if_history_exceeds_max_backlog(memory_backend_with_history: ChannelsBackend) -> None:
+    channels_plugin = ChannelsPlugin(
+        backend=memory_backend_with_history,
+        create_ws_route_handlers=True,
+        ws_handler_send_history=3,
+        channels=["foo"],
+        subscriber_max_backlog=2,
+    )
+    app = Litestar(plugins=[channels_plugin])
+
+    async with AsyncTestClient(app) as client:
+        for i in range(3):
+            await channels_plugin.wait_published(i, "foo")
+        try:
+            with anyio.fail_after(1):
+                async with await client.websocket_connect("/foo") as ws:
+                    await ws.receive_text()
+        except TimeoutError as exc:
+            raise AssertionError("Deadlock in websocket connection") from exc
 
 
 @pytest.mark.flaky(reruns=5)


### PR DESCRIPTION
## Description
Fixes #5011 
- raise an exception in the `subscribe` if the configuration will cause a deadlock since design does not allow consuming events during subscription
- start background worker in the `_ws_handler_func` before putting history to consume events from queue

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5012">https://litestar-org.github.io/litestar-docs-preview/5012</a> 
