### PR TITLE
feat(stores): add hash-based storage strategy to RedisStore (part 2 of #4992)

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -6,6 +6,15 @@
 .. changelog:: 3.0.0
     :date: 2364-01-27
 
+    .. change:: Fix ``RedisStore.get`` truncating ``renew_for`` timedeltas of one day or more
+        :type: bugfix
+        :pr: 5053
+
+        :meth:`RedisStore.get <litestar.stores.redis.RedisStore.get>` converted a
+        :class:`~datetime.timedelta` ``renew_for`` value with ``timedelta.seconds``, which drops the
+        ``days`` component. Renewing for ``timedelta(days=1)`` therefore set an expiry of ``0``
+        seconds and deleted the key. The conversion now uses ``timedelta.total_seconds()``.
+
     .. change:: Add support for ``leeway`` parameter in JWT security backends
         :type: feature
         :pr: 5037

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -6,6 +6,26 @@
 .. changelog:: 3.0.0
     :date: 2364-01-27
 
+    .. change:: Add hash-based storage strategy to ``RedisStore``
+        :type: feature
+        :pr: 5054
+        :issue: 4992
+        :breaking:
+
+        :class:`~litestar.stores.redis.RedisStore` gained a ``strategy`` parameter.
+        With ``strategy="hash"`` all values of a namespace are stored as fields of a single Redis
+        hash named after the namespace, using per-field expiration (requires Redis 7.4 or newer).
+        ``strategy="keys"`` keeps the previous ``<namespace>:<key>`` layout. ``delete_all`` on a
+        hash namespace unlinks the hash in one operation and only scans for child-namespace
+        hashes instead of every stored key.
+
+        The default (``strategy=None``) detects the server version on first use and selects
+        ``"hash"`` for Redis 7.4 and newer, ``"keys"`` otherwise. Data written in one layout
+        is not visible through the other; pass ``strategy="keys"`` to keep reading existing
+        ``<namespace>:<key>`` data. The ``"hash"`` strategy requires a namespace.
+
+        The minimum supported ``redis`` (redis-py) version is now ``5.0.8``.
+
     .. change:: Fix ``RedisStore.get`` truncating ``renew_for`` timedeltas of one day or more
         :type: bugfix
         :pr: 5053

--- a/docs/usage/stores.rst
+++ b/docs/usage/stores.rst
@@ -179,6 +179,35 @@ Defining stores hierarchically like this still allows to easily clear everything
 :meth:`delete_all <.base.Store.delete_all>` on the root store.
 
 
+Storage layout of the ``RedisStore``
+++++++++++++++++++++++++++++++++++++
+
+:class:`RedisStore <.redis.RedisStore>` supports two storage layouts, controlled by the ``strategy`` parameter.
+With ``strategy="keys"``, every value is stored as its own Redis key, named ``<namespace>:<key>``. With
+``strategy="hash"``, all values within a namespace are stored as fields of a single Redis hash, keyed by the
+namespace itself, using per-field expiration; this requires Redis 7.4 or newer.
+:meth:`RedisStore.delete_all <.redis.RedisStore.delete_all>` on a ``"hash"`` namespace unlinks the namespace hash in
+a single operation and only scans for child-namespace hashes, instead of for every stored key.
+
+By default (``strategy=None``), the layout is chosen automatically: the server version is detected on first use,
+and ``"hash"`` is selected for Redis 7.4 and newer, falling back to ``"keys"`` otherwise. Explicitly passing ``strategy="keys"`` or ``strategy="hash"`` is always honoured as-is. Child stores
+created via :meth:`with_namespace <.redis.RedisStore.with_namespace>` inherit their parent's strategy, and
+``strategy="hash"`` requires a namespace to be set.
+
+.. code-block:: python
+
+    from litestar.stores.redis import RedisStore
+
+    store = RedisStore.with_client(strategy="hash")
+
+.. warning::
+    The ``"keys"`` and ``"hash"`` layouts do not share data; values written under one strategy are not visible
+    through the other. When upgrading a deployment running Redis 7.4 or newer, pass ``strategy="keys"``
+    explicitly to keep reading data written before the upgrade, since the default would otherwise switch to the
+    ``"hash"`` layout. Under the ``"hash"`` layout a whole namespace is a single Redis key, so all of its data
+    lives in one cluster slot and one memory object.
+
+
 Managing stores with the registry
 ---------------------------------
 

--- a/litestar/stores/redis.py
+++ b/litestar/stores/redis.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from datetime import timedelta
 from typing import TYPE_CHECKING, Literal, cast, overload
 
@@ -20,15 +21,115 @@ if TYPE_CHECKING:
 __all__ = ("RedisStore",)
 
 
+# script to get and renew a key in one atomic step
+_GET_AND_RENEW_SCRIPT = b"""
+local key = KEYS[1]
+local renew = tonumber(ARGV[1])
+
+local data = redis.call('GET', key)
+local ttl = redis.call('TTL', key)
+
+if ttl > 0 then
+    redis.call('EXPIRE', key, renew)
+end
+
+return data
+"""
+
+# script to delete all keys in the namespace
+_DELETE_ALL_SCRIPT = b"""
+local cursor = 0
+
+repeat
+    local result = redis.call('SCAN', cursor, 'MATCH', ARGV[1])
+    for _,key in ipairs(result[2]) do
+        redis.call('UNLINK', key)
+    end
+    cursor = tonumber(result[1])
+until cursor == 0
+"""
+
+
+class _RedisStrategy(ABC):
+    """Internal backend performing the actual Redis commands for :class:`RedisStore`."""
+
+    __slots__ = ("_redis", "namespace")
+
+    def __init__(self, redis: Redis, namespace: str | None) -> None:
+        self._redis = redis
+        self.namespace = namespace
+
+    @abstractmethod
+    async def set(self, key: str, value: bytes, expires_in: int | timedelta | None, keep_ttl: bool) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get(self, key: str, renew_for: int | timedelta | None) -> bytes | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def delete(self, key: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def delete_all(self) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def exists(self, key: str) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def expires_in(self, key: str) -> int | None:
+        raise NotImplementedError
+
+
+class _KeysStrategy(_RedisStrategy):
+    """Store each value under its own ``<namespace>:<key>`` Redis key."""
+
+    __slots__ = ("_delete_all_script", "_get_and_renew_script")
+
+    def __init__(self, redis: Redis, namespace: str | None) -> None:
+        super().__init__(redis, namespace)
+        # script to get and renew a key in one atomic step
+        self._get_and_renew_script = redis.register_script(_GET_AND_RENEW_SCRIPT)
+        # script to delete all keys in the namespace
+        self._delete_all_script = redis.register_script(_DELETE_ALL_SCRIPT)
+
+    def _make_key(self, key: str) -> str:
+        prefix = f"{self.namespace}:" if self.namespace else ""
+        return prefix + key
+
+    async def set(self, key: str, value: bytes, expires_in: int | timedelta | None, keep_ttl: bool) -> None:
+        await self._redis.set(self._make_key(key), value, ex=expires_in, keepttl=keep_ttl)
+
+    async def get(self, key: str, renew_for: int | timedelta | None) -> bytes | None:
+        redis_key = self._make_key(key)
+        if renew_for:
+            if isinstance(renew_for, timedelta):
+                renew_for = renew_for.seconds
+            data = await self._get_and_renew_script(keys=[redis_key], args=[renew_for])
+            return cast("bytes | None", data)
+        return await self._redis.get(redis_key)
+
+    async def delete(self, key: str) -> None:
+        await self._redis.delete(self._make_key(key))
+
+    async def delete_all(self) -> None:
+        await self._delete_all_script(keys=[], args=[f"{self.namespace}*:*"])
+
+    async def exists(self, key: str) -> bool:
+        return await self._redis.exists(self._make_key(key)) == 1
+
+    async def expires_in(self, key: str) -> int | None:
+        ttl = await self._redis.ttl(self._make_key(key))
+        return None if ttl == -2 else ttl
+
+
 class RedisStore(NamespacedStore):
     """Redis based, thread and process safe asynchronous key/value store."""
 
-    __slots__ = (
-        "_delete_all_script",
-        "_get_and_renew_script",
-        "_redis",
-        "handle_client_shutdown",
-    )
+    __slots__ = ("_redis", "_strategy", "handle_client_shutdown")
 
     def __init__(
         self, redis: Redis, namespace: str | None | EmptyType = Empty, handle_client_shutdown: bool = False
@@ -46,37 +147,7 @@ class RedisStore(NamespacedStore):
         self.namespace: str | None = value_or_default(namespace, "LITESTAR")
         self.handle_client_shutdown = handle_client_shutdown
 
-        # script to get and renew a key in one atomic step
-        self._get_and_renew_script = self._redis.register_script(
-            b"""
-        local key = KEYS[1]
-        local renew = tonumber(ARGV[1])
-
-        local data = redis.call('GET', key)
-        local ttl = redis.call('TTL', key)
-
-        if ttl > 0 then
-            redis.call('EXPIRE', key, renew)
-        end
-
-        return data
-        """
-        )
-
-        # script to delete all keys in the namespace
-        self._delete_all_script = self._redis.register_script(
-            b"""
-        local cursor = 0
-
-        repeat
-            local result = redis.call('SCAN', cursor, 'MATCH', ARGV[1])
-            for _,key in ipairs(result[2]) do
-                redis.call('UNLINK', key)
-            end
-            cursor = tonumber(result[1])
-        until cursor == 0
-        """
-        )
+        self._strategy: _RedisStrategy = _KeysStrategy(redis, self.namespace)
 
     async def _shutdown(self) -> None:
         if self.handle_client_shutdown:
@@ -136,10 +207,6 @@ class RedisStore(NamespacedStore):
             handle_client_shutdown=self.handle_client_shutdown,
         )
 
-    def _make_key(self, key: str) -> str:
-        prefix = f"{self.namespace}:" if self.namespace else ""
-        return prefix + key
-
     @overload
     async def set(
         self,
@@ -184,7 +251,7 @@ class RedisStore(NamespacedStore):
             raise ValueError("Cannot set both 'expires_in' and 'keep_ttl': these options are mutually exclusive")
         if isinstance(value, str):
             value = value.encode("utf-8")
-        await self._redis.set(self._make_key(key), value, ex=expires_in, keepttl=keep_ttl)
+        await self._strategy.set(key, value, expires_in, keep_ttl)
 
     async def get(self, key: str, renew_for: int | timedelta | None = None) -> bytes | None:
         """Get a value.
@@ -201,13 +268,7 @@ class RedisStore(NamespacedStore):
             The value associated with ``key`` if it exists and is not expired, else
             ``None``
         """
-        key = self._make_key(key)
-        if renew_for:
-            if isinstance(renew_for, timedelta):
-                renew_for = renew_for.seconds
-            data = await self._get_and_renew_script(keys=[key], args=[renew_for])
-            return cast("bytes | None", data)
-        return await self._redis.get(key)
+        return await self._strategy.get(key, renew_for)
 
     async def delete(self, key: str) -> None:
         """Delete a value.
@@ -217,7 +278,7 @@ class RedisStore(NamespacedStore):
         Args:
             key: Key of the value to delete
         """
-        await self._redis.delete(self._make_key(key))
+        await self._strategy.delete(key)
 
     async def delete_all(self) -> None:
         """Delete all stored values in the virtual key namespace.
@@ -228,15 +289,14 @@ class RedisStore(NamespacedStore):
         if not self.namespace:
             raise ImproperlyConfiguredException("Cannot perform delete operation: No namespace configured")
 
-        await self._delete_all_script(keys=[], args=[f"{self.namespace}*:*"])
+        await self._strategy.delete_all()
 
     async def exists(self, key: str) -> bool:
         """Check if a given ``key`` exists."""
-        return await self._redis.exists(self._make_key(key)) == 1
+        return await self._strategy.exists(key)
 
     async def expires_in(self, key: str) -> int | None:
         """Get the time in seconds ``key`` expires in. If no such ``key`` exists or no
         expiry time was set, return ``None``.
         """
-        ttl = await self._redis.ttl(self._make_key(key))
-        return None if ttl == -2 else ttl
+        return await self._strategy.expires_in(key)

--- a/litestar/stores/redis.py
+++ b/litestar/stores/redis.py
@@ -50,6 +50,10 @@ until cursor == 0
 """
 
 
+def _to_seconds(value: int | timedelta) -> int:
+    return int(value.total_seconds()) if isinstance(value, timedelta) else value
+
+
 class _RedisStrategy(ABC):
     """Internal backend performing the actual Redis commands for :class:`RedisStore`."""
 
@@ -106,8 +110,7 @@ class _KeysStrategy(_RedisStrategy):
     async def get(self, key: str, renew_for: int | timedelta | None) -> bytes | None:
         redis_key = self._make_key(key)
         if renew_for:
-            if isinstance(renew_for, timedelta):
-                renew_for = renew_for.seconds
+            renew_for = _to_seconds(renew_for)
             data = await self._get_and_renew_script(keys=[redis_key], args=[renew_for])
             return cast("bytes | None", data)
         return await self._redis.get(redis_key)

--- a/litestar/stores/redis.py
+++ b/litestar/stores/redis.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Literal, cast, overload
 
 from redis.asyncio import Redis
 from redis.asyncio.connection import ConnectionPool
+from redis.exceptions import ResponseError
 
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.types import Empty, EmptyType
@@ -49,19 +50,60 @@ repeat
 until cursor == 0
 """
 
+# script to get and renew a hash field in one atomic step
+_HASH_GET_AND_RENEW_SCRIPT = b"""
+local key = KEYS[1]
+local field = ARGV[1]
+local renew = tonumber(ARGV[2])
+
+local data = redis.call('HGET', key, field)
+local ttl = redis.call('HTTL', key, 'FIELDS', 1, field)[1]
+
+if ttl > 0 then
+    redis.call('HEXPIRE', key, renew, 'FIELDS', 1, field)
+end
+
+return data
+"""
+
+# script to set a hash field and its expiry in one atomic step. HSET discards a field's
+# existing TTL, so the TTL has to be read before and re-applied after the write when it
+# should be kept (ARGV[3] == -1). Unlike the renew script, the expiry is in milliseconds so
+# that sub-second TTLs work
+_HASH_SET_SCRIPT = b"""
+local key = KEYS[1]
+local field = ARGV[1]
+local value = ARGV[2]
+local px = tonumber(ARGV[3])
+
+if px == -1 then
+    px = redis.call('HPTTL', key, 'FIELDS', 1, field)[1]
+    redis.call('HSET', key, field, value)
+    if px > 0 then
+        redis.call('HPEXPIRE', key, px, 'FIELDS', 1, field)
+    end
+else
+    redis.call('HSET', key, field, value)
+    redis.call('HPEXPIRE', key, px, 'FIELDS', 1, field)
+end
+"""
+
 
 def _to_seconds(value: int | timedelta) -> int:
     return int(value.total_seconds()) if isinstance(value, timedelta) else value
 
 
+def _to_milliseconds(value: int | timedelta) -> int:
+    return int(value.total_seconds() * 1000) if isinstance(value, timedelta) else value * 1000
+
+
 class _RedisStrategy(ABC):
     """Internal backend performing the actual Redis commands for :class:`RedisStore`."""
 
-    __slots__ = ("_redis", "namespace")
+    __slots__ = ("_redis",)
 
-    def __init__(self, redis: Redis, namespace: str | None) -> None:
+    def __init__(self, redis: Redis) -> None:
         self._redis = redis
-        self.namespace = namespace
 
     @abstractmethod
     async def set(self, key: str, value: bytes, expires_in: int | timedelta | None, keep_ttl: bool) -> None:
@@ -91,10 +133,11 @@ class _RedisStrategy(ABC):
 class _KeysStrategy(_RedisStrategy):
     """Store each value under its own ``<namespace>:<key>`` Redis key."""
 
-    __slots__ = ("_delete_all_script", "_get_and_renew_script")
+    __slots__ = ("_delete_all_script", "_get_and_renew_script", "namespace")
 
     def __init__(self, redis: Redis, namespace: str | None) -> None:
-        super().__init__(redis, namespace)
+        super().__init__(redis)
+        self.namespace = namespace
         # script to get and renew a key in one atomic step
         self._get_and_renew_script = redis.register_script(_GET_AND_RENEW_SCRIPT)
         # script to delete all keys in the namespace
@@ -129,13 +172,72 @@ class _KeysStrategy(_RedisStrategy):
         return None if ttl == -2 else ttl
 
 
+class _HashStrategy(_RedisStrategy):
+    """Store all values of a namespace as fields of a single Redis hash named after the
+    namespace, using per-field expiration (Redis 7.4+).
+    """
+
+    __slots__ = ("_delete_all_script", "_get_and_renew_script", "_set_script", "namespace")
+
+    def __init__(self, redis: Redis, namespace: str) -> None:
+        super().__init__(redis)
+        self.namespace = namespace
+        # script to get and renew a hash field in one atomic step
+        self._get_and_renew_script = redis.register_script(_HASH_GET_AND_RENEW_SCRIPT)
+        # script to set a hash field and its expiry in one atomic step
+        self._set_script = redis.register_script(_HASH_SET_SCRIPT)
+        # script to delete the hashes of all child namespaces
+        self._delete_all_script = redis.register_script(_DELETE_ALL_SCRIPT)
+
+    async def set(self, key: str, value: bytes, expires_in: int | timedelta | None, keep_ttl: bool) -> None:
+        if keep_ttl:
+            expires_in_ms = -1
+        elif expires_in is not None:
+            expires_in_ms = _to_milliseconds(expires_in)
+            # validate before the script runs: HSET would already have written the value by
+            # the time HPEXPIRE rejects the expiry
+            if expires_in_ms <= 0:
+                raise ValueError("'expires_in' must be a positive duration")
+        else:
+            # HSET discards any TTL on the field, which is what SET does for plain keys too
+            await self._redis.hset(self.namespace, key, value)
+            return
+        await self._set_script(keys=[self.namespace], args=[key, value, expires_in_ms])
+
+    async def get(self, key: str, renew_for: int | timedelta | None) -> bytes | None:
+        if renew_for:
+            data = await self._get_and_renew_script(keys=[self.namespace], args=[key, _to_seconds(renew_for)])
+            return cast("bytes | None", data)
+        return await self._redis.hget(self.namespace, key)
+
+    async def delete(self, key: str) -> None:
+        await self._redis.hdel(self.namespace, key)
+
+    async def delete_all(self) -> None:
+        # the namespace itself is a single hash; child namespaces are separate hashes. Like the
+        # keys layout's pattern, the glob can also match unrelated keys sharing the prefix
+        await self._redis.unlink(self.namespace)
+        await self._delete_all_script(keys=[], args=[f"{self.namespace}_*"])
+
+    async def exists(self, key: str) -> bool:
+        return bool(await self._redis.hexists(self.namespace, key))
+
+    async def expires_in(self, key: str) -> int | None:
+        ttl = (await self._redis.httl(self.namespace, key))[0]  # type: ignore[attr-defined]
+        return None if ttl == -2 else ttl
+
+
 class RedisStore(NamespacedStore):
     """Redis based, thread and process safe asynchronous key/value store."""
 
-    __slots__ = ("_redis", "_strategy", "handle_client_shutdown")
+    __slots__ = ("_redis", "_strategy", "handle_client_shutdown", "strategy")
 
     def __init__(
-        self, redis: Redis, namespace: str | None | EmptyType = Empty, handle_client_shutdown: bool = False
+        self,
+        redis: Redis,
+        namespace: str | None | EmptyType = Empty,
+        handle_client_shutdown: bool = False,
+        strategy: Literal["keys", "hash"] | None = None,
     ) -> None:
         """Initialize :class:`RedisStore`
 
@@ -145,12 +247,64 @@ class RedisStore(NamespacedStore):
                 defaults to ``LITESTAR``. Namespacing can be explicitly disabled by passing
                 ``None``. This will make :meth:`.delete_all` unavailable.
             handle_client_shutdown: If ``True``, handle the shutdown of the `redis` instance automatically during the store's lifespan. Should be set to `True` unless the shutdown is handled externally
+            strategy: How values are laid out in Redis. ``"keys"`` stores every value under
+                its own ``<namespace>:<key>`` key. ``"hash"`` stores all values of a namespace
+                as fields of a single hash named after the namespace, using per-field
+                expiration; this requires Redis 7.4 or newer and a namespace, and lets
+                :meth:`.delete_all` remove the namespace in a single operation. On older
+                servers, ``"hash"`` fails only once an expiry is set, i.e. after values
+                without expiry have already been written. If ``None``, the server version is
+                detected on first use and ``"hash"`` is used on Redis 7.4+, ``"keys"``
+                otherwise. Data written with one strategy is not visible through the other.
         """
         self._redis = redis
         self.namespace: str | None = value_or_default(namespace, "LITESTAR")
         self.handle_client_shutdown = handle_client_shutdown
+        self.strategy: Literal["keys", "hash"] | None = strategy
+        self._strategy: _RedisStrategy | None = self._initial_strategy(strategy)
 
-        self._strategy: _RedisStrategy = _KeysStrategy(redis, self.namespace)
+    def _initial_strategy(self, strategy: Literal["keys", "hash"] | None) -> _RedisStrategy | None:
+        match strategy, self.namespace:
+            case "hash", None | "":
+                raise ImproperlyConfiguredException("The 'hash' strategy requires a namespace")
+            case "hash", str(namespace):
+                return _HashStrategy(self._redis, namespace)
+            case ("keys", _) | (None, None | ""):
+                return _KeysStrategy(self._redis, self.namespace)
+            case None, _:
+                # resolved on first use by detecting the server version
+                return None
+            case _:
+                raise ImproperlyConfiguredException(f"Unknown strategy {strategy!r}. Expected 'keys', 'hash' or None")
+
+    async def _get_strategy(self) -> _RedisStrategy:
+        # Concurrent first calls may both run the detection. That is harmless: the result is
+        # identical and strategies are stateless, so no lock is needed (an asyncio.Lock would
+        # also break the anyio/trio backends).
+        if self._strategy is None:
+            self._strategy = await self._detect_strategy()
+        return self._strategy
+
+    async def _detect_strategy(self) -> _RedisStrategy:
+        try:
+            info = await self._redis.info("server")
+            major, minor = (int(part) for part in str(info["redis_version"]).split(".")[:2])
+        except (ResponseError, KeyError, ValueError, TypeError):
+            # e.g. INFO not permitted, or a server reporting a non-standard version string
+            return _KeysStrategy(self._redis, self.namespace)
+        # detection only runs with a namespace (see _initial_strategy); the check narrows the type
+        if (major, minor) >= (7, 4) and self.namespace:
+            return _HashStrategy(self._redis, self.namespace)
+        return _KeysStrategy(self._redis, self.namespace)
+
+    def _strategy_name(self) -> Literal["keys", "hash"] | None:
+        match self._strategy:
+            case _HashStrategy():
+                return "hash"
+            case _KeysStrategy():
+                return "keys"
+            case _:
+                return self.strategy
 
     async def _shutdown(self) -> None:
         if self.handle_client_shutdown:
@@ -174,6 +328,7 @@ class RedisStore(NamespacedStore):
         username: str | None = None,
         password: str | None = None,
         namespace: str | None | EmptyType = Empty,
+        strategy: Literal["keys", "hash"] | None = None,
     ) -> RedisStore:
         """Initialize a :class:`RedisStore` instance with a new class:`redis.asyncio.Redis` instance.
 
@@ -184,6 +339,7 @@ class RedisStore(NamespacedStore):
             username: Redis username to use
             password: Redis password to use
             namespace: Virtual key namespace to use
+            strategy: Storage layout to use. See :class:`RedisStore`
         """
         pool: ConnectionPool[Connection] = ConnectionPool.from_url(
             url=url,
@@ -197,6 +353,7 @@ class RedisStore(NamespacedStore):
             redis=Redis(connection_pool=pool),
             namespace=namespace,
             handle_client_shutdown=True,
+            strategy=strategy,
         )
 
     def with_namespace(self, namespace: str) -> RedisStore:
@@ -208,6 +365,7 @@ class RedisStore(NamespacedStore):
             redis=self._redis,
             namespace=f"{self.namespace}_{namespace}" if self.namespace else namespace,
             handle_client_shutdown=self.handle_client_shutdown,
+            strategy=self._strategy_name(),
         )
 
     @overload
@@ -254,7 +412,8 @@ class RedisStore(NamespacedStore):
             raise ValueError("Cannot set both 'expires_in' and 'keep_ttl': these options are mutually exclusive")
         if isinstance(value, str):
             value = value.encode("utf-8")
-        await self._strategy.set(key, value, expires_in, keep_ttl)
+        strategy = await self._get_strategy()
+        await strategy.set(key, value, expires_in, keep_ttl)
 
     async def get(self, key: str, renew_for: int | timedelta | None = None) -> bytes | None:
         """Get a value.
@@ -271,7 +430,8 @@ class RedisStore(NamespacedStore):
             The value associated with ``key`` if it exists and is not expired, else
             ``None``
         """
-        return await self._strategy.get(key, renew_for)
+        strategy = await self._get_strategy()
+        return await strategy.get(key, renew_for)
 
     async def delete(self, key: str) -> None:
         """Delete a value.
@@ -281,7 +441,8 @@ class RedisStore(NamespacedStore):
         Args:
             key: Key of the value to delete
         """
-        await self._strategy.delete(key)
+        strategy = await self._get_strategy()
+        await strategy.delete(key)
 
     async def delete_all(self) -> None:
         """Delete all stored values in the virtual key namespace.
@@ -292,14 +453,17 @@ class RedisStore(NamespacedStore):
         if not self.namespace:
             raise ImproperlyConfiguredException("Cannot perform delete operation: No namespace configured")
 
-        await self._strategy.delete_all()
+        strategy = await self._get_strategy()
+        await strategy.delete_all()
 
     async def exists(self, key: str) -> bool:
         """Check if a given ``key`` exists."""
-        return await self._strategy.exists(key)
+        strategy = await self._get_strategy()
+        return await strategy.exists(key)
 
     async def expires_in(self, key: str) -> int | None:
         """Get the time in seconds ``key`` expires in. If no such ``key`` exists or no
         expiry time was set, return ``None``.
         """
-        return await self._strategy.expires_in(key)
+        strategy = await self._get_strategy()
+        return await strategy.expires_in(key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ piccolo = ["piccolo", "litestar-piccolo"]
 polyfactory = ["polyfactory>=2.6.3"]
 prometheus = ["prometheus-client"]
 pydantic = ["pydantic>=2", "email-validator", "pydantic-extra-types"]
-redis = ["redis[hiredis]>=4.4.4,!=5.3.*"]  # 5.3.0 introduced some issues with the channels plugin; need to investigate
+redis = ["redis[hiredis]>=5.0.8,!=5.3.*"]  # 5.3.0 introduced some issues with the channels plugin; need to investigate
 sqlalchemy = ["advanced-alchemy @ git+https://github.com/litestar-org/advanced-alchemy.git@main"]
 standard = [
   "litestar[cli]",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,8 +82,18 @@ def mock_asgi_app() -> ASGIApp:
 
 
 @pytest.fixture()
-def redis_store(redis_client: AsyncRedis) -> RedisStore:
-    return RedisStore(redis=redis_client)
+def redis_store_keys(redis_client: AsyncRedis) -> RedisStore:
+    return RedisStore(redis=redis_client, strategy="keys")
+
+
+@pytest.fixture()
+def redis_store_hash(redis_client: AsyncRedis) -> RedisStore:
+    return RedisStore(redis=redis_client, strategy="hash")
+
+
+@pytest.fixture(params=["keys", "hash"])
+def redis_store(request: FixtureRequest, redis_client: AsyncRedis) -> RedisStore:
+    return RedisStore(redis=redis_client, strategy=request.param)
 
 
 @pytest.fixture()
@@ -115,7 +125,8 @@ def file_store_create_directories_flag_false(tmp_path: Path) -> FileStore:
 
 @pytest.fixture(
     params=[
-        pytest.param("redis_store", marks=pytest.mark.xdist_group("redis")),
+        pytest.param("redis_store_keys", id="redis_store[keys]", marks=pytest.mark.xdist_group("redis")),
+        pytest.param("redis_store_hash", id="redis_store[hash]", marks=pytest.mark.xdist_group("redis")),
         pytest.param("valkey_store", marks=pytest.mark.xdist_group("valkey")),
         "memory_store",
         "file_store",

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -7,17 +7,19 @@ import string
 from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from _pytest.fixtures import FixtureRequest
 from pytest_mock import MockerFixture
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import ResponseError
 from time_machine import Traveller
 
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.stores.file import FileStore
 from litestar.stores.memory import MemoryStore
-from litestar.stores.redis import RedisStore, _KeysStrategy
+from litestar.stores.redis import RedisStore, _HashStrategy, _KeysStrategy
 from litestar.stores.registry import StoreRegistry
 from litestar.stores.valkey import ValkeyStore
 
@@ -36,6 +38,15 @@ def mock_redis() -> None:
 @pytest.fixture()
 def mock_valkey() -> None:
     patch("litestar.Store.valkey_backend.Valkey")
+
+
+async def _force_expire_redis(store: RedisStore, key: str) -> None:
+    """Expire a key immediately; time travel does not affect the Redis server."""
+    strategy = await store._get_strategy()
+    if isinstance(strategy, _HashStrategy):
+        await store._redis.hexpire(store.namespace, 0, key)  # type: ignore[attr-defined]
+    else:
+        await store._redis.expire(f"{store.namespace}:{key}", 0)
 
 
 async def test_get(store: Store) -> None:
@@ -76,7 +87,7 @@ async def test_expires(store: Store, frozen_datetime: Traveller) -> None:
     if isinstance(store, RedisStore):
         # shifting time does not affect the Redis instance
         # this is done to emulate auto-expiration
-        await store._redis.expire(f"{store.namespace}:foo", 0)
+        await _force_expire_redis(store, "foo")
     if isinstance(store, ValkeyStore):
         await store._valkey.expire(f"{store.namespace}:foo", 0)
 
@@ -191,7 +202,7 @@ async def test_expires_in(store: Store, frozen_datetime: Traveller) -> None:
     assert math.ceil(expiration / 10) == 1
 
     if isinstance(store, RedisStore):
-        await store._redis.expire(f"{store.namespace}:foo", 0)
+        await _force_expire_redis(store, "foo")
     elif isinstance(store, ValkeyStore):
         await store._valkey.expire(f"{store.namespace}:foo", 0)
     expiration = await store.expires_in("foo")
@@ -335,10 +346,10 @@ async def test_valkey_delete_all_no_namespace_raises(valkey_client: Valkey) -> N
 
 
 @pytest.mark.xdist_group("redis")
-def test_redis_namespaced_key(redis_store: RedisStore) -> None:
-    assert redis_store.namespace == "LITESTAR"
-    assert isinstance(redis_store._strategy, _KeysStrategy)
-    assert redis_store._strategy._make_key("foo") == "LITESTAR:foo"
+def test_redis_namespaced_key(redis_store_keys: RedisStore) -> None:
+    assert redis_store_keys.namespace == "LITESTAR"
+    assert isinstance(redis_store_keys._strategy, _KeysStrategy)
+    assert redis_store_keys._strategy._make_key("foo") == "LITESTAR:foo"
 
 
 @pytest.mark.xdist_group("valkey")
@@ -354,6 +365,7 @@ def test_redis_with_namespace(redis_store: RedisStore) -> None:
     assert namespaced_test.namespace == "LITESTAR_TEST"
     assert namespaced_test_foo.namespace == "LITESTAR_TEST_FOO"
     assert namespaced_test._redis is redis_store._redis
+    assert namespaced_test.strategy == redis_store.strategy
 
 
 @pytest.mark.xdist_group("valkey")
@@ -448,7 +460,8 @@ def test_file_with_namespace_invalid_namespace_char(file_store: FileStore, inval
 
 @pytest.fixture(
     params=[
-        pytest.param("redis_store", marks=pytest.mark.xdist_group("redis")),
+        pytest.param("redis_store_keys", id="redis_store[keys]", marks=pytest.mark.xdist_group("redis")),
+        pytest.param("redis_store_hash", id="redis_store[hash]", marks=pytest.mark.xdist_group("redis")),
         pytest.param("valkey_store", marks=pytest.mark.xdist_group("valkey")),
         "file_store",
     ]
@@ -581,3 +594,138 @@ async def test_valkey_store_with_client_shutdown(valkey_service: None) -> None:
         for x in valkey_store._valkey.connection_pool._available_connections
         + list(valkey_store._valkey.connection_pool._in_use_connections)
     )
+
+
+@pytest.mark.parametrize(
+    "version, expected",
+    [
+        ("7.4.0", _HashStrategy),
+        ("8.0.1", _HashStrategy),
+        ("7.2.4", _KeysStrategy),
+        ("6.2.11", _KeysStrategy),
+        ("255.255.255", _HashStrategy),
+        ("garbage", _KeysStrategy),
+        (7.4, _HashStrategy),
+    ],
+)
+async def test_redis_strategy_auto_detect(version: str | float, expected: type) -> None:
+    redis = MagicMock()
+    redis.info = AsyncMock(return_value={"redis_version": version})
+    store = RedisStore(redis=redis)
+
+    assert store._strategy is None
+    strategy = await store._get_strategy()
+    assert isinstance(strategy, expected)
+    redis.info.assert_awaited_once_with("server")
+
+    await store._get_strategy()
+    redis.info.assert_awaited_once_with("server")
+
+
+async def test_redis_strategy_detect_noperm_falls_back_to_keys() -> None:
+    redis = MagicMock()
+    redis.info = AsyncMock(side_effect=ResponseError("NOPERM"))
+    store = RedisStore(redis=redis)
+
+    strategy = await store._get_strategy()
+    assert isinstance(strategy, _KeysStrategy)
+
+
+async def test_redis_strategy_detect_missing_version_falls_back_to_keys() -> None:
+    redis = MagicMock()
+    redis.info = AsyncMock(return_value={})
+    store = RedisStore(redis=redis)
+
+    strategy = await store._get_strategy()
+    assert isinstance(strategy, _KeysStrategy)
+
+
+async def test_redis_strategy_detect_connection_error_propagates() -> None:
+    redis = MagicMock()
+    redis.info = AsyncMock(side_effect=RedisConnectionError())
+    store = RedisStore(redis=redis)
+
+    with pytest.raises(RedisConnectionError):
+        await store.get("x")
+
+
+@pytest.mark.parametrize("strategy", ["keys", "hash"])
+async def test_redis_explicit_strategy_skips_detection(strategy: str) -> None:
+    redis = MagicMock()
+    redis.info = AsyncMock(return_value={"redis_version": "7.4.0"})
+    store = RedisStore(redis=redis, strategy=strategy)  # type: ignore[arg-type]
+
+    resolved = await store._get_strategy()
+    redis.info.assert_not_awaited()
+    assert isinstance(resolved, _HashStrategy if strategy == "hash" else _KeysStrategy)
+
+
+@pytest.mark.parametrize("namespace", [None, ""])
+def test_redis_hash_strategy_requires_namespace(namespace: str | None) -> None:
+    with pytest.raises(ImproperlyConfiguredException):
+        RedisStore(redis=MagicMock(), namespace=namespace, strategy="hash")
+
+
+@pytest.mark.parametrize("namespace", [None, ""])
+async def test_redis_no_namespace_defaults_to_keys(namespace: str | None) -> None:
+    redis = MagicMock()
+    redis.info = AsyncMock(return_value={"redis_version": "7.4.0"})
+    store = RedisStore(redis=redis, namespace=namespace)
+
+    assert isinstance(store._strategy, _KeysStrategy)
+    redis.info.assert_not_awaited()
+
+
+@pytest.mark.xdist_group("redis")
+async def test_redis_with_namespace_propagates_resolved_strategy(redis_client: Redis) -> None:
+    store = RedisStore(redis=redis_client)
+    await store._get_strategy()
+
+    child = store.with_namespace("x")
+
+    assert child.strategy == store._strategy_name()
+    assert child.strategy is not None
+
+
+@pytest.mark.xdist_group("redis")
+async def test_redis_hash_layout(redis_store_hash: RedisStore) -> None:
+    await redis_store_hash.set("foo", b"bar")
+
+    assert await redis_store_hash._redis.hgetall("LITESTAR") == {b"foo": b"bar"}
+    assert await redis_store_hash._redis.exists("LITESTAR:foo") == 0
+
+
+@pytest.mark.xdist_group("redis")
+async def test_redis_hash_delete_all_scopes(redis_store_hash: RedisStore) -> None:
+    await redis_store_hash.set("a", b"a-value")
+    await redis_store_hash.with_namespace("FOO").set("b", b"b-value")
+    await redis_store_hash._redis.hset("LITESTARX", "k", b"v")
+    await redis_store_hash._redis.set("unrelated", b"v")
+
+    await redis_store_hash.delete_all()
+
+    assert await redis_store_hash.get("a") is None
+    assert await redis_store_hash.with_namespace("FOO").get("b") is None
+    assert await redis_store_hash._redis.hget("LITESTARX", "k") == b"v"
+    assert await redis_store_hash._redis.get("unrelated") == b"v"
+
+
+@pytest.mark.xdist_group("redis")
+@pytest.mark.flaky(reruns=5)
+async def test_redis_hash_set_subsecond_ttl(redis_store_hash: RedisStore) -> None:
+    await redis_store_hash.set("foo", b"bar", expires_in=timedelta(milliseconds=200))
+
+    await asyncio.sleep(0.5)
+
+    assert await redis_store_hash.get("foo") is None
+
+
+@pytest.mark.xdist_group("redis")
+@pytest.mark.parametrize("expires_in", [0, -5, timedelta(microseconds=-1000)])
+async def test_redis_hash_set_invalid_expires_in_does_not_write(
+    redis_store_hash: RedisStore, expires_in: int | timedelta
+) -> None:
+    with pytest.raises(ValueError):
+        await redis_store_hash.set("foo", b"bar", expires_in=expires_in)
+
+    assert await redis_store_hash.exists("foo") is False

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -17,7 +17,7 @@ from time_machine import Traveller
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.stores.file import FileStore
 from litestar.stores.memory import MemoryStore
-from litestar.stores.redis import RedisStore
+from litestar.stores.redis import RedisStore, _KeysStrategy
 from litestar.stores.registry import StoreRegistry
 from litestar.stores.valkey import ValkeyStore
 
@@ -337,7 +337,8 @@ async def test_valkey_delete_all_no_namespace_raises(valkey_client: Valkey) -> N
 @pytest.mark.xdist_group("redis")
 def test_redis_namespaced_key(redis_store: RedisStore) -> None:
     assert redis_store.namespace == "LITESTAR"
-    assert redis_store._make_key("foo") == "LITESTAR:foo"
+    assert isinstance(redis_store._strategy, _KeysStrategy)
+    assert redis_store._strategy._make_key("foo") == "LITESTAR:foo"
 
 
 @pytest.mark.xdist_group("valkey")

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -102,7 +102,7 @@ async def test_get_and_renew(store: Store, renew_for: int | timedelta, frozen_da
 
 
 @pytest.mark.flaky(reruns=5)
-@pytest.mark.parametrize("renew_for", [10, timedelta(seconds=10)])
+@pytest.mark.parametrize("renew_for", [10, timedelta(seconds=10), timedelta(days=1)])
 @pytest.mark.xdist_group("redis")
 async def test_get_and_renew_redis(redis_store: RedisStore, renew_for: int | timedelta) -> None:
     # we can't sleep() in frozen datetime, and frozen datetime doesn't affect the redis

--- a/uv.lock
+++ b/uv.lock
@@ -2191,7 +2191,7 @@ requires-dist = [
     { name = "pydantic-extra-types", marker = "extra == 'pydantic'" },
     { name = "pyjwt", marker = "extra == 'jwt'", specifier = ">=2.9.0" },
     { name = "pyyaml", marker = "extra == 'yaml'" },
-    { name = "redis", extras = ["hiredis"], marker = "extra == 'redis'", specifier = ">=4.4.4,!=5.3.*" },
+    { name = "redis", extras = ["hiredis"], marker = "extra == 'redis'", specifier = ">=5.0.8,!=5.3.*" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=13.0.0" },
     { name = "rich-click", marker = "extra == 'cli'", specifier = ">=1.9.9" },
     { name = "sniffio", specifier = ">=1.3.1" },


### PR DESCRIPTION
## Description

Closes #4992

Part 2 of two. Stacked on #5053 (the refactor that extracted the strategy layer); the diff includes those commits until #5053 is merged.

### What changes

`RedisStore` gains a `strategy` parameter (`"keys"`, `"hash"` or `None`, also on `with_client`):

- `"keys"`: the existing layout, one Redis key per value named `<namespace>:<key>`.
- `"hash"`: all values of a namespace are fields of a single Redis hash whose key is the namespace itself, using per-field expiration (Redis 7.4+). `delete_all` unlinks the namespace hash in one operation and only scans for child-namespace hashes (`<namespace>_*`) instead of every stored key.
- `None` (default): the server version is detected on first use via `INFO server`; `"hash"` on Redis 7.4+, `"keys"` otherwise. If `INFO` is not permitted or the version cannot be parsed, `"keys"` is used. `"hash"` requires a namespace. `with_namespace()` children inherit the parent's resolved strategy.

Both strategies are internal classes behind a small ABC; `RedisStore` keeps the full `Store` API and proxies to the resolved strategy. Resolution is a single `match` in `__init__`; operations have no strategy branching.

### Implementation notes

- `HSET` clears a field's TTL, so set-with-expiry and `keep_ttl` are one Lua script (`HPTTL` → `HSET` → `HPEXPIRE`). Expiry is in milliseconds so sub-second TTLs work.
- get-and-renew is a Lua script mirroring the keys one (`HGET` → `HTTL` → conditional `HEXPIRE`). `HGETEX` is not used because it sets a TTL unconditionally, which would break "renew only if the value already had an expiry". `HSETEX`/`HGETEX` are Redis 8 only and would add a second version branch; possible follow-up.
- The minimum `redis` (redis-py) version is raised to 5.0.8, the first release with the hash field expiration methods. `types-redis` stubs do not know them, hence one `# type: ignore[attr-defined]` (same as the existing `aclose`).
- Invalid `expires_in` (<= 0) is rejected before the script runs, so no partial write.

### Compatibility

Breaking for deployments on Redis 7.4+ that rely on data persisting across the upgrade: the default switches to the hash layout, and data written in one layout is not visible through the other. Pass `strategy="keys"` to keep the old layout. Documented in the changelog and usage docs.

Open question: `store.strategy` holds the requested value, so it stays `None` after auto-detection. Happy to add a read-only property exposing the resolved strategy if wanted.

### Validation

- `tests/unit/test_stores.py`: the `redis_store` fixture is parametrized over both strategies, so every existing Redis test runs under both layouts. New tests cover detection and fallbacks, namespace validation, the hash layout, `delete_all` scoping, sub-second TTL and invalid `expires_in`.
- Verified against Redis 7.4 and 8.x and against redis-py 5.0.8 and 7.4.0.
- mypy, pyright, slotscheck, ruff and Sphinx lint pass.


<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5054">https://litestar-org.github.io/litestar-docs-preview/5054</a> 
