### PR TITLE
perf: change how the deprecated resolves per request

### DIFF
--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -720,7 +720,7 @@ class HTTPRouteHandler(BaseRouteHandler):
         response_data: Any = None
         parameter_model = self._get_kwargs_model_for_route(request.scope["path_params"].keys())
 
-        if before_request_handler := self.resolve_before_request():
+        if before_request_handler := self.before_request:
             response_data = await before_request_handler(request)
 
         # create and enter an AsyncExit stack as we may or may not have a

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -99,6 +99,7 @@ class HTTPRouteHandler(BaseRouteHandler):
         "_kwargs_models",
         "_request_class",
         "_request_max_body_size",
+        "_resolved_before_request",
         "_response_class",
         "_response_type_handler",
         "_sync_to_thread",
@@ -305,6 +306,11 @@ class HTTPRouteHandler(BaseRouteHandler):
         self.background = background
         self.before_request: AsyncBeforeRequestHookHandler | None = (
             ensure_async_callable(before_request) if before_request else None
+        )
+        self._resolved_before_request: AsyncAnyCallable | None = (
+            self.resolve_before_request()
+            if type(self).resolve_before_request is not HTTPRouteHandler.resolve_before_request
+            else self.before_request
         )
         self.cache = cache
         self.cache_control = cache_control
@@ -720,7 +726,7 @@ class HTTPRouteHandler(BaseRouteHandler):
         response_data: Any = None
         parameter_model = self._get_kwargs_model_for_route(request.scope["path_params"].keys())
 
-        if before_request_handler := self.before_request:
+        if before_request_handler := self._resolved_before_request:
             response_data = await before_request_handler(request)
 
         # create and enter an AsyncExit stack as we may or may not have a

--- a/litestar/handlers/http_handlers/base.py
+++ b/litestar/handlers/http_handlers/base.py
@@ -307,11 +307,7 @@ class HTTPRouteHandler(BaseRouteHandler):
         self.before_request: AsyncBeforeRequestHookHandler | None = (
             ensure_async_callable(before_request) if before_request else None
         )
-        self._resolved_before_request: AsyncAnyCallable | None = (
-            self.resolve_before_request()
-            if type(self).resolve_before_request is not HTTPRouteHandler.resolve_before_request
-            else self.before_request
-        )
+        self._resolved_before_request: AsyncAnyCallable | None = self.before_request
         self.cache = cache
         self.cache_control = cache_control
         self.cache_key_builder = cache_key_builder
@@ -541,6 +537,9 @@ class HTTPRouteHandler(BaseRouteHandler):
 
     def on_registration(self, route: BaseRoute, app: Litestar) -> None:
         super().on_registration(route=route, app=app)
+
+        if type(self).resolve_before_request is not HTTPRouteHandler.resolve_before_request:
+            self._resolved_before_request = self.resolve_before_request()
 
         if self._request_max_body_size is Empty:
             raise ImproperlyConfiguredException(

--- a/tests/unit/test_handlers/test_http_handlers/test_resolution.py
+++ b/tests/unit/test_handlers/test_http_handlers/test_resolution.py
@@ -5,7 +5,9 @@ import pytest
 from litestar import Controller, Litestar, Request, Response, Router, get, post
 from litestar.datastructures import ResponseHeader
 from litestar.exceptions import ImproperlyConfiguredException
-from litestar.types import Empty
+from litestar.handlers import HTTPRouteHandler
+from litestar.testing import create_test_client
+from litestar.types import AsyncAnyCallable, Empty
 
 
 def test_resolve_request_max_body_size() -> None:
@@ -105,6 +107,22 @@ def test_resolve_before_request() -> None:
     app = Litestar(route_handlers=[handler])
     resolved_handler = app.route_handler_method_map["/"]["GET"]
     assert resolved_handler.resolve_before_request() is resolved_handler.before_request  # type: ignore[attr-defined]
+
+
+def test_overridden_resolve_before_request_is_used() -> None:
+    async def overriding_hook(request: Request) -> dict:
+        return {"from": "override"}
+
+    class CustomHandler(HTTPRouteHandler):
+        def resolve_before_request(self) -> AsyncAnyCallable | None:
+            return overriding_hook
+
+    @get("/", handler_class=CustomHandler)
+    async def handler() -> dict:
+        return {"from": "handler"}
+
+    with create_test_client(route_handlers=[handler]) as client:
+        assert client.get("/").json() == {"from": "override"}
 
 
 def test_resolve_after_response() -> None:


### PR DESCRIPTION
Currently ``_call_handler_function`` call the ``@litestar_deprecated`` on every request, paying a little cost and emitting a unwanted ``DeprecationWarning`` from internal code. Switeched to ``before_request`` attribute directly. The deprecation still fires for user code calling the method explicitly.

Important to note, there is no test for that and in ``pyproject.toml``, we mark that so I am not sure how to add a test for that https://github.com/litestar-org/litestar/blob/cbc0c51abd59b11e7b429be0aba6639e38488e2c/pyproject.toml#L227

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5040">https://litestar-org.github.io/litestar-docs-preview/5040</a> 
