### PR TITLE
docs: fix two docstring typos

### DIFF
--- a/litestar/openapi/spec/parameter.py
+++ b/litestar/openapi/spec/parameter.py
@@ -83,7 +83,7 @@ class Parameter(BaseSchemaObject):
     """
 
     style: str | None = None
-    """Describes how the parameter value will be serialized depending on the ype of the parameter value. Default values
+    """Describes how the parameter value will be serialized depending on the type of the parameter value. Default values
     (based on value of ``in``):
 
     - for ``query`` - ``form``

--- a/litestar/response/streaming.py
+++ b/litestar/response/streaming.py
@@ -180,7 +180,7 @@ class Stream(Response[StreamType[Union[str, bytes]]]):
         status_code: int | None = None,
         type_encoders: TypeEncodersMap | None = None,
     ) -> ASGIResponse:
-        """Create an ASGIStreamingResponse from a StremaingResponse instance.
+        """Create an ASGIStreamingResponse from a StreamingResponse instance.
 
         Args:
             background: Background task(s) to be executed after the response is sent.


### PR DESCRIPTION
Two typo fixes in docstrings, no behavior change:

- `litestar/response/streaming.py`: "StremaingResponse" -> "StreamingResponse"
- `litestar/openapi/spec/parameter.py`: "the ype of the parameter value" -> "the type of the parameter value"

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5015">https://litestar-org.github.io/litestar-docs-preview/5015</a> 
