### PR TITLE
perf: precompute CORS Access-Control-Allow-Headers/Methods values

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -6,23 +6,6 @@
 .. changelog:: 3.0.0
     :date: 2364-01-27
 
-    .. change:: Precompute CORS ``Access-Control-Allow-Headers`` and ``Access-Control-Allow-Methods`` values
-        :type: feature
-        :breaking:
-
-        ``CORSMiddleware`` now builds the ``Access-Control-Allow-Headers`` and
-        ``Access-Control-Allow-Methods`` header values once at construction time
-        instead of re-sorting and re-joining the configured values on every
-        response, slightly reducing per-response overhead when CORS is enabled.
-
-        This only affects code that mutates the middleware's ``allow_headers`` or
-        ``allow_methods`` attributes after construction, which is no longer
-        reflected in response headers. Litestar reads
-        :class:`~litestar.config.cors.CORSConfig` exactly once at application
-        startup, and the rest of the derived CORS state (``preflight_headers``,
-        ``simple_headers`` and the compiled origin regex) was already frozen at
-        construction, so mutating configuration at runtime was never supported.
-
     .. change:: Fix ``TypeError`` when generating a schema for a union of enums
         :type: bugfix
         :pr: 4997

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -6,6 +6,23 @@
 .. changelog:: 3.0.0
     :date: 2364-01-27
 
+    .. change:: Precompute CORS ``Access-Control-Allow-Headers`` and ``Access-Control-Allow-Methods`` values
+        :type: feature
+        :breaking:
+
+        ``CORSMiddleware`` now builds the ``Access-Control-Allow-Headers`` and
+        ``Access-Control-Allow-Methods`` header values once at construction time
+        instead of re-sorting and re-joining the configured values on every
+        response, slightly reducing per-response overhead when CORS is enabled.
+
+        This only affects code that mutates the middleware's ``allow_headers`` or
+        ``allow_methods`` attributes after construction, which is no longer
+        reflected in response headers. Litestar reads
+        :class:`~litestar.config.cors.CORSConfig` exactly once at application
+        startup, and the rest of the derived CORS state (``preflight_headers``,
+        ``simple_headers`` and the compiled origin regex) was already frozen at
+        construction, so mutating configuration at runtime was never supported.
+
     .. change:: Fix ``TypeError`` when generating a schema for a union of enums
         :type: bugfix
         :pr: 4997

--- a/litestar/middleware/_internal/cors.py
+++ b/litestar/middleware/_internal/cors.py
@@ -59,6 +59,8 @@ class CORSMiddleware(ASGIMiddleware):
         self.is_allow_all_origins = "*" in self.allow_origins
         self.is_allow_all_methods = "*" in self.allow_methods
         self.is_allow_all_headers = "*" in self.allow_headers
+        self.allow_headers_value = ", ".join(sorted(set(self.allow_headers)))
+        self.allow_methods_value = ", ".join(sorted(set(self.allow_methods)))
         self.allowed_origins_regex = _build_allowed_origins_regex(
             allow_origins=self.allow_origins,
             allow_origin_regex=self.allow_origin_regex,
@@ -141,9 +143,9 @@ class CORSMiddleware(ASGIMiddleware):
                     headers["Access-Control-Allow-Origin"] = origin
                     headers["Vary"] = "Origin"
 
-                headers["Access-Control-Allow-Headers"] = ", ".join(sorted(set(self.allow_headers)))
+                headers["Access-Control-Allow-Headers"] = self.allow_headers_value
 
-                headers["Access-Control-Allow-Methods"] = ", ".join(sorted(set(self.allow_methods)))
+                headers["Access-Control-Allow-Methods"] = self.allow_methods_value
 
             await send(message)
 


### PR DESCRIPTION
Build both header values once in ``CORSMiddleware.__init__`` instead of sorting and joining the configured lists on every response. Breaking only for code mutating allow_headers/allow_methods after construction, matching the rest of the CORS state that is already frozen there.