### PR TITLE
fix(dto): push Meta constraints into Optional's non-None arm

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -6,6 +6,20 @@
 .. changelog:: 3.0.0
     :date: 2364-01-27
 
+    .. change:: Fix ``TypeError`` from ``MsgspecDTO`` on ``Optional[Annotated[T, Meta(...)]]`` struct fields
+        :type: bugfix
+        :issue: 5025
+
+        A request to a handler using ``MsgspecDTO`` for a struct with a field like
+        ``Optional[Annotated[str, msgspec.Meta(min_length=1)]]`` raised
+        ``TypeError: Can only set `min_length` on a str, bytes, or collection type``
+        during request decoding, returning HTTP 500. The DTO transfer model was
+        built as ``Annotated[Optional[str], Meta(min_length=1)]`` — with the
+        constraint on the outer ``Union`` rather than the ``str`` arm — which
+        ``msgspec`` rejects. Meta constraints are now pushed into the non-``None``
+        arm of an ``Optional`` field when the transfer model is generated,
+        mirroring ``Optional[Annotated[T, Meta(...)]]`` which ``msgspec`` accepts.
+
     .. change:: Fix ``TypeError`` when generating a schema for a union of enums
         :type: bugfix
         :pr: 4997

--- a/litestar/dto/_backend.py
+++ b/litestar/dto/_backend.py
@@ -15,6 +15,8 @@ from typing import (
     Protocol,
     Union,
     cast,
+    get_args,
+    get_origin,
 )
 
 import msgspec
@@ -818,6 +820,23 @@ def _create_struct_field_meta_for_field_definition(field_definition: TransferDTO
     )
 
 
+def _wrap_field_type_with_metadata(field_type: Any, metadata: Any) -> Any:
+    """Attach ``metadata`` to ``field_type``, pushing it into the non-``None`` arm of an ``Optional``.
+
+    ``msgspec`` rejects ``Annotated[Optional[str], Meta(min_length=1)]`` because constraints
+    like ``min_length`` may only be applied to the base type they constrain, not to the
+    outer union. When ``field_type`` is ``Union[X, None]`` with a single non-``None`` arm,
+    wrap ``X`` instead and rebuild the union, mirroring ``Optional[Annotated[X, ...]]`` which
+    ``msgspec`` accepts. Other shapes are wrapped directly.
+    """
+    if get_origin(field_type) is Union:
+        args = get_args(field_type)
+        non_none = tuple(a for a in args if a is not type(None))
+        if len(non_none) == 1 and len(non_none) < len(args):
+            return Union[Annotated[non_none[0], metadata], None]
+    return Annotated[field_type, metadata]
+
+
 def _create_struct_for_field_definitions(
     *,
     model_name: str,
@@ -837,12 +856,12 @@ def _create_struct_for_field_definitions(
 
         if field_definition.passthrough_constraints:
             if (field_meta := _create_struct_field_meta_for_field_definition(field_definition)) is not None:
-                field_type = Annotated[field_type, field_meta]
+                field_type = _wrap_field_type_with_metadata(field_type, field_meta)
         elif field_definition.kwarg_definition:
-            field_type = Annotated[field_type, field_definition.kwarg_definition]
+            field_type = _wrap_field_type_with_metadata(field_type, field_definition.kwarg_definition)
 
         struct_fields.append(
-            (  # pyright: ignore[reportArgumentType]
+            (
                 field_definition.name,
                 field_type,
                 _create_msgspec_field(field_definition),

--- a/tests/unit/test_dto/test_factory/test_backends/test_backends.py
+++ b/tests/unit/test_dto/test_factory/test_backends/test_backends.py
@@ -646,6 +646,51 @@ class Outer(msgspec.Struct):
         assert data.some_field == value
 
 
+@pytest.mark.parametrize(
+    ("meta_kwargs", "invalid_value"),
+    (
+        ({"min_length": 1}, ""),
+        ({"max_length": 2}, "abc"),
+        ({"pattern": "^a"}, "b"),
+        ({"gt": 0}, 0),
+        ({"ge": 1}, 0),
+        ({"lt": 10}, 10),
+        ({"le": 5}, 6),
+    ),
+)
+def test_msgspec_dto_optional_annotated_meta_constraint(
+    asgi_connection: Request[Any, Any, Any],
+    create_module: Callable[[str], ModuleType],
+    meta_kwargs: dict[str, Any],
+    invalid_value: Any,
+) -> None:
+    # https://github.com/litestar-org/litestar/issues/5025
+
+    inner_type = "int" if any(k in meta_kwargs for k in ("gt", "ge", "lt", "le")) else "str"
+    meta_repr = ", ".join(f"{k}={v!r}" for k, v in meta_kwargs.items())
+    module = create_module(f"""
+from typing import Annotated, Optional
+import msgspec
+
+class Body(msgspec.Struct):
+    value: Optional[Annotated[{inner_type}, msgspec.Meta({meta_repr})]] = None
+""")
+
+    backend = DTOCodegenBackend(
+        handler_id="test",
+        dto_factory=MsgspecDTO[module.Body],  # type: ignore[name-defined]
+        field_definition=TransferDTOFieldDefinition.from_annotation(module.Body),
+        model_type=module.Body,
+        wrapper_attribute_name=None,
+        is_data_field=True,
+    )
+
+    assert backend.populate_data_from_builtins({"value": None}, asgi_connection).value is None
+
+    with pytest.raises(msgspec.ValidationError):
+        backend.populate_data_from_builtins({"value": invalid_value}, asgi_connection)
+
+
 def test_nested_union_with_multiple_composite_types_raises(
     asgi_connection: Request[Any, Any, Any],
     create_module: Callable[[str], ModuleType],


### PR DESCRIPTION
### Summary

Building the msgspec transfer model for a struct field like
`Optional[Annotated[str, msgspec.Meta(min_length=1)]]` produced
`Annotated[Optional[str], Meta(min_length=1)]` — with the constraint on the outer
`Union` rather than the `str` arm. `msgspec` rejects that shape
(`min_length`/`max_length`/`pattern`/`gt`/`ge`/`lt`/`le`/`multiple_of` may only
sit on the base type they constrain), so decoding raised

```
TypeError: Can only set `min_length` on a str, bytes, or collection type - type
`typing.Annotated[typing.Optional[str], msgspec.Meta(min_length=1, examples=[])]` is invalid
```

at request time in `_backend.py::parse_raw` / `parse_builtins`, and the handler
returned HTTP 500.

### Root cause

`kwarg_definition_from_field` (extended in #4815 to recognise
`Optional[Annotated[T, Meta(...)]]`) correctly lifts the inner `Meta` into a
`ParameterKwarg`. But when `_create_struct_for_field_definitions` rebuilds the
transfer struct, it does:

```python
if field_definition.passthrough_constraints:
    if (field_meta := _create_struct_field_meta_for_field_definition(field_definition)) is not None:
        field_type = Annotated[field_type, field_meta]
```

`field_type` here is `Union[str, None]` (from
`_create_transfer_model_type_annotation`) — so the `Meta` lands on the outer
`Union`, not on the `str` arm the user originally annotated.

### Fix

When the transfer `field_type` is `Union[X, None]` with a single non-`None`
arm, wrap `X` with the `Meta` instead and rebuild the union, mirroring
`Optional[Annotated[X, ...]]` which `msgspec` accepts. Other shapes are
wrapped directly, as before. The same helper is used for the
non-`passthrough_constraints` branch so a `ParameterKwarg` foreign annotation
lands in the same place — no behaviour change for msgspec there, but keeps the
two branches consistent.

### Testing

- Added `test_msgspec_dto_optional_annotated_meta_constraint` parametrised
  over the seven `msgspec.Meta` constraints that trip the outer-union check
  (`min_length`, `max_length`, `pattern`, `gt`, `ge`, `lt`, `le`), each
  asserting that
  - `None` decodes cleanly (Optional stays honoured), and
  - a value violating the constraint raises `msgspec.ValidationError`
    (pinning that the constraint is enforced on the inner arm, not silently
    dropped).
- Full `tests/unit/test_dto` + `tests/unit/test_openapi` — 552 passed, 1 skipped, 1 xfailed.
- The pre-existing pyright ignore on the `struct_fields.append(...)` tuple
  became unnecessary once the wrapping goes through a helper returning `Any`,
  so it is removed. `uv run pyright litestar/dto/_backend.py` and
  `uv run mypy litestar/dto/_backend.py` are both clean.

### Reproducer

Before this change:

```python
from typing import Annotated, Optional
from msgspec import Struct, Meta
from litestar import Litestar, post
from litestar.dto import MsgspecDTO
from litestar.testing import TestClient


class Body(Struct):
    text: Optional[Annotated[str, Meta(min_length=1)]] = None


@post("/", dto=MsgspecDTO[Body])
async def handler(data: Body) -> None: ...


with TestClient(Litestar(route_handlers=[handler])) as c:
    print(c.post("/", json={"text": "any"}).status_code)  # 500 before, 201 after
    print(c.post("/", json={"text": ""}).status_code)     # 400 (constraint enforced)
    print(c.post("/", json={"text": None}).status_code)   # 201 (Optional honoured)
```

Fixes #5025