### PR TITLE
perf: use frozenset for sequence query parameter names

### DIFF
--- a/litestar/_kwargs/extractors.py
+++ b/litestar/_kwargs/extractors.py
@@ -126,7 +126,7 @@ def create_connection_value_extractor(
 
 @lru_cache(1024)
 def create_query_default_dict(
-    parsed_query: tuple[tuple[str, str], ...], sequence_query_parameter_names: tuple[str, ...]
+    parsed_query: tuple[tuple[str, str], ...], sequence_query_parameter_names: frozenset[str]
 ) -> defaultdict[str, list[str] | str]:
     """Transform a list of tuples into a default dict. Ensures non-list values are not wrapped in a list.
 

--- a/litestar/_kwargs/kwargs_model.py
+++ b/litestar/_kwargs/kwargs_model.py
@@ -129,7 +129,7 @@ class KwargsModel:
         self.expected_query_params = expected_query_params
         self.expected_reserved_kwargs = expected_reserved_kwargs
         self.expected_data_dto = expected_data_dto
-        self.sequence_query_parameter_names = tuple(sequence_query_parameter_names)
+        self.sequence_query_parameter_names = frozenset(sequence_query_parameter_names)
 
         self.has_kwargs = (
             expected_cookie_params


### PR DESCRIPTION
Instead of using a ``tuple`` to store ``sequence_query_parameter_names`` in KwargsModel.
Replaced it by a ``frozenset``
The previous use of ``tuple``did not held any duplicates so it does not change the behavior

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5039">https://litestar-org.github.io/litestar-docs-preview/5039</a> 
