### PR TITLE
fix: retrieve pydantic example from json_schema_extra

### DIFF
--- a/litestar/plugins/pydantic/utils.py
+++ b/litestar/plugins/pydantic/utils.py
@@ -240,6 +240,10 @@ def get_model_info(
     model_field_info = model.model_fields
     title = model_config.get("title")
     example = model_config.get("example")
+    if example is None:
+        extra = model_config.get('json_schema_extra')
+        if isinstance(extra, dict):
+            example = extra.get('example')
 
     model_fields: dict[str, pydantic.fields.FieldInfo] = {
         k: getattr(f, "field_info", f) for k, f in model_field_info.items()


### PR DESCRIPTION
Add logic to retrieve example from json_schema_extra if not set.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
- follow [Litestar's AI Policy](https://github.com/litestar-org/.github/blob/main/AI_POLICY.md)

If the pull request is not yet ready for review (e.g. tests or other checks are still failing),
please submit it as a draft PR, to avoid noise for reviewers.
-->

## Description

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Pydantic models were not passing through examples via model_config = ConfigDict(json_schema_extra={'example':{'name':'XanthanGum'}}

Mentioned in #3181, point 6.