### PR TITLE
fix: correct session cookie chunking and reassembly

### DIFF
--- a/litestar/middleware/session/client_side.py
+++ b/litestar/middleware/session/client_side.py
@@ -38,7 +38,11 @@ if TYPE_CHECKING:
     from litestar.types import Message, Scope, ScopeSession
 
 NONCE_SIZE = 12
+# Retained for backwards compatibility; no longer used. The space available for a cookie's value is now
+# measured from the cookie itself, see ``ClientSideSessionBackend._chunk_size``.
 CHUNK_SIZE = 4096 - 64
+MAX_COOKIE_SIZE: Final = 4096
+"""The maximum size of a single cookie, as mandated by :rfc:`6265`."""
 AAD = b"additional_authenticated_data="
 SET_COOKIE_INCLUDE = {f.name for f in fields(Cookie) if f.name not in {"key", "secret"}}
 CLEAR_COOKIE_INCLUDE = {f.name for f in fields(Cookie) if f.name not in {"key", "secret", "max_age"}}
@@ -70,6 +74,22 @@ class ClientSideSessionBackend(BaseSessionBackend["CookieBackendConfig"]):
             extract_dataclass_items(config, exclude_none=True, include=CLEAR_COOKIE_INCLUDE)
         )
 
+    def _chunk_size(self, name: str) -> int:
+        """Return the number of bytes available for the value of a cookie named ``name``.
+
+        The budget is measured from a cookie with a zero-length value, which is itself emitted quoted
+        (``session=""``). The two quote bytes are therefore already accounted for, which matters because
+        base64 values contain ``+``, ``/`` and ``=`` and are consequently quoted as well.
+
+        Args:
+            name: Key the cookie will be emitted under.
+
+        Returns:
+            The maximum length of that cookie's value.
+        """
+        overhead = len(Cookie(value="", key=name, **self._set_cookie_params).to_header(header=""))
+        return MAX_COOKIE_SIZE - overhead
+
     def dump_data(self, data: Any, scope: Scope | None = None) -> list[bytes]:
         """Given serializable data, including pydantic models and numpy types, dump it into a bytes string, encrypt,
         encode and split it into chunks of the desirable size.
@@ -83,14 +103,27 @@ class ClientSideSessionBackend(BaseSessionBackend["CookieBackendConfig"]):
               string that is encrypted using AES-CGM.
 
         Returns:
-            List of encoded bytes string of a maximum length equal to the ``CHUNK_SIZE`` constant.
+            List of encoded bytes strings, each short enough that the cookie carrying it stays within the
+            :rfc:`6265` size limit of ``MAX_COOKIE_SIZE`` bytes.
         """
         serialized = self.serialize_data(data, scope)
         associated_data = encode_json({"expires_at": round(time.time()) + self.config.max_age})
         nonce = urandom(NONCE_SIZE)
         encrypted = self.aesgcm.encrypt(nonce, serialized, associated_data=associated_data)
         encoded = b64encode(nonce + encrypted + AAD + associated_data)
-        return [encoded[i : i + CHUNK_SIZE] for i in range(0, len(encoded), CHUNK_SIZE)]
+        if len(encoded) <= self._chunk_size(self.config.key):
+            return [encoded]
+
+        # Chunks are stored under ``<key>-<index>``, so the space left for the value depends on how many
+        # digits the largest index takes. Widen the allowance until the resulting chunk count no longer
+        # needs more digits than the size it was computed for.
+        digits = 1
+        while True:
+            size = self._chunk_size(f"{self.config.key}-{'9' * digits}")
+            count = -(-len(encoded) // size)
+            if len(str(count - 1)) <= digits:
+                return [encoded[i : i + size] for i in range(0, len(encoded), size)]
+            digits += 1
 
     def load_data(self, data: list[bytes]) -> dict[str, Any]:
         """Given a list of strings, decodes them into the session object.
@@ -111,8 +144,26 @@ class ClientSideSessionBackend(BaseSessionBackend["CookieBackendConfig"]):
             return self.deserialize_data(decrypted)
         return {}
 
+    def _chunk_index(self, key: str) -> int:
+        """Return the numeric index of a session chunk cookie.
+
+        The configured key may itself contain hyphens, so the index is read from the suffix left after
+        the key rather than by splitting the name on ``-``.
+
+        Args:
+            key: A cookie key matching the session-cookie pattern.
+
+        Returns:
+            The index of the chunk, or ``-1`` for the unchunked cookie.
+        """
+        suffix = key[len(self.config.key) :]
+        return int(suffix[1:]) if suffix else -1
+
     def get_cookie_keys(self, connection: ASGIConnection) -> list[str]:
         """Return a list of cookie-keys from the connection if they match the session-cookie pattern.
+
+        The keys are returned in chunk order, so that the values they hold can be concatenated back into
+        the original payload.
 
         Args:
             connection: An ASGIConnection instance
@@ -120,7 +171,10 @@ class ClientSideSessionBackend(BaseSessionBackend["CookieBackendConfig"]):
         Returns:
             A list of session-cookie keys
         """
-        return sorted(key for key in connection.cookies if self.cookie_re.fullmatch(key))
+        return sorted(
+            (key for key in connection.cookies if self.cookie_re.fullmatch(key)),
+            key=self._chunk_index,
+        )
 
     def get_cookie_key_set(self, connection: ASGIConnection) -> set[str]:
         """Return a set of cookie-keys from the connection if they match the session-cookie pattern.
@@ -232,7 +286,8 @@ class CookieBackendConfig(BaseBackendConfig[ClientSideSessionBackend]):
     ``<data>`` is the session data.
 
     Notes:
-        - If a session cookie exceeds 4KB in size it is split. In this case the key will be of the format
+        - Session data that does not fit into a single cookie is split across as many as are needed, each of
+          them within the :rfc:`6265` limit of 4096 bytes. In this case the keys will be of the format
           ``session-{segment number}``.
 
     """

--- a/litestar/middleware/session/client_side.py
+++ b/litestar/middleware/session/client_side.py
@@ -120,6 +120,12 @@ class ClientSideSessionBackend(BaseSessionBackend["CookieBackendConfig"]):
         digits = 1
         while True:
             size = self._chunk_size(f"{self.config.key}-{'9' * digits}")
+            if size < 1:
+                raise ImproperlyConfiguredException(
+                    f"The name and attributes of the {self.config.key!r} session cookie take up all "
+                    f"{MAX_COOKIE_SIZE} bytes a cookie may occupy, leaving no room for session data. "
+                    "Shorten the configured 'key', 'path' or 'domain'."
+                )
             count = -(-len(encoded) // size)
             if len(str(count - 1)) <= digits:
                 return [encoded[i : i + size] for i in range(0, len(encoded), size)]

--- a/tests/unit/test_middleware/test_session/test_client_side_backend.py
+++ b/tests/unit/test_middleware/test_session/test_client_side_backend.py
@@ -291,6 +291,19 @@ def test_session_cookies_do_not_exceed_max_cookie_size(
         assert len(header) <= MAX_COOKIE_SIZE
 
 
+def test_dump_data_raises_when_cookie_attributes_leave_no_room() -> None:
+    """A configuration whose cookie name and attributes fill the entire size limit must fail loudly.
+
+    Emitting no cookies at all would log every user out with nothing in the response, and nothing in the
+    logs, to point at the cause.
+    """
+    config = CookieBackendConfig(secret=os.urandom(16), path="/" + "p" * MAX_COOKIE_SIZE)
+    backend = ClientSideSessionBackend(config=config)
+
+    with pytest.raises(ImproperlyConfiguredException, match="leaving no room for session data"):
+        backend.dump_data(create_session())
+
+
 async def test_store_in_message_clears_cookies_when_session_grows_gt_chunk_size(
     cookie_session_backend: ClientSideSessionBackend,
 ) -> None:

--- a/tests/unit/test_middleware/test_session/test_client_side_backend.py
+++ b/tests/unit/test_middleware/test_session/test_client_side_backend.py
@@ -15,6 +15,7 @@ from litestar.middleware.session import SessionMiddleware
 from litestar.middleware.session.client_side import (
     AAD,
     CHUNK_SIZE,
+    MAX_COOKIE_SIZE,
     ClientSideSessionBackend,
     CookieBackendConfig,
 )
@@ -87,8 +88,8 @@ def test_dump_and_load_data(session: dict, cookie_session_backend: ClientSideSes
     ciphertext = cookie_session_backend.dump_data(session)
     assert isinstance(ciphertext, list)
 
-    for text in ciphertext:
-        assert len(text) <= CHUNK_SIZE
+    for cookie in cookie_session_backend._create_session_cookies(ciphertext):
+        assert len(cookie.to_header(header="")) <= MAX_COOKIE_SIZE
 
     plain_text = cookie_session_backend.load_data(ciphertext)
     assert plain_text == session
@@ -222,6 +223,72 @@ def test_load_data_should_raise_invalid_tag_if_tampered_aad(cookie_session_backe
 
     with pytest.raises(InvalidTag):
         cookie_session_backend.load_data(encoded)
+
+
+def test_get_cookie_keys_are_ordered_by_chunk_index(cookie_session_backend: ClientSideSessionBackend) -> None:
+    """Chunk cookies must be ordered by their numeric index, not by name.
+
+    A lexicographic sort places ``session-10`` between ``session-1`` and ``session-2``, so the two orders
+    only agree while there are fewer than ten chunks.
+    """
+    expected = [f"session-{i}" for i in range(12)]
+    connection = RequestFactory().get("/", headers={"Cookie": "; ".join(f"{key}=x" for key in expected)})
+
+    assert cookie_session_backend.get_cookie_keys(connection) == expected
+
+
+@pytest.mark.parametrize("key", ["session", "my-session"])
+def test_large_session_round_trips(key: str) -> None:
+    """A session spread over more than ten cookies must be reassembled in the right order."""
+    payload = "x" * 40_000
+
+    @get("/set")
+    def set_handler(request: Request) -> None:
+        request.session["payload"] = payload
+
+    @get("/get")
+    def get_handler(request: Request) -> dict[str, Any]:
+        return request.session
+
+    config = CookieBackendConfig(secret=os.urandom(16), key=key)
+    with create_test_client([set_handler, get_handler], middleware=[config.middleware]) as client:
+        response = client.get("/set")
+        # more than ten cookies, otherwise the ordering this asserts on is not exercised
+        assert len(response.headers.get_list("set-cookie")) > 10
+
+        assert client.get("/get").json() == {"payload": payload}
+
+
+@pytest.mark.parametrize("session_size", [8, 3_000, 60_000])
+@pytest.mark.parametrize(
+    "cookie_params",
+    [
+        {},
+        {"secure": True},
+        {"secure": True, "domain": "example.com", "path": "/a/rather/long/path/segment"},
+    ],
+)
+@pytest.mark.parametrize("key", ["session", "s" * 60, "k" * 250])
+def test_session_cookies_do_not_exceed_max_cookie_size(
+    key: str, cookie_params: dict[str, Any], session_size: int
+) -> None:
+    """Every emitted ``Set-Cookie`` header must stay within the :rfc:`6265` limit.
+
+    The cookie name and its attributes count towards that limit, so the space left for the value depends
+    on the configured key and cookie parameters.
+    """
+
+    @get("/")
+    def handler(request: Request) -> None:
+        request.session["payload"] = "x" * session_size
+
+    config = CookieBackendConfig(secret=os.urandom(16), key=key, **cookie_params)
+    with create_test_client([handler], middleware=[config.middleware]) as client:
+        headers = client.get("/").headers.get_list("set-cookie")
+
+    assert headers
+    for header in headers:
+        assert len(header) <= MAX_COOKIE_SIZE
 
 
 async def test_store_in_message_clears_cookies_when_session_grows_gt_chunk_size(


### PR DESCRIPTION
## Description

Fixes two bugs in the client-side session backend. They interact, so both are fixed here.

Fixes #5021

**1. Chunks are reassembled in the wrong order (not previously reported)**

I ran into this while verifying #5021. Happy to file it as a separate issue if you would rather track it on its own.

A large session is split across `session-0`, `session-1`, ... and reassembled with a plain `sorted()`, which orders the names alphabetically. Alphabetically `session-10` comes before `session-2`, so once a session needs ten or more cookies the payload is concatenated out of order and the session is lost. Below ten chunks the two orders agree, which is why this has gone unnoticed.

Usually the session decodes to empty and the user is silently logged out. Sometimes the misordered payload yields malformed JSON in the associated-data segment, raising `SerializationException`, which `load_from_connection` does not suppress, so the request returns a 500.

**2. Chunks exceed the 4096-byte cookie limit (#5021)**

`CHUNK_SIZE = 4096 - 64` reserves a fixed 64 bytes for the cookie name and attributes. The real overhead is 66 with the default key and `secure=True`, and grows with the key, `domain` and `path`, so every full chunk goes over the limit. Some proxies then silently drop every `Set-Cookie` header on the response.

Fixing #5021 produces smaller, and therefore more, chunks, which makes the ordering bug easier to hit. Hence one PR.

## The fix

- `get_cookie_keys` sorts by the numeric chunk index instead of the cookie name. The index is read from the suffix after the configured key rather than by splitting on `-`, so keys that contain a hyphen (`my-session`) stay correct.
- The per-cookie budget is measured rather than assumed, as suggested in #5021. A zero-length value is itself emitted quoted (`session=""`), so the quoting that base64 values incur is already accounted for.
- If `key`, `path` and `domain` fill the 4096 bytes on their own, that measurement goes negative and no cookie was emitted at all, a silent logout with a 200 response. It now raises `ImproperlyConfiguredException`.

## Verification

The MCVE from #5021, run unchanged. The "before" column matches the output posted in the issue byte-for-byte:

```
BEFORE                                AFTER
session-0      4098  OVER LIMIT by 2  session-0      4096  OK
session_cdp-0  4102  OVER LIMIT by 6  session_cdp-0  4096  OK
```

Sessions of 40,000 B (14 chunks), 200,000 B (67) and 900,000 B (298) were all lost before and all round-trip now.

Across 4 key lengths x 3 attribute combinations x 5 session sizes:

```
before: 1908 cookies | over limit: 1540 | worst overrun: 289 bytes
after:  1953 cookies | over limit:    0 | worst overrun:   0 bytes
```

## Tests

Four tests added to `tests/unit/test_middleware/test_session/test_client_side_backend.py`:

- `test_get_cookie_keys_are_ordered_by_chunk_index` asserts the ordering directly.
- `test_large_session_round_trips` checks that a session needing more than ten cookies survives a round trip, over both `session` and `my-session`.
- `test_session_cookies_do_not_exceed_max_cookie_size` checks that every emitted `Set-Cookie` is within 4096 bytes, over key lengths 7, 60 and 250 and three attribute combinations.
- `test_dump_data_raises_when_cookie_attributes_leave_no_room` covers the new guard.

`test_dump_and_load_data` previously asserted `len(value) <= CHUNK_SIZE`. It now checks the emitted header against `MAX_COOKIE_SIZE`, since the fixed constant no longer determines the limit.


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5022">https://litestar-org.github.io/litestar-docs-preview/5022</a> 
