### PR TITLE
refactor(stores): extract Redis strategy class (part 1 of #4992)

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -6,6 +6,15 @@
 .. changelog:: 3.0.0
     :date: 2364-01-27
 
+    .. change:: Fix ``RedisStore.get`` truncating ``renew_for`` timedeltas of one day or more
+        :type: bugfix
+        :pr: 5053
+
+        :meth:`RedisStore.get <litestar.stores.redis.RedisStore.get>` converted a
+        :class:`~datetime.timedelta` ``renew_for`` value with ``timedelta.seconds``, which drops the
+        ``days`` component. Renewing for ``timedelta(days=1)`` therefore set an expiry of ``0``
+        seconds and deleted the key. The conversion now uses ``timedelta.total_seconds()``.
+
     .. change:: Add support for ``leeway`` parameter in JWT security backends
         :type: feature
         :pr: 5037

--- a/litestar/stores/redis.py
+++ b/litestar/stores/redis.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from datetime import timedelta
 from typing import TYPE_CHECKING, Literal, cast, overload
 
@@ -20,15 +21,115 @@ if TYPE_CHECKING:
 __all__ = ("RedisStore",)
 
 
+# script to get and renew a key in one atomic step
+_GET_AND_RENEW_SCRIPT = b"""
+local key = KEYS[1]
+local renew = tonumber(ARGV[1])
+
+local data = redis.call('GET', key)
+local ttl = redis.call('TTL', key)
+
+if ttl > 0 then
+    redis.call('EXPIRE', key, renew)
+end
+
+return data
+"""
+
+# script to delete all keys in the namespace
+_DELETE_ALL_SCRIPT = b"""
+local cursor = 0
+
+repeat
+    local result = redis.call('SCAN', cursor, 'MATCH', ARGV[1])
+    for _,key in ipairs(result[2]) do
+        redis.call('UNLINK', key)
+    end
+    cursor = tonumber(result[1])
+until cursor == 0
+"""
+
+
+class _RedisStrategy(ABC):
+    """Internal backend performing the actual Redis commands for :class:`RedisStore`."""
+
+    __slots__ = ("_redis", "namespace")
+
+    def __init__(self, redis: Redis, namespace: str | None) -> None:
+        self._redis = redis
+        self.namespace = namespace
+
+    @abstractmethod
+    async def set(self, key: str, value: bytes, expires_in: int | timedelta | None, keep_ttl: bool) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get(self, key: str, renew_for: int | timedelta | None) -> bytes | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def delete(self, key: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def delete_all(self) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def exists(self, key: str) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def expires_in(self, key: str) -> int | None:
+        raise NotImplementedError
+
+
+class _KeysStrategy(_RedisStrategy):
+    """Store each value under its own ``<namespace>:<key>`` Redis key."""
+
+    __slots__ = ("_delete_all_script", "_get_and_renew_script")
+
+    def __init__(self, redis: Redis, namespace: str | None) -> None:
+        super().__init__(redis, namespace)
+        # script to get and renew a key in one atomic step
+        self._get_and_renew_script = redis.register_script(_GET_AND_RENEW_SCRIPT)
+        # script to delete all keys in the namespace
+        self._delete_all_script = redis.register_script(_DELETE_ALL_SCRIPT)
+
+    def _make_key(self, key: str) -> str:
+        prefix = f"{self.namespace}:" if self.namespace else ""
+        return prefix + key
+
+    async def set(self, key: str, value: bytes, expires_in: int | timedelta | None, keep_ttl: bool) -> None:
+        await self._redis.set(self._make_key(key), value, ex=expires_in, keepttl=keep_ttl)
+
+    async def get(self, key: str, renew_for: int | timedelta | None) -> bytes | None:
+        redis_key = self._make_key(key)
+        if renew_for:
+            if isinstance(renew_for, timedelta):
+                renew_for = renew_for.seconds
+            data = await self._get_and_renew_script(keys=[redis_key], args=[renew_for])
+            return cast("bytes | None", data)
+        return await self._redis.get(redis_key)
+
+    async def delete(self, key: str) -> None:
+        await self._redis.delete(self._make_key(key))
+
+    async def delete_all(self) -> None:
+        await self._delete_all_script(keys=[], args=[f"{self.namespace}*:*"])
+
+    async def exists(self, key: str) -> bool:
+        return await self._redis.exists(self._make_key(key)) == 1
+
+    async def expires_in(self, key: str) -> int | None:
+        ttl = await self._redis.ttl(self._make_key(key))
+        return None if ttl == -2 else ttl
+
+
 class RedisStore(NamespacedStore):
     """Redis based, thread and process safe asynchronous key/value store."""
 
-    __slots__ = (
-        "_delete_all_script",
-        "_get_and_renew_script",
-        "_redis",
-        "handle_client_shutdown",
-    )
+    __slots__ = ("_redis", "_strategy", "handle_client_shutdown")
 
     def __init__(
         self, redis: Redis, namespace: str | None | EmptyType = Empty, handle_client_shutdown: bool = False
@@ -46,37 +147,7 @@ class RedisStore(NamespacedStore):
         self.namespace: str | None = value_or_default(namespace, "LITESTAR")
         self.handle_client_shutdown = handle_client_shutdown
 
-        # script to get and renew a key in one atomic step
-        self._get_and_renew_script = self._redis.register_script(
-            b"""
-        local key = KEYS[1]
-        local renew = tonumber(ARGV[1])
-
-        local data = redis.call('GET', key)
-        local ttl = redis.call('TTL', key)
-
-        if ttl > 0 then
-            redis.call('EXPIRE', key, renew)
-        end
-
-        return data
-        """
-        )
-
-        # script to delete all keys in the namespace
-        self._delete_all_script = self._redis.register_script(
-            b"""
-        local cursor = 0
-
-        repeat
-            local result = redis.call('SCAN', cursor, 'MATCH', ARGV[1])
-            for _,key in ipairs(result[2]) do
-                redis.call('UNLINK', key)
-            end
-            cursor = tonumber(result[1])
-        until cursor == 0
-        """
-        )
+        self._strategy: _RedisStrategy = _KeysStrategy(redis, self.namespace)
 
     async def _shutdown(self) -> None:
         if self.handle_client_shutdown:
@@ -136,10 +207,6 @@ class RedisStore(NamespacedStore):
             handle_client_shutdown=self.handle_client_shutdown,
         )
 
-    def _make_key(self, key: str) -> str:
-        prefix = f"{self.namespace}:" if self.namespace else ""
-        return prefix + key
-
     @overload
     async def set(
         self,
@@ -184,7 +251,7 @@ class RedisStore(NamespacedStore):
             raise ValueError("Cannot set both 'expires_in' and 'keep_ttl': these options are mutually exclusive")
         if isinstance(value, str):
             value = value.encode("utf-8")
-        await self._redis.set(self._make_key(key), value, ex=expires_in, keepttl=keep_ttl)
+        await self._strategy.set(key, value, expires_in, keep_ttl)
 
     async def get(self, key: str, renew_for: int | timedelta | None = None) -> bytes | None:
         """Get a value.
@@ -201,13 +268,7 @@ class RedisStore(NamespacedStore):
             The value associated with ``key`` if it exists and is not expired, else
             ``None``
         """
-        key = self._make_key(key)
-        if renew_for:
-            if isinstance(renew_for, timedelta):
-                renew_for = renew_for.seconds
-            data = await self._get_and_renew_script(keys=[key], args=[renew_for])
-            return cast("bytes | None", data)
-        return await self._redis.get(key)
+        return await self._strategy.get(key, renew_for)
 
     async def delete(self, key: str) -> None:
         """Delete a value.
@@ -217,7 +278,7 @@ class RedisStore(NamespacedStore):
         Args:
             key: Key of the value to delete
         """
-        await self._redis.delete(self._make_key(key))
+        await self._strategy.delete(key)
 
     async def delete_all(self) -> None:
         """Delete all stored values in the virtual key namespace.
@@ -228,15 +289,14 @@ class RedisStore(NamespacedStore):
         if not self.namespace:
             raise ImproperlyConfiguredException("Cannot perform delete operation: No namespace configured")
 
-        await self._delete_all_script(keys=[], args=[f"{self.namespace}*:*"])
+        await self._strategy.delete_all()
 
     async def exists(self, key: str) -> bool:
         """Check if a given ``key`` exists."""
-        return await self._redis.exists(self._make_key(key)) == 1
+        return await self._strategy.exists(key)
 
     async def expires_in(self, key: str) -> int | None:
         """Get the time in seconds ``key`` expires in. If no such ``key`` exists or no
         expiry time was set, return ``None``.
         """
-        ttl = await self._redis.ttl(self._make_key(key))
-        return None if ttl == -2 else ttl
+        return await self._strategy.expires_in(key)

--- a/litestar/stores/redis.py
+++ b/litestar/stores/redis.py
@@ -50,6 +50,10 @@ until cursor == 0
 """
 
 
+def _to_seconds(value: int | timedelta) -> int:
+    return int(value.total_seconds()) if isinstance(value, timedelta) else value
+
+
 class _RedisStrategy(ABC):
     """Internal backend performing the actual Redis commands for :class:`RedisStore`."""
 
@@ -106,8 +110,7 @@ class _KeysStrategy(_RedisStrategy):
     async def get(self, key: str, renew_for: int | timedelta | None) -> bytes | None:
         redis_key = self._make_key(key)
         if renew_for:
-            if isinstance(renew_for, timedelta):
-                renew_for = renew_for.seconds
+            renew_for = _to_seconds(renew_for)
             data = await self._get_and_renew_script(keys=[redis_key], args=[renew_for])
             return cast("bytes | None", data)
         return await self._redis.get(redis_key)

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -17,7 +17,7 @@ from time_machine import Traveller
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.stores.file import FileStore
 from litestar.stores.memory import MemoryStore
-from litestar.stores.redis import RedisStore
+from litestar.stores.redis import RedisStore, _KeysStrategy
 from litestar.stores.registry import StoreRegistry
 from litestar.stores.valkey import ValkeyStore
 
@@ -337,7 +337,8 @@ async def test_valkey_delete_all_no_namespace_raises(valkey_client: Valkey) -> N
 @pytest.mark.xdist_group("redis")
 def test_redis_namespaced_key(redis_store: RedisStore) -> None:
     assert redis_store.namespace == "LITESTAR"
-    assert redis_store._make_key("foo") == "LITESTAR:foo"
+    assert isinstance(redis_store._strategy, _KeysStrategy)
+    assert redis_store._strategy._make_key("foo") == "LITESTAR:foo"
 
 
 @pytest.mark.xdist_group("valkey")

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -102,7 +102,7 @@ async def test_get_and_renew(store: Store, renew_for: int | timedelta, frozen_da
 
 
 @pytest.mark.flaky(reruns=5)
-@pytest.mark.parametrize("renew_for", [10, timedelta(seconds=10)])
+@pytest.mark.parametrize("renew_for", [10, timedelta(seconds=10), timedelta(days=1)])
 @pytest.mark.xdist_group("redis")
 async def test_get_and_renew_redis(redis_store: RedisStore, renew_for: int | timedelta) -> None:
     # we can't sleep() in frozen datetime, and frozen datetime doesn't affect the redis


### PR DESCRIPTION
## Description

This pr is part 1 of two parts. The first part refactors to introduce strategy class. The second part will introduce hashkey class and strategy key to redisstore init. That will let consumers control which strategy to use and store cache information.

Related: #4992


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5053">https://litestar-org.github.io/litestar-docs-preview/5053</a> 
