### PR TITLE
docs: use absolute URL for contribution guide link in PyPI README

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ or read more about it [here](https://docs.litestar.dev/latest/benchmarks) in our
 Litestar is open to contributions big and small. You can always [join our discord](https://discord.gg/litestar) server
 or [join our Matrix](https://matrix.to/#/#litestar:matrix.org) space
 to discuss contributions and project maintenance. For guidelines on how to contribute, please
-see [the contribution guide](CONTRIBUTING.rst).
+see [the contribution guide](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst).
 
 <!-- contributors-start -->
 

--- a/docs/PYPI_README.md
+++ b/docs/PYPI_README.md
@@ -311,4 +311,4 @@ or read more about it [here](https://docs.litestar.dev/latest/benchmarks) in our
 Litestar is open to contributions big and small. You can always [join our discord](https://discord.gg/litestar) server
 or [join our Matrix](https://matrix.to/#/#litestar:matrix.org) space
 to discuss contributions and project maintenance. For guidelines on how to contribute, please
-see [the contribution guide](CONTRIBUTING.rst).
+see [the contribution guide](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.rst).


### PR DESCRIPTION
`docs/PYPI_README.md` is rendered on the PyPI project page, where relative links do not resolve. The contribution guide link was relative (`CONTRIBUTING.rst`), so it 404s there — and it also does not resolve inside `docs/`, since `CONTRIBUTING.rst` lives at the repository root.

Every other outbound link in that file is already absolute; this makes the contribution guide link match.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5016">https://litestar-org.github.io/litestar-docs-preview/5016</a> 
