### PR TITLE
docs: restore SQLAlchemy offset pagination example

### DIFF
--- a/docs/examples/pagination/using_offset_pagination_with_sqlalchemy.py
+++ b/docs/examples/pagination/using_offset_pagination_with_sqlalchemy.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,11 +14,17 @@ from litestar.params import FromQuery
 class Base(DeclarativeBase): ...
 
 
-class Person(Base):
+class PersonModel(Base):
     __tablename__ = "person"
 
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str]
+
+
+@dataclasses.dataclass
+class Person:
+    id: int
+    name: str
 
 
 # the paginator implements the same two methods as the in-memory example, but each one is
@@ -28,12 +36,12 @@ class PersonOffsetPaginator(AbstractAsyncOffsetPaginator[Person]):
         self.db_session = db_session
 
     async def get_total(self) -> int:
-        total = await self.db_session.scalar(select(func.count()).select_from(Person))
+        total = await self.db_session.scalar(select(func.count()).select_from(PersonModel))
         return total or 0
 
     async def get_items(self, limit: int, offset: int) -> list[Person]:
-        people = await self.db_session.scalars(select(Person).limit(limit).offset(offset))
-        return list(people)
+        people = await self.db_session.scalars(select(PersonModel).limit(limit).offset(offset))
+        return [Person(id=person.id, name=person.name) for person in people]
 
 
 # the paginator is provided as a dependency so that Litestar injects the request-scoped
@@ -55,7 +63,7 @@ sqlalchemy_config = SQLAlchemyAsyncConfig(
 async def on_startup() -> None:
     """Populate the in-memory database so the example returns data."""
     async with sqlalchemy_config.create_session_maker()() as db_session:
-        db_session.add_all([Person(name=f"Person {i}") for i in range(1, 51)])
+        db_session.add_all([PersonModel(name=f"Person {i}") for i in range(1, 51)])
         await db_session.commit()
 
 

--- a/docs/examples/pagination/using_offset_pagination_with_sqlalchemy.py
+++ b/docs/examples/pagination/using_offset_pagination_with_sqlalchemy.py
@@ -1,0 +1,66 @@
+from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from litestar import Litestar, get
+from litestar.di import NamedDependency, Provide
+from litestar.pagination import AbstractAsyncOffsetPaginator, OffsetPagination
+from litestar.params import FromQuery
+
+
+class Base(DeclarativeBase): ...
+
+
+class Person(Base):
+    __tablename__ = "person"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str]
+
+
+# the paginator implements the same two methods as the in-memory example, but each one is
+# now a coroutine that queries the database through an injected SQLAlchemy session.
+
+
+class PersonOffsetPaginator(AbstractAsyncOffsetPaginator[Person]):
+    def __init__(self, db_session: NamedDependency[AsyncSession]) -> None:
+        self.db_session = db_session
+
+    async def get_total(self) -> int:
+        total = await self.db_session.scalar(select(func.count()).select_from(Person))
+        return total or 0
+
+    async def get_items(self, limit: int, offset: int) -> list[Person]:
+        people = await self.db_session.scalars(select(Person).limit(limit).offset(offset))
+        return list(people)
+
+
+# the paginator is provided as a dependency so that Litestar injects the request-scoped
+# session into it. A class is always a synchronous callable, hence 'sync_to_thread=False'.
+@get("/people", dependencies={"paginator": Provide(PersonOffsetPaginator, sync_to_thread=False)})
+async def people_handler(
+    paginator: NamedDependency[PersonOffsetPaginator], limit: FromQuery[int], offset: FromQuery[int]
+) -> OffsetPagination[Person]:
+    return await paginator(limit=limit, offset=offset)
+
+
+sqlalchemy_config = SQLAlchemyAsyncConfig(
+    connection_string="sqlite+aiosqlite:///:memory:",
+    metadata=Base.metadata,
+    create_all=True,
+)
+
+
+async def on_startup() -> None:
+    """Populate the in-memory database so the example returns data."""
+    async with sqlalchemy_config.create_session_maker()() as db_session:
+        db_session.add_all([Person(name=f"Person {i}") for i in range(1, 51)])
+        await db_session.commit()
+
+
+app = Litestar(
+    route_handlers=[people_handler],
+    plugins=[SQLAlchemyPlugin(config=sqlalchemy_config)],
+    on_startup=[on_startup],
+)

--- a/docs/usage/responses.rst
+++ b/docs/usage/responses.rst
@@ -894,6 +894,10 @@ Offset Pagination With SQLAlchemy
 When retrieving paginated data from the database using SQLAlchemy, the Paginator instance requires an SQLAlchemy session
 instance to make queries. This can be achieved with :doc:`/usage/dependency-injection`
 
+.. literalinclude:: /examples/pagination/using_offset_pagination_with_sqlalchemy.py
+    :caption: Offset Pagination with SQLAlchemy
+    :language: python
+
 
 Cursor Pagination
 +++++++++++++++++

--- a/tests/examples/test_pagination/test_using_offset_pagination_with_sqlalchemy.py
+++ b/tests/examples/test_pagination/test_using_offset_pagination_with_sqlalchemy.py
@@ -1,0 +1,19 @@
+import pytest
+from docs.examples.pagination.using_offset_pagination_with_sqlalchemy import app
+
+from litestar.status_codes import HTTP_200_OK
+from litestar.testing import TestClient
+
+
+# 'advanced_alchemy.extensions.litestar' calls its own deprecated 'set_async_context' from
+# 'provide_session' on every request, which 'filterwarnings = error' would turn into a 500.
+@pytest.mark.filterwarnings("ignore:Call to deprecated function 'set_async_context':DeprecationWarning")
+def test_using_offset_pagination_with_sqlalchemy() -> None:
+    with TestClient(app) as client:
+        response = client.get("/people", params={"limit": 5, "offset": 0})
+        assert response.status_code == HTTP_200_OK
+        response_data = response.json()
+        assert len(response_data["items"]) == 5
+        assert response_data["total"] == 50
+        assert response_data["limit"] == 5
+        assert response_data["offset"] == 0


### PR DESCRIPTION
## Description

The "Offset Pagination With SQLAlchemy" section of `docs/usage/responses.rst` currently has a
heading and one sentence of prose, but no code. The `literalinclude` directive and the example
file it pointed at were dropped during a namespace refactor, so the section says the paginator
needs a session supplied through dependency injection and then shows nothing.

This restores the example:

- **`docs/examples/pagination/using_offset_pagination_with_sqlalchemy.py`** (new) — an in-memory
  async SQLite engine, a declarative `PersonModel` seeded with 50 rows at startup, a
  `PersonOffsetPaginator(AbstractAsyncOffsetPaginator[Person])` that runs a count and a
  `LIMIT`/`OFFSET` select against an injected `AsyncSession`, and a single `GET /people` handler
  returning `OffsetPagination[Person]` over a plain `Person` dataclass.
- **`docs/usage/responses.rst`** — the `literalinclude` under the existing heading, formatted to
  match the neighbouring pagination sections.
- **`tests/examples/test_pagination/test_using_offset_pagination_with_sqlalchemy.py`** (new) —
  drives the app with `TestClient` and asserts the status code, item count, and the
  `total`/`limit`/`offset` fields, mirroring the existing offset pagination test.

Following the guidance in #4141, the example uses the current `SQLAlchemyPlugin` rather than the
deprecated `SQLAlchemyInitPlugin` that caused the original breakage, and supplies the paginator as
`Provide(PersonOffsetPaginator, sync_to_thread=False)` — a class is always a synchronous callable,
so omitting that emits a `LitestarWarning`.

### Why the response model is a dataclass

The example deliberately separates the persistence model (`PersonModel`) from the response model
(`Person`), rather than returning the SQLAlchemy model directly.

Returning the declarative model makes Litestar resolve a DTO for the handler. DTO backends are
kept in a process-global `ClassVar` registry keyed by `handler_id`, which is
`f"{self!s}::{id(self)}"` — it embeds the handler's memory address. With a module-level `app`, as
every docs example uses, that lookup can miss once other tests have run in the same xdist worker,
and the request fails with:

```
KeyError: '...people_handler::4658571296'
  litestar/dto/base_dto.py:126 in data_to_encodable_type
```

This passes when the test runs in isolation and fails under `pytest docs/examples tests -n auto`,
which is what CI runs. Setting `return_dto=SQLAlchemyDTO[Person]` explicitly does not help — the
registration itself is what goes missing. Converting to a dataclass in `get_items` sidesteps the
DTO path entirely and matches how the other pagination examples are written. Worth noting that the
existing `docs/examples/sqla/plugins/sqlalchemy_async_plugin_example.py` also returns a declarative
model and has no test, so nothing currently exercises this path.

Happy to revisit if maintainers would rather the example return the model directly and the
underlying `handler_id` fragility be addressed instead.

### Note for reviewers

The test needs a narrowly scoped `filterwarnings` ignore. `advanced_alchemy`'s `provide_session`
calls advanced-alchemy's own deprecated `set_async_context` on every request, and this repo's
`filterwarnings = ["error"]` turns that into a 500. It is not specific to this example — the same
failure reproduces against the existing `docs/examples/sqla/plugins/sqlalchemy_async_plugin_example.py`
— so the ignore is a workaround for an upstream issue and can be dropped once that is fixed. This
is a separate problem from the DTO one above; both had to be handled.

Two smaller choices, both open to feedback: the injected parameters use `NamedDependency[...]`
because Litestar otherwise emits a deprecation warning asking for them explicitly, and `get_total`
ends with `return total or 0` purely to satisfy `scalar()`'s `Optional[int]` typing.

Closes #4234
Closes #4141


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5046">https://litestar-org.github.io/litestar-docs-preview/5046</a> 
