### PR TITLE
fix(jwt): removed duplicated jwt token validation

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -6,6 +6,22 @@
 .. changelog:: 3.0.0
     :date: 2364-01-27
 
+    .. change:: Remove duplicated JWT token validation
+        :type: bugfix
+        :pr: tbd
+        :breaking:
+
+        ``Token.__post_init__`` checked ``exp`` and ``iat`` a second time, after PyJWT
+        had already checked them while decoding.
+
+        Incoming tokens are now checked by PyJWT only. The check that a new token is not
+        already expired moved to ``Token.validate_issued_claims``, which is called by
+        ``Token.encode``.
+
+        ``Token(sub=..., exp=<in the past>)`` no longer raises an error when it is
+        created - it raises from ``encode()`` instead. Token subclasses that override
+        ``__post_init__`` to issue such tokens must now override ``validate_issued_claims``.
+
     .. change:: Add support for ``leeway`` parameter in JWT security backends
         :type: feature
         :pr: 5037

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -8,7 +8,7 @@
 
     .. change:: Remove duplicated JWT token validation
         :type: bugfix
-        :pr: tbd
+        :pr: 5044
         :breaking:
 
         ``Token.__post_init__`` checked ``exp`` and ``iat`` a second time, after PyJWT

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -14,13 +14,20 @@
         ``Token.__post_init__`` checked ``exp`` and ``iat`` a second time, after PyJWT
         had already checked them while decoding.
 
-        Incoming tokens are now checked by PyJWT only. The check that a new token is not
-        already expired moved to ``Token.validate_issued_claims``, which is called by
-        ``Token.encode``.
+        Incoming tokens are now checked by PyJWT. The checks that a new token is not
+        already expired, and was not issued in the future, moved to ``Token.validate_issued_claims``,
+        which is called by ``Token.encode``.
 
-        ``Token(sub=..., exp=<in the past>)`` no longer raises an error when it is
-        created - it raises from ``encode()`` instead. Token subclasses that override
-        ``__post_init__`` to issue such tokens must now override ``validate_issued_claims``.
+        ``Token(sub=..., exp=<in the past>)`` no longer raises an error when it is created - it
+        raises from ``encode()`` instead. The same is true of ``Token(sub=..., iat=<in the future>)``.
+        Token subclasses that override ``__post_init__`` to issue such tokens must now override
+        ``validate_issued_claims``.
+
+        These changes also fix the ``verify_expiry`` parameter.
+
+        If you override ``Token.decode_payload``, your override is now responsible for the ``exp``,
+        ``iat`` and ``nbf`` claims. Before, ``__post_init__`` caught an expired token even if the
+        override did not.
 
     .. change:: Add support for ``leeway`` parameter in JWT security backends
         :type: feature

--- a/litestar/security/jwt/token.py
+++ b/litestar/security/jwt/token.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import dataclasses
 from collections.abc import Sequence  # noqa: TC003
 from dataclasses import asdict, dataclass, field
-from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any, Final, TypedDict
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import jwt
 import msgspec
@@ -18,8 +18,6 @@ __all__ = (
     "JWTDecodeOptions",
     "Token",
 )
-
-_LEEWAY_EXTRA_KEY: Final = "__leeway__"
 
 
 def _normalize_datetime(value: datetime) -> datetime:
@@ -68,26 +66,24 @@ class Token:
     """Extra fields that were found on the JWT token."""
 
     def __post_init__(self) -> None:
-        leeway = self.extras.pop(_LEEWAY_EXTRA_KEY, 0)
-
         if len(self.sub) < 1:
             raise ImproperlyConfiguredException("sub must be a string with a length greater than 0")
 
-        if isinstance(self.exp, datetime) and (
-            ((exp := _normalize_datetime(self.exp)) + timedelta(seconds=leeway)).timestamp()
-            >= _normalize_datetime(datetime.now(UTC)).timestamp()
-        ):
-            self.exp = exp
-        else:
-            raise ImproperlyConfiguredException(f"exp value must be a datetime in the future, leeway is {leeway}")
+        if not isinstance(self.exp, datetime):
+            raise ImproperlyConfiguredException("exp must be a datetime instance")
+        if not isinstance(self.iat, datetime):
+            raise ImproperlyConfiguredException("iat must be a datetime instance")
 
-        if isinstance(self.iat, datetime) and (
-            ((iat := _normalize_datetime(self.iat)) - timedelta(seconds=leeway)).timestamp()
-            <= _normalize_datetime(datetime.now(UTC)).timestamp()
-        ):
-            self.iat = iat
-        else:
-            raise ImproperlyConfiguredException(f"iat must be a current or past time, leeway is {leeway}")
+        self.exp = _normalize_datetime(self.exp)
+        self.iat = _normalize_datetime(self.iat)
+
+    def validate_issued_claims(self) -> None:
+        """Verify token is fit to be issued."""
+        now = _normalize_datetime(datetime.now(UTC)).timestamp()
+        if isinstance(self.exp, datetime) and self.exp.timestamp() < now:
+            raise ImproperlyConfiguredException("exp value must be a datetime in the future")
+        if isinstance(self.iat, datetime) and self.iat.timestamp() > now:
+            raise ImproperlyConfiguredException("iat must be a current or past time")
 
     @classmethod
     def decode_payload(
@@ -194,11 +190,6 @@ class Token:
             extras = payload.setdefault("extras", {})
             for key in extra_fields:
                 extras[key] = payload.pop(key)
-
-            if _LEEWAY_EXTRA_KEY in extras:
-                raise ImproperlyConfiguredException(f"{_LEEWAY_EXTRA_KEY} is a reserved key and cannot be set")
-
-            extras[_LEEWAY_EXTRA_KEY] = leeway
             return msgspec.convert(payload, cls, strict=False)
         except (
             KeyError,
@@ -240,8 +231,10 @@ class Token:
             An encoded token string.
 
         Raises:
-            ImproperlyConfiguredException: If encoding fails.
+            ImproperlyConfiguredException: If the token is not fit to be issued, or if
+                encoding fails.
         """
+        self.validate_issued_claims()
         try:
             return jwt.encode(
                 payload={k: v for k, v in asdict(self).items() if v is not None},

--- a/tests/unit/test_security/test_jwt/test_auth.py
+++ b/tests/unit/test_security/test_jwt/test_auth.py
@@ -842,10 +842,10 @@ async def test_jwt_auth_require_claims(
 @pytest.mark.parametrize(
     "token_expiration, verify_expiry, expected_status_code",
     [
-        pytest.param((datetime.now(tz=UTC) + timedelta(days=1)).timestamp(), True, 200, id="valid-verify"),
-        pytest.param((datetime.now(tz=UTC) + timedelta(days=1)).timestamp(), False, 200, id="valid-no_verify"),
-        pytest.param((datetime.now(tz=UTC) - timedelta(days=1)).timestamp(), False, 200, id="invalid-no_verify"),
-        pytest.param((datetime.now(tz=UTC) - timedelta(days=1)).timestamp(), True, 401, id="invalid-verify"),
+        pytest.param(datetime.now(tz=UTC) + timedelta(days=1), True, 200, id="valid-verify"),
+        pytest.param(datetime.now(tz=UTC) + timedelta(days=1), False, 200, id="valid-no_verify"),
+        pytest.param(datetime.now(tz=UTC) - timedelta(days=1), False, 200, id="invalid-no_verify"),
+        pytest.param(datetime.now(tz=UTC) - timedelta(days=1), True, 401, id="invalid-verify"),
     ],
 )
 async def test_jwt_auth_verify_exp(
@@ -856,10 +856,10 @@ async def test_jwt_auth_verify_exp(
 ) -> None:
     @dataclasses.dataclass
     class CustomToken(Token):
-        def __post_init__(self) -> None:
+        def validate_issued_claims(self) -> None:
             pass
 
-    jwt_auth, client = create_jwt_app(verify_expiry=verify_expiry, token_cls=CustomToken)
+    jwt_auth, client = create_jwt_app(verify_expiry=verify_expiry)
 
     header = jwt_auth.format_auth_header(
         CustomToken(

--- a/tests/unit/test_security/test_jwt/test_token.py
+++ b/tests/unit/test_security/test_jwt/test_token.py
@@ -105,12 +105,10 @@ def test_exp_validation(exp: datetime) -> None:
         # this does not work on windows. see https://bugs.python.org/issue29097
         pytest.skip("Skipping because .timestamp is weird on windows sometimes")
 
+    token = Token(sub="123", exp=exp, iat=(datetime.now() - timedelta(seconds=30)))
+
     with pytest.raises(ImproperlyConfiguredException):
-        Token(
-            sub="123",
-            exp=exp,
-            iat=(datetime.now() - timedelta(seconds=30)),
-        ).encode(secret=secrets.token_hex(), algorithm="HS256")
+        token.encode(secret=secrets.token_hex(), algorithm="HS256")
 
 
 @given(iat=datetimes(min_value=datetime.now() + timedelta(days=1)))
@@ -119,12 +117,10 @@ def test_iat_validation(iat: datetime) -> None:
         # this does not work on windows. see https://bugs.python.org/issue29097
         pytest.skip("Skipping because .timestamp is weird on windows sometimes")
 
+    token = Token(sub="123", iat=iat, exp=(iat + timedelta(seconds=120)))
+
     with pytest.raises(ImproperlyConfiguredException):
-        Token(
-            sub="123",
-            iat=iat,
-            exp=(iat + timedelta(seconds=120)),
-        ).encode(secret=secrets.token_hex(), algorithm="HS256")
+        token.encode(secret=secrets.token_hex(), algorithm="HS256")
 
 
 def test_sub_validation() -> None:
@@ -382,3 +378,20 @@ def test_verify_exp() -> None:
 
     with pytest.raises(NotAuthorizedException):
         Token.decode(encoded_token=encoded_token, secret=token_secret, algorithm="HS256")
+
+
+def test_datetime_claim_type_validation() -> None:
+    now = datetime.now()
+
+    with pytest.raises(ImproperlyConfiguredException, match="exp must be a datetime instance"):
+        Token(
+            sub="123",
+            exp=(now + timedelta(seconds=120)).timestamp(),  # type: ignore[arg-type]
+        )
+
+    with pytest.raises(ImproperlyConfiguredException, match="iat must be a datetime instance"):
+        Token(
+            sub="123",
+            exp=(now + timedelta(seconds=120)),
+            iat=(now - timedelta(seconds=30)).timestamp(),  # type: ignore[arg-type]
+        )

--- a/tests/unit/test_security/test_jwt/test_token.py
+++ b/tests/unit/test_security/test_jwt/test_token.py
@@ -110,7 +110,7 @@ def test_exp_validation(exp: datetime) -> None:
             sub="123",
             exp=exp,
             iat=(datetime.now() - timedelta(seconds=30)),
-        )
+        ).encode(secret=secrets.token_hex(), algorithm="HS256")
 
 
 @given(iat=datetimes(min_value=datetime.now() + timedelta(days=1)))
@@ -124,7 +124,7 @@ def test_iat_validation(iat: datetime) -> None:
             sub="123",
             iat=iat,
             exp=(iat + timedelta(seconds=120)),
-        )
+        ).encode(secret=secrets.token_hex(), algorithm="HS256")
 
 
 def test_sub_validation() -> None:
@@ -369,40 +369,16 @@ def test_leeway_iat() -> None:
         Token.decode(encoded_token=encoded_token, secret=token_secret, algorithm="HS256")
 
 
-@pytest.mark.parametrize(
-    "reserved_claim",
-    [
-        pytest.param({"__leeway__": 9999}, id="claim"),
-        pytest.param({"extras": {"__leeway__": 9999}}, id="extras"),
-    ],
-)
-def test_leeway_with_extras(reserved_claim: dict[str, Any]) -> None:
+def test_verify_exp() -> None:
     token_secret = secrets.token_hex()
     raw_token = {
         "sub": secrets.token_hex(),
         "iat": (datetime.now(UTC) - timedelta(seconds=30)),
-        "exp": (datetime.now(UTC) + timedelta(seconds=30)),
-        **reserved_claim,
+        "exp": (datetime.now(UTC) - timedelta(seconds=30)),
     }
     encoded_token = jwt.encode(payload=raw_token, key=token_secret, algorithm="HS256")
+    token = Token.decode(encoded_token=encoded_token, secret=token_secret, algorithm="HS256", verify_exp=False)
+    assert token.sub == raw_token["sub"]
 
-    with pytest.raises(NotAuthorizedException) as exc_info:
-        Token.decode(encoded_token=encoded_token, secret=token_secret, algorithm="HS256", leeway=_LEEWAY)
-
-    assert isinstance(exc_info.value.__cause__, ImproperlyConfiguredException)
-    assert "is a reserved key" in str(exc_info.value.__cause__)
-
-
-def test_leeway_is_not_encoded_into_extras() -> None:
-    token_secret = secrets.token_hex()
-    token = Token(
-        sub=secrets.token_hex(),
-        exp=(datetime.now(UTC) + timedelta(seconds=30)),
-        extras={"__leeway__": _LEEWAY},
-    )
-    assert token.extras == {}
-
-    encoded_token = token.encode(token_secret, "HS256")
-    payload = jwt.decode(encoded_token, token_secret, algorithms=["HS256"])
-    assert "__leeway__" not in payload.get("extras", {})
-    assert Token.decode(encoded_token=encoded_token, secret=token_secret, algorithm="HS256").extras == {}
+    with pytest.raises(NotAuthorizedException):
+        Token.decode(encoded_token=encoded_token, secret=token_secret, algorithm="HS256")


### PR DESCRIPTION
## Description

The project has had a bug about validating `Token`'s `exp` and `iat` parameters twice. The first one inside PyJWT while decoding, and once again in `Token.__post_init__` method. So because of that there was the workarounds like `__leeway__` reserved key in `Token.extras`. And didn't correctly working `verify_expiry` parameter in `False` state.

## What I do

I moved these checks from `Token.__post_init__` into a new `Token.validate_issued_claims` method, which `Token.encode` calls.  The workaround with the `leeway` parameter is gone as well.

<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5044">https://litestar-org.github.io/litestar-docs-preview/5044</a> 
