### PR TITLE
fix(tests): ignore click.utils deprecation warnings (#5020)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,6 +231,7 @@ filterwarnings = [
   "ignore: datetime.datetime.utcnow:DeprecationWarning:time_machine",
   "ignore:Use of deprecated default '__check_model__':DeprecationWarning:polyfactory:",
   "ignore:Registering routes.*:litestar.exceptions.base_exceptions.LitestarWarning",
+  "ignore:.*'click\\.utils\\..*' is deprecated:DeprecationWarning",
   "ignore::pytest.PytestUnraisableExceptionWarning:", # ignore temporarily until the underlying issue can be fixed, which requires the new async-aware test client
 ]
 markers = [


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](https://github.com/litestar-org/litestar/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Description

Closes #5020.

Adds a pytest warning filter for `click.utils` deprecation warnings. Click 8.5.0 deprecated utilities such as `get_binary_stream`, `get_text_stream`, and `PacifyFlushWrapper`, which `rich-click` 1.9.8 imports at top level. This caused the `Test server integration` CI job (which upgrades uvicorn/click dependencies beyond the lockfile) to fail during test collection due to `filterwarnings = ["error"]`.

## Related Issues

Closes #5020

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5026">https://litestar-org.github.io/litestar-docs-preview/5026</a> 
