### PR TITLE
perf(di): build canonical dependency graph

### DIFF
--- a/litestar/_kwargs/dependencies.py
+++ b/litestar/_kwargs/dependencies.py
@@ -2,10 +2,21 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-__all__ = ("DependencyContainer", "create_dependency_batches", "map_dependencies_recursively", "resolve_dependency")
+from litestar.exceptions import ImproperlyConfiguredException
+
+__all__ = (
+    "DependencyContainer",
+    "DependencyGraph",
+    "create_dependency_batches",
+    "create_dependency_graph",
+    "map_dependencies_recursively",
+    "resolve_dependency",
+)
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from litestar._kwargs.cleanup import DependencyCleanupGroup
     from litestar.connection import ASGIConnection
     from litestar.di import Provide
@@ -34,6 +45,89 @@ class DependencyContainer:
 
     def __hash__(self) -> int:
         return hash(self.key)
+
+
+class DependencyGraph:
+    """Canonical graph of the dependencies reachable by a handler."""
+
+    __slots__ = ("nodes", "paths", "roots")
+
+    def __init__(self) -> None:
+        self.nodes: dict[str, DependencyContainer] = {}
+        self.paths: dict[str, tuple[str, ...]] = {}
+        self.roots: set[DependencyContainer] = set()
+
+
+def create_dependency_graph(dependency_keys: Iterable[str], dependencies: dict[str, Provide]) -> DependencyGraph:
+    """Create a canonical graph containing only dependencies reachable from ``dependency_keys``.
+
+    Each dependency key is represented by exactly one :class:`DependencyContainer`. The graph is traversed
+    iteratively so deeply nested dependency chains don't consume the Python call stack. Cycles are rejected with the
+    dependency path that introduced them.
+
+    Args:
+        dependency_keys: Keys directly requested by the handler.
+        dependencies: All providers available to the handler.
+
+    Returns:
+        The reachable dependency graph.
+
+    Raises:
+        ImproperlyConfiguredException: If the dependency graph contains a cycle.
+    """
+    graph = DependencyGraph()
+    adjacency: dict[str, tuple[str, ...]] = {}
+    states: dict[str, int] = {}
+
+    def get_node(key: str) -> DependencyContainer:
+        if (node := graph.nodes.get(key)) is None:
+            node = graph.nodes[key] = DependencyContainer(key=key, provide=dependencies[key], dependencies=[])
+        return node
+
+    def get_sub_dependency_keys(key: str) -> tuple[str, ...]:
+        if (keys := adjacency.get(key)) is None:
+            keys = adjacency[key] = tuple(
+                field_name for field_name in dependencies[key].signature_model._fields if field_name in dependencies
+            )
+        return keys
+
+    for root_key in dependency_keys:
+        root = get_node(root_key)
+        graph.roots.add(root)
+        graph.paths.setdefault(root_key, (root_key,))
+
+        if states.get(root_key) == 2:
+            continue
+
+        states[root_key] = 1
+        stack: list[tuple[str, int]] = [(root_key, 0)]
+
+        while stack:
+            key, next_child_index = stack[-1]
+            sub_dependency_keys = get_sub_dependency_keys(key)
+
+            if next_child_index == len(sub_dependency_keys):
+                states[key] = 2
+                stack.pop()
+                continue
+
+            sub_dependency_key = sub_dependency_keys[next_child_index]
+            stack[-1] = (key, next_child_index + 1)
+            graph.nodes[key].dependencies.append(get_node(sub_dependency_key))
+
+            state = states.get(sub_dependency_key, 0)
+            if state == 1:
+                active_path = [active_key for active_key, _ in stack]
+                cycle_start = active_path.index(sub_dependency_key)
+                cycle = [*active_path[cycle_start:], sub_dependency_key]
+                raise ImproperlyConfiguredException(f"Dependency cycle detected: {' -> '.join(cycle)}")
+
+            if state == 0:
+                graph.paths[sub_dependency_key] = (*graph.paths[key], sub_dependency_key)
+                states[sub_dependency_key] = 1
+                stack.append((sub_dependency_key, 0))
+
+    return graph
 
 
 async def resolve_dependency(

--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -10,6 +10,7 @@ from litestar._kwargs.cleanup import DependencyCleanupGroup
 from litestar._kwargs.dependencies import (
     DependencyContainer,
     create_dependency_batches,
+    create_dependency_graph,
     resolve_dependency,
 )
 from litestar._kwargs.extractors import (
@@ -67,6 +68,21 @@ class HandlerContext:
         if self.dependencies:
             out += f", dependencies={' -> '.join(self.dependencies[::-1])!r}"
         return out + f"] {msg}"
+
+
+@dataclasses.dataclass(slots=True)
+class _SignatureMetadata:
+    data_field_definition: FieldDefinition | None
+    expected_cookie_params: set[ParameterDefinition]
+    expected_data_dto: type[AbstractDTO] | None
+    expected_form_data: tuple[RequestEncodingType | str, FieldDefinition] | None
+    expected_header_params: set[ParameterDefinition]
+    expected_msgpack_data: FieldDefinition | None
+    expected_path_params: set[ParameterDefinition]
+    expected_query_params: set[ParameterDefinition]
+    expected_reserved_kwargs: set[str]
+    is_data_optional: bool
+    sequence_query_parameter_names: set[str]
 
 
 class KwargsModel:
@@ -208,26 +224,21 @@ class KwargsModel:
         cls,
         path_parameters: set[str],
         layered_parameters: dict[str, FieldDefinition],
-        dependencies: dict[str, Provide],
+        dependency_keys: set[str],
         field_definitions: dict[str, FieldDefinition],
-    ) -> tuple[set[ParameterDefinition], set[DependencyContainer]]:
+    ) -> set[ParameterDefinition]:
         """Get parameter_definitions for the construction of KwargsModel instance.
 
         Args:
             path_parameters: Any expected path parameters.
             layered_parameters: A string keyed dictionary of layered parameters.
-            dependencies: A string keyed dictionary mapping dependency providers.
+            dependency_keys: Keys of dependencies directly requested by the signature.
             field_definitions: The SignatureModel fields.
 
         Returns:
-            A Tuple of sets
+            A set of parameter definitions.
         """
-        expected_dependencies = {
-            cls._create_dependency_graph(key=key, dependencies=dependencies)
-            for key in dependencies
-            if key in field_definitions
-        }
-        ignored_keys = {*RESERVED_KWARGS, *(dependency.key for dependency in expected_dependencies)}
+        ignored_keys = {*RESERVED_KWARGS, *dependency_keys}
 
         param_definitions = {
             *(
@@ -272,36 +283,31 @@ class KwargsModel:
                 )
             )
 
-        return param_definitions, expected_dependencies
+        return param_definitions
 
     @classmethod
-    def create_for_signature_model(  # noqa: C901
+    def _create_signature_metadata(
         cls,
         signature_model: type[SignatureModel],
-        parsed_signature: ParsedSignature,
         dependencies: dict[str, Provide],
+        dependency_keys: set[str],
         path_parameters: set[str],
         layered_parameters: dict[str, FieldDefinition],
-        ctx: BaseRouteHandler | HandlerContext | None = None,
-    ) -> KwargsModel:
-        """Pre-determine what parameters are required for a given combination of route + route handler. It is executed
-        during the application bootstrap process.
+        ctx: HandlerContext | None,
+    ) -> _SignatureMetadata:
+        """Create request metadata local to a single handler or dependency signature.
 
         Args:
-            signature_model: A :class:`SignatureModel <litestar._signature.SignatureModel>` subclass.
-            parsed_signature: A :class:`ParsedSignature <litestar._signature.ParsedSignature>` instance.
+            signature_model: Signature model to inspect.
             dependencies: A string keyed dictionary mapping dependency providers.
+            dependency_keys: Keys of dependencies directly requested by the signature.
             path_parameters: Any expected path parameters.
             layered_parameters: A string keyed dictionary of layered parameters.
-            ctx: Route handler / Route handler context
+            ctx: Route handler context.
 
         Returns:
-            An instance of KwargsModel
+            Metadata extracted from the signature.
         """
-
-        if ctx is not None and not isinstance(ctx, HandlerContext):
-            ctx = HandlerContext(handler=ctx.name or ctx.handler_name, paths=sorted(ctx.paths))
-
         field_definitions = signature_model._fields
 
         cls._validate_raw_kwargs(
@@ -311,18 +317,16 @@ class KwargsModel:
             layered_parameters=layered_parameters,
         )
 
-        param_definitions, expected_dependencies = cls._get_param_definitions(
+        param_definitions = cls._get_param_definitions(
             path_parameters=path_parameters,
             layered_parameters=layered_parameters,
-            dependencies=dependencies,
+            dependency_keys=dependency_keys,
             field_definitions=field_definitions,
         )
 
-        for dep_field_name in dependencies:
+        for dep_field_name in dependency_keys:
             dep_field_def = field_definitions.get(dep_field_name)
-            if dep_field_def is None:
-                continue
-            if not dep_field_def.is_annotated:
+            if dep_field_def is not None and not dep_field_def.is_annotated:
                 msg = (
                     f"Inferred dependency field {dep_field_name!r}. Mark the field explicitly "
                     f"with 'NamedDependency[{dep_field_def.raw}]'. Inferred dependencies will "
@@ -370,64 +374,18 @@ class KwargsModel:
                 media_type = data_field_definition.kwarg_definition.media_type
 
             if media_type in (RequestEncodingType.MULTI_PART, RequestEncodingType.URL_ENCODED):
-                expected_form_data = (media_type, data_field_definition)  # pyright: ignore[reportAssignmentType]
+                expected_form_data = (media_type, data_field_definition)
                 expected_data_dto = signature_model._data_dto
             elif signature_model._data_dto:
                 expected_data_dto = signature_model._data_dto
             elif media_type == RequestEncodingType.MESSAGEPACK:
                 expected_msgpack_data = data_field_definition
 
-        expected_data_field_defs = []
+        is_data_optional = bool(data_field_definition and data_field_definition.is_optional)
 
-        for dependency in expected_dependencies:
-            dependency_kwargs_model = cls.create_for_signature_model(
-                signature_model=dependency.provide.signature_model,
-                parsed_signature=parsed_signature,
-                dependencies=dependencies,
-                path_parameters=path_parameters,
-                layered_parameters=layered_parameters,
-                ctx=dataclasses.replace(ctx, dependencies=[*ctx.dependencies, dependency.key]) if ctx else None,
-            )
-
-            expected_path_parameters = merge_parameter_sets(
-                expected_path_parameters, dependency_kwargs_model.expected_path_params
-            )
-            expected_query_parameters = merge_parameter_sets(
-                expected_query_parameters, dependency_kwargs_model.expected_query_params
-            )
-            expected_cookie_parameters = merge_parameter_sets(
-                expected_cookie_parameters, dependency_kwargs_model.expected_cookie_params
-            )
-            expected_header_parameters = merge_parameter_sets(
-                expected_header_parameters, dependency_kwargs_model.expected_header_params
-            )
-
-            if "data" in dependency_kwargs_model.expected_reserved_kwargs:
-                if "data" in expected_reserved_kwargs:
-                    cls._validate_dependency_data(
-                        expected_form_data=expected_form_data,
-                        dependency_kwargs_model=dependency_kwargs_model,
-                    )
-                expected_data_field_defs.append(dependency.provide.signature_model._fields["data"])
-
-            expected_reserved_kwargs.update(dependency_kwargs_model.expected_reserved_kwargs)
-            sequence_query_parameter_names.update(dependency_kwargs_model.sequence_query_parameter_names)
-
-        if handler_data_field := field_definitions.get("data"):
-            expected_data_field_defs.append(handler_data_field)
-
-        if expected_data_field_defs:
-            cls._validate_data_field_definitions(expected_data_field_defs, ctx)
-
-        is_data_optional = (
-            field_definitions["data"].is_optional
-            if "data" in expected_reserved_kwargs and "data" in field_definitions
-            else False
-        )
-
-        return KwargsModel(
+        return _SignatureMetadata(
+            data_field_definition=data_field_definition,
             expected_cookie_params=expected_cookie_parameters,
-            expected_dependencies=expected_dependencies,
             expected_data_dto=expected_data_dto,
             expected_form_data=expected_form_data,
             expected_header_params=expected_header_parameters,
@@ -436,6 +394,126 @@ class KwargsModel:
             expected_query_params=expected_query_parameters,
             expected_reserved_kwargs=expected_reserved_kwargs,
             is_data_optional=is_data_optional,
+            sequence_query_parameter_names=sequence_query_parameter_names,
+        )
+
+    @classmethod
+    def create_for_signature_model(
+        cls,
+        signature_model: type[SignatureModel],
+        parsed_signature: ParsedSignature,
+        dependencies: dict[str, Provide],
+        path_parameters: set[str],
+        layered_parameters: dict[str, FieldDefinition],
+        ctx: BaseRouteHandler | HandlerContext | None = None,
+    ) -> KwargsModel:
+        """Pre-determine what parameters are required for a given combination of route + route handler. It is executed
+        during the application bootstrap process.
+
+        Args:
+            signature_model: A :class:`SignatureModel <litestar._signature.SignatureModel>` subclass.
+            parsed_signature: A :class:`ParsedSignature <litestar._signature.ParsedSignature>` instance.
+            dependencies: A string keyed dictionary mapping dependency providers.
+            path_parameters: Any expected path parameters.
+            layered_parameters: A string keyed dictionary of layered parameters.
+            ctx: Route handler / Route handler context
+
+        Returns:
+            An instance of KwargsModel
+        """
+        if ctx is not None and not isinstance(ctx, HandlerContext):
+            ctx = HandlerContext(handler=ctx.name or ctx.handler_name, paths=sorted(ctx.paths))
+
+        root_dependency_keys = tuple(key for key in dependencies if key in signature_model._fields)
+        dependency_graph = create_dependency_graph(dependency_keys=root_dependency_keys, dependencies=dependencies)
+        root_metadata = cls._create_signature_metadata(
+            signature_model=signature_model,
+            dependencies=dependencies,
+            dependency_keys=set(root_dependency_keys),
+            path_parameters=path_parameters,
+            layered_parameters=layered_parameters,
+            ctx=ctx,
+        )
+
+        expected_path_parameters = root_metadata.expected_path_params
+        expected_query_parameters = root_metadata.expected_query_params
+        expected_cookie_parameters = root_metadata.expected_cookie_params
+        expected_header_parameters = root_metadata.expected_header_params
+        expected_reserved_kwargs = root_metadata.expected_reserved_kwargs
+        sequence_query_parameter_names = root_metadata.sequence_query_parameter_names
+        expected_data_field_defs = (
+            [root_metadata.data_field_definition] if root_metadata.data_field_definition is not None else []
+        )
+        dependency_metadata_by_key: dict[str, _SignatureMetadata] = {}
+
+        for dependency in dependency_graph.nodes.values():
+            dependency_ctx = (
+                dataclasses.replace(ctx, dependencies=[*ctx.dependencies, *dependency_graph.paths[dependency.key]])
+                if ctx
+                else None
+            )
+            dependency_metadata = cls._create_signature_metadata(
+                signature_model=dependency.provide.signature_model,
+                dependencies=dependencies,
+                dependency_keys={sub_dependency.key for sub_dependency in dependency.dependencies},
+                path_parameters=path_parameters,
+                layered_parameters=layered_parameters,
+                ctx=dependency_ctx,
+            )
+            dependency_metadata_by_key[dependency.key] = dependency_metadata
+
+            expected_path_parameters = merge_parameter_sets(
+                expected_path_parameters, dependency_metadata.expected_path_params
+            )
+            expected_query_parameters = merge_parameter_sets(
+                expected_query_parameters, dependency_metadata.expected_query_params
+            )
+            expected_cookie_parameters = merge_parameter_sets(
+                expected_cookie_parameters, dependency_metadata.expected_cookie_params
+            )
+            expected_header_parameters = merge_parameter_sets(
+                expected_header_parameters, dependency_metadata.expected_header_params
+            )
+
+            if dependency_metadata.data_field_definition is not None:
+                expected_data_field_defs.append(dependency_metadata.data_field_definition)
+
+            expected_reserved_kwargs.update(dependency_metadata.expected_reserved_kwargs)
+            sequence_query_parameter_names.update(dependency_metadata.sequence_query_parameter_names)
+
+        metadata_and_dependencies = (
+            (root_metadata, dependency_graph.roots),
+            *(
+                (dependency_metadata_by_key[dependency.key], dependency.dependencies)
+                for dependency in dependency_graph.nodes.values()
+            ),
+        )
+        for metadata, direct_dependencies in metadata_and_dependencies:
+            if metadata.data_field_definition is None:
+                continue
+            for dependency in direct_dependencies:
+                dependency_metadata = dependency_metadata_by_key[dependency.key]
+                if dependency_metadata.data_field_definition is None:
+                    continue
+                cls._validate_dependency_data(
+                    expected_form_data=metadata.expected_form_data,
+                    dependency_expected_form_data=dependency_metadata.expected_form_data,
+                )
+
+        if expected_data_field_defs:
+            cls._validate_data_field_definitions(expected_data_field_defs, ctx)
+
+        return KwargsModel(
+            expected_cookie_params=expected_cookie_parameters,
+            expected_dependencies=dependency_graph.roots,
+            expected_data_dto=root_metadata.expected_data_dto,
+            expected_form_data=root_metadata.expected_form_data,
+            expected_header_params=expected_header_parameters,
+            expected_msgpack_data=root_metadata.expected_msgpack_data,
+            expected_path_params=expected_path_parameters,
+            expected_query_params=expected_query_parameters,
+            expected_reserved_kwargs=expected_reserved_kwargs,
+            is_data_optional=root_metadata.is_data_optional,
             sequence_query_parameter_names=sequence_query_parameter_names,
         )
 
@@ -480,32 +558,19 @@ class KwargsModel:
         return cleanup_group
 
     @classmethod
-    def _create_dependency_graph(cls, key: str, dependencies: dict[str, Provide]) -> DependencyContainer:
-        """Create a graph like structure of dependencies, with each dependency including its own dependencies as a
-        list.
-        """
-        provide = dependencies[key]
-        sub_dependency_keys = [k for k in provide.signature_model._fields if k in dependencies]
-        return DependencyContainer(
-            key=key,
-            provide=provide,
-            dependencies=[cls._create_dependency_graph(key=k, dependencies=dependencies) for k in sub_dependency_keys],
-        )
-
-    @classmethod
     def _validate_dependency_data(
         cls,
         expected_form_data: tuple[RequestEncodingType | str, FieldDefinition] | None,
-        dependency_kwargs_model: KwargsModel,
+        dependency_expected_form_data: tuple[RequestEncodingType | str, FieldDefinition] | None,
     ) -> None:
         """Validate that the 'data' kwarg is compatible across dependencies."""
-        if bool(expected_form_data) != bool(dependency_kwargs_model.expected_form_data):
+        if bool(expected_form_data) != bool(dependency_expected_form_data):
             raise ImproperlyConfiguredException(
                 "Dependencies have incompatible 'data' kwarg types: one expects JSON and the other expects form-data"
             )
-        if expected_form_data and dependency_kwargs_model.expected_form_data:
+        if expected_form_data and dependency_expected_form_data:
             local_media_type = expected_form_data[0]
-            dependency_media_type = dependency_kwargs_model.expected_form_data[0]
+            dependency_media_type = dependency_expected_form_data[0]
             if local_media_type != dependency_media_type:
                 raise ImproperlyConfiguredException(
                     "Dependencies have incompatible form-data encoding: one expects url-encoded and the other expects multi-part"

--- a/tests/unit/test_kwargs/test_dependency_batches.py
+++ b/tests/unit/test_kwargs/test_dependency_batches.py
@@ -1,8 +1,13 @@
+from collections import Counter
+from typing import Any, cast
+
 import pytest
 
-from litestar._kwargs.dependencies import DependencyContainer, create_dependency_batches
+from litestar import Litestar
+from litestar._kwargs.dependencies import DependencyContainer, create_dependency_batches, create_dependency_graph
+from litestar._kwargs.kwargs_model import KwargsModel
 from litestar.di import NamedDependency, Provide
-from litestar.exceptions import HTTPException, ValidationException
+from litestar.exceptions import HTTPException, ImproperlyConfiguredException, ValidationException
 from litestar.handlers import get
 from litestar.status_codes import HTTP_400_BAD_REQUEST, HTTP_422_UNPROCESSABLE_ENTITY, HTTP_500_INTERNAL_SERVER_ERROR
 from litestar.testing import create_test_client
@@ -60,6 +65,91 @@ def test_dependency_batches(
 ) -> None:
     calculated_batches = create_dependency_batches(dependency_tree)
     assert calculated_batches == expected_batches
+
+
+def test_dependency_graph_reuses_shared_nodes() -> None:
+    async def shared() -> int:
+        return 1
+
+    async def left(shared: NamedDependency[int]) -> int:
+        return shared
+
+    async def right(shared: NamedDependency[int]) -> int:
+        return shared
+
+    dependencies = {"shared": Provide(shared), "left": Provide(left), "right": Provide(right)}
+
+    @get(path="/", dependencies=dependencies)
+    async def handler(left: NamedDependency[int], right: NamedDependency[int]) -> int:
+        return left + right
+
+    Litestar(route_handlers=[handler], openapi_config=None)
+    graph = create_dependency_graph(dependency_keys=("left", "right"), dependencies=dependencies)
+
+    assert set(graph.nodes) == {"shared", "left", "right"}
+    assert graph.nodes["left"].dependencies[0] is graph.nodes["shared"]
+    assert graph.nodes["right"].dependencies[0] is graph.nodes["shared"]
+
+
+def test_dependency_signature_metadata_is_created_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: Counter[int] = Counter()
+    original = cast("Any", KwargsModel._create_signature_metadata).__func__
+
+    def track_metadata(cls: type[KwargsModel], *args: Any, **kwargs: Any) -> Any:
+        signature_model = kwargs["signature_model"]
+        calls[id(signature_model)] += 1
+        return original(cls, *args, **kwargs)
+
+    monkeypatch.setattr(KwargsModel, "_create_signature_metadata", classmethod(track_metadata))
+
+    async def first() -> int:
+        return 1
+
+    async def second(first: NamedDependency[int]) -> int:
+        return first
+
+    async def third(first: NamedDependency[int], second: NamedDependency[int]) -> int:
+        return first + second
+
+    async def fourth(first: NamedDependency[int], second: NamedDependency[int], third: NamedDependency[int]) -> int:
+        return first + second + third
+
+    @get(path="/")
+    async def handler(fourth: NamedDependency[int]) -> int:
+        return fourth
+
+    dependencies = {
+        "first": Provide(first),
+        "second": Provide(second),
+        "third": Provide(third),
+        "fourth": Provide(fourth),
+    }
+    Litestar(
+        route_handlers=[handler],
+        dependencies=dependencies,
+        openapi_config=None,
+    )
+
+    assert all(calls[id(provider.signature_model)] == 1 for provider in dependencies.values())
+
+
+def test_dependency_cycle_raises_configuration_error() -> None:
+    async def first(second: NamedDependency[int]) -> int:
+        return second
+
+    async def second(first: NamedDependency[int]) -> int:
+        return first
+
+    @get(path="/")
+    async def handler(first: NamedDependency[int]) -> int:
+        return first
+
+    with pytest.raises(ImproperlyConfiguredException, match="Dependency cycle detected: first -> second -> first"):
+        Litestar(
+            route_handlers=[handler],
+            dependencies={"first": Provide(first), "second": Provide(second)},
+            openapi_config=None,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<html><head></head><body><h2>Description</h2><p>The previous dependency-graph construction recursively expanded every dependency path into a separate tree. When multiple dependencies referenced the same sub-dependency, the corresponding <code inline="">DependencyContainer</code> and signature metadata were recreated for every reachable path.</p><p>For dense or highly convergent dependency DAGs, this caused the amount of bootstrap work to grow exponentially with the number of dependencies.</p><p>This PR:</p><ul><li><p>Builds a canonical graph containing exactly one <code inline="">DependencyContainer</code> per reachable dependency key.</p></li><li><p>Uses iterative traversal to avoid consuming the Python call stack for deeply nested dependency chains.</p></li><li><p>Extracts and validates signature metadata once per dependency, then merges it into the handler's <code inline="">KwargsModel</code>.</p></li><li><p>Preserves shared nodes across multiple dependency branches.</p></li><li><p>Detects dependency cycles and raises an <code inline="">ImproperlyConfiguredException</code> containing the cycle path.</p></li><li><p>Adds tests covering shared-node reuse, single-pass metadata creation, and cycle detection.</p></li></ul><p>For example, a dense graph with 16 dependencies previously expanded into 32,768 duplicated nodes. The canonical graph contains only 16 nodes.</p><h3>Benchmarks</h3><p>Benchmark environment:</p><ul><li><p>Python 3.13.7</p></li><li><p><code inline="">Litestar(..., openapi_config=None)</code></p></li><li><p>Dense dependency DAG:</p><ul><li><p><code inline="">d0</code> has no dependencies.</p></li><li><p>Each <code inline="">dN</code> depends on every preceding dependency.</p></li><li><p>The route handler requests only the final dependency.</p></li></ul></li><li><p>Results are median application initialization times.</p></li><li><p>Before: 3 repetitions.</p></li><li><p>After: 5 repetitions.</p></li></ul>
Dependencies | Before | After | Speedup
-- | -- | -- | --
12 | 64.731 ms | 10.068 ms | 6.43×
14 | 329.805 ms | 10.883 ms | 30.30×
16 | 1,255.295 ms | 12.982 ms | 96.69×

<p>These are local synthetic microbenchmarks of application startup and do not measure request throughput.</p><h3>Testing</h3><p>Added tests verifying that:</p><ul><li><p>Shared dependencies reuse the same canonical graph node.</p></li><li><p>Signature metadata is created exactly once per reachable dependency.</p></li><li><p>Dependency cycles produce a configuration error containing the detected cycle path.</p></li></ul><p>The targeted dependency-batch test module passes successfully:</p><pre><code class="language-text">12 passed
</code></pre></body></html>