### PR TITLE
perf: use frozenset field lookups in logging data extraction

### DIFF
--- a/litestar/data_extractors.py
+++ b/litestar/data_extractors.py
@@ -165,6 +165,8 @@ class ConnectionDataExtractor:
     async def extract(
         self, connection: ASGIConnection[Any, Any, Any, Any], fields: Iterable[str]
     ) -> ExtractedRequestData:
+        if not isinstance(fields, (set, frozenset)):
+            fields = frozenset(fields)
         extractors = (
             {**self.connection_extractors, **self.request_extractors}  # type: ignore[misc]
             if isinstance(connection, Request)

--- a/litestar/middleware/logging.py
+++ b/litestar/middleware/logging.py
@@ -80,6 +80,7 @@ class LoggingMiddleware(ASGIMiddleware):
         self.request_log_message = request_log_message
         self.response_log_message = response_log_message
         self.request_log_fields = request_log_fields
+        self._request_log_fields_set = frozenset(request_log_fields)
         self.response_log_fields = response_log_fields
         self.log_structured = log_structured
 
@@ -200,7 +201,7 @@ class LoggingMiddleware(ASGIMiddleware):
         data: dict[str, Any] = {"message": self.request_log_message}
         serializer = get_serializer_from_scope(request.scope)
 
-        extracted_data = await self.request_extractor.extract(connection=request, fields=self.request_log_fields)
+        extracted_data = await self.request_extractor.extract(connection=request, fields=self._request_log_fields_set)
 
         for key in self.request_log_fields:
             data[key] = self._serialize_value(serializer, extracted_data.get(key))


### PR DESCRIPTION
LoggingMiddleware precomputes ``request_log_fields`` as a frozenset at ``__init__`` and passes it per request instead of scanning a ``tuple``.

Small performance gain and no API change

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5038">https://litestar-org.github.io/litestar-docs-preview/5038</a> 
