### PR TITLE
fix(openapi): document model-typed reserved kwargs

### DIFF
--- a/litestar/_openapi/parameters.py
+++ b/litestar/_openapi/parameters.py
@@ -21,6 +21,12 @@ if TYPE_CHECKING:
 
 __all__ = ("create_parameters_for_handler",)
 
+_DOCUMENTABLE_RESERVED_KWARGS: dict[str, ParamType] = {
+    "query": ParamType.QUERY,
+    "headers": ParamType.HEADER,
+    "cookies": ParamType.COOKIE,
+}
+
 
 class ParameterCollection:
     """Facilitates conditional deduplication of parameters.
@@ -178,6 +184,58 @@ class ParameterFactory:
         )
         return self.create_parameter(field_definition=field_definition, parameter_name=parameter_name)
 
+    def _get_model_schema(self, field_definition: FieldDefinition) -> Schema | None:
+        """Return the object schema for a model-typed reserved kwarg.
+
+        Args:
+            field_definition: The reserved kwarg field definition.
+
+        Returns:
+            The model schema, or ``None`` when the field is not an object model.
+        """
+
+        def resolve_schema(schema: Schema | Reference) -> Schema:
+            return schema if isinstance(schema, Schema) else self.context.schema_registry.from_reference(schema).schema
+
+        def find_object_schema(schema: Schema | Reference) -> Schema | None:
+            resolved_schema = resolve_schema(schema)
+            if resolved_schema.properties is not None:
+                return resolved_schema
+
+            for schema_variant in (*(resolved_schema.one_of or ()), *(resolved_schema.all_of or ())):
+                if object_schema := find_object_schema(schema_variant):
+                    return object_schema
+
+            return None
+
+        return find_object_schema(self.schema_creator.for_field_definition(field_definition))
+
+    def _create_parameters_from_model(self, field_definition: FieldDefinition, param_type: ParamType) -> None:
+        """Create parameters from the properties of a model-typed reserved kwarg.
+
+        Args:
+            field_definition: The model field definition.
+            param_type: The OpenAPI parameter location.
+        """
+        if (schema := self._get_model_schema(field_definition)) is None:
+            return
+
+        required = set(schema.required or [])
+        for parameter_name, parameter_schema in (schema.properties or {}).items():
+            description = parameter_schema.description if isinstance(parameter_schema, Schema) else None
+            if isinstance(parameter_schema, Reference):
+                description = self.context.schema_registry.from_reference(parameter_schema).schema.description
+
+            self.parameters.add(
+                Parameter(
+                    description=description,
+                    name=parameter_name,
+                    param_in=param_type,
+                    required=parameter_name in required,
+                    schema=parameter_schema,
+                )
+            )
+
     def create_parameters_for_field_definitions(self, fields: dict[str, FieldDefinition]) -> None:
         """Add Parameter models to the handler's collection for the given field definitions.
 
@@ -222,6 +280,13 @@ class ParameterFactory:
 
         for field_name, field_definition in intersection_fields:
             self.parameters.add(self.get_layered_parameter(field_name=field_name, field_definition=field_definition))
+
+        for kwarg_name, param_type in _DOCUMENTABLE_RESERVED_KWARGS.items():
+            if reserved_field_definition := fields.get(kwarg_name):
+                self._create_parameters_from_model(
+                    field_definition=reserved_field_definition,
+                    param_type=param_type,
+                )
 
     def create_parameters_for_handler(self) -> list[Parameter]:
         """Create a list of path/query/header Parameter models for the given PathHandler."""

--- a/tests/unit/test_openapi/test_parameters.py
+++ b/tests/unit/test_openapi/test_parameters.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Annotated, Any, NewType, Optional, cast
 from uuid import UUID
 
 import pytest
+from pydantic import BaseModel, Field
 
 from litestar import Controller, Litestar, Router, get
 from litestar._openapi.datastructures import OpenAPIContext
@@ -622,3 +623,105 @@ def test_reference_parameter_keeps_component_description_when_wrapper_has_none()
     parameters = _create_parameters(app=Litestar(route_handlers=[handler]), path="/genders")
 
     assert parameters[0].description == Gender.__doc__
+
+
+def test_issue_2015_pydantic_model_query_generates_parameters() -> None:
+    # https://github.com/litestar-org/litestar/issues/2015
+    class EvenOdd(BaseModel):
+        even: Annotated[str, Field(pattern=r"^\d*[02468]$")]
+        odd: Annotated[str, Field(pattern=r"^\d*[13579]$")]
+
+    @get("/")
+    async def handler(query: EvenOdd) -> EvenOdd:
+        return query
+
+    app = Litestar([handler])
+    params = app.openapi_schema.paths["/"].get.parameters  # type: ignore[index, union-attr]
+
+    assert params is not None
+    param_map = {param.name: param for param in cast("list[OpenAPIParameter]", params)}
+    assert param_map["even"].param_in == ParamType.QUERY
+    assert param_map["even"].required is True
+    assert param_map["odd"].param_in == ParamType.QUERY
+    assert param_map["odd"].required is True
+
+
+def test_issue_2015_model_headers_and_cookies_generate_parameters() -> None:
+    # https://github.com/litestar-org/litestar/issues/2015
+    @dataclasses.dataclass
+    class RequestHeaders:
+        x_api_key: str
+
+    @dataclasses.dataclass
+    class RequestCookies:
+        session_id: str
+
+    @get("/")
+    async def handler(headers: RequestHeaders, cookies: RequestCookies) -> None:
+        return None
+
+    app = Litestar([handler])
+    params = app.openapi_schema.paths["/"].get.parameters  # type: ignore[index, union-attr]
+
+    assert params is not None
+    param_map = {param.name: param for param in cast("list[OpenAPIParameter]", params)}
+    assert param_map["x_api_key"].param_in == ParamType.HEADER
+    assert param_map["x_api_key"].required is True
+    assert param_map["session_id"].param_in == ParamType.COOKIE
+    assert param_map["session_id"].required is True
+
+
+def test_issue_2015_optional_model_query_generates_parameters() -> None:
+    # https://github.com/litestar-org/litestar/issues/2015
+    class SearchQuery(BaseModel):
+        query: str
+        page: int = 1
+
+    @get("/")
+    async def handler(query: SearchQuery | None = None) -> None:
+        return None
+
+    app = Litestar([handler])
+    params = app.openapi_schema.paths["/"].get.parameters  # type: ignore[index, union-attr]
+
+    assert params is not None
+    param_map = {param.name: param for param in cast("list[OpenAPIParameter]", params)}
+    assert param_map["query"].required is True
+    assert param_map["page"].required is False
+
+
+def test_issue_2015_nested_model_parameter_keeps_reference_schema() -> None:
+    # https://github.com/litestar-org/litestar/issues/2015
+    class Pagination(BaseModel):
+        page: int
+
+    class SearchQuery(BaseModel):
+        pagination: Pagination
+
+    @get("/")
+    async def handler(query: SearchQuery) -> None:
+        return None
+
+    app = Litestar([handler])
+    params = app.openapi_schema.paths["/"].get.parameters  # type: ignore[index, union-attr]
+
+    assert params is not None
+    param_map = {param.name: param for param in cast("list[OpenAPIParameter]", params)}
+    assert isinstance(param_map["pagination"].schema, Reference)
+
+
+def test_issue_2015_annotated_model_query_generates_parameters() -> None:
+    # https://github.com/litestar-org/litestar/issues/2015
+    class SearchQuery(BaseModel):
+        query: str
+
+    @get("/")
+    async def handler(query: Annotated[SearchQuery, QueryParameter(description="Search filters")]) -> None:
+        return None
+
+    app = Litestar([handler])
+    params = app.openapi_schema.paths["/"].get.parameters  # type: ignore[index, union-attr]
+
+    assert params is not None
+    param_map = {param.name: param for param in cast("list[OpenAPIParameter]", params)}
+    assert param_map["query"].param_in == ParamType.QUERY


### PR DESCRIPTION
## Summary

- Document model-typed `query`, `headers`, and `cookies` kwargs as individual OpenAPI parameters.
- Support optional and `Annotated[...]` model wrappers while preserving nested schema references.
- Add regression coverage for issue #2015.

## Validation

- `pytest tests/unit/test_openapi`: 288 passed, 1 xfailed
- `pytest tests/unit/test_kwargs`: 253 passed, 1 xfailed
- Targeted mypy: passed
- Ruff check and format: passed
- `git diff --check`: passed
- Pre-commit selected hooks passed except `unasyncd`, which crashes in its isolated hook environment with `TypeError: File.__init__() got an unexpected keyword argument 'limiter'` before checking files.

Fixes #2015