### PR TITLE
feat(redis): support NX and XX in RedisStore.set

### DIFF
--- a/litestar/stores/redis.py
+++ b/litestar/stores/redis.py
@@ -147,6 +147,8 @@ class RedisStore(NamespacedStore):
         value: str | bytes,
         expires_in: int | timedelta | None = ...,
         keep_ttl: Literal[False] = ...,
+        nx: bool = ...,
+        xx: bool = ...,
     ) -> None: ...
 
     @overload
@@ -157,6 +159,8 @@ class RedisStore(NamespacedStore):
         expires_in: None = ...,
         *,
         keep_ttl: Literal[True],
+        nx: bool = ...,
+        xx: bool = ...,
     ) -> None: ...
 
     async def set(
@@ -165,6 +169,8 @@ class RedisStore(NamespacedStore):
         value: str | bytes,
         expires_in: int | timedelta | None = None,
         keep_ttl: bool = False,
+        nx: bool = False,
+        xx: bool = False,
     ) -> None:
         """Set a value.
 
@@ -173,6 +179,8 @@ class RedisStore(NamespacedStore):
             value: Value to store
             expires_in: Time in seconds before the key is considered expired
             keep_ttl: If ``True``, the TTL of the key will not be changed. If ``False``, the TTL of the key will be set to the value of ``expires_in``
+            nx: If ``True``, set the value only if the key does not already exist
+            xx: If ``True``, set the value only if the key already exists
 
         Raises:
             ValueError: If both ``expires_in`` and ``keep_ttl`` are set, as these options are mutually exclusive
@@ -184,7 +192,7 @@ class RedisStore(NamespacedStore):
             raise ValueError("Cannot set both 'expires_in' and 'keep_ttl': these options are mutually exclusive")
         if isinstance(value, str):
             value = value.encode("utf-8")
-        await self._redis.set(self._make_key(key), value, ex=expires_in, keepttl=keep_ttl)
+        await self._redis.set(self._make_key(key), value, ex=expires_in, keepttl=keep_ttl, nx=nx, xx=xx)
 
     async def get(self, key: str, renew_for: int | timedelta | None = None) -> bytes | None:
         """Get a value.

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -264,6 +264,28 @@ async def test_redis_set_with_keep_ttl(redis_store: RedisStore) -> None:
     assert await redis_store.get("foo") == b"updated"
 
 
+@pytest.mark.xdist_group("redis")
+async def test_redis_set_with_nx_and_xx(redis_store: RedisStore) -> None:
+    """Test that nx and xx conditionally create or update keys."""
+
+    # Test nx (set if not exists)
+    await redis_store.set("nx", b"created", nx=True)
+    assert await redis_store.get("nx") == b"created"
+
+    # Test xx (set if exists)
+    await redis_store.set("nx", b"not-created", nx=True)
+    assert await redis_store.get("nx") == b"created"
+
+    # Test xx (set if exists)
+    await redis_store.set("xx", b"not-created", xx=True)
+    assert await redis_store.get("xx") is None
+
+    # Now create the key and then update it with xx=True
+    await redis_store.set("xx", b"created")
+    await redis_store.set("xx", b"updated", xx=True)
+    assert await redis_store.get("xx") == b"updated"
+
+
 @patch("litestar.stores.valkey.Valkey")
 @patch("litestar.stores.valkey.ConnectionPool.from_url")
 def test_valkey_with_non_default(connection_pool_from_url_mock: Mock, mock_valkey: Mock) -> None:


### PR DESCRIPTION
## Description

Add `NX` and `XX` options to `RedisStore.set()` to support Redis atomic conditional writes.

### Problem

Currently, `RedisStore.set()` does not expose Redis `NX`/`XX` options.

This makes implementing idempotency safely difficult. For example:

```py
if not await store.get(idempotency_key):
    await store.set(idempotency_key, "processing") 
    await create_record()
```

Two concurrent requests can both execute `GET`, receive `None`, and then both create records.

Redis `SET NX` solves this atomically:

```py
created = await store.set(
    idempotency_key,
    "processing",
    expires_in=3600,
    nx=True,
)

if not created:
    # Already exists / being processed
    ...
```

Only one concurrent request can successfully create the key.

### Proposed Change

Expose `nx` and `xx` in `RedisStore.set()`:

```py 
await store.set(
    key,
    value,
    expires_in=3600,
    nx=True,
)
```

and:

```py
await store.set(
    key,
    value,
    xx=True,
)
```

The method should return whether the conditional `SET` succeeded, allowing callers to determine whether they acquired the key.

`NX` and `XX` should be mutually exclusive.

### Motivation

This enables common Redis patterns directly through `RedisStore`, including:

- Idempotency keys
- Distributed locks
- Atomic "create if not exists"
- Conditional cache updates

It also avoids requiring developers to bypass `RedisStore` and access the underlying Redis client directly.

### Backward Compatibility

Existing calls without `nx` or `xx` retain the current behavior.

### Tests

Add tests covering:

- `NX` with an existing/non-existing key
- `XX` with an existing/non-existing key
- `NX` + `XX` validation



<!-- docs-preview -->

<hr>
📚 Documentation preview 📚: <a href="https://litestar-org.github.io/litestar-docs-preview/5065">https://litestar-org.github.io/litestar-docs-preview/5065</a> 
