### PR TITLE
fix(dto): 500 error when Optional field has msgspec.Meta constraint

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -8,6 +8,7 @@
 
     .. change:: Fix ``TypeError`` when Optional field has msgspec.Meta constraint
         :type: bugfix
+        :pr: 5032
         :issue: 5025
 
         Previously, attempting to use the Optional data type in a ``msgspec.Struct`` with a

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -6,6 +6,21 @@
 .. changelog:: 3.0.0
     :date: 2364-01-27
 
+    .. change:: Fix ``TypeError`` when Optional field has msgspec.Meta constraint
+        :type: bugfix
+        :issue: 5025
+
+        Previously, attempting to use the Optional data type in a ``msgspec.Struct`` with a
+        msgspec constraint resulted in a ``TypeError``. This occurred because the ``msgspec.Meta``
+        annotation was applied to the entire union, not the original data type. ``msgspec`` does
+        not allow such an annotation.
+
+        Now, only the non-None data type is annotated in the structure field, and msgspec
+        correctly handles constraints. And None is still accepted.
+
+        This also affected partial DTOs with an ``Optional`` field, which previously also
+        returned a 500, now - 400.
+
     .. change:: Fix ``TypeError`` when generating a schema for a union of enums
         :type: bugfix
         :pr: 4997

--- a/litestar/dto/_backend.py
+++ b/litestar/dto/_backend.py
@@ -6,16 +6,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Collection, Mapping, Set
 from dataclasses import replace
-from typing import (
-    TYPE_CHECKING,
-    Annotated,
-    Any,
-    ClassVar,
-    Final,
-    Protocol,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Final, Protocol, Union, cast, get_args, get_origin
 
 import msgspec
 from msgspec import UNSET, Struct, UnsetType, convert, defstruct, field
@@ -37,6 +28,7 @@ from litestar.enums import RequestEncodingType
 from litestar.params import KwargDefinition
 from litestar.serialization import decode_json, decode_msgpack
 from litestar.types import Empty
+from litestar.types.builtin_types import NoneType, UnionTypes
 from litestar.typing import FieldDefinition
 from litestar.utils import unique_name_for_scope
 
@@ -837,7 +829,13 @@ def _create_struct_for_field_definitions(
 
         if field_definition.passthrough_constraints:
             if (field_meta := _create_struct_field_meta_for_field_definition(field_definition)) is not None:
-                field_type = Annotated[field_type, field_meta]
+                field_types = get_args(field_type)
+                non_none = [t for t in field_types if t not in (NoneType, msgspec.UnsetType)]
+                if get_origin(field_type) in UnionTypes and len(non_none) == 1:
+                    constrained = non_none[0]
+                    field_type = Union[tuple(Annotated[t, field_meta] if t is constrained else t for t in field_types)]
+                else:
+                    field_type = Annotated[field_type, field_meta]
         elif field_definition.kwarg_definition:
             field_type = Annotated[field_type, field_definition.kwarg_definition]
 

--- a/tests/unit/test_dto/test_factory/test_integration.py
+++ b/tests/unit/test_dto/test_factory/test_integration.py
@@ -904,6 +904,47 @@ def test_msgspec_dto_copies_constraints(
         assert client.post("/", json={"bar": request_data}).status_code == 400
 
 
+def test_msgspec_dto_copies_constraints_for_optional_field(use_experimental_dto_backend: bool) -> None:
+    # https://github.com/litestar-org/litestar/issues/5025
+    class Foo(msgspec.Struct):
+        bar: Annotated[str, msgspec.Meta(min_length=2)] | None
+        baz: Annotated[str, msgspec.Meta(max_length=2)] | None
+
+    @post(
+        "/",
+        dto=Annotated[MsgspecDTO[Foo], DTOConfig(experimental_codegen_backend=use_experimental_dto_backend)],  # type: ignore[arg-type]
+        signature_types={Foo},
+    )
+    def handler(data: Foo) -> None:
+        pass
+
+    with create_test_client([handler]) as client:
+        assert client.post("/", json={"bar": "1", "baz": "123"}).status_code == 400
+        assert client.post("/", json={"bar": "123", "baz": "1"}).status_code == 201
+        assert client.post("/", json={"bar": None, "baz": None}).status_code == 201
+
+
+def test_msgspec_dto_copies_constraints_for_optional_field_partial(use_experimental_dto_backend: bool) -> None:
+    # https://github.com/litestar-org/litestar/issues/5025
+    class Foo(msgspec.Struct):
+        bar: Annotated[int, msgspec.Meta(gt=10)] | None = None
+
+    class FooDTO(MsgspecDTO[Foo]):
+        config = DTOConfig(partial=True, experimental_codegen_backend=use_experimental_dto_backend)
+
+    @post(
+        "/",
+        dto=FooDTO,
+        signature_types={Foo},
+    )
+    def handler(data: Foo) -> None:
+        pass
+
+    with create_test_client([handler]) as client:
+        assert client.post("/", json={"bar": 5}).status_code == 400
+        assert client.post("/", json={"bar": 11}).status_code == 201
+
+
 def test_msgspec_dto_dont_copy_length_constraint_for_partial_dto() -> None:
     class Foo(msgspec.Struct):
         bar: Annotated[str, msgspec.Meta(min_length=2)]


### PR DESCRIPTION
## Description

Previously, attempting to use the Optional data type in a `msgspec.Struct` with a msgspec constraint resulted in a `TypeError`. This occurred because the `msgspec.Meta` annotation was applied to the entire union, not the original data type. `msgspec` does not allow such an annotation.

Now, only the non-None data type is annotated in the structure field, and msgspec correctly handles constraints.
And None is still accepted.

This also affected partial DTOs with an `Optional` field, which previously also returned a 500, now - 400.

Closes #5025 