### PR TITLE
feat(jwt): add support for leeway param in jwt security backends

### DIFF
--- a/docs/examples/security/jwt/custom_decode_payload.py
+++ b/docs/examples/security/jwt/custom_decode_payload.py
@@ -16,6 +16,7 @@ class CustomToken(Token):
         issuer: str | Sequence[str] | None = None,
         audience: str | Sequence[str] | None = None,
         options: JWTDecodeOptions | None = None,
+        leeway: int = 0,
     ) -> Any:
         payload = super().decode_payload(
             encoded_token=encoded_token,
@@ -24,6 +25,7 @@ class CustomToken(Token):
             issuer=issuer,
             audience=audience,
             options=options,
+            leeway=leeway,
         )
         payload["sub"] = payload["sub"].split("@", maxsplit=1)[1]
         return payload

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -8,7 +8,7 @@
 
     .. change:: Add support for ``leeway`` parameter in JWT security backends
         :type: feature
-        :pr: tbd
+        :pr: 5037
         :issue: 4584
         :breaking:
 

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -6,6 +6,19 @@
 .. changelog:: 3.0.0
     :date: 2364-01-27
 
+    .. change:: Add support for ``leeway`` parameter in JWT security backends
+        :type: feature
+        :pr: tbd
+        :issue: 4584
+        :breaking:
+
+        Add support for ``leeway`` parameter in JWT security backends, which allows set
+        a number of potential seconds as a clock error for expired tokens.
+
+        ``Token.decode`` and ``Token.decode_payload`` now take a ``leeway`` argument.
+        Custom token classes overriding either method must accept it and forward to
+        ``super()``, otherwise decoding raises ``TypeError``.
+
     .. change:: Fix ``TypeError`` when generating a schema for a union of enums
         :type: bugfix
         :pr: 4997

--- a/litestar/security/jwt/auth.py
+++ b/litestar/security/jwt/auth.py
@@ -73,6 +73,8 @@ class BaseJWTAuth(Generic[UserType, TokenT], AbstractSecurityConfig[UserType, To
     """
     token_cls: type[Token] = Token
     """Target type the JWT payload will be converted into"""
+    leeway: int = 0
+    """The number of potential seconds as a clock error for expired tokens."""
     accepted_audiences: Sequence[str] | None = None
     """Audiences to accept when verifying the token. If given, and the audience in the
     token does not match, a 401 response is returned
@@ -153,6 +155,7 @@ class BaseJWTAuth(Generic[UserType, TokenT], AbstractSecurityConfig[UserType, To
             verify_expiry=self.verify_expiry,
             verify_not_before=self.verify_not_before,
             strict_audience=self.strict_audience,
+            leeway=self.leeway,
         )
 
     def login(
@@ -326,6 +329,8 @@ class JWTAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, TokenT]):
     """
     token_cls: type[Token] = Token
     """Target type the JWT payload will be converted into"""
+    leeway: int = 0
+    """The number of potential seconds as a clock error for expired tokens."""
     accepted_audiences: Sequence[str] | None = None
     """Audiences to accept when verifying the token. If given, and the audience in the
     token does not match, a 401 response is returned
@@ -430,6 +435,8 @@ class JWTCookieAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, TokenT]):
     """
     token_cls: type[Token] = Token
     """Target type the JWT payload will be converted into"""
+    leeway: int = 0
+    """The number of potential seconds as a clock error for expired tokens."""
     accepted_audiences: Sequence[str] | None = None
     """Audiences to accept when verifying the token. If given, and the audience in the
     token does not match, a 401 response is returned
@@ -499,6 +506,7 @@ class JWTCookieAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, TokenT]):
             verify_expiry=self.verify_expiry,
             verify_not_before=self.verify_not_before,
             strict_audience=self.strict_audience,
+            leeway=self.leeway,
         )
 
     def login(
@@ -670,6 +678,8 @@ class OAuth2PasswordBearerAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, 
     """
     token_cls: type[Token] = Token
     """Target type the JWT payload will be converted into"""
+    leeway: int = 0
+    """The number of potential seconds as a clock error for expired tokens."""
     accepted_audiences: Sequence[str] | None = None
     """Audiences to accept when verifying the token. If given, and the audience in the
     token does not match, a 401 response is returned
@@ -719,6 +729,7 @@ class OAuth2PasswordBearerAuth(Generic[UserType, TokenT], BaseJWTAuth[UserType, 
             verify_expiry=self.verify_expiry,
             verify_not_before=self.verify_not_before,
             strict_audience=self.strict_audience,
+            leeway=self.leeway,
         )
 
     @property

--- a/litestar/security/jwt/middleware.py
+++ b/litestar/security/jwt/middleware.py
@@ -29,6 +29,7 @@ class JWTAuthenticationMiddleware(AbstractAuthenticationMiddleware):
     __slots__ = (
         "algorithm",
         "auth_header",
+        "leeway",
         "require_claims",
         "retrieve_user_handler",
         "revoked_token_handler",
@@ -60,6 +61,7 @@ class JWTAuthenticationMiddleware(AbstractAuthenticationMiddleware):
         verify_not_before: bool = True,
         strict_audience: bool = False,
         revoked_token_handler: Callable[[Token, ASGIConnection[Any, Any, Any, Any]], Awaitable[Any]] | None = None,
+        leeway: int = 0,
     ) -> None:
         """Check incoming requests for an encoded token in the auth header specified, and if present retrieve the user
         from persistence using the provided function.
@@ -91,6 +93,7 @@ class JWTAuthenticationMiddleware(AbstractAuthenticationMiddleware):
                 ``accepted_audiences`` is a sequence of length 1
             revoked_token_handler: A function that receives a :class:`Token <.security.jwt.Token>` and returns a boolean
                 indicating whether the token has been revoked.
+            leeway: A number of potential seconds as a clock error for expired tokens.
         """
         super().__init__(
             app=app,
@@ -111,6 +114,7 @@ class JWTAuthenticationMiddleware(AbstractAuthenticationMiddleware):
         self.verify_expiry = verify_expiry
         self.verify_not_before = verify_not_before
         self.strict_audience = strict_audience
+        self.leeway = leeway
 
     async def authenticate_request(self, connection: ASGIConnection[Any, Any, Any, Any]) -> AuthenticationResult:
         """Given an HTTP Connection, parse the JWT api key stored in the header and retrieve the user correlating to the
@@ -156,6 +160,7 @@ class JWTAuthenticationMiddleware(AbstractAuthenticationMiddleware):
             verify_exp=self.verify_expiry,
             verify_nbf=self.verify_not_before,
             strict_audience=self.strict_audience,
+            leeway=self.leeway,
         )
 
         user = await self.retrieve_user_handler(token, connection)
@@ -195,6 +200,7 @@ class JWTCookieAuthenticationMiddleware(JWTAuthenticationMiddleware):
         verify_not_before: bool = True,
         strict_audience: bool = False,
         revoked_token_handler: Callable[[Token, ASGIConnection[Any, Any, Any, Any]], Awaitable[Any]] | None = None,
+        leeway: int = 0,
     ) -> None:
         """Check incoming requests for an encoded token in the auth header or cookie name specified, and if present
         retrieves the user from persistence using the provided function.
@@ -227,6 +233,7 @@ class JWTCookieAuthenticationMiddleware(JWTAuthenticationMiddleware):
                 ``accepted_audiences`` is a sequence of length 1
             revoked_token_handler: A function that receives a :class:`Token <.security.jwt.Token>` and returns a boolean
                 indicating whether the token has been revoked.
+            leeway: A number of potential seconds as a clock error for expired tokens.
         """
         super().__init__(
             algorithm=algorithm,
@@ -246,6 +253,7 @@ class JWTCookieAuthenticationMiddleware(JWTAuthenticationMiddleware):
             verify_expiry=verify_expiry,
             verify_not_before=verify_not_before,
             strict_audience=strict_audience,
+            leeway=leeway,
         )
         self.auth_cookie_key = auth_cookie_key
 

--- a/litestar/security/jwt/token.py
+++ b/litestar/security/jwt/token.py
@@ -199,9 +199,7 @@ class Token:
                 raise ImproperlyConfiguredException(f"{_LEEWAY_EXTRA_KEY} is a reserved key and cannot be set")
 
             extras[_LEEWAY_EXTRA_KEY] = leeway
-            token = msgspec.convert(payload, cls, strict=False)
-            token.extras.pop(_LEEWAY_EXTRA_KEY, None)
-            return token
+            return msgspec.convert(payload, cls, strict=False)
         except (
             KeyError,
             jwt.exceptions.InvalidTokenError,

--- a/litestar/security/jwt/token.py
+++ b/litestar/security/jwt/token.py
@@ -4,7 +4,7 @@ import dataclasses
 from collections.abc import Sequence  # noqa: TC003
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, Final, TypedDict
 
 import jwt
 import msgspec
@@ -19,7 +19,7 @@ __all__ = (
     "Token",
 )
 
-_LEEWAY_EXTRA_KEY = "__leeway__"
+_LEEWAY_EXTRA_KEY: Final = "__leeway__"
 
 
 def _normalize_datetime(value: datetime) -> datetime:

--- a/litestar/security/jwt/token.py
+++ b/litestar/security/jwt/token.py
@@ -83,11 +83,12 @@ class Token:
             raise ImproperlyConfiguredException(f"exp value must be a datetime in the future, leeway is {leeway}")
 
         if isinstance(self.iat, datetime) and (
-            (iat := _normalize_datetime(self.iat)).timestamp() <= _normalize_datetime(datetime.now(UTC)).timestamp()
+            ((iat := _normalize_datetime(self.iat)) - timedelta(seconds=leeway)).timestamp()
+            <= _normalize_datetime(datetime.now(UTC)).timestamp()
         ):
             self.iat = iat
         else:
-            raise ImproperlyConfiguredException("iat must be a current or past time")
+            raise ImproperlyConfiguredException(f"iat must be a current or past time, leeway is {leeway}")
 
     @classmethod
     def decode_payload(

--- a/litestar/security/jwt/token.py
+++ b/litestar/security/jwt/token.py
@@ -68,7 +68,6 @@ class Token:
     """Extra fields that were found on the JWT token."""
 
     def __post_init__(self) -> None:
-        # using extras because of msgspec.convert in decode method below doesn't support InitVar
         leeway = self.extras.get(_LEEWAY_EXTRA_KEY, 0)
 
         if len(self.sub) < 1:

--- a/litestar/security/jwt/token.py
+++ b/litestar/security/jwt/token.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 from collections.abc import Sequence  # noqa: TC003
 from dataclasses import asdict, dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import jwt
@@ -18,6 +18,8 @@ __all__ = (
     "JWTDecodeOptions",
     "Token",
 )
+
+_LEEWAY_EXTRA_KEY = "__leeway__"
 
 
 def _normalize_datetime(value: datetime) -> datetime:
@@ -66,15 +68,19 @@ class Token:
     """Extra fields that were found on the JWT token."""
 
     def __post_init__(self) -> None:
+        # using extras because of msgspec.convert in decode method below doesn't support InitVar
+        leeway = self.extras.get(_LEEWAY_EXTRA_KEY, 0)
+
         if len(self.sub) < 1:
             raise ImproperlyConfiguredException("sub must be a string with a length greater than 0")
 
         if isinstance(self.exp, datetime) and (
-            (exp := _normalize_datetime(self.exp)).timestamp() >= _normalize_datetime(datetime.now(UTC)).timestamp()
+            ((exp := _normalize_datetime(self.exp)) + timedelta(seconds=leeway)).timestamp()
+            >= _normalize_datetime(datetime.now(UTC)).timestamp()
         ):
             self.exp = exp
         else:
-            raise ImproperlyConfiguredException("exp value must be a datetime in the future")
+            raise ImproperlyConfiguredException(f"exp value must be a datetime in the future, leeway is {leeway}")
 
         if isinstance(self.iat, datetime) and (
             (iat := _normalize_datetime(self.iat)).timestamp() <= _normalize_datetime(datetime.now(UTC)).timestamp()
@@ -92,6 +98,7 @@ class Token:
         issuer: str | Sequence[str] | None = None,
         audience: str | Sequence[str] | None = None,
         options: JWTDecodeOptions | None = None,
+        leeway: int = 0,
     ) -> Any:
         """Decode and verify the JWT and return its payload"""
         return jwt.decode(
@@ -101,6 +108,7 @@ class Token:
             issuer=issuer,
             audience=audience,
             options=options,  # type: ignore[arg-type]
+            leeway=leeway,
         )
 
     @classmethod
@@ -115,6 +123,7 @@ class Token:
         verify_exp: bool = True,
         verify_nbf: bool = True,
         strict_audience: bool = False,
+        leeway: int = 0,
     ) -> Self:
         """Decode a passed in token string and return a Token instance.
 
@@ -137,6 +146,7 @@ class Token:
                 a single value, and not a list of values, and matches ``audience``
                 exactly. Requires the value passed to the ``audience`` to be a sequence
                 of length 1
+            leeway: The number of potential seconds as a clock error for expired tokens.
 
         Returns:
             A decoded Token instance.
@@ -172,6 +182,7 @@ class Token:
                 audience=audience,
                 issuer=issuer,
                 options=options,
+                leeway=leeway,
             )
             # msgspec can do these conversions as well, but to keep backwards
             # compatibility, we do it ourselves, since the datetime parsing works a
@@ -183,7 +194,14 @@ class Token:
             extras = payload.setdefault("extras", {})
             for key in extra_fields:
                 extras[key] = payload.pop(key)
-            return msgspec.convert(payload, cls, strict=False)
+
+            if _LEEWAY_EXTRA_KEY in extras:
+                raise ImproperlyConfiguredException(f"{_LEEWAY_EXTRA_KEY} is a reserved key and cannot be set")
+
+            extras[_LEEWAY_EXTRA_KEY] = leeway
+            token = msgspec.convert(payload, cls, strict=False)
+            token.extras.pop(_LEEWAY_EXTRA_KEY, None)
+            return token
         except (
             KeyError,
             jwt.exceptions.InvalidTokenError,

--- a/litestar/security/jwt/token.py
+++ b/litestar/security/jwt/token.py
@@ -68,7 +68,7 @@ class Token:
     """Extra fields that were found on the JWT token."""
 
     def __post_init__(self) -> None:
-        leeway = self.extras.get(_LEEWAY_EXTRA_KEY, 0)
+        leeway = self.extras.pop(_LEEWAY_EXTRA_KEY, 0)
 
         if len(self.sub) < 1:
             raise ImproperlyConfiguredException("sub must be a string with a length greater than 0")

--- a/tests/unit/test_security/test_jwt/test_auth.py
+++ b/tests/unit/test_security/test_jwt/test_auth.py
@@ -902,6 +902,7 @@ async def test_jwt_auth_verify_nbf(
 _LEEWAY: Final = 2
 
 
+@pytest.mark.time_machine(datetime(2026, 9, 3))
 @pytest.mark.parametrize(
     "seconds, expected_status_code",
     [

--- a/tests/unit/test_security/test_jwt/test_auth.py
+++ b/tests/unit/test_security/test_jwt/test_auth.py
@@ -895,3 +895,33 @@ async def test_jwt_auth_verify_nbf(
 
     response = client.get("/", headers={"Authorization": header})
     assert response.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
+    "leeway, expected_status_code",
+    [
+        pytest.param(2, 200, id="with_leeway"),
+        pytest.param(0, 401, id="without_leeway"),
+    ],
+)
+async def test_jwt_auth_leeway(
+    leeway: int,
+    expected_status_code: int,
+    create_jwt_app: CreateJWTApp,
+) -> None:
+    @dataclasses.dataclass
+    class CustomToken(Token):
+        def __post_init__(self) -> None:
+            pass
+
+    jwt_auth, client = create_jwt_app(leeway=leeway)
+
+    header = jwt_auth.format_auth_header(
+        CustomToken(
+            sub="foo",
+            exp=(datetime.now(tz=UTC) - timedelta(seconds=1)),
+        ).encode(jwt_auth.token_secret, jwt_auth.algorithm),
+    )
+
+    response = client.get("/", headers={"Authorization": header})
+    assert response.status_code == expected_status_code

--- a/tests/unit/test_security/test_jwt/test_auth.py
+++ b/tests/unit/test_security/test_jwt/test_auth.py
@@ -5,7 +5,7 @@ import secrets
 import string
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any, Optional, TypeAlias
+from typing import TYPE_CHECKING, Any, Final, Optional, TypeAlias
 from uuid import uuid4
 
 import jwt
@@ -23,6 +23,8 @@ from litestar.testing import TestClient, create_test_client
 from tests.models import User, UserFactory
 
 if TYPE_CHECKING:
+    from time_machine import Traveller
+
     from litestar.connection import ASGIConnection
 
 
@@ -897,31 +899,33 @@ async def test_jwt_auth_verify_nbf(
     assert response.status_code == expected_status_code
 
 
+_LEEWAY: Final = 2
+
+
 @pytest.mark.parametrize(
-    "leeway, expected_status_code",
+    "seconds, expected_status_code",
     [
-        pytest.param(2, 200, id="with_leeway"),
-        pytest.param(0, 401, id="without_leeway"),
+        pytest.param(_LEEWAY - 1, 200, id="with_leeway"),
+        pytest.param(_LEEWAY, 401, id="at_leeway"),
+        pytest.param(_LEEWAY + 1, 401, id="past_leeway"),
     ],
 )
 async def test_jwt_auth_leeway(
-    leeway: int,
+    seconds: int,
     expected_status_code: int,
     create_jwt_app: CreateJWTApp,
+    frozen_datetime: "Traveller",
 ) -> None:
-    @dataclasses.dataclass
-    class CustomToken(Token):
-        def __post_init__(self) -> None:
-            pass
-
-    jwt_auth, client = create_jwt_app(leeway=leeway)
+    jwt_auth, client = create_jwt_app(leeway=_LEEWAY)
 
     header = jwt_auth.format_auth_header(
-        CustomToken(
+        Token(
             sub="foo",
-            exp=(datetime.now(tz=UTC) - timedelta(seconds=1)),
+            exp=datetime.now(tz=UTC),
         ).encode(jwt_auth.token_secret, jwt_auth.algorithm),
     )
+
+    frozen_datetime.shift(seconds)
 
     response = client.get("/", headers={"Authorization": header})
     assert response.status_code == expected_status_code

--- a/tests/unit/test_security/test_jwt/test_auth.py
+++ b/tests/unit/test_security/test_jwt/test_auth.py
@@ -917,6 +917,8 @@ async def test_jwt_auth_leeway(
     create_jwt_app: CreateJWTApp,
     frozen_datetime: "Traveller",
 ) -> None:
+    # According to RFC 7519 and PyJWT implementation, a token is expired ON OR AFTER (exp + leeway).
+    # So the exact moment it hits the deadline, it must return 401.
     jwt_auth, client = create_jwt_app(leeway=_LEEWAY)
 
     header = jwt_auth.format_auth_header(

--- a/tests/unit/test_security/test_jwt/test_token.py
+++ b/tests/unit/test_security/test_jwt/test_token.py
@@ -6,7 +6,7 @@ import sys
 from collections.abc import Sequence
 from dataclasses import asdict
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, Final
 from uuid import uuid4
 
 import jwt
@@ -17,6 +17,8 @@ from hypothesis.strategies import datetimes
 from litestar.exceptions import ImproperlyConfiguredException, NotAuthorizedException
 from litestar.security.jwt import Token
 from litestar.security.jwt.token import JWTDecodeOptions
+
+_LEEWAY: Final = 2
 
 
 @pytest.mark.parametrize("algorithm", ["HS256", "HS384", "HS512"])
@@ -289,6 +291,7 @@ def test_custom_decode_payload() -> None:
             issuer: str | Sequence[str] | None = None,
             audience: str | Sequence[str] | None = None,
             options: JWTDecodeOptions | None = None,
+            leeway: int = 0,
         ) -> Any:
             payload = super().decode_payload(
                 encoded_token=encoded_token,
@@ -332,3 +335,43 @@ def test_token_issuer(issuer: str | list[str] | None) -> None:
     )
 
     assert token.iss == iss
+
+
+def test_leeway() -> None:
+    token_secret = secrets.token_hex()
+    raw_token = {
+        "sub": secrets.token_hex(),
+        "iat": (datetime.now(UTC) - timedelta(seconds=30)),
+        "exp": (datetime.now(UTC) - timedelta(seconds=1)),
+    }
+    encoded_token = jwt.encode(payload=raw_token, key=token_secret, algorithm="HS256")
+    token = Token.decode(encoded_token=encoded_token, secret=token_secret, algorithm="HS256", leeway=_LEEWAY)
+    assert token.sub == raw_token["sub"]
+    assert token.extras == {}
+
+    with pytest.raises(NotAuthorizedException):
+        Token.decode(encoded_token=encoded_token, secret=token_secret, algorithm="HS256")
+
+
+@pytest.mark.parametrize(
+    "reserved_claim",
+    [
+        pytest.param({"__leeway__": 9999}, id="claim"),
+        pytest.param({"extras": {"__leeway__": 9999}}, id="extras"),
+    ],
+)
+def test_leeway_with_extras(reserved_claim: dict[str, Any]) -> None:
+    token_secret = secrets.token_hex()
+    raw_token = {
+        "sub": secrets.token_hex(),
+        "iat": (datetime.now(UTC) - timedelta(seconds=30)),
+        "exp": (datetime.now(UTC) + timedelta(seconds=30)),
+        **reserved_claim,
+    }
+    encoded_token = jwt.encode(payload=raw_token, key=token_secret, algorithm="HS256")
+
+    with pytest.raises(NotAuthorizedException) as exc_info:
+        Token.decode(encoded_token=encoded_token, secret=token_secret, algorithm="HS256", leeway=_LEEWAY)
+
+    assert isinstance(exc_info.value.__cause__, ImproperlyConfiguredException)
+    assert "is a reserved key" in str(exc_info.value.__cause__)

--- a/tests/unit/test_security/test_jwt/test_token.py
+++ b/tests/unit/test_security/test_jwt/test_token.py
@@ -337,12 +337,28 @@ def test_token_issuer(issuer: str | list[str] | None) -> None:
     assert token.iss == iss
 
 
-def test_leeway() -> None:
+def test_leeway_exp() -> None:
     token_secret = secrets.token_hex()
     raw_token = {
         "sub": secrets.token_hex(),
         "iat": (datetime.now(UTC) - timedelta(seconds=30)),
         "exp": (datetime.now(UTC) - timedelta(seconds=1)),
+    }
+    encoded_token = jwt.encode(payload=raw_token, key=token_secret, algorithm="HS256")
+    token = Token.decode(encoded_token=encoded_token, secret=token_secret, algorithm="HS256", leeway=_LEEWAY)
+    assert token.sub == raw_token["sub"]
+    assert token.extras == {}
+
+    with pytest.raises(NotAuthorizedException):
+        Token.decode(encoded_token=encoded_token, secret=token_secret, algorithm="HS256")
+
+
+def test_leeway_iat() -> None:
+    token_secret = secrets.token_hex()
+    raw_token = {
+        "sub": secrets.token_hex(),
+        "iat": (datetime.now(UTC) + timedelta(seconds=1)),
+        "exp": (datetime.now(UTC) + timedelta(seconds=30)),
     }
     encoded_token = jwt.encode(payload=raw_token, key=token_secret, algorithm="HS256")
     token = Token.decode(encoded_token=encoded_token, secret=token_secret, algorithm="HS256", leeway=_LEEWAY)

--- a/tests/unit/test_security/test_jwt/test_token.py
+++ b/tests/unit/test_security/test_jwt/test_token.py
@@ -391,3 +391,18 @@ def test_leeway_with_extras(reserved_claim: dict[str, Any]) -> None:
 
     assert isinstance(exc_info.value.__cause__, ImproperlyConfiguredException)
     assert "is a reserved key" in str(exc_info.value.__cause__)
+
+
+def test_leeway_is_not_encoded_into_extras() -> None:
+    token_secret = secrets.token_hex()
+    token = Token(
+        sub=secrets.token_hex(),
+        exp=(datetime.now(UTC) + timedelta(seconds=30)),
+        extras={"__leeway__": _LEEWAY},
+    )
+    assert token.extras == {}
+
+    encoded_token = token.encode(token_secret, "HS256")
+    payload = jwt.decode(encoded_token, token_secret, algorithms=["HS256"])
+    assert "__leeway__" not in payload.get("extras", {})
+    assert Token.decode(encoded_token=encoded_token, secret=token_secret, algorithm="HS256").extras == {}


### PR DESCRIPTION
## Description

Add `leeway` parameter support to set allowed clock error margin in second for token validation.
I mirrored `jwt.decode` logic so `leeway` parameter also respected by `iat` checks, not only `exp`.

### Why changes are breaking

Because of I added `leeway` parameter in `decode` and `decode_payload` methods' signatures, users who redefined either method in their code should add this parameter in signature, otherwise they will get TypeError. 

Closes #4584 

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5037">https://litestar-org.github.io/litestar-docs-preview/5037</a> 
