### PR TITLE
docs(cli): fix autodiscovery paths in CLI help text

### DIFF
--- a/litestar/cli/main.py
+++ b/litestar/cli/main.py
@@ -31,11 +31,12 @@ __all__ = ("litestar_group",)
 def litestar_group(ctx: click.Context, app_path: str | None, app_dir: Path | None = None) -> None:
     """Litestar CLI.
 
-    The application to will be automatically discovered if it's in one of these
-    canonical paths: 'app.py', 'asgi.py', 'application.py' or 'app/__init__.py'.
-    When auto-discovering application factories, functions with the name 'create_app'
-    are considered, or functions that are annotated as returning a 'Litestar'
-    instance.
+    The application will be automatically discovered if it's in one of these
+    canonical paths: 'app.py', 'app/', 'application.py' or 'application/'.
+    Submodules within 'app/' and 'application/' directories are also scanned.
+    When auto-discovering application factories, functions with the name
+    'create_app' are considered, or functions that are annotated as returning
+    a 'Litestar' instance.
 
     Alternatively, the application can be specified explicitly via the '--app' option
     ('litestar --app=<module name>.<submodule>:<app instance or factory>') or the


### PR DESCRIPTION
## Description

Fix inaccurate autodiscovery paths listed in the `litestar` CLI help text.

### Changes

- Remove `asgi.py` which was never in `AUTODISCOVERY_FILE_NAMES`
- Add `application/` directory path (was missing)
- Add note about submodule scanning within `app/` and `application/`
- Fix `"to will be"` typo

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5030">https://litestar-org.github.io/litestar-docs-preview/5030</a> 
