### PR TITLE
fix: do not suggest FromQuery for path parameter defaults

### DIFF
--- a/litestar/utils/errors.py
+++ b/litestar/utils/errors.py
@@ -5,16 +5,34 @@ from litestar.exceptions import ImproperlyConfiguredException
 from litestar.params import BodyKwarg, KwargDefinition, ParameterKwarg
 
 
+def _has_explicit_param_type(default: ParameterKwarg) -> bool:
+    """Whether ``default.param_type`` reflects an explicit choice by the user.
+
+    ``ParameterKwarg.param_type`` defaults to :attr:`ParamType.QUERY <litestar.enums.ParamType>` and
+    is only reassigned when one of the ``header``/``cookie``/``query`` arguments is given. A plain
+    ``Parameter()`` therefore reports ``QUERY`` even when it annotates a path parameter, since
+    whether a parameter is a path parameter is decided by the route path rather than the annotation.
+    The dedicated subclasses (:class:`~litestar.params.PathParameter` and friends) each set
+    ``param_type`` themselves, so for those the value is meaningful.
+    """
+    return type(default) is not ParameterKwarg or any(
+        value is not None for value in (default.header, default.cookie, default.query)
+    )
+
+
 def raise_for_kwarg_as_default(default: KwargDefinition) -> NoReturn:
     if isinstance(default, BodyKwarg):
         alternative = "Annotated[<type>, Body(...)]"
     elif isinstance(default, ParameterKwarg) and not default.is_constrained:
-        alternative = {
-            ParamType.QUERY: "FromQuery",
-            ParamType.HEADER: "FromHeader",
-            ParamType.COOKIE: "FromCookie",
-            ParamType.PATH: "FromPath",
-        }[default.param_type]
+        if _has_explicit_param_type(default):
+            alternative = {
+                ParamType.QUERY: "FromQuery",
+                ParamType.HEADER: "FromHeader",
+                ParamType.COOKIE: "FromCookie",
+                ParamType.PATH: "FromPath",
+            }[default.param_type]
+        else:
+            alternative = "Annotated[<type>, Parameter(...)]"
     else:
         alternative = f"Annotated[<type>, {type(default).__name__}(...)]"
     msg = f"Usage of parameter defaults to declare metadata is no longer supported. Use '{alternative}' instead"

--- a/tests/unit/test_typing.py
+++ b/tests/unit/test_typing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass
-from typing import Any, ForwardRef, Generic, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, ForwardRef, Generic, List, Optional, Tuple, TypeVar, Union
 
 import msgspec
 import pytest
@@ -24,7 +24,15 @@ try:
 except ImportError:
     TypeAliasType = TeTypeAliasType
 
-from litestar.params import KwargDefinition, ParameterKwarg
+from litestar.params import (
+    CookieParameter,
+    HeaderParameter,
+    KwargDefinition,
+    Parameter,
+    ParameterKwarg,
+    PathParameter,
+    QueryParameter,
+)
 from litestar.typing import FieldDefinition
 from tests.unit.test_utils.test_signature import T, _check_field_definition, field_definition_int, test_type_hints
 
@@ -483,3 +491,45 @@ def test_kwarg_definition_as_default_raises() -> None:
         ImproperlyConfiguredException, match="Usage of parameter defaults to declare metadata is no longer supported."
     ):
         FieldDefinition.from_annotation(int, default=ParameterKwarg())
+
+
+@pytest.mark.parametrize(
+    ("default", "expected"),
+    (
+        (QueryParameter(), "FromQuery"),
+        (PathParameter(), "FromPath"),
+        (HeaderParameter(), "FromHeader"),
+        (CookieParameter(), "FromCookie"),
+    ),
+)
+def test_kwarg_definition_as_default_suggests_dedicated_alias(default: ParameterKwarg, expected: str) -> None:
+    with pytest.raises(ImproperlyConfiguredException, match=f"Use '{expected}' instead"):
+        FieldDefinition.from_annotation(int, default=default)
+
+
+@pytest.mark.parametrize(
+    ("make_default", "expected"),
+    (
+        (lambda: Parameter(query="query_param"), "FromQuery"),
+        (lambda: Parameter(header="X-Header"), "FromHeader"),
+        (lambda: Parameter(cookie="cookie_param"), "FromCookie"),
+    ),
+)
+def test_kwarg_definition_as_default_with_explicit_source_suggests_dedicated_alias(
+    make_default: Callable[[], ParameterKwarg], expected: str
+) -> None:
+    with pytest.warns(DeprecationWarning):
+        default = make_default()
+
+    with pytest.raises(ImproperlyConfiguredException, match=f"Use '{expected}' instead"):
+        FieldDefinition.from_annotation(int, default=default)
+
+
+def test_kwarg_definition_as_default_without_explicit_source_suggests_parameter() -> None:
+    """``Parameter()`` does not record where the value comes from, so no dedicated alias can be named.
+
+    ``ParameterKwarg.param_type`` defaults to ``ParamType.QUERY``, which made a path parameter - whose
+    type is decided by the route path rather than by the annotation - suggest ``FromQuery``.
+    """
+    with pytest.raises(ImproperlyConfiguredException, match=r"Use 'Annotated\[<type>, Parameter\(\.\.\.\)\]' instead"):
+        FieldDefinition.from_annotation(int, default=Parameter(description="a description"))


### PR DESCRIPTION
Closes #5018

## Description

`raise_for_kwarg_as_default` maps `ParameterKwarg.param_type` to the replacement syntax it recommends. For a plain `Parameter()` that mapping is unreliable: `param_type` defaults to `ParamType.QUERY` and only changes when `header=`, `cookie=` or `query=` is passed, so a path parameter is told to use `FromQuery`.

This adds a check for whether `param_type` was actually chosen, and only uses the alias mapping when it was. Otherwise the message falls back to `Annotated[<type>, Parameter(...)]`, which is valid for every parameter kind.

`param_type` counts as chosen when either the default is one of the dedicated subclasses (`QueryParameter`, `PathParameter`, `HeaderParameter`, `CookieParameter`), which set it themselves, or one of `header=` / `cookie=` / `query=` was passed.

The route path is not usable at this point. `FieldDefinition.from_annotation` inspects one parameter in isolation, and `raise_for_kwarg_as_default` is also called from DTO field generation where no route exists at all.

Side effect worth noting: the `ParamType.PATH: "FromPath"` entry was previously unreachable, since nothing could set `param_type` to `PATH` on a value reaching this function. It becomes reachable through `PathParameter()`.

## Tests

Three tests added to `tests/unit/test_typing.py`:

* `test_kwarg_definition_as_default_without_explicit_source_suggests_parameter` — covers the reported bug, and fails without the fix.
* `test_kwarg_definition_as_default_suggests_dedicated_alias` — the four dedicated subclasses still name their alias, including `FromPath`.
* `test_kwarg_definition_as_default_with_explicit_source_suggests_dedicated_alias` — the deprecated `header=` / `cookie=` / `query=` kwargs still name their alias.

608 tests pass across `test_typing`, `test_kwargs`, `test_signature` and `test_openapi`. ruff, mypy, pyright and slotscheck are clean.